### PR TITLE
feat(rpc): restore evm2 RPC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=3de1c3763acd75907d874ed054ec784c99686c8c)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "eyre",
  "ruint",
@@ -3631,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3875,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=222463ca2da7ccb9981af1a2714f91987716c4fb)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "eyre",
  "ruint",
@@ -3631,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3875,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=3de1c3763acd75907d874ed054ec784c99686c8c)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,8 +3587,9 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
+ "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -3606,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3621,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "eyre",
  "ruint",
@@ -3630,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3648,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3671,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3681,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3694,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3721,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3731,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613#0b3330b4a1dbfc1f277accbc42c0b45d0bc77613"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=3de1c3763acd75907d874ed054ec784c99686c8c#3de1c3763acd75907d874ed054ec784c99686c8c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3874,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=0b3330b4a1dbfc1f277accbc42c0b45d0bc77613)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=3de1c3763acd75907d874ed054ec784c99686c8c)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,7 +3975,6 @@ dependencies = [
  "eyre",
  "futures-util",
  "reth-ethereum",
- "reth-rpc-api",
 ]
 
 [[package]]
@@ -9895,9 +9894,11 @@ dependencies = [
  "reth-db-api",
  "reth-engine-primitives",
  "reth-errors",
+ "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-execution-types",
  "reth-metrics",
  "reth-network-api",
  "reth-network-peers",
@@ -10045,6 +10046,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "auto_impl",
  "dyn-clone",
+ "evm2",
  "jsonrpsee-types",
  "reth-evm",
  "reth-primitives-traits",
@@ -10161,6 +10163,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-eips",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -10169,6 +10172,7 @@ dependencies = [
  "alloy-transport",
  "derive_more",
  "evm2",
+ "evm2-inspectors",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=222463ca2da7ccb9981af1a2714f91987716c4fb)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "eyre",
  "ruint",
@@ -3631,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998#28ac0a24a1fefda7ecf4c453aa3d099c2ee58998"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=222463ca2da7ccb9981af1a2714f91987716c4fb#222463ca2da7ccb9981af1a2714f91987716c4fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3875,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=28ac0a24a1fefda7ecf4c453aa3d099c2ee58998)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=222463ca2da7ccb9981af1a2714f91987716c4fb)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3462,6 +3462,7 @@ dependencies = [
  "ark-serialize 0.6.0",
  "arrayref",
  "aurora-engine-modexp",
+ "auto_impl",
  "aws-lc-rs",
  "bitvec",
  "blst",
@@ -3485,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -3504,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3519,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "eyre",
  "ruint",
@@ -3528,12 +3529,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3546,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3569,7 +3570,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3579,7 +3580,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3592,7 +3593,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3619,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=d0db90562a67cd09a2f5f16a7f61784428784575#d0db90562a67cd09a2f5f16a7f61784428784575"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9", default-features = false }
-evm2-jit-build = { git = "https://github.com/alloy-rs/evm2", rev = "0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9", default-features = false }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "d0db90562a67cd09a2f5f16a7f61784428784575", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "d0db90562a67cd09a2f5f16a7f61784428784575", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "d0db90562a67cd09a2f5f16a7f61784428784575", default-features = false }
+evm2-jit-build = { git = "https://github.com/alloy-rs/evm2", rev = "d0db90562a67cd09a2f5f16a7f61784428784575", default-features = false }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "d0db90562a67cd09a2f5f16a7f61784428784575" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "0b3330b4a1dbfc1f277accbc42c0b45d0bc77613", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "0b3330b4a1dbfc1f277accbc42c0b45d0bc77613", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "0b3330b4a1dbfc1f277accbc42c0b45d0bc77613", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "0b3330b4a1dbfc1f277accbc42c0b45d0bc77613" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c" }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "0b3330b4a1dbfc1f277accbc42c0b45d0bc77613" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "3de1c3763acd75907d874ed054ec784c99686c8c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb" }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1" }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "222463ca2da7ccb9981af1a2714f91987716c4fb" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "3de1c3763acd75907d874ed054ec784c99686c8c" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998" }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "3de1c3763acd75907d874ed054ec784c99686c8c" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "28ac0a24a1fefda7ecf4c453aa3d099c2ee58998" }

--- a/crates/cli/commands/src/config_cmd.rs
+++ b/crates/cli/commands/src/config_cmd.rs
@@ -24,7 +24,9 @@ impl Command {
         } else {
             let path = match self.config.as_ref() {
                 Some(path) => path,
-                None => bail!("No config file provided. Use --config <FILE> or pass --default"),
+                None => {
+                    bail!("No config file provided. Use --config <FILE> or pass --default");
+                }
             };
             if !path.exists() {
                 bail!("Config file does not exist: {}", path.display());

--- a/crates/cli/commands/src/download/archive.rs
+++ b/crates/cli/commands/src/download/archive.rs
@@ -203,7 +203,7 @@ impl ArchiveProcessor {
                         "Failed integrity validation after {} attempts for {}",
                         MAX_DOWNLOAD_RETRIES,
                         archive.file_name
-                    )
+                    );
                 }
             }
         }

--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -742,7 +742,7 @@ fn state_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
         return collect_files_recursive(source_datadir, Path::new("db"));
     }
 
-    eyre::bail!("Could not find source state DB directory under {}", source_datadir.display())
+    eyre::bail!("Could not find source state DB directory under {}", source_datadir.display());
 }
 
 fn rocksdb_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {

--- a/crates/cli/commands/src/download/manifest_cmd.rs
+++ b/crates/cli/commands/src/download/manifest_cmd.rs
@@ -126,7 +126,7 @@ fn infer_snapshot_block_from_db(source_datadir: &std::path::Path) -> Result<u64>
 
     eyre::bail!(
         "Could not infer --block from source DB (Finish checkpoint missing); pass --block manually"
-    )
+    );
 }
 
 /// Infers the snapshot block from the highest header static-file range.

--- a/crates/cli/commands/src/p2p/bootnode.rs
+++ b/crates/cli/commands/src/p2p/bootnode.rs
@@ -202,7 +202,9 @@ impl Command {
                     advertised_ips: vec![first_ip, second_ip],
                 })
             }
-            _ => eyre::bail!("--nat can be provided at most twice"),
+            _ => {
+                eyre::bail!("--nat can be provided at most twice");
+            }
         }
     }
 
@@ -283,7 +285,9 @@ async fn bind_socket(addr: SocketAddr) -> eyre::Result<Arc<UdpSocket>> {
 fn fixed_external_ip(nat: &NatResolver) -> eyre::Result<IpAddr> {
     match nat {
         NatResolver::ExternalIp(ip) => Ok(*ip),
-        _ => eyre::bail!("--nat can only be repeated with extip:<IP> values"),
+        _ => {
+            eyre::bail!("--nat can only be repeated with extip:<IP> values");
+        }
     }
 }
 

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -76,7 +76,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     eyre::bail!(
                         "Invalid number of bodies received. Expected: 1. Received: {}",
                         result.len()
-                    )
+                    );
                 }
                 let body = result.into_iter().next().unwrap();
                 tracing::info!(target: "reth::cli", ?body, "Successfully downloaded body")
@@ -185,7 +185,7 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
         if config.peers.trusted_nodes.is_empty() && self.network.trusted_only {
             eyre::bail!(
                 "No trusted nodes. Set trusted peer with `--trusted-peer <enode record>` or set `--trusted-only` to `false`"
-            )
+            );
         }
 
         config.peers.trusted_nodes_only |= self.network.trusted_only;

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -178,7 +178,7 @@ impl Subcommands {
         if target > last {
             eyre::bail!(
                 "Target block number {target} is higher than the latest block number {last}"
-            )
+            );
         }
         Ok(target)
     }

--- a/crates/e2e-test-utils/src/rpc.rs
+++ b/crates/e2e-test-utils/src/rpc.rs
@@ -3,15 +3,12 @@ use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_network::eip2718::Decodable2718;
 use alloy_primitives::{Bytes, B256};
 use reth_chainspec::EthereumHardforks;
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, EvmEnvFor, TxEnvFor};
 use reth_node_api::{BlockTy, FullNodeComponents};
 use reth_node_builder::{rpc::RpcRegistry, NodeTypes};
 use reth_provider::BlockReader;
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_eth_api::{
-    helpers::{
-        EthApiSpec, EthTransactions, TraceBlockEnv, TraceEvmInstance, TraceExt, TraceTxEnvelope,
-    },
+    helpers::{EthApiSpec, EthTransactions, TraceExt},
     EthApiTypes,
 };
 
@@ -32,23 +29,7 @@ where
         let eth_api = self.inner.eth_api();
         eth_api.send_raw_transaction(raw_tx).await
     }
-}
 
-// TODO: Tighten these bounds once raw debug transaction lookup is split from trace/debug execution.
-// `envelope_by_hash` only needs raw transaction bytes, but `DebugApiServer` currently gates
-// `raw_transaction` behind the broader trace-capable EVM bounds.
-impl<Node, EthApi> RpcTestContext<Node, EthApi>
-where
-    Node: FullNodeComponents<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
-    EthApi::Evm: ConfigureEvm,
-    EvmEnvFor<EthApi::Evm>: AsRef<TraceBlockEnv>,
-    <EthApi::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-    TxEnvFor<EthApi::Evm>: AsRef<TraceTxEnvelope> + Clone,
-    EthApi: EthApiSpec<Provider: BlockReader<Block = BlockTy<Node::Types>>>
-        + EthTransactions
-        + TraceExt,
-{
     /// Retrieves a transaction envelope by its hash
     pub async fn envelope_by_hash(
         &self,

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -227,7 +227,7 @@ where
         let res = self.to_engine.fork_choice_updated(state, None).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid fork choice update {state:?}: {res:?}")
+            eyre::bail!("Invalid fork choice update {state:?}: {res:?}");
         }
 
         Ok(())
@@ -245,7 +245,7 @@ where
             .await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid payload status")
+            eyre::bail!("Invalid payload status");
         }
 
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
@@ -257,14 +257,14 @@ where
         let Some(Ok(payload)) =
             self.payload_builder.resolve_kind(payload_id, PayloadKind::WaitForPending).await
         else {
-            eyre::bail!("No payload")
+            eyre::bail!("No payload");
         };
 
         let header = payload.block().sealed_header().clone();
         let res = self.to_engine.new_payload(payload.into()).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid payload")
+            eyre::bail!("Invalid payload");
         }
 
         self.last_block_hashes.push_back(header.hash());

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -387,7 +387,7 @@ mod tests {
         executor.apply_pre_execution_changes().expect("serial pre-exec");
         for (index, tx) in txs.iter().cloned().enumerate() {
             executor
-                .execute_transaction(evm_config.tx_env(tx))
+                .execute_transaction(tx.into())
                 .unwrap_or_else(|err| panic!("serial tx {index} failed: {err:?}"));
         }
         let (output, bal) = executor.finish_with_block_access_list().expect("serial post-exec");

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -11,8 +11,8 @@ use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender
 use prewarm::PrewarmMetrics;
 use rayon::prelude::*;
 use reth_evm::{
-    ConfigureEvm, ConvertTx, ExecutableTxFor, ExecutableTxIterator, ExecutableTxParts,
-    ExecutableTxTuple, TxEnvFor, WithTxEnv,
+    BlockExecutorTransactionFor, ConfigureEvm, ConvertTx, ExecutableTxFor, ExecutableTxIterator,
+    ExecutableTxParts, ExecutableTxTuple, WithTxEnv,
 };
 use reth_execution_types::EvmState;
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
@@ -45,7 +45,8 @@ pub mod receipt_root_task;
 pub const SMALL_BLOCK_TX_THRESHOLD: usize = 5;
 
 /// Type alias for [`PayloadHandle`] returned by payload processor spawn methods.
-type IteratorTx<Evm, I> = RecoveredTx<TxEnvFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
+type IteratorTx<Evm, I> =
+    RecoveredTx<BlockExecutorTransactionFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
 
 type IteratorPayloadHandle<Evm, I> = PayloadHandle<
     IteratorTx<Evm, I>,
@@ -53,11 +54,13 @@ type IteratorPayloadHandle<Evm, I> = PayloadHandle<
     <<Evm as ConfigureEvm>::Primitives as NodePrimitives>::Receipt,
 >;
 
-type IteratorPrewarmTxReceiver<Evm, I> =
-    PrewarmTxReceiver<TxEnvFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
+type IteratorPrewarmTxReceiver<Evm, I> = PrewarmTxReceiver<
+    BlockExecutorTransactionFor<Evm>,
+    <I as ExecutableTxIterator<Evm>>::Recovered,
+>;
 
 type IteratorExecuteTxReceiver<Evm, I> = ExecuteTxReceiver<
-    TxEnvFor<Evm>,
+    BlockExecutorTransactionFor<Evm>,
     <I as ExecutableTxIterator<Evm>>::Recovered,
     <I as ExecutableTxTuple>::Error,
 >;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -11,8 +11,8 @@ use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender
 use prewarm::PrewarmMetrics;
 use rayon::prelude::*;
 use reth_evm::{
-    BlockExecutorTransactionFor, ConfigureEvm, ConvertTx, ExecutableTxFor, ExecutableTxIterator,
-    ExecutableTxParts, ExecutableTxTuple, WithTxEnv,
+    ConfigureEvm, ConvertTx, ExecutableTxFor, ExecutableTxIterator, ExecutableTxParts,
+    ExecutableTxTuple, TxFor, WithTxEnv,
 };
 use reth_execution_types::EvmState;
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
@@ -45,8 +45,7 @@ pub mod receipt_root_task;
 pub const SMALL_BLOCK_TX_THRESHOLD: usize = 5;
 
 /// Type alias for [`PayloadHandle`] returned by payload processor spawn methods.
-type IteratorTx<Evm, I> =
-    RecoveredTx<BlockExecutorTransactionFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
+type IteratorTx<Evm, I> = RecoveredTx<TxFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
 
 type IteratorPayloadHandle<Evm, I> = PayloadHandle<
     IteratorTx<Evm, I>,
@@ -54,13 +53,11 @@ type IteratorPayloadHandle<Evm, I> = PayloadHandle<
     <<Evm as ConfigureEvm>::Primitives as NodePrimitives>::Receipt,
 >;
 
-type IteratorPrewarmTxReceiver<Evm, I> = PrewarmTxReceiver<
-    BlockExecutorTransactionFor<Evm>,
-    <I as ExecutableTxIterator<Evm>>::Recovered,
->;
+type IteratorPrewarmTxReceiver<Evm, I> =
+    PrewarmTxReceiver<TxFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
 
 type IteratorExecuteTxReceiver<Evm, I> = ExecuteTxReceiver<
-    BlockExecutorTransactionFor<Evm>,
+    TxFor<Evm>,
     <I as ExecutableTxIterator<Evm>>::Recovered,
     <I as ExecutableTxTuple>::Error,
 >;

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -160,7 +160,6 @@ where
     ) -> IteratorPayloadHandle<Evm, I>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
-        TxEnvFor<Evm>: Clone + Send + 'static,
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count, parallel_bal_execution);
@@ -209,10 +208,7 @@ where
         transactions: I,
         transaction_count: usize,
         parallel_bal_execution: bool,
-    ) -> (IteratorPrewarmTxReceiver<Evm, I>, IteratorExecuteTxReceiver<Evm, I>)
-    where
-        TxEnvFor<Evm>: Clone + Send + 'static,
-    {
+    ) -> (IteratorPrewarmTxReceiver<Evm, I>, IteratorExecuteTxReceiver<Evm, I>) {
         let (prewarm_tx, prewarm_rx) = mpsc::sync_channel(transaction_count);
         let (execute_tx, execute_rx) = crossbeam_channel::bounded(transaction_count);
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -19,12 +19,12 @@ use crate::tree::{
 use alloy_eip7928::bal::DecodedBal;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_primitives::{keccak256, Address, B256, U256};
-use core::{borrow::Borrow, convert::Infallible};
+use core::convert::Infallible;
 use metrics::{Counter, Gauge, Histogram};
 use rayon::prelude::*;
 use reth_evm::{
     database::StateProviderDatabase, ConfigureEvm, Evm as EvmInstance, EvmEnv, EvmFor,
-    ExecutableTxFor,
+    ExecutableTxFor, RecoveredTx,
 };
 use reth_execution_types::{EvmStateChangeSink, ExecutionAccountChangeRef, ExecutionStorageChange};
 use reth_metrics::Metrics;
@@ -228,12 +228,13 @@ where
 
             let start = Instant::now();
 
-            let (tx_env, _tx) = tx.into_parts();
+            let (_tx_env, tx) = tx.into_parts();
+            let tx_env = ctx.evm_config.tx_env(tx.to_recovered());
             // Prewarm workers must not commit speculative writes into the reused worker EVM:
             // task scheduling would otherwise make later prewarm reads observe non-canonical state.
             let mut proof_targets = PrewarmProofTargetsSink::default();
 
-            match evm.transact_and_discard(tx_env.borrow(), &mut proof_targets) {
+            match evm.transact_and_discard(&tx_env, &mut proof_targets) {
                 Ok(()) => {}
                 Err(err) => {
                     trace!(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -448,7 +448,6 @@ where
     where
         V: PayloadValidator<T, Block = N::Block> + Clone,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
-        TxEnvFor<Evm>: Clone + Send + 'static,
     {
         let parent_hash = input.parent_hash();
         let _jit_pause = JitPauseGuard::new(&self.evm_config);
@@ -1279,10 +1278,7 @@ where
             N::Receipt,
         >,
         InsertBlockErrorKind,
-    >
-    where
-        TxEnvFor<Evm>: Clone + Send + 'static,
-    {
+    > {
         let start = Instant::now();
         let handle = self.payload_processor.spawn_with_state_root_streams(
             env,
@@ -1666,7 +1662,6 @@ where
     N: NodePrimitives,
     V: PayloadValidator<Types, Block = N::Block> + Clone,
     Evm: ConfigureEngineEvm<Types::ExecutionData, Primitives = N> + 'static,
-    TxEnvFor<Evm>: Clone + Send + 'static,
     Types: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
 {
     fn validate_payload_attributes_against_header(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -131,8 +131,9 @@ use reth_engine_primitives::{
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
-    database::StateProviderDatabase, BlockExecutor, BlockExecutorFactory, ConfigureEvm, EvmEnvFor,
-    ExecutableTxFor, ExecutionCtxFor, RecoveredTx, TxEnvFor,
+    database::StateProviderDatabase, BlockExecutor, BlockExecutorFactory,
+    BlockExecutorTransactionFor, ConfigureEvm, EvmEnvFor, ExecutableTxFor, ExecutionCtxFor,
+    RecoveredTx,
 };
 use reth_execution_cache::{CacheFillMode, CacheStats, SavedCache};
 use reth_payload_primitives::{
@@ -1140,7 +1141,7 @@ where
     where
         Tx: ExecutableTxFor<Evm>,
         Err: core::error::Error + Send + Sync + 'static,
-        Executor: BlockExecutor<Primitives = N, Transaction = TxEnvFor<Evm>>,
+        Executor: BlockExecutor<Primitives = N, Transaction = BlockExecutorTransactionFor<Evm>>,
     {
         let pre_exec_start = Instant::now();
         debug_span!(target: "engine::tree", "pre_execution").in_scope(|| {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -131,9 +131,8 @@ use reth_engine_primitives::{
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
-    database::StateProviderDatabase, BlockExecutor, BlockExecutorFactory,
-    BlockExecutorTransactionFor, ConfigureEvm, EvmEnvFor, ExecutableTxFor, ExecutionCtxFor,
-    RecoveredTx,
+    database::StateProviderDatabase, BlockExecutor, BlockExecutorFactory, ConfigureEvm, EvmEnvFor,
+    ExecutableTxFor, ExecutionCtxFor, RecoveredTx, TxFor,
 };
 use reth_execution_cache::{CacheFillMode, CacheStats, SavedCache};
 use reth_payload_primitives::{
@@ -1141,7 +1140,7 @@ where
     where
         Tx: ExecutableTxFor<Evm>,
         Err: core::error::Error + Send + Sync + 'static,
-        Executor: BlockExecutor<Primitives = N, Transaction = BlockExecutorTransactionFor<Evm>>,
+        Executor: BlockExecutor<Primitives = N, Transaction = TxFor<Evm>>,
     {
         let pre_exec_start = Instant::now();
         debug_span!(target: "engine::tree", "pre_execution").in_scope(|| {

--- a/crates/ethereum/evm/src/convert.rs
+++ b/crates/ethereum/evm/src/convert.rs
@@ -10,7 +10,7 @@ use alloy_rpc_types_engine::ExecutionData;
 use evm2::{env::BlockEnv, ethereum::RecoveredTxEnvelope, SpecId};
 use reth_chainspec::EthereumHardforks;
 use reth_ethereum_primitives::TransactionSigned;
-use reth_evm::{ExecutableTxParts, FromTxWithEncoded, RecoveredTx};
+use reth_evm::{ExecutableTxParts, FromRecoveredTx, FromTxWithEncoded, RecoveredTx};
 
 /// Map the latest active Ethereum hardfork at `timestamp` or `block_number` to a [`SpecId`].
 pub(crate) fn spec_id_by_timestamp_and_block_number<C>(
@@ -141,6 +141,12 @@ impl From<Recovered<TransactionSigned>> for EthTxEnv {
     }
 }
 
+impl FromRecoveredTx<TransactionSigned> for EthTxEnv {
+    fn from_recovered_tx(tx: Recovered<TransactionSigned>) -> Self {
+        tx.into()
+    }
+}
+
 impl FromTxWithEncoded<TransactionSigned> for EthTxEnv {}
 
 /// Recovered Ethereum transaction paired with its cached transaction environment.
@@ -178,7 +184,7 @@ impl ExecutableTxParts<EthTxEnv, TransactionSigned> for ExecutableRecoveredTx {
 
 /// Converts an owned recovered Reth Ethereum transaction into a recovered envelope.
 pub(crate) fn recovered_tx_envelope(tx: Recovered<TransactionSigned>) -> RecoveredTxEnvelope {
-    tx.into()
+    tx.convert()
 }
 
 #[cfg(test)]

--- a/crates/ethereum/evm/src/convert.rs
+++ b/crates/ethereum/evm/src/convert.rs
@@ -7,11 +7,7 @@ use alloy_consensus::{
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, BlockNumber, BlockTimestamp, B256, U256};
 use alloy_rpc_types_engine::ExecutionData;
-use evm2::{
-    env::BlockEnv,
-    ethereum::{LazyTxEip7702, RecoveredTxEnvelope},
-    SpecId,
-};
+use evm2::{env::BlockEnv, ethereum::RecoveredTxEnvelope, SpecId};
 use reth_chainspec::EthereumHardforks;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::{ExecutableTxParts, FromTxWithEncoded, RecoveredTx};
@@ -127,11 +123,6 @@ pub struct EthTxEnv {
 }
 
 impl EthTxEnv {
-    /// Returns the wrapped transaction envelope.
-    pub const fn as_envelope(&self) -> &RecoveredTxEnvelope {
-        &self.envelope
-    }
-
     /// Returns the original transaction hash.
     pub const fn tx_hash(&self) -> B256 {
         self.tx_hash
@@ -140,24 +131,6 @@ impl EthTxEnv {
     /// Consumes the wrapper and returns the transaction envelope.
     pub fn into_envelope(self) -> RecoveredTxEnvelope {
         self.envelope
-    }
-}
-
-impl AsRef<RecoveredTxEnvelope> for EthTxEnv {
-    fn as_ref(&self) -> &RecoveredTxEnvelope {
-        self.as_envelope()
-    }
-}
-
-impl From<RecoveredTxEnvelope> for EthTxEnv {
-    fn from(envelope: RecoveredTxEnvelope) -> Self {
-        Self { envelope, tx_hash: B256::ZERO }
-    }
-}
-
-impl core::borrow::Borrow<RecoveredTxEnvelope> for EthTxEnv {
-    fn borrow(&self) -> &RecoveredTxEnvelope {
-        self.as_envelope()
     }
 }
 
@@ -205,26 +178,7 @@ impl ExecutableTxParts<EthTxEnv, TransactionSigned> for ExecutableRecoveredTx {
 
 /// Converts an owned recovered Reth Ethereum transaction into a recovered envelope.
 pub(crate) fn recovered_tx_envelope(tx: Recovered<TransactionSigned>) -> RecoveredTxEnvelope {
-    let (tx, signer) = tx.into_parts();
-    match tx {
-        TransactionSigned::Legacy(tx) => {
-            RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(tx.strip_signature(), signer))
-        }
-        TransactionSigned::Eip2930(tx) => {
-            RecoveredTxEnvelope::Eip2930(Recovered::new_unchecked(tx.strip_signature(), signer))
-        }
-        TransactionSigned::Eip1559(tx) => {
-            RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(tx.strip_signature(), signer))
-        }
-        TransactionSigned::Eip4844(tx) => RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(
-            tx.strip_signature().into(),
-            signer,
-        )),
-        TransactionSigned::Eip7702(tx) => RecoveredTxEnvelope::Eip7702(Recovered::new_unchecked(
-            LazyTxEip7702::from_recovered_authorizations(tx.strip_signature()),
-            signer,
-        )),
-    }
+    tx.into()
 }
 
 #[cfg(test)]

--- a/crates/ethereum/evm/src/convert.rs
+++ b/crates/ethereum/evm/src/convert.rs
@@ -155,6 +155,12 @@ impl AsRef<RecoveredTxEnvelope> for EthTxEnv {
     }
 }
 
+impl From<RecoveredTxEnvelope> for EthTxEnv {
+    fn from(envelope: RecoveredTxEnvelope) -> Self {
+        Self { envelope, tx_hash: B256::ZERO }
+    }
+}
+
 impl core::borrow::Borrow<RecoveredTxEnvelope> for EthTxEnv {
     fn borrow(&self) -> &RecoveredTxEnvelope {
         self.as_envelope()

--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -293,7 +293,7 @@ where
 }
 
 /// Additional block-level execution context.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct BlockExecutionContext<'a> {
     /// Pre-block system calls to run before transaction execution.
     pub system_calls: Option<BlockSystemCalls>,
@@ -303,12 +303,6 @@ pub(crate) struct BlockExecutionContext<'a> {
     pub withdrawals: Option<&'a [Withdrawal]>,
     /// Deposit contract address used to derive EIP-6110 deposit requests from receipts.
     pub deposit_contract_address: Option<Address>,
-}
-
-impl Default for BlockExecutionContext<'_> {
-    fn default() -> Self {
-        Self { system_calls: None, ommers: None, withdrawals: None, deposit_contract_address: None }
-    }
 }
 
 /// Inputs required by Ethereum pre-block system calls.

--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -13,10 +13,12 @@ use alloc::{
     vec::Vec,
 };
 #[cfg(test)]
-use alloy_consensus::transaction::Recovered;
-#[cfg(test)]
 use alloy_consensus::TxType;
-use alloy_consensus::{constants::ETH_TO_WEI, transaction::Transaction, BlockHeader, Header};
+use alloy_consensus::{
+    constants::ETH_TO_WEI,
+    transaction::{Recovered, Transaction},
+    BlockHeader, Header,
+};
 use alloy_eips::{
     eip2718::Typed2718,
     eip4895::Withdrawal,
@@ -470,10 +472,7 @@ where
 }
 
 pub(crate) fn transaction_blob_gas_used(transaction: &RecoveredTxEnvelope) -> u64 {
-    transaction
-        .as_eip4844()
-        .map(|tx| tx.inner().blob_gas_used().unwrap_or_default())
-        .unwrap_or_default()
+    transaction.as_eip4844().map(|tx| tx.blob_gas_used().unwrap_or_default()).unwrap_or_default()
 }
 
 /// Hooks invoked while executing an Ethereum block.
@@ -704,7 +703,7 @@ pub(crate) fn execute_transaction<T: EvmTypes>(
     block_state: &mut BlockStateAccumulator,
     stream_hashed_state: bool,
     on_hashed_state_update: &mut impl FnMut(HashedPostState),
-    transaction: &T::Tx,
+    transaction: &Recovered<T::Tx>,
 ) -> Result<TxResult<T>, EthExecutionError>
 where
     T::Tx: Typed2718,
@@ -725,7 +724,7 @@ pub(crate) fn execute_transaction_with_commit_condition<T: EvmTypes>(
     block_state: &mut BlockStateAccumulator,
     stream_hashed_state: bool,
     on_hashed_state_update: &mut impl FnMut(HashedPostState),
-    transaction: &T::Tx,
+    transaction: &Recovered<T::Tx>,
     should_commit: impl FnOnce(&TxResult<T>) -> CommitChanges,
 ) -> Result<Option<TxResult<T>>, EthExecutionError>
 where
@@ -767,7 +766,7 @@ where
 
 pub(crate) fn execute_transaction_without_commit<T: EvmTypes>(
     evm: &mut Evm<'_, T>,
-    transaction: &T::Tx,
+    transaction: &Recovered<T::Tx>,
 ) -> Result<TxResultWithState<T>, EthExecutionError>
 where
     T::Tx: Typed2718,

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -12,12 +12,12 @@ use crate::{
     EthBlockExecutionCtx, EthEvmEnv, EthTxEnv, RethReceiptBuilder,
 };
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
-use alloy_consensus::{Header, TxType};
+use alloy_consensus::{Header, Transaction, TxType};
 use alloy_eip7928::{BlockAccessIndex, BlockAccessList};
 use alloy_eips::{eip2718::Typed2718, eip4895::Withdrawal, eip7685::Requests};
 use alloy_primitives::{Address, B256};
 use evm2::{
-    ethereum::RecoveredTxEnvelope,
+    ethereum::TxEnvelope,
     evm::{Bal, BlockStateAccumulator, StateChangeSource},
     interpreter::Host,
     BaseEvmTypes, Evm, EvmTypes, TxResult, TxResultWithState,
@@ -34,7 +34,7 @@ use reth_trie_common::HashedPostState;
 #[expect(missing_debug_implementations)]
 pub struct EthBlockExecutor<'a, T = BaseEvmTypes>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
     T::Tx: Typed2718,
     T::TxResultExt: Send,
 {
@@ -94,7 +94,7 @@ impl HashedStateMode {
 
 impl<'a, T> EthBlockExecutor<'a, T>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
     T::Tx: Typed2718,
     T::TxResultExt: Send,
 {
@@ -228,7 +228,7 @@ where
 
 impl<'a, T> BlockExecutor for EthBlockExecutor<'a, T>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
     T::Tx: Typed2718,
     T::TxResultExt: Send,
 {
@@ -433,7 +433,7 @@ where
 /// One block execution segment inside a merged big-block payload.
 pub struct EthBigBlockSegment<'a, T = BaseEvmTypes>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
 {
     /// Transaction index at which this segment starts.
     pub start_tx: usize,
@@ -445,7 +445,7 @@ where
 
 impl<'a, T> Clone for EthBigBlockSegment<'a, T>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
 {
     fn clone(&self) -> Self {
         Self { start_tx: self.start_tx, evm_env: self.evm_env.clone(), ctx: self.ctx.clone() }
@@ -454,7 +454,7 @@ where
 
 impl<'a, T> core::fmt::Debug for EthBigBlockSegment<'a, T>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
     T::SpecId: core::fmt::Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -469,7 +469,7 @@ where
 /// Execution plan for a merged big-block payload.
 pub struct EthBigBlockPlan<'a, T = BaseEvmTypes>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
 {
     /// Ordered execution segments.
     pub segments: Vec<EthBigBlockSegment<'a, T>>,
@@ -481,7 +481,7 @@ where
 
 impl<'a, T> Clone for EthBigBlockPlan<'a, T>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -494,7 +494,7 @@ where
 
 impl<'a, T> core::fmt::Debug for EthBigBlockPlan<'a, T>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
     T::SpecId: core::fmt::Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -508,7 +508,7 @@ where
 
 impl<'a, T> EthBigBlockPlan<'a, T>
 where
-    T: EvmTypes<Tx = RecoveredTxEnvelope>,
+    T: EvmTypes<Tx = TxEnvelope>,
 {
     /// Creates a plan and adds hashes for the boundaries between segments.
     pub fn new(
@@ -556,7 +556,7 @@ struct FinishedBigBlockSegment {
 pub struct EthBigBlockExecutor<'a, C, F = crate::factory::RethEvmFactory>
 where
     F: EvmFactory,
-    F::Types: EvmTypes<Tx = RecoveredTxEnvelope>,
+    F::Types: EvmTypes<Tx = TxEnvelope>,
     <F::Types as evm2::EvmTypesHost>::Tx: Typed2718,
     <F::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {
@@ -579,7 +579,7 @@ impl<'a, C, F> EthBigBlockExecutor<'a, C, F>
 where
     C: EthereumHardforks,
     F: EvmFactory,
-    F::Types: EvmTypes<Tx = RecoveredTxEnvelope>,
+    F::Types: EvmTypes<Tx = TxEnvelope>,
     <F::Types as evm2::EvmTypesHost>::Tx: Typed2718,
     <F::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {
@@ -770,7 +770,7 @@ impl<'a, C, F> BlockExecutor for EthBigBlockExecutor<'a, C, F>
 where
     C: EthereumHardforks,
     F: EvmFactory,
-    F::Types: EvmTypes<Tx = RecoveredTxEnvelope>,
+    F::Types: EvmTypes<Tx = TxEnvelope>,
     <F::Types as evm2::EvmTypesHost>::Tx: Typed2718,
     <F::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -22,11 +22,11 @@ use crate::{
 
 /// Factory used to construct an evm2-backed EVM.
 ///
-/// The transaction type defaults to Ethereum's recovered envelope so the standard block
+/// The transaction type defaults to Ethereum's envelope so the standard block
 /// executor remains ergonomic. Custom-node integrations can select a different evm2 transaction
 /// type by implementing `EvmFactory<CustomTx>` and using that factory with their own executor and
 /// primitives.
-pub trait EvmFactory<Tx = evm2::ethereum::RecoveredTxEnvelope>:
+pub trait EvmFactory<Tx = evm2::ethereum::TxEnvelope>:
     Clone + core::fmt::Debug + Send + Sync + Unpin + 'static
 where
     <Self::Types as evm2::EvmTypesHost>::BlockEnvExt: Send + Sync,
@@ -160,7 +160,7 @@ where
     type Primitives = EthPrimitives;
     type EvmFactory = F;
     type EvmTypes = F::Types;
-    type EvmTransaction = evm2::ethereum::RecoveredTxEnvelope;
+    type EvmTransaction = evm2::ethereum::TxEnvelope;
     type Transaction = EthTxEnv;
     type Evm<'a> = evm2::Evm<'a, F::Types>;
     type EvmEnv = EthEvmEnv<F::Types>;
@@ -360,7 +360,7 @@ where
     type Primitives = EthPrimitives;
     type EvmFactory = F;
     type EvmTypes = F::Types;
-    type EvmTransaction = evm2::ethereum::RecoveredTxEnvelope;
+    type EvmTransaction = evm2::ethereum::TxEnvelope;
     type Transaction = EthTxEnv;
     type Evm<'a> = evm2::Evm<'a, F::Types>;
     type EvmEnv = EthEvmEnv<F::Types>;

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -60,6 +60,7 @@ where
 {
     type Primitives = EthPrimitives;
     type EvmFactory = EvmFactory;
+    type EvmTypes = evm2::BaseEvmTypes;
     type EvmTransaction = evm2::ethereum::RecoveredTxEnvelope;
     type Transaction = EthTxEnv;
     type Evm<'a> = evm2::Evm<'a, evm2::BaseEvmTypes>;

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -174,6 +174,7 @@ where
 {
     type Primitives = EthPrimitives;
     type EvmFactory = EvmFactory;
+    type EvmTypes = evm2::BaseEvmTypes;
     type EvmTransaction = evm2::ethereum::RecoveredTxEnvelope;
     type Transaction = EthTxEnv;
     type Evm<'a> = evm2::Evm<'a, evm2::BaseEvmTypes>;

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -30,6 +30,7 @@ pub trait EvmFactory<Tx = evm2::ethereum::TxEnvelope>:
     Clone + core::fmt::Debug + Send + Sync + Unpin + 'static
 where
     <Self::Types as evm2::EvmTypesHost>::BlockEnvExt: Send + Sync,
+    <Self::Types as evm2::EvmTypesHost>::EvmExt: Default,
     <Self::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {
     /// Runtime evm2 type family used by the EVM.

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -96,6 +96,8 @@ impl AsRef<evm2::env::BlockEnv> for EthEvmEnv {
 }
 
 impl EvmEnv for EthEvmEnv {
+    type EvmTypes = evm2::BaseEvmTypes;
+
     fn spec_id(&self) -> evm2::SpecId {
         self.spec
     }

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -96,6 +96,30 @@ impl AsRef<evm2::env::BlockEnv> for EthEvmEnv {
 }
 
 impl EvmEnv for EthEvmEnv {
+    fn spec_id(&self) -> evm2::SpecId {
+        self.spec
+    }
+
+    fn chain_id(&self) -> u64 {
+        self.version.chain_id
+    }
+
+    fn block_env(&self) -> &evm2::env::BlockEnv {
+        &self.block
+    }
+
+    fn block_env_mut(&mut self) -> &mut evm2::env::BlockEnv {
+        &mut self.block
+    }
+
+    fn version(&self) -> &evm2::Version {
+        &self.version
+    }
+
+    fn version_mut(&mut self) -> &mut evm2::Version {
+        &mut self.version
+    }
+
     fn block_base_fee(&self) -> u64 {
         self.block.basefee.to()
     }

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -10,8 +10,7 @@ use reth_engine_primitives::EngineTypes;
 use reth_ethereum_consensus::EthBeaconConsensus;
 use reth_ethereum_engine_primitives::{EthBuiltPayload, EthPayloadAttributes};
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, NextBlockEnvAttributes};
-use reth_evm_ethereum::EthTxEnv;
+use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
 #[cfg(not(feature = "jit"))]
 use reth_evm_ethereum::RethEvmFactory;
 #[cfg(feature = "jit")]
@@ -154,10 +153,7 @@ impl<N, NetworkT> EthApiBuilder<N> for EthereumEthApiBuilder<NetworkT>
 where
     N: FullNodeComponents<
         Types: NodeTypes<ChainSpec: Hardforks + EthereumHardforks>,
-        Evm: ConfigureEvm<
-            NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>,
-            BlockExecutorFactory: BlockExecutorFactory<Transaction = EthTxEnv>,
-        >,
+        Evm: ConfigureEvm<NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>>,
     >,
     NetworkT: RpcTypes<TransactionRequest: SignableTxRequest<TxTy<N::Types>>>,
     EthRpcConverterFor<N, NetworkT>: RpcConvert<

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -10,7 +10,7 @@ use reth_engine_primitives::EngineTypes;
 use reth_ethereum_consensus::EthBeaconConsensus;
 use reth_ethereum_engine_primitives::{EthBuiltPayload, EthPayloadAttributes};
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, EvmEnvFor, NextBlockEnvAttributes, TxEnvFor};
+use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
 #[cfg(not(feature = "jit"))]
 use reth_evm_ethereum::RethEvmFactory;
 #[cfg(feature = "jit")]
@@ -49,9 +49,8 @@ use reth_rpc_eth_api::{
     helpers::{
         config::{EthConfigApiServer, EthConfigHandler},
         pending_block::BuildPendingEnv,
-        TraceBlockEnv, TraceEvmInstance, TraceTxEnvelope,
     },
-    RpcConvert, RpcNodeCore, RpcTypes, SignableTxRequest,
+    RpcConvert, RpcTypes, SignableTxRequest,
 };
 use reth_rpc_eth_types::{error::FromEvmError, EthApiError};
 use reth_rpc_server_types::RethRpcModule;
@@ -323,11 +322,6 @@ where
         Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthB: EthApiBuilder<N>,
-    <EthB::EthApi as RpcNodeCore>::Evm: ConfigureEvm,
-    EvmEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceBlockEnv>,
-    <<EthB::EthApi as RpcNodeCore>::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'evm> BlockExecutorFactory<Evm<'evm> = TraceEvmInstance<'evm>>,
-    TxEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceTxEnvelope> + Clone,
     PVB: Send,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -405,11 +399,6 @@ where
         Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
     EthB: EthApiBuilder<N>,
-    <EthB::EthApi as RpcNodeCore>::Evm: ConfigureEvm,
-    EvmEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceBlockEnv>,
-    <<EthB::EthApi as RpcNodeCore>::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'evm> BlockExecutorFactory<Evm<'evm> = TraceEvmInstance<'evm>>,
-    TxEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceTxEnvelope> + Clone,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -10,7 +10,8 @@ use reth_engine_primitives::EngineTypes;
 use reth_ethereum_consensus::EthBeaconConsensus;
 use reth_ethereum_engine_primitives::{EthBuiltPayload, EthPayloadAttributes};
 use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
-use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
+use reth_evm::{BlockExecutorFactory, ConfigureEvm, NextBlockEnvAttributes};
+use reth_evm_ethereum::EthTxEnv;
 #[cfg(not(feature = "jit"))]
 use reth_evm_ethereum::RethEvmFactory;
 #[cfg(feature = "jit")]
@@ -153,7 +154,10 @@ impl<N, NetworkT> EthApiBuilder<N> for EthereumEthApiBuilder<NetworkT>
 where
     N: FullNodeComponents<
         Types: NodeTypes<ChainSpec: Hardforks + EthereumHardforks>,
-        Evm: ConfigureEvm<NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>>,
+        Evm: ConfigureEvm<
+            NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>,
+            BlockExecutorFactory: BlockExecutorFactory<Transaction = EthTxEnv>,
+        >,
     >,
     NetworkT: RpcTypes<TransactionRequest: SignableTxRequest<TxTy<N::Types>>>,
     EthRpcConverterFor<N, NetworkT>: RpcConvert<

--- a/crates/evm/evm/src/aliases.rs
+++ b/crates/evm/evm/src/aliases.rs
@@ -27,7 +27,7 @@ pub type TxEnvFor<Evm> =
     <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::EvmTransaction;
 
 /// Type alias for the transaction consumed by the configured block executor.
-pub type BlockExecutorTransactionFor<Evm> =
+pub type TxFor<Evm> =
     <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::Transaction;
 
 /// Helper to access the configured execution context.

--- a/crates/evm/evm/src/aliases.rs
+++ b/crates/evm/evm/src/aliases.rs
@@ -15,6 +15,13 @@ pub type EvmEnvFor<Evm> =
 pub type EvmFor<'a, Evm> =
     <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::Evm<'a>;
 
+/// Type alias for the configured runtime EVM type family.
+pub type EvmTypesFor<Evm> =
+    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::EvmTypes;
+
+/// Type alias for a configured EVM transaction result with detached state changes.
+pub type TxResultWithStateFor<Evm> = evm2::TxResultWithState<EvmTypesFor<Evm>>;
+
 /// Type alias for the configured transaction environment.
 pub type TxEnvFor<Evm> =
     <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::Transaction;

--- a/crates/evm/evm/src/aliases.rs
+++ b/crates/evm/evm/src/aliases.rs
@@ -1,6 +1,7 @@
 //! Helper aliases when working with [`ConfigureEvm`] and the traits in this crate.
 
 use crate::{execute::BlockExecutorFactory, ConfigureEvm};
+use alloy_consensus::transaction::Recovered;
 
 /// Helper to access the configured EVM factory state.
 pub type EvmFactoryFor<Evm> =
@@ -23,8 +24,9 @@ pub type EvmTypesFor<Evm> =
 pub type TxResultWithStateFor<Evm> = evm2::TxResultWithState<EvmTypesFor<Evm>>;
 
 /// Type alias for the configured transaction environment.
-pub type TxEnvFor<Evm> =
-    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::EvmTransaction;
+pub type TxEnvFor<Evm> = Recovered<
+    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::EvmTransaction,
+>;
 
 /// Type alias for the transaction consumed by the configured block executor.
 pub type TxFor<Evm> =

--- a/crates/evm/evm/src/aliases.rs
+++ b/crates/evm/evm/src/aliases.rs
@@ -24,6 +24,10 @@ pub type TxResultWithStateFor<Evm> = evm2::TxResultWithState<EvmTypesFor<Evm>>;
 
 /// Type alias for the configured transaction environment.
 pub type TxEnvFor<Evm> =
+    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::EvmTransaction;
+
+/// Type alias for the transaction consumed by the configured block executor.
+pub type BlockExecutorTransactionFor<Evm> =
     <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::Transaction;
 
 /// Helper to access the configured execution context.

--- a/crates/evm/evm/src/database.rs
+++ b/crates/evm/evm/src/database.rs
@@ -5,9 +5,8 @@ use core::ops::{Deref, DerefMut};
 #[cfg(feature = "std")]
 use evm2::{
     bytecode::Bytecode,
-    evm::{AccountInfo, Database, DbResult, DynDatabase},
+    evm::{AccountInfo, Database},
     interpreter::Word,
-    ErrorCode,
 };
 use reth_primitives_traits::Account;
 use reth_storage_api::{AccountReader, BlockHashReader, BytecodeReader, StateProvider};
@@ -96,75 +95,6 @@ impl<DB> Deref for StateProviderDatabase<DB> {
 impl<DB> DerefMut for StateProviderDatabase<DB> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
-    }
-}
-
-/// Borrowed adapter for reusing a dynamic database without moving it into an EVM.
-pub struct BorrowedDatabase<'a, DB: ?Sized>(&'a mut DB);
-
-impl<'a, DB: ?Sized> BorrowedDatabase<'a, DB> {
-    /// Creates a new borrowed database adapter.
-    pub const fn new(db: &'a mut DB) -> Self {
-        Self(db)
-    }
-}
-
-impl<DB> core::fmt::Debug for BorrowedDatabase<'_, DB>
-where
-    DB: ?Sized,
-{
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BorrowedDatabase").finish_non_exhaustive()
-    }
-}
-
-#[cfg(feature = "std")]
-impl<DB> DynDatabase for BorrowedDatabase<'_, DB>
-where
-    DB: DynDatabase + ?Sized,
-{
-    fn get_account(&mut self, address: &Address) -> DbResult<Option<AccountInfo>> {
-        self.0.get_account(address)
-    }
-
-    fn get_code_by_hash(&mut self, code_hash: &B256) -> DbResult<Bytecode> {
-        self.0.get_code_by_hash(code_hash)
-    }
-
-    fn get_storage(&mut self, address: &Address, key: &Word) -> DbResult<Word> {
-        self.0.get_storage(address, key)
-    }
-
-    fn get_block_hash(&mut self, number: &Word) -> DbResult<Option<B256>> {
-        self.0.get_block_hash(number)
-    }
-
-    fn error(&mut self, code: ErrorCode) -> evm2::AnyError {
-        self.0.error(code)
-    }
-}
-
-#[cfg(feature = "std")]
-impl<DB> Database for BorrowedDatabase<'_, DB>
-where
-    DB: DynDatabase + ?Sized,
-{
-    type Error = evm2::AnyError;
-
-    fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
-        self.0.get_account(address).map_err(|code| self.0.error(code))
-    }
-
-    fn get_code_by_hash(&mut self, code_hash: &B256) -> Result<Bytecode, Self::Error> {
-        self.0.get_code_by_hash(code_hash).map_err(|code| self.0.error(code))
-    }
-
-    fn get_storage(&mut self, address: &Address, key: &Word) -> Result<Word, Self::Error> {
-        self.0.get_storage(address, key).map_err(|code| self.0.error(code))
-    }
-
-    fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
-        self.0.get_block_hash(number).map_err(|code| self.0.error(code))
     }
 }
 

--- a/crates/evm/evm/src/database.rs
+++ b/crates/evm/evm/src/database.rs
@@ -145,6 +145,30 @@ where
 }
 
 #[cfg(feature = "std")]
+impl<DB> Database for BorrowedDatabase<'_, DB>
+where
+    DB: DynDatabase + ?Sized,
+{
+    type Error = evm2::AnyError;
+
+    fn get_account(&mut self, address: &Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.0.get_account(address).map_err(|code| self.0.error(code))
+    }
+
+    fn get_code_by_hash(&mut self, code_hash: &B256) -> Result<Bytecode, Self::Error> {
+        self.0.get_code_by_hash(code_hash).map_err(|code| self.0.error(code))
+    }
+
+    fn get_storage(&mut self, address: &Address, key: &Word) -> Result<Word, Self::Error> {
+        self.0.get_storage(address, key).map_err(|code| self.0.error(code))
+    }
+
+    fn get_block_hash(&mut self, number: &Word) -> Result<Option<B256>, Self::Error> {
+        self.0.get_block_hash(number).map_err(|code| self.0.error(code))
+    }
+}
+
+#[cfg(feature = "std")]
 impl<DB> Database for StateProviderDatabase<DB>
 where
     DB: EvmStateProvider,

--- a/crates/evm/evm/src/engine.rs
+++ b/crates/evm/evm/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::{
     execute::{ExecutableTxFor, ExecutableTxParts, RecoveredTx},
-    BlockExecutorTransactionFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
+    ConfigureEvm, EvmEnvFor, ExecutionCtxFor, TxFor,
 };
 use alloy_consensus::transaction::Either;
 use rayon::prelude::*;
@@ -136,10 +136,7 @@ impl<T, Evm: ConfigureEvm> ExecutableTxIterator<Evm> for T
 where
     T: ExecutableTxTuple<Tx: ExecutableTxFor<Evm, Recovered: Send + Sync>>,
 {
-    type Recovered = <T::Tx as ExecutableTxParts<
-        BlockExecutorTransactionFor<Evm>,
-        TxTy<Evm::Primitives>,
-    >>::Recovered;
+    type Recovered = <T::Tx as ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>>>::Recovered;
 }
 
 /// Wraps `Either<L, R>` to implement both [`IntoParallelIterator`] and [`IntoIterator`],

--- a/crates/evm/evm/src/engine.rs
+++ b/crates/evm/evm/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::{
     execute::{ExecutableTxFor, ExecutableTxParts, RecoveredTx},
-    ConfigureEvm, EvmEnvFor, ExecutionCtxFor, TxEnvFor,
+    BlockExecutorTransactionFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
 };
 use alloy_consensus::transaction::Either;
 use rayon::prelude::*;
@@ -136,7 +136,10 @@ impl<T, Evm: ConfigureEvm> ExecutableTxIterator<Evm> for T
 where
     T: ExecutableTxTuple<Tx: ExecutableTxFor<Evm, Recovered: Send + Sync>>,
 {
-    type Recovered = <T::Tx as ExecutableTxParts<TxEnvFor<Evm>, TxTy<Evm::Primitives>>>::Recovered;
+    type Recovered = <T::Tx as ExecutableTxParts<
+        BlockExecutorTransactionFor<Evm>,
+        TxTy<Evm::Primitives>,
+    >>::Recovered;
 }
 
 /// Wraps `Either<L, R>` to implement both [`IntoParallelIterator`] and [`IntoIterator`],

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -3,7 +3,7 @@
 use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxFor};
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
-    transaction::{Either, Recovered},
+    transaction::{Either, Recovered, Transaction as AlloyTransaction},
     BlockHeader as _, Header, TxReceipt,
 };
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessIndex, BlockAccessList};
@@ -139,18 +139,18 @@ pub trait Evm {
     /// Runtime EVM type family.
     type EvmTypes: evm2::EvmTypes<Tx = Self::Transaction>;
     /// Transaction environment consumed by this EVM.
-    type Transaction: evm2::ethereum::TransactionExt;
+    type Transaction: AlloyTransaction;
 
     /// Executes a transaction without committing its state changes.
     fn transact(
         &mut self,
-        transaction: &Self::Transaction,
+        transaction: &Recovered<Self::Transaction>,
     ) -> Result<evm2::TxResultWithState<Self::EvmTypes>, BlockExecutionError>;
 
     /// Executes a transaction with an inspector without committing its state changes.
     fn transact_with_inspector<I>(
         &mut self,
-        transaction: &Self::Transaction,
+        transaction: &Recovered<Self::Transaction>,
         inspector: I,
     ) -> Result<(I, evm2::TxResultWithState<Self::EvmTypes>), BlockExecutionError>
     where
@@ -183,7 +183,7 @@ pub trait Evm {
     /// `sink`.
     fn transact_and_discard<S>(
         &mut self,
-        transaction: &Self::Transaction,
+        transaction: &Recovered<Self::Transaction>,
         sink: &mut S,
     ) -> Result<(), BlockExecutionError>
     where
@@ -191,15 +191,13 @@ pub trait Evm {
         S::Error: Debug;
 }
 
-impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + evm2::ethereum::TransactionExt>> Evm
-    for evm2::Evm<'a, T>
-{
+impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + AlloyTransaction>> Evm for evm2::Evm<'a, T> {
     type EvmTypes = T;
     type Transaction = T::Tx;
 
     fn transact(
         &mut self,
-        transaction: &Self::Transaction,
+        transaction: &Recovered<Self::Transaction>,
     ) -> Result<evm2::TxResultWithState<T>, BlockExecutionError> {
         let resolution = transaction_resolution(evm2::Evm::transact(self, transaction));
         resolve_transaction(self, resolution)
@@ -207,7 +205,7 @@ impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + evm2::ethereum::TransactionExt>> Evm
 
     fn transact_with_inspector<I: evm2::Inspector<T> + 'a>(
         &mut self,
-        transaction: &Self::Transaction,
+        transaction: &Recovered<Self::Transaction>,
         inspector: I,
     ) -> Result<(I, evm2::TxResultWithState<T>), BlockExecutionError> {
         // TODO(dani): use either `&mut Inspector` or `clear_inspector_as`.
@@ -255,7 +253,7 @@ impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + evm2::ethereum::TransactionExt>> Evm
 
     fn transact_and_discard<S>(
         &mut self,
-        transaction: &Self::Transaction,
+        transaction: &Recovered<Self::Transaction>,
         sink: &mut S,
     ) -> Result<(), BlockExecutionError>
     where
@@ -437,7 +435,7 @@ pub trait BlockExecutorFactory {
     /// Transaction environment consumed by the configured EVM instance.
     type EvmTypes: evm2::EvmTypes<Tx = Self::EvmTransaction, TxResultExt: Send>;
     /// Transaction environment consumed by the configured EVM instance.
-    type EvmTransaction: evm2::ethereum::TransactionExt;
+    type EvmTransaction: AlloyTransaction;
     /// Transaction environment consumed by executors from this factory.
     type Transaction: Debug + Clone + Send + Sync + 'static;
     /// EVM instance consumed by executors from this factory.
@@ -1314,12 +1312,12 @@ pub trait FromRecoveredTx<T> {
     fn from_recovered_tx(tx: Recovered<T>) -> Self;
 }
 
-impl<T, TxEnv> FromRecoveredTx<T> for TxEnv
+impl<T, TxEnv> FromRecoveredTx<T> for Recovered<TxEnv>
 where
-    TxEnv: From<Recovered<T>>,
+    TxEnv: From<T>,
 {
     fn from_recovered_tx(tx: Recovered<T>) -> Self {
-        tx.into()
+        tx.convert()
     }
 }
 

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -1,8 +1,6 @@
 //! Traits for execution.
 
-#[cfg(feature = "std")]
-use crate::database::BorrowedDatabase;
-use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxEnvFor};
+use crate::{BlockExecutorTransactionFor, ConfigureEvm, Database, DynDatabase, EvmEnv};
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
     transaction::{Either, Recovered},
@@ -11,7 +9,7 @@ use alloy_consensus::{
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessIndex, BlockAccessList};
 use alloy_eips::eip2718::{Typed2718, WithEncoded};
 use alloy_primitives::{Address, B256};
-use core::{borrow::Borrow, fmt::Debug};
+use core::fmt::Debug;
 #[cfg(feature = "std")]
 use evm2::evm::{CacheDB, Db};
 use evm2::{evm::BlockStateAccumulator, registry::HandlerError, ErrorCode};
@@ -141,7 +139,7 @@ pub trait Evm {
     /// Runtime EVM type family.
     type EvmTypes: evm2::EvmTypes<Tx = Self::Transaction>;
     /// Transaction environment consumed by this EVM.
-    type Transaction;
+    type Transaction: evm2::ethereum::TransactionExt;
 
     /// Executes a transaction without committing its state changes.
     fn transact(
@@ -162,6 +160,9 @@ pub trait Evm {
     fn set_inspector<I>(&mut self, inspector: I)
     where
         I: evm2::Inspector<Self::EvmTypes> + 'static;
+
+    /// Returns active precompile addresses and identifiers.
+    fn precompile_ids(&self) -> Vec<(Address, evm2::precompiles::PrecompileId)>;
 
     /// Returns whether an address is an active precompile.
     fn has_precompile(&self, address: &Address) -> bool;
@@ -190,9 +191,8 @@ pub trait Evm {
         S::Error: Debug;
 }
 
-impl<T> Evm for evm2::Evm<'_, T>
-where
-    T: evm2::EvmTypes<Tx: Typed2718>,
+impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + evm2::ethereum::TransactionExt>> Evm
+    for evm2::Evm<'a, T>
 {
     type EvmTypes = T;
     type Transaction = T::Tx;
@@ -205,14 +205,12 @@ where
         resolve_transaction(self, resolution)
     }
 
-    fn transact_with_inspector<I>(
+    fn transact_with_inspector<I: evm2::Inspector<T> + 'a>(
         &mut self,
         transaction: &Self::Transaction,
         inspector: I,
-    ) -> Result<(I, evm2::TxResultWithState<T>), BlockExecutionError>
-    where
-        I: evm2::Inspector<T> + 'static,
-    {
+    ) -> Result<(I, evm2::TxResultWithState<T>), BlockExecutionError> {
+        // TODO(dani): use either `&mut Inspector` or `clear_inspector_as`.
         evm2::Evm::set_inspector(self, inspector);
         let resolution = transaction_resolution(evm2::Evm::transact(self, transaction));
         let result = resolve_transaction(self, resolution);
@@ -222,11 +220,12 @@ where
         result.map(|result| (*inspector, result))
     }
 
-    fn set_inspector<I>(&mut self, inspector: I)
-    where
-        I: evm2::Inspector<T> + 'static,
-    {
+    fn set_inspector<I: evm2::Inspector<T> + 'a>(&mut self, inspector: I) {
         evm2::Evm::set_inspector(self, inspector);
+    }
+
+    fn precompile_ids(&self) -> Vec<(Address, evm2::precompiles::PrecompileId)> {
+        self.precompiles().precompile_ids()
     }
 
     fn has_precompile(&self, address: &Address) -> bool {
@@ -247,6 +246,7 @@ where
         &mut self,
         moves: impl IntoIterator<Item = (Address, Address)>,
     ) -> Result<(), evm2::precompiles::MovePrecompileError> {
+        // TODO(dani): precompiles_as_mut
         let mut precompiles = evm2::Precompiles::<T>::base(self.spec_id());
         precompiles.as_map_mut().move_precompiles(moves)?;
         self.set_precompiles(precompiles);
@@ -437,9 +437,9 @@ pub trait BlockExecutorFactory {
     /// Transaction environment consumed by the configured EVM instance.
     type EvmTypes: evm2::EvmTypes<Tx = Self::EvmTransaction, TxResultExt: Send>;
     /// Transaction environment consumed by the configured EVM instance.
-    type EvmTransaction;
+    type EvmTransaction: evm2::ethereum::TransactionExt;
     /// Transaction environment consumed by executors from this factory.
-    type Transaction: Borrow<Self::EvmTransaction> + Debug + Clone + Send + Sync + 'static;
+    type Transaction: Debug + Clone + Send + Sync + 'static;
     /// EVM instance consumed by executors from this factory.
     type Evm<'a>: Evm<EvmTypes = Self::EvmTypes, Transaction = Self::EvmTransaction>;
     /// EVM environment consumed by this factory.
@@ -1026,10 +1026,10 @@ where
 
         executor.apply_pre_execution_changes()?;
         for transaction in block.transactions_recovered() {
-            let (tx_env, _) =
-                <_ as ExecutableTxParts<TxEnvFor<Evm>, TxTy<Evm::Primitives>>>::into_parts(
-                    transaction,
-                );
+            let (tx_env, _) = <_ as ExecutableTxParts<
+                BlockExecutorTransactionFor<Evm>,
+                TxTy<Evm::Primitives>,
+            >>::into_parts(transaction);
             executor.execute_transaction(tx_env)?;
         }
         let (output, block_access_list) = executor.finish_with_block_access_list()?;
@@ -1051,11 +1051,8 @@ where
         block: &RecoveredBlock<<Self::Primitives as NodePrimitives>::Block>,
     ) -> Result<BlockExecutionResult<<Self::Primitives as NodePrimitives>::Receipt>, Self::Error>
     {
-        let (output, block_access_list) = Self::execute_block_with_database(
-            &self.evm_config,
-            block,
-            BorrowedDatabase::new(&mut self.batch_database),
-        )?;
+        let (output, block_access_list) =
+            Self::execute_block_with_database(&self.evm_config, block, &mut self.batch_database)?;
         self.block_access_list = block_access_list;
         self.batch_database.commit_source(&output.state);
 
@@ -1076,7 +1073,7 @@ where
         let (output, block_access_list) = Self::execute_block_with_database_and_state_hook(
             &self.evm_config,
             block,
-            BorrowedDatabase::new(&mut self.batch_database),
+            &mut self.batch_database,
             Some(Box::new(state_hook)),
         )?;
         self.block_access_list = block_access_list;
@@ -1420,12 +1417,14 @@ where
 /// A helper trait marking a type that can be converted into an [`ExecutableTxParts`] for block
 /// executor.
 pub trait ExecutableTxFor<Evm: ConfigureEvm>:
-    ExecutableTxParts<TxEnvFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
+    ExecutableTxParts<BlockExecutorTransactionFor<Evm>, TxTy<Evm::Primitives>>
+    + RecoveredTx<TxTy<Evm::Primitives>>
 {
 }
 
 impl<T, Evm: ConfigureEvm> ExecutableTxFor<Evm> for T where
-    T: ExecutableTxParts<TxEnvFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
+    T: ExecutableTxParts<BlockExecutorTransactionFor<Evm>, TxTy<Evm::Primitives>>
+        + RecoveredTx<TxTy<Evm::Primitives>>
 {
 }
 

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -3,18 +3,18 @@
 #[cfg(feature = "std")]
 use crate::database::BorrowedDatabase;
 use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxEnvFor};
-use alloc::{format, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
     transaction::{Either, Recovered},
     BlockHeader as _, Header, TxReceipt,
 };
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessIndex, BlockAccessList};
-use alloy_eips::eip2718::{Typed2718, WithEncoded};
+use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::{Address, B256};
 use core::{borrow::Borrow, fmt::Debug};
-use evm2::evm::BlockStateAccumulator;
 #[cfg(feature = "std")]
 use evm2::evm::{CacheDB, Db};
+use evm2::{evm::BlockStateAccumulator, registry::HandlerError, ErrorCode};
 pub use reth_execution_errors::{
     BlockExecutionError, BlockValidationError, EvmError, InternalBlockExecutionError,
     InvalidTxError,
@@ -141,6 +141,41 @@ pub trait Evm {
     /// Transaction environment consumed by this EVM.
     type Transaction;
 
+    /// Executes a transaction without committing its state changes.
+    fn transact(
+        &mut self,
+        transaction: &Self::Transaction,
+    ) -> Result<evm2::TxResultWithState, BlockExecutionError>;
+
+    /// Executes a transaction with an inspector without committing its state changes.
+    fn transact_with_inspector<I>(
+        &mut self,
+        transaction: &Self::Transaction,
+        inspector: I,
+    ) -> Result<(I, evm2::TxResultWithState), BlockExecutionError>
+    where
+        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static;
+
+    /// Sets the inspector used by subsequent transactions.
+    fn set_inspector<I>(&mut self, inspector: I)
+    where
+        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static;
+
+    /// Returns whether an address is an active precompile.
+    fn has_precompile(&self, address: &Address) -> bool;
+
+    /// Returns account information visible through the accepted state overlay.
+    fn account_info(
+        &mut self,
+        address: &Address,
+    ) -> Result<Option<evm2::evm::AccountInfo>, BlockExecutionError>;
+
+    /// Applies precompile address moves to the active precompile set.
+    fn move_precompiles(
+        &mut self,
+        moves: impl IntoIterator<Item = (Address, Address)>,
+    ) -> Result<(), evm2::precompiles::MovePrecompileError>;
+
     /// Executes a transaction and discards its writes while streaming observed state changes into
     /// `sink`.
     fn transact_and_discard<S>(
@@ -153,11 +188,64 @@ pub trait Evm {
         S::Error: Debug;
 }
 
-impl<'a, T> Evm for evm2::Evm<'a, T>
-where
-    T: evm2::EvmTypes<Tx: Typed2718>,
-{
-    type Transaction = T::Tx;
+impl Evm for evm2::Evm<'_, evm2::BaseEvmTypes> {
+    type Transaction = evm2::ethereum::RecoveredTxEnvelope;
+
+    fn transact(
+        &mut self,
+        transaction: &Self::Transaction,
+    ) -> Result<evm2::TxResultWithState, BlockExecutionError> {
+        let resolution = transaction_resolution(evm2::Evm::transact(self, transaction));
+        resolve_transaction(self, resolution)
+    }
+
+    fn transact_with_inspector<I>(
+        &mut self,
+        transaction: &Self::Transaction,
+        inspector: I,
+    ) -> Result<(I, evm2::TxResultWithState), BlockExecutionError>
+    where
+        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static,
+    {
+        evm2::Evm::set_inspector(self, inspector);
+        let resolution = transaction_resolution(evm2::Evm::transact(self, transaction));
+        let result = resolve_transaction(self, resolution);
+        let inspector = self.clear_inspector().expect("inspector was set before execution");
+        // SAFETY: the boxed inspector was created from `I` immediately above and was not replaced.
+        let inspector = unsafe { Box::from_raw(Box::into_raw(inspector).cast::<I>()) };
+        result.map(|result| (*inspector, result))
+    }
+
+    fn set_inspector<I>(&mut self, inspector: I)
+    where
+        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static,
+    {
+        evm2::Evm::set_inspector(self, inspector);
+    }
+
+    fn has_precompile(&self, address: &Address) -> bool {
+        self.precompiles().contains(address)
+    }
+
+    fn account_info(
+        &mut self,
+        address: &Address,
+    ) -> Result<Option<evm2::evm::AccountInfo>, BlockExecutionError> {
+        match self.state_mut().account_info_untracked(address) {
+            Ok(account) => Ok(account),
+            Err(code) => Err(BlockExecutionError::other(self.database_mut().error(code))),
+        }
+    }
+
+    fn move_precompiles(
+        &mut self,
+        moves: impl IntoIterator<Item = (Address, Address)>,
+    ) -> Result<(), evm2::precompiles::MovePrecompileError> {
+        let mut precompiles = evm2::Precompiles::base(self.spec_id());
+        precompiles.as_map_mut().move_precompiles(moves)?;
+        self.set_precompiles(precompiles);
+        Ok(())
+    }
 
     fn transact_and_discard<S>(
         &mut self,
@@ -185,14 +273,52 @@ where
     }
 }
 
+enum TransactionResolution {
+    Result(evm2::TxResultWithState),
+    DatabaseError(ErrorCode),
+    HandlerError(HandlerError),
+}
+
+fn transaction_resolution(
+    executed: Result<evm2::ExecutedTx<'_, '_, evm2::BaseEvmTypes>, HandlerError>,
+) -> TransactionResolution {
+    match executed {
+        Ok(executed) => {
+            if let Some(code) = executed.result().error_code {
+                let _ = executed.discard();
+                TransactionResolution::DatabaseError(code)
+            } else {
+                TransactionResolution::Result(executed.detach())
+            }
+        }
+        Err(err) => TransactionResolution::HandlerError(err),
+    }
+}
+
+fn resolve_transaction(
+    evm: &mut evm2::Evm<'_, evm2::BaseEvmTypes>,
+    resolution: TransactionResolution,
+) -> Result<evm2::TxResultWithState, BlockExecutionError> {
+    match resolution {
+        TransactionResolution::Result(result) => Ok(result),
+        TransactionResolution::DatabaseError(code) |
+        TransactionResolution::HandlerError(HandlerError::Fatal(code)) => {
+            Err(BlockExecutionError::other(evm.database_mut().error(code)))
+        }
+        TransactionResolution::HandlerError(err) => {
+            Err(BlockValidationError::Other(Box::new(err)).into())
+        }
+    }
+}
+
 /// A configured block executor.
 pub trait BlockExecutor: Sized {
     /// The primitive types used by the executor.
     type Primitives: NodePrimitives;
     /// EVM instance used by this executor.
-    type Evm;
+    type Evm: Evm;
     /// Transaction environment consumed by this executor.
-    type Transaction;
+    type Transaction: FromTxWithEncoded<TxTy<Self::Primitives>>;
     /// Raw transaction execution result produced before receipt conversion.
     type TransactionResult;
     /// Owned transaction execution result and detached state changes.
@@ -303,9 +429,9 @@ pub trait BlockExecutorFactory {
     /// Additional EVM factory configuration owned by this executor factory.
     type EvmFactory;
     /// Transaction environment consumed by the configured EVM instance.
-    type EvmTransaction;
+    type EvmTransaction: Borrow<evm2::ethereum::RecoveredTxEnvelope>;
     /// Transaction environment consumed by executors from this factory.
-    type Transaction: Borrow<Self::EvmTransaction>;
+    type Transaction: Borrow<Self::EvmTransaction> + Debug + Clone + Send + Sync + 'static;
     /// EVM instance consumed by executors from this factory.
     type Evm<'a>: Evm<Transaction = Self::EvmTransaction>;
     /// EVM environment consumed by this factory.
@@ -319,6 +445,7 @@ pub trait BlockExecutorFactory {
         Primitives = Self::Primitives,
         Evm = Self::Evm<'a>,
         Transaction = Self::Transaction,
+        TransactionResult = evm2::TxResult,
         TransactionOutput = GasOutput,
     >
     where
@@ -421,6 +548,8 @@ pub trait BlockAssembler<F: BlockExecutorFactory> {
 pub struct BlockBuilderOutcome<N: NodePrimitives> {
     /// Result of block execution.
     pub execution_result: BlockExecutionResult<N::Receipt>,
+    /// Changed state produced by block execution.
+    pub execution_state: reth_execution_types::IndexedBlockState,
     /// Hashed state after execution.
     pub hashed_state: HashedPostState,
     /// Trie updates collected during state-root calculation.
@@ -436,7 +565,11 @@ pub trait BlockBuilder: Sized {
     /// The primitive types used by the inner [`BlockExecutor`].
     type Primitives: NodePrimitives;
     /// Inner block executor.
-    type Executor: BlockExecutor<Primitives = Self::Primitives, TransactionOutput = GasOutput>;
+    type Executor: BlockExecutor<
+        Primitives = Self::Primitives,
+        TransactionResult = evm2::TxResult,
+        TransactionOutput = GasOutput,
+    >;
     /// EVM environment used for block execution.
     type EvmEnv: EvmEnv;
 
@@ -592,8 +725,12 @@ impl<'a, F, Executor, Assembler, N> BlockBuilder
     for BasicBlockBuilder<'a, F, Executor, Assembler, N>
 where
     F: BlockExecutorFactory<Primitives = N>,
-    Executor:
-        BlockExecutor<Primitives = N, Transaction = F::Transaction, TransactionOutput = GasOutput>,
+    Executor: BlockExecutor<
+        Primitives = N,
+        Transaction = F::Transaction,
+        TransactionResult = evm2::TxResult,
+        TransactionOutput = GasOutput,
+    >,
     Assembler: BlockAssembler<F, Block = N::Block>,
     N: NodePrimitives,
     TxTy<N>: Clone,
@@ -660,6 +797,7 @@ where
 
         Ok(BlockBuilderOutcome {
             execution_result: output.result,
+            execution_state: output.state,
             hashed_state,
             trie_updates,
             block,

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -9,7 +9,7 @@ use alloy_consensus::{
     BlockHeader as _, Header, TxReceipt,
 };
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessIndex, BlockAccessList};
-use alloy_eips::eip2718::WithEncoded;
+use alloy_eips::eip2718::{Typed2718, WithEncoded};
 use alloy_primitives::{Address, B256};
 use core::{borrow::Borrow, fmt::Debug};
 #[cfg(feature = "std")]
@@ -138,6 +138,8 @@ impl CommitChanges {
 
 /// A configured EVM instance.
 pub trait Evm {
+    /// Runtime EVM type family.
+    type EvmTypes: evm2::EvmTypes<Tx = Self::Transaction>;
     /// Transaction environment consumed by this EVM.
     type Transaction;
 
@@ -145,21 +147,21 @@ pub trait Evm {
     fn transact(
         &mut self,
         transaction: &Self::Transaction,
-    ) -> Result<evm2::TxResultWithState, BlockExecutionError>;
+    ) -> Result<evm2::TxResultWithState<Self::EvmTypes>, BlockExecutionError>;
 
     /// Executes a transaction with an inspector without committing its state changes.
     fn transact_with_inspector<I>(
         &mut self,
         transaction: &Self::Transaction,
         inspector: I,
-    ) -> Result<(I, evm2::TxResultWithState), BlockExecutionError>
+    ) -> Result<(I, evm2::TxResultWithState<Self::EvmTypes>), BlockExecutionError>
     where
-        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static;
+        I: evm2::Inspector<Self::EvmTypes> + 'static;
 
     /// Sets the inspector used by subsequent transactions.
     fn set_inspector<I>(&mut self, inspector: I)
     where
-        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static;
+        I: evm2::Inspector<Self::EvmTypes> + 'static;
 
     /// Returns whether an address is an active precompile.
     fn has_precompile(&self, address: &Address) -> bool;
@@ -188,13 +190,17 @@ pub trait Evm {
         S::Error: Debug;
 }
 
-impl Evm for evm2::Evm<'_, evm2::BaseEvmTypes> {
-    type Transaction = evm2::ethereum::RecoveredTxEnvelope;
+impl<T> Evm for evm2::Evm<'_, T>
+where
+    T: evm2::EvmTypes<Tx: Typed2718>,
+{
+    type EvmTypes = T;
+    type Transaction = T::Tx;
 
     fn transact(
         &mut self,
         transaction: &Self::Transaction,
-    ) -> Result<evm2::TxResultWithState, BlockExecutionError> {
+    ) -> Result<evm2::TxResultWithState<T>, BlockExecutionError> {
         let resolution = transaction_resolution(evm2::Evm::transact(self, transaction));
         resolve_transaction(self, resolution)
     }
@@ -203,9 +209,9 @@ impl Evm for evm2::Evm<'_, evm2::BaseEvmTypes> {
         &mut self,
         transaction: &Self::Transaction,
         inspector: I,
-    ) -> Result<(I, evm2::TxResultWithState), BlockExecutionError>
+    ) -> Result<(I, evm2::TxResultWithState<T>), BlockExecutionError>
     where
-        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static,
+        I: evm2::Inspector<T> + 'static,
     {
         evm2::Evm::set_inspector(self, inspector);
         let resolution = transaction_resolution(evm2::Evm::transact(self, transaction));
@@ -218,7 +224,7 @@ impl Evm for evm2::Evm<'_, evm2::BaseEvmTypes> {
 
     fn set_inspector<I>(&mut self, inspector: I)
     where
-        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static,
+        I: evm2::Inspector<T> + 'static,
     {
         evm2::Evm::set_inspector(self, inspector);
     }
@@ -241,7 +247,7 @@ impl Evm for evm2::Evm<'_, evm2::BaseEvmTypes> {
         &mut self,
         moves: impl IntoIterator<Item = (Address, Address)>,
     ) -> Result<(), evm2::precompiles::MovePrecompileError> {
-        let mut precompiles = evm2::Precompiles::base(self.spec_id());
+        let mut precompiles = evm2::Precompiles::<T>::base(self.spec_id());
         precompiles.as_map_mut().move_precompiles(moves)?;
         self.set_precompiles(precompiles);
         Ok(())
@@ -273,15 +279,15 @@ impl Evm for evm2::Evm<'_, evm2::BaseEvmTypes> {
     }
 }
 
-enum TransactionResolution {
-    Result(evm2::TxResultWithState),
+enum TransactionResolution<T: evm2::EvmTypes> {
+    Result(evm2::TxResultWithState<T>),
     DatabaseError(ErrorCode),
     HandlerError(HandlerError),
 }
 
-fn transaction_resolution(
-    executed: Result<evm2::ExecutedTx<'_, '_, evm2::BaseEvmTypes>, HandlerError>,
-) -> TransactionResolution {
+fn transaction_resolution<T: evm2::EvmTypes>(
+    executed: Result<evm2::ExecutedTx<'_, '_, T>, HandlerError>,
+) -> TransactionResolution<T> {
     match executed {
         Ok(executed) => {
             if let Some(code) = executed.result().error_code {
@@ -295,10 +301,10 @@ fn transaction_resolution(
     }
 }
 
-fn resolve_transaction(
-    evm: &mut evm2::Evm<'_, evm2::BaseEvmTypes>,
-    resolution: TransactionResolution,
-) -> Result<evm2::TxResultWithState, BlockExecutionError> {
+fn resolve_transaction<T: evm2::EvmTypes>(
+    evm: &mut evm2::Evm<'_, T>,
+    resolution: TransactionResolution<T>,
+) -> Result<evm2::TxResultWithState<T>, BlockExecutionError> {
     match resolution {
         TransactionResolution::Result(result) => Ok(result),
         TransactionResolution::DatabaseError(code) |
@@ -429,13 +435,15 @@ pub trait BlockExecutorFactory {
     /// Additional EVM factory configuration owned by this executor factory.
     type EvmFactory;
     /// Transaction environment consumed by the configured EVM instance.
-    type EvmTransaction: Borrow<evm2::ethereum::RecoveredTxEnvelope>;
+    type EvmTypes: evm2::EvmTypes<Tx = Self::EvmTransaction, TxResultExt: Send>;
+    /// Transaction environment consumed by the configured EVM instance.
+    type EvmTransaction;
     /// Transaction environment consumed by executors from this factory.
     type Transaction: Borrow<Self::EvmTransaction> + Debug + Clone + Send + Sync + 'static;
     /// EVM instance consumed by executors from this factory.
-    type Evm<'a>: Evm<Transaction = Self::EvmTransaction>;
+    type Evm<'a>: Evm<EvmTypes = Self::EvmTypes, Transaction = Self::EvmTransaction>;
     /// EVM environment consumed by this factory.
-    type EvmEnv: EvmEnv;
+    type EvmEnv: EvmEnv<EvmTypes = Self::EvmTypes>;
     /// Execution context for a block or payload.
     type ExecutionCtx<'a>: Debug + Clone + Send
     where
@@ -445,7 +453,7 @@ pub trait BlockExecutorFactory {
         Primitives = Self::Primitives,
         Evm = Self::Evm<'a>,
         Transaction = Self::Transaction,
-        TransactionResult = evm2::TxResult,
+        TransactionResult = evm2::TxResult<Self::EvmTypes>,
         TransactionOutput = GasOutput,
     >
     where
@@ -565,11 +573,7 @@ pub trait BlockBuilder: Sized {
     /// The primitive types used by the inner [`BlockExecutor`].
     type Primitives: NodePrimitives;
     /// Inner block executor.
-    type Executor: BlockExecutor<
-        Primitives = Self::Primitives,
-        TransactionResult = evm2::TxResult,
-        TransactionOutput = GasOutput,
-    >;
+    type Executor: BlockExecutor<Primitives = Self::Primitives, TransactionOutput = GasOutput>;
     /// EVM environment used for block execution.
     type EvmEnv: EvmEnv;
 
@@ -727,8 +731,9 @@ where
     F: BlockExecutorFactory<Primitives = N>,
     Executor: BlockExecutor<
         Primitives = N,
+        Evm: Evm<EvmTypes = F::EvmTypes>,
         Transaction = F::Transaction,
-        TransactionResult = evm2::TxResult,
+        TransactionResult = evm2::TxResult<F::EvmTypes>,
         TransactionOutput = GasOutput,
     >,
     Assembler: BlockAssembler<F, Block = N::Block>,

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -1,6 +1,6 @@
 //! Traits for execution.
 
-use crate::{BlockExecutorTransactionFor, ConfigureEvm, Database, DynDatabase, EvmEnv};
+use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxFor};
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
     transaction::{Either, Recovered},
@@ -1026,10 +1026,10 @@ where
 
         executor.apply_pre_execution_changes()?;
         for transaction in block.transactions_recovered() {
-            let (tx_env, _) = <_ as ExecutableTxParts<
-                BlockExecutorTransactionFor<Evm>,
-                TxTy<Evm::Primitives>,
-            >>::into_parts(transaction);
+            let (tx_env, _) =
+                <_ as ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>>>::into_parts(
+                    transaction,
+                );
             executor.execute_transaction(tx_env)?;
         }
         let (output, block_access_list) = executor.finish_with_block_access_list()?;
@@ -1417,14 +1417,12 @@ where
 /// A helper trait marking a type that can be converted into an [`ExecutableTxParts`] for block
 /// executor.
 pub trait ExecutableTxFor<Evm: ConfigureEvm>:
-    ExecutableTxParts<BlockExecutorTransactionFor<Evm>, TxTy<Evm::Primitives>>
-    + RecoveredTx<TxTy<Evm::Primitives>>
+    ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
 {
 }
 
 impl<T, Evm: ConfigureEvm> ExecutableTxFor<Evm> for T where
-    T: ExecutableTxParts<BlockExecutorTransactionFor<Evm>, TxTy<Evm::Primitives>>
-        + RecoveredTx<TxTy<Evm::Primitives>>
+    T: ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
 {
 }
 

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -236,7 +236,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// Configured block executor factory.
     type BlockExecutorFactory: crate::execute::BlockExecutorFactory<
         Primitives = Self::Primitives,
-        EvmTransaction: FromRecoveredTx<TxTy<Self::Primitives>>,
+        EvmTransaction: From<TxTy<Self::Primitives>>,
         Transaction: FromTxWithEncoded<TxTy<Self::Primitives>>,
     >;
 

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -236,6 +236,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     /// Configured block executor factory.
     type BlockExecutorFactory: crate::execute::BlockExecutorFactory<
         Primitives = Self::Primitives,
+        EvmTransaction: FromRecoveredTx<TxTy<Self::Primitives>>,
         Transaction: FromTxWithEncoded<TxTy<Self::Primitives>>,
     >;
 

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -157,6 +157,24 @@ impl EvmTransactionValidationGasRules {
 
 /// Resolved EVM environment data needed by the EVM execution path.
 pub trait EvmEnv: Debug + Clone + Send + Sync + 'static {
+    /// Returns the active EVM specification.
+    fn spec_id(&self) -> evm2::SpecId;
+
+    /// Returns the active chain ID.
+    fn chain_id(&self) -> u64;
+
+    /// Returns the configured block environment.
+    fn block_env(&self) -> &evm2::env::BlockEnv;
+
+    /// Returns the configured block environment mutably.
+    fn block_env_mut(&mut self) -> &mut evm2::env::BlockEnv;
+
+    /// Returns the active EVM version.
+    fn version(&self) -> &evm2::Version;
+
+    /// Returns the active EVM version mutably.
+    fn version_mut(&mut self) -> &mut evm2::Version;
+
     /// Returns the block base fee resolved for this environment.
     fn block_base_fee(&self) -> u64;
 

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -157,17 +157,20 @@ impl EvmTransactionValidationGasRules {
 
 /// Resolved EVM environment data needed by the EVM execution path.
 pub trait EvmEnv: Debug + Clone + Send + Sync + 'static {
+    /// Runtime EVM type family.
+    type EvmTypes: evm2::EvmTypes;
+
     /// Returns the active EVM specification.
-    fn spec_id(&self) -> evm2::SpecId;
+    fn spec_id(&self) -> <Self::EvmTypes as evm2::EvmTypesHost>::SpecId;
 
     /// Returns the active chain ID.
     fn chain_id(&self) -> u64;
 
     /// Returns the configured block environment.
-    fn block_env(&self) -> &evm2::env::BlockEnv;
+    fn block_env(&self) -> &evm2::env::BlockEnv<Self::EvmTypes>;
 
     /// Returns the configured block environment mutably.
-    fn block_env_mut(&mut self) -> &mut evm2::env::BlockEnv;
+    fn block_env_mut(&mut self) -> &mut evm2::env::BlockEnv<Self::EvmTypes>;
 
     /// Returns the active EVM version.
     fn version(&self) -> &evm2::Version;

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -5,7 +5,7 @@
 //!  - The network implementation.
 //!  - The payload builder service.
 //!
-//! Components depend on a fully type configured node: [FullNodeTypes](crate::node::FullNodeTypes).
+//! Components depend on a fully type configured node: [`FullNodeTypes`].
 
 mod builder;
 mod consensus;

--- a/crates/node/builder/src/launch/invalid_block_hook.rs
+++ b/crates/node/builder/src/launch/invalid_block_hook.rs
@@ -105,7 +105,7 @@ where
                     healthy_node_rpc_client.clone(),
                 )),
                 InvalidBlockHookType::PreState | InvalidBlockHookType::Opcode => {
-                    eyre::bail!("invalid block hook {hook:?} is not implemented yet")
+                    eyre::bail!("invalid block hook {hook:?} is not implemented yet");
                 }
             } as Box<dyn InvalidBlockHook<_>>)
         })

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -22,7 +22,6 @@ use jsonrpsee::RpcModule;
 use parking_lot::Mutex;
 use reth_chain_state::{CanonStateSubscriptions, StateTrieOverlayManager};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, EvmEnvFor, TxEnvFor};
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineApiValidator, EngineTypes, FullNodeComponents, FullNodeTypes,
     NodeAddOns, NodeTypes, PayloadTypes, PayloadValidator, PrimitivesTy, TreeConfig,
@@ -34,15 +33,14 @@ use reth_node_core::{
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
 use reth_rpc::{
-    eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer, RpcNodeCore},
+    eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
     AdminApi,
 };
 use reth_rpc_api::{eth::helpers::EthTransactions, IntoEngineApiRpcModule};
 use reth_rpc_builder::{
     auth::{AuthRpcModule, AuthServerHandle},
     config::RethRpcServerConfig,
-    RpcModuleBuilder, RpcRegistryInner, RpcServerConfig, RpcServerHandle, TraceBlockEnv,
-    TraceEvmInstance, TraceTxEnvelope, TransportRpcModules,
+    RpcModuleBuilder, RpcRegistryInner, RpcServerConfig, RpcServerHandle, TransportRpcModules,
 };
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_rpc_eth_types::{cache::cache_new_blocks_task, EthConfig, EthStateCache};
@@ -940,11 +938,6 @@ where
     N: FullNodeComponents,
     N::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
     EthB: EthApiBuilder<N>,
-    <EthB::EthApi as RpcNodeCore>::Evm: ConfigureEvm,
-    EvmEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceBlockEnv>,
-    <<EthB::EthApi as RpcNodeCore>::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'evm> BlockExecutorFactory<Evm<'evm> = TraceEvmInstance<'evm>>,
-    TxEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceTxEnvelope> + Clone,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
@@ -1250,11 +1243,6 @@ where
     N: FullNodeComponents,
     <N as FullNodeTypes>::Provider: ChainSpecProvider<ChainSpec: EthereumHardforks>,
     EthB: EthApiBuilder<N>,
-    <EthB::EthApi as RpcNodeCore>::Evm: ConfigureEvm,
-    EvmEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceBlockEnv>,
-    <<EthB::EthApi as RpcNodeCore>::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'evm> BlockExecutorFactory<Evm<'evm> = TraceEvmInstance<'evm>>,
-    TxEnvFor<<EthB::EthApi as RpcNodeCore>::Evm>: AsRef<TraceTxEnvelope> + Clone,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -1466,7 +1454,6 @@ where
             <Node::Types as NodeTypes>::Payload,
             Block = BlockTy<Node::Types>,
         > + Clone,
-    TxEnvFor<Node::Evm>: Clone + Send + 'static,
 {
     type EngineValidator = BasicEngineValidator<Node::Provider, Node::Evm, EV::Validator>;
 

--- a/crates/node/core/src/utils.rs
+++ b/crates/node/core/src/utils.rs
@@ -41,7 +41,7 @@ where
 
     let Some(header) = response else {
         client.report_bad_message(peer_id);
-        eyre::bail!("Invalid number of headers received. Expected: 1. Received: 0")
+        eyre::bail!("Invalid number of headers received. Expected: 1. Received: 0");
     };
 
     let header = SealedHeader::seal_slow(header);
@@ -77,7 +77,7 @@ where
 
     let Some(body) = response else {
         client.report_bad_message(peer_id);
-        eyre::bail!("Invalid number of bodies received. Expected: 1. Received: 0")
+        eyre::bail!("Invalid number of bodies received. Expected: 1. Received: 0");
     };
 
     let block = SealedBlock::from_sealed_parts(header, body);

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -29,7 +29,7 @@ pub trait RethApi {
         count: Option<U64>,
     ) -> RpcResult<Option<serde_json::Value>>;
 
-    /// Controls the revmc JIT backend.
+    /// Controls the JIT backend, if one is configured.
     #[method(name = "jit")]
     async fn reth_jit(&self, action: RethJitAction) -> RpcResult<()>;
 

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -29,7 +29,7 @@ pub trait RethApi {
         count: Option<U64>,
     ) -> RpcResult<Option<serde_json::Value>>;
 
-    /// Controls the JIT backend, if one is configured.
+    /// Controls the revmc JIT backend.
     #[method(name = "jit")]
     async fn reth_jit(&self, action: RethJitAction) -> RpcResult<()>;
 

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -33,7 +33,7 @@ use jsonrpsee::{
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_consensus::FullConsensus;
 use reth_engine_primitives::{ConsensusEngineEvent, ConsensusEngineHandle};
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, EvmEnvFor, TxEnvFor};
+use reth_evm::ConfigureEvm;
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_payload_primitives::PayloadTypes;
 use reth_primitives_traits::{NodePrimitives, TxTy};
@@ -43,7 +43,6 @@ use reth_rpc::{
 };
 use reth_rpc_api::servers::*;
 use reth_rpc_engine_api::RethEngineApi;
-pub use reth_rpc_eth_api::helpers::{TraceBlockEnv, TraceEvmInstance, TraceTxEnvelope};
 use reth_rpc_eth_api::{
     helpers::{
         pending_block::PendingEnvBuilder, Call, EthApiSpec, EthTransactions, LoadPendingBlock,
@@ -343,12 +342,7 @@ where
         RpcRegistryInner<Provider, Pool, Network, EthApi, EvmConfig, Consensus>,
     )
     where
-        EthApi: FullEthApiServer<Provider = Provider, Pool = Pool> + TraceExt,
-        EthApi::Evm: ConfigureEvm,
-        EvmEnvFor<EthApi::Evm>: AsRef<TraceBlockEnv>,
-        <EthApi::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<EthApi::Evm>: AsRef<TraceTxEnvelope> + Clone,
+        EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
         Payload: PayloadTypes,
     {
         let config = module_config.config.clone().unwrap_or_default();
@@ -398,12 +392,7 @@ where
         engine_events: EventSender<ConsensusEngineEvent<N>>,
     ) -> TransportRpcModules<()>
     where
-        EthApi: FullEthApiServer<Provider = Provider, Pool = Pool> + TraceExt,
-        EthApi::Evm: ConfigureEvm,
-        EvmEnvFor<EthApi::Evm>: AsRef<TraceBlockEnv>,
-        <EthApi::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<EthApi::Evm>: AsRef<TraceTxEnvelope> + Clone,
+        EthApi: FullEthApiServer<Provider = Provider, Pool = Pool>,
     {
         if module_config.is_empty() {
             TransportRpcModules::default()
@@ -709,10 +698,6 @@ where
     pub fn register_ots(&mut self) -> &mut Self
     where
         EthApi: TraceExt + EthTransactions<Primitives = N>,
-        EthApi::Evm: ConfigureEvm,
-        <EthApi::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<EthApi::Evm>: AsRef<TraceTxEnvelope>,
     {
         let otterscan_api = self.otterscan_api();
         self.modules.insert(RethRpcModule::Ots, otterscan_api.into_rpc().into());
@@ -727,11 +712,6 @@ where
     pub fn register_debug(&mut self) -> &mut Self
     where
         EthApi: EthTransactions + TraceExt,
-        EthApi::Evm: ConfigureEvm,
-        EvmEnvFor<EthApi::Evm>: AsRef<TraceBlockEnv>,
-        <EthApi::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<EthApi::Evm>: AsRef<TraceTxEnvelope> + Clone,
     {
         let debug_api = self.debug_api();
         self.modules.insert(RethRpcModule::Debug, debug_api.into_rpc().into());
@@ -746,10 +726,6 @@ where
     pub fn register_trace(&mut self) -> &mut Self
     where
         EthApi: TraceExt,
-        EthApi::Evm: ConfigureEvm,
-        <EthApi::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<EthApi::Evm>: AsRef<TraceTxEnvelope>,
     {
         let trace_api = self.trace_api();
         self.modules.insert(RethRpcModule::Trace, trace_api.into_rpc().into());
@@ -890,12 +866,7 @@ where
         + ChangeSetReader,
     Pool: TransactionPool + Clone + 'static,
     Network: NetworkInfo + Peers + Clone + 'static,
-    EthApi: FullEthApiServer + TraceExt,
-    EthApi::Evm: ConfigureEvm,
-    EvmEnvFor<EthApi::Evm>: AsRef<TraceBlockEnv>,
-    <EthApi::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-    TxEnvFor<EthApi::Evm>: AsRef<TraceTxEnvelope> + Clone,
+    EthApi: FullEthApiServer,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
     Consensus: FullConsensus<N> + Clone + 'static,
 {

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -23,6 +23,7 @@ alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-json-rpc.workspace = true
+evm2.workspace = true
 
 # io
 jsonrpsee-types.workspace = true

--- a/crates/rpc/rpc-convert/src/fees.rs
+++ b/crates/rpc/rpc-convert/src/fees.rs
@@ -1,0 +1,106 @@
+use alloy_primitives::{B256, U256};
+use core::cmp::min;
+
+/// Helper type for representing the fees of a transaction request.
+#[derive(Debug)]
+pub struct CallFees {
+    /// EIP-1559 priority fee.
+    pub max_priority_fee_per_gas: Option<U256>,
+    /// Effective gas price used by the call.
+    pub gas_price: U256,
+    /// Maximum fee per blob gas for EIP-4844 transactions.
+    pub max_fee_per_blob_gas: Option<U256>,
+}
+
+impl CallFees {
+    /// Ensures transaction request fee fields do not conflict and resolves their effective values.
+    pub fn ensure_fees(
+        call_gas_price: Option<U256>,
+        call_max_fee: Option<U256>,
+        call_priority_fee: Option<U256>,
+        block_base_fee: U256,
+        blob_versioned_hashes: Option<&[B256]>,
+        max_fee_per_blob_gas: Option<U256>,
+        block_blob_fee: Option<U256>,
+    ) -> Result<Self, CallFeesError> {
+        fn effective_gas_price(
+            max_fee_per_gas: Option<U256>,
+            max_priority_fee_per_gas: Option<U256>,
+            block_base_fee: U256,
+        ) -> Result<U256, CallFeesError> {
+            match max_fee_per_gas {
+                Some(max_fee) => {
+                    let priority_fee = max_priority_fee_per_gas.unwrap_or(U256::ZERO);
+                    if !(max_fee.is_zero() && priority_fee.is_zero()) && max_fee < block_base_fee {
+                        return Err(CallFeesError::FeeCapTooLow)
+                    }
+                    if max_fee < priority_fee {
+                        return Err(CallFeesError::TipAboveFeeCap)
+                    }
+                    Ok(min(
+                        max_fee,
+                        block_base_fee
+                            .checked_add(priority_fee)
+                            .ok_or(CallFeesError::TipVeryHigh)?,
+                    ))
+                }
+                None => block_base_fee
+                    .checked_add(max_priority_fee_per_gas.unwrap_or(U256::ZERO))
+                    .ok_or(CallFeesError::TipVeryHigh),
+            }
+        }
+
+        let has_blob_hashes = blob_versioned_hashes.is_some_and(|hashes| !hashes.is_empty());
+        match (call_gas_price, call_max_fee, call_priority_fee, max_fee_per_blob_gas) {
+            (gas_price, None, None, None) => Ok(Self {
+                gas_price: gas_price.unwrap_or(U256::ZERO),
+                max_priority_fee_per_gas: None,
+                max_fee_per_blob_gas: has_blob_hashes.then_some(block_blob_fee).flatten(),
+            }),
+            (None, max_fee_per_gas, max_priority_fee_per_gas, None) => Ok(Self {
+                gas_price: effective_gas_price(
+                    max_fee_per_gas,
+                    max_priority_fee_per_gas,
+                    block_base_fee,
+                )?,
+                max_priority_fee_per_gas,
+                max_fee_per_blob_gas: has_blob_hashes.then_some(block_blob_fee).flatten(),
+            }),
+            (None, max_fee_per_gas, max_priority_fee_per_gas, Some(max_fee_per_blob_gas)) => {
+                if !has_blob_hashes {
+                    return Err(CallFeesError::BlobTransactionMissingBlobHashes)
+                }
+                Ok(Self {
+                    gas_price: effective_gas_price(
+                        max_fee_per_gas,
+                        max_priority_fee_per_gas,
+                        block_base_fee,
+                    )?,
+                    max_priority_fee_per_gas,
+                    max_fee_per_blob_gas: Some(max_fee_per_blob_gas),
+                })
+            }
+            _ => Err(CallFeesError::ConflictingFeeFieldsInRequest),
+        }
+    }
+}
+
+/// Error from validating transaction request fee fields.
+#[derive(Debug, thiserror::Error)]
+pub enum CallFeesError {
+    /// Legacy and EIP-1559 fee fields were both specified.
+    #[error("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")]
+    ConflictingFeeFieldsInRequest,
+    /// The fee cap is below the block base fee.
+    #[error("max fee per gas less than block base fee")]
+    FeeCapTooLow,
+    /// The priority fee is above the total fee cap.
+    #[error("max priority fee per gas higher than max fee per gas")]
+    TipAboveFeeCap,
+    /// The priority fee calculation overflowed.
+    #[error("max priority fee per gas higher than 2^256-1")]
+    TipVeryHigh,
+    /// A blob transaction has no versioned hashes.
+    #[error("blob transaction missing blob hashes")]
+    BlobTransactionMissingBlobHashes,
+}

--- a/crates/rpc/rpc-convert/src/lib.rs
+++ b/crates/rpc/rpc-convert/src/lib.rs
@@ -10,11 +10,15 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+mod fees;
 mod rpc;
 pub mod transaction;
 
+pub use fees::{CallFees, CallFeesError};
 pub use rpc::*;
-pub use transaction::{RpcConvert, RpcConverter, TransactionConversionError};
+pub use transaction::{
+    EthTxEnvError, RpcConvert, RpcConverter, TransactionConversionError, TryIntoTxEnv,
+};
 
 // Re-export traits from reth-rpc-traits
 pub use reth_rpc_traits::{

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -11,7 +11,7 @@ use alloy_primitives::{Address, TxKind, U256};
 use alloy_rpc_types_eth::{request::TransactionInputError, TransactionInfo, TransactionRequest};
 use core::error;
 use dyn_clone::DynClone;
-use evm2::ethereum::RecoveredTxEnvelope;
+use evm2::ethereum::{RecoveredTxEnvelope, TxEnvelope};
 use reth_evm::{ConfigureEvm, EvmEnv, EvmEnvFor, TxEnvFor};
 use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, SealedBlock, SealedHeader, SealedHeaderFor, TransactionMeta,
@@ -433,46 +433,51 @@ fn transaction_request_to_evm2(
     let gas_price = gas_price.saturating_to();
     let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or_default().saturating_to();
 
-    Ok(match tx_type {
-        TxType::Legacy => RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-            TxLegacy { chain_id: Some(chain_id), nonce, gas_price, gas_limit, to, value, input },
-            caller,
-        )),
-        TxType::Eip2930 => RecoveredTxEnvelope::Eip2930(Recovered::new_unchecked(
-            TxEip2930 { chain_id, nonce, gas_price, gas_limit, to, value, access_list, input },
-            caller,
-        )),
-        TxType::Eip1559 => RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(
-            TxEip1559 {
-                chain_id,
-                nonce,
-                gas_limit,
-                max_fee_per_gas: gas_price,
-                max_priority_fee_per_gas,
-                to,
-                value,
-                access_list,
-                input,
-            },
-            caller,
-        )),
-        TxType::Eip4844 => RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(
-            TxEip4844Variant::TxEip4844(TxEip4844 {
-                chain_id,
-                nonce,
-                gas_limit,
-                max_fee_per_gas: gas_price,
-                max_priority_fee_per_gas,
-                to: to.to().copied().ok_or(EthTxEnvError::BlobTransactionIsCreate)?,
-                value,
-                access_list,
-                blob_versioned_hashes: blob_versioned_hashes.unwrap_or_default(),
-                max_fee_per_blob_gas: max_fee_per_blob_gas.unwrap_or_default().saturating_to(),
-                input,
-            }),
-            caller,
-        )),
-        TxType::Eip7702 => RecoveredTxEnvelope::from(Recovered::new_unchecked(
+    let tx = match tx_type {
+        TxType::Legacy => TxEnvelope::Legacy(TxLegacy {
+            chain_id: Some(chain_id),
+            nonce,
+            gas_price,
+            gas_limit,
+            to,
+            value,
+            input,
+        }),
+        TxType::Eip2930 => TxEnvelope::Eip2930(TxEip2930 {
+            chain_id,
+            nonce,
+            gas_price,
+            gas_limit,
+            to,
+            value,
+            access_list,
+            input,
+        }),
+        TxType::Eip1559 => TxEnvelope::Eip1559(TxEip1559 {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas: gas_price,
+            max_priority_fee_per_gas,
+            to,
+            value,
+            access_list,
+            input,
+        }),
+        TxType::Eip4844 => TxEnvelope::Eip4844(TxEip4844Variant::TxEip4844(TxEip4844 {
+            chain_id,
+            nonce,
+            gas_limit,
+            max_fee_per_gas: gas_price,
+            max_priority_fee_per_gas,
+            to: to.to().copied().ok_or(EthTxEnvError::BlobTransactionIsCreate)?,
+            value,
+            access_list,
+            blob_versioned_hashes: blob_versioned_hashes.unwrap_or_default(),
+            max_fee_per_blob_gas: max_fee_per_blob_gas.unwrap_or_default().saturating_to(),
+            input,
+        })),
+        TxType::Eip7702 => TxEnvelope::Eip7702(
             TxEip7702 {
                 chain_id,
                 nonce,
@@ -484,10 +489,11 @@ fn transaction_request_to_evm2(
                 access_list,
                 authorization_list: authorization_list.unwrap_or_default(),
                 input,
-            },
-            caller,
-        )),
-    })
+            }
+            .into(),
+        ),
+    };
+    Ok(Recovered::new_unchecked(tx, caller))
 }
 
 /// Converts rpc transaction requests into transaction environment using a closure.

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -1,11 +1,18 @@
 //! Compatibility functions for rpc `Transaction` type.
-use crate::{RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes, SignableTxRequest};
-use alloy_consensus::{error::ValueError, transaction::Recovered};
-use alloy_primitives::Address;
-use alloy_rpc_types_eth::TransactionInfo;
+use crate::{
+    CallFees, RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes, SignableTxRequest,
+};
+use alloy_consensus::{
+    error::ValueError,
+    transaction::{Recovered, TxEip4844Variant},
+    TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy, TxType,
+};
+use alloy_primitives::{Address, TxKind, U256};
+use alloy_rpc_types_eth::{request::TransactionInputError, TransactionInfo, TransactionRequest};
 use core::error;
 use dyn_clone::DynClone;
-use reth_evm::{ConfigureEvm, EvmEnvFor, TxEnvFor};
+use evm2::ethereum::RecoveredTxEnvelope;
+use reth_evm::{ConfigureEvm, EvmEnv, EvmEnvFor, TxEnvFor};
 use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, SealedBlock, SealedHeader, SealedHeaderFor, TransactionMeta,
     TxTy,
@@ -295,9 +302,19 @@ where
 
 /// Converts `TxReq` into `TxEnv`.
 ///
-/// The default `()` implementation is intentionally unsupported in the active EVM path because
-/// executable RPC calls are stubbed. Sync-critical transaction conversion uses
-/// [`SimTxConverter`] instead.
+/// Where:
+/// * `TxReq` is a transaction request received from an RPC API
+/// * `TxEnv` is the corresponding transaction environment for execution
+///
+/// The `TxEnvConverter` has two blanket implementations:
+/// * `()` assuming `TxReq` implements [`TryIntoTxEnv`] and is used as default for [`RpcConverter`].
+/// * `Fn(TxReq, &EvmEnvFor<Evm>) -> Result<TxEnv, E>` and can be applied using
+///   [`RpcConverter::with_tx_env_converter`].
+///
+/// One should prefer to implement [`TryIntoTxEnv`] for `TxReq` to get the `TxEnvConverter`
+/// implementation for free, thanks to the blanket implementation, unless the conversion requires
+/// more context. For example, some configuration parameters or access handles to database, network,
+/// etc.
 pub trait TxEnvConverter<TxReq, Evm: ConfigureEvm>:
     Debug + Send + Sync + Unpin + Clone + 'static
 {
@@ -314,20 +331,164 @@ pub trait TxEnvConverter<TxReq, Evm: ConfigureEvm>:
     ) -> Result<TxEnvFor<Evm>, Self::Error>;
 }
 
+/// Converts a transaction request into an executable transaction environment.
+pub trait TryIntoTxEnv<T, EvmEnv> {
+    /// Error returned by the conversion.
+    type Err;
+
+    /// Performs the conversion.
+    fn try_into_tx_env(self, evm_env: &EvmEnv) -> Result<T, Self::Err>;
+}
+
+/// Ethereum transaction environment conversion error.
+#[derive(Debug, thiserror::Error)]
+pub enum EthTxEnvError {
+    /// Error while validating transaction fees.
+    #[error(transparent)]
+    CallFees(#[from] crate::CallFeesError),
+    /// Both data and input fields are set and differ.
+    #[error(transparent)]
+    Input(#[from] TransactionInputError),
+    /// Blob transaction has no call target.
+    #[error("blob transaction is a create transaction")]
+    BlobTransactionIsCreate,
+    /// EIP-7702 transaction has no call target.
+    #[error("EIP-7702 authorization list has invalid fields")]
+    AuthorizationListInvalidFields,
+}
+
+impl<T, Env> TryIntoTxEnv<T, Env> for TransactionRequest
+where
+    T: From<RecoveredTxEnvelope>,
+    Env: EvmEnv,
+{
+    type Err = EthTxEnvError;
+
+    fn try_into_tx_env(self, evm_env: &Env) -> Result<T, Self::Err> {
+        transaction_request_to_evm2(self, evm_env).map(Into::into)
+    }
+}
+
 impl<TxReq, Evm> TxEnvConverter<TxReq, Evm> for ()
 where
+    TxReq: TryIntoTxEnv<TxEnvFor<Evm>, EvmEnvFor<Evm>>,
     Evm: ConfigureEvm,
 {
-    type Error = TransactionConversionError;
+    type Error = TxReq::Err;
 
     fn convert_tx_env(
         &self,
         tx_req: TxReq,
         evm_env: &EvmEnvFor<Evm>,
     ) -> Result<TxEnvFor<Evm>, Self::Error> {
-        let _ = (tx_req, evm_env);
-        Err(TransactionConversionError::UnsupportedTxEnv)
+        tx_req.try_into_tx_env(evm_env)
     }
+}
+
+fn transaction_request_to_evm2(
+    request: TransactionRequest,
+    evm_env: &impl EvmEnv,
+) -> Result<RecoveredTxEnvelope, EthTxEnvError> {
+    if request.blob_versioned_hashes.as_ref().is_some_and(Vec::is_empty) {
+        return Err(crate::CallFeesError::BlobTransactionMissingBlobHashes.into())
+    }
+
+    let tx_type = request.minimal_tx_type();
+    let TransactionRequest {
+        from,
+        to,
+        gas_price,
+        max_fee_per_gas,
+        max_priority_fee_per_gas,
+        gas,
+        value,
+        input,
+        nonce,
+        access_list,
+        chain_id,
+        blob_versioned_hashes,
+        max_fee_per_blob_gas,
+        authorization_list,
+        transaction_type: _,
+        sidecar: _,
+    } = request;
+    let input = input.try_into_unique_input()?.unwrap_or_default();
+    let CallFees { max_priority_fee_per_gas, gas_price, max_fee_per_blob_gas } =
+        CallFees::ensure_fees(
+            gas_price.map(U256::from),
+            max_fee_per_gas.map(U256::from),
+            max_priority_fee_per_gas.map(U256::from),
+            U256::from(evm_env.block_base_fee()),
+            blob_versioned_hashes.as_deref(),
+            max_fee_per_blob_gas.map(U256::from),
+            Some(U256::from(evm_env.block_blob_base_fee())),
+        )?;
+
+    let caller = from.unwrap_or_default();
+    let to = to.unwrap_or(TxKind::Create);
+    let gas_limit = gas.unwrap_or_else(|| evm_env.block_env().gas_limit.saturating_to());
+    let nonce = nonce.unwrap_or_default();
+    let chain_id = chain_id.unwrap_or_else(|| evm_env.chain_id());
+    let value = value.unwrap_or_default();
+    let access_list = access_list.unwrap_or_default();
+    let gas_price = gas_price.saturating_to();
+    let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or_default().saturating_to();
+
+    Ok(match tx_type {
+        TxType::Legacy => RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+            TxLegacy { chain_id: Some(chain_id), nonce, gas_price, gas_limit, to, value, input },
+            caller,
+        )),
+        TxType::Eip2930 => RecoveredTxEnvelope::Eip2930(Recovered::new_unchecked(
+            TxEip2930 { chain_id, nonce, gas_price, gas_limit, to, value, access_list, input },
+            caller,
+        )),
+        TxType::Eip1559 => RecoveredTxEnvelope::Eip1559(Recovered::new_unchecked(
+            TxEip1559 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas: gas_price,
+                max_priority_fee_per_gas,
+                to,
+                value,
+                access_list,
+                input,
+            },
+            caller,
+        )),
+        TxType::Eip4844 => RecoveredTxEnvelope::Eip4844(Recovered::new_unchecked(
+            TxEip4844Variant::TxEip4844(TxEip4844 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas: gas_price,
+                max_priority_fee_per_gas,
+                to: to.to().copied().ok_or(EthTxEnvError::BlobTransactionIsCreate)?,
+                value,
+                access_list,
+                blob_versioned_hashes: blob_versioned_hashes.unwrap_or_default(),
+                max_fee_per_blob_gas: max_fee_per_blob_gas.unwrap_or_default().saturating_to(),
+                input,
+            }),
+            caller,
+        )),
+        TxType::Eip7702 => RecoveredTxEnvelope::from(Recovered::new_unchecked(
+            TxEip7702 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas: gas_price,
+                max_priority_fee_per_gas,
+                to: to.to().copied().ok_or(EthTxEnvError::AuthorizationListInvalidFields)?,
+                value,
+                access_list,
+                authorization_list: authorization_list.unwrap_or_default(),
+                input,
+            },
+            caller,
+        )),
+    })
 }
 
 /// Converts rpc transaction requests into transaction environment using a closure.
@@ -365,10 +526,6 @@ pub enum TransactionConversionError {
     /// Other conversion errors.
     #[error("{0}")]
     Other(String),
-
-    /// Transaction environment conversion is unsupported in the active EVM RPC stub path.
-    #[error("transaction environment conversion is unsupported by the active EVM execution path")]
-    UnsupportedTxEnv,
 }
 /// Generic RPC response object converter for `Evm` and network `Network`.
 ///
@@ -379,7 +536,8 @@ pub enum TransactionConversionError {
 /// network and EVM associated primitives:
 /// * [`FromConsensusTx`]: from signed transaction into RPC response object.
 /// * [`TryIntoSimTx`]: from RPC transaction request into a simulated transaction.
-/// * [`TxEnvConverter`]: from RPC transaction request into an executable transaction.
+/// * [`TryIntoTxEnv`] or [`TxEnvConverter`]: from RPC transaction request into an executable
+///   transaction.
 /// * [`TxInfoMapper`]: from [`TransactionInfo`] into [`FromConsensusTx::TxInfo`]. Should be
 ///   implemented for a dedicated struct that is assigned to `Map`. If [`FromConsensusTx::TxInfo`]
 ///   is [`TransactionInfo`] then `()` can be used as `Map` which trivially passes over the input

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -357,15 +357,14 @@ pub enum EthTxEnvError {
     AuthorizationListInvalidFields,
 }
 
-impl<T, Env> TryIntoTxEnv<T, Env> for TransactionRequest
+impl<Env> TryIntoTxEnv<RecoveredTxEnvelope, Env> for TransactionRequest
 where
-    T: From<RecoveredTxEnvelope>,
     Env: EvmEnv,
 {
     type Err = EthTxEnvError;
 
-    fn try_into_tx_env(self, evm_env: &Env) -> Result<T, Self::Err> {
-        transaction_request_to_evm2(self, evm_env).map(Into::into)
+    fn try_into_tx_env(self, evm_env: &Env) -> Result<RecoveredTxEnvelope, Self::Err> {
+        transaction_request_to_evm2(self, evm_env)
     }
 }
 

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 
 [dependencies]
 # reth
+evm2.workspace = true
 reth-chain-state.workspace = true
+evm2-inspectors = { workspace = true, features = ["std"] }
 reth-primitives-traits = { workspace = true, features = ["rpc-compat"] }
 reth-errors.workspace = true
 reth-evm.workspace = true
@@ -28,8 +30,6 @@ reth-network-api.workspace = true
 reth-node-api.workspace = true
 reth-trie-common = { workspace = true, features = ["eip1186"] }
 reth-prune-types.workspace = true
-evm2.workspace = true
-evm2-inspectors = { workspace = true, features = ["std"] }
 
 # ethereum
 alloy-rlp.workspace = true
@@ -61,8 +61,5 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [features]
-js-tracer = [
-    "reth-rpc-eth-types/js-tracer",
-    "evm2-inspectors/js-tracer",
-]
+js-tracer = ["evm2-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -5,7 +5,8 @@ use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::BlockId;
 use reth_errors::RethError;
 use reth_evm::{
-    database::StateProviderDatabase, BlockExecutor, ConfigureEvm, ExecutableTxParts, TxEnvFor,
+    database::StateProviderDatabase, BlockExecutor, BlockExecutorTransactionFor, ConfigureEvm,
+    ExecutableTxParts,
 };
 use reth_primitives_traits::TxTy;
 use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
@@ -51,7 +52,7 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock + RpcNodeCoreExt {
                 executor.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
                 for block_tx in block.transactions_recovered() {
                     let (tx_env, _) = <_ as ExecutableTxParts<
-                        TxEnvFor<Self::Evm>,
+                        BlockExecutorTransactionFor<Self::Evm>,
                         TxTy<Self::Primitives>,
                     >>::into_parts(block_tx);
                     executor.execute_transaction(tx_env).map_err(Self::Error::from_eth_err)?;

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -5,8 +5,7 @@ use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::BlockId;
 use reth_errors::RethError;
 use reth_evm::{
-    database::StateProviderDatabase, BlockExecutor, BlockExecutorTransactionFor, ConfigureEvm,
-    ExecutableTxParts,
+    database::StateProviderDatabase, BlockExecutor, ConfigureEvm, ExecutableTxParts, TxFor,
 };
 use reth_primitives_traits::TxTy;
 use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
@@ -52,7 +51,7 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock + RpcNodeCoreExt {
                 executor.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
                 for block_tx in block.transactions_recovered() {
                     let (tx_env, _) = <_ as ExecutableTxParts<
-                        BlockExecutorTransactionFor<Self::Evm>,
+                        TxFor<Self::Evm>,
                         TxTy<Self::Primitives>,
                     >>::into_parts(block_tx);
                     executor.execute_transaction(tx_env).map_err(Self::Error::from_eth_err)?;

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -6,7 +6,7 @@ use crate::{
     helpers::estimate::EstimateCall, FromEvmError, FullEthApiTypes, RpcBlock, RpcNodeCore,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
-use alloy_eips::eip2930::AccessListResult;
+use alloy_eips::{eip1559::calc_effective_gas_price, eip2930::AccessListResult};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_eth::{
@@ -14,11 +14,7 @@ use alloy_rpc_types_eth::{
     state::{EvmOverrides, StateOverride},
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
-use evm2::{
-    ethereum::RecoveredTxEnvelope,
-    evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource},
-    TxResultWithState,
-};
+use evm2::evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource};
 use evm2_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use futures::Future;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
@@ -27,7 +23,7 @@ use reth_evm::{
     cancelled::CancelOnDrop,
     database::{BorrowedDatabase, StateProviderDatabase},
     execute::{BlockBuilder, BlockExecutorFactory},
-    ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, TxEnvFor,
+    ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, EvmTypesFor, TxEnvFor, TxResultWithStateFor,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
@@ -36,7 +32,7 @@ use reth_rpc_eth_types::{
     cache::db::{apply_block_overrides, apply_state_overrides, StateProviderTraitObjWrapper},
     error::{AsEthApiError, FromEthApiError},
     simulate::{self, EthSimulateError},
-    EthApiError, RpcInvalidTransactionError, StateCacheDb,
+    EthApiError, StateCacheDb,
 };
 use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
 use std::{borrow::Borrow, fmt};
@@ -250,7 +246,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     );
                     parent = simulated_header;
 
-                    let block = simulate::build_simulated_block::<Self::Error, _>(
+                    let block = simulate::build_simulated_block::<Self::Error, _, _>(
                         result.block,
                         results,
                         return_full_transactions.into(),
@@ -505,8 +501,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
             let tx_env =
                 this.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut db))?;
-            let transaction: &RecoveredTxEnvelope = tx_env.borrow().borrow();
-            if !request_has_gas_limit && transaction.effective_gas_price(None) > 0 {
+            if !request_has_gas_limit &&
+                request_gas_price(request.as_ref(), evm_env.block_base_fee()) > 0
+            {
                 let cap =
                     this.caller_gas_allowance(BorrowedDatabase::new(&mut db), &evm_env, &tx_env)?;
                 // no gas limit was provided in the request, so we need to cap the request's gas
@@ -568,27 +565,10 @@ pub trait Call:
     /// Returns the max gas limit that the caller can afford given a transaction environment.
     fn caller_gas_allowance(
         &self,
-        mut db: impl Database<Error: Into<EthApiError>>,
-        _evm_env: &EvmEnvFor<Self::Evm>,
+        db: impl Database<Error: Into<EthApiError>>,
+        evm_env: &EvmEnvFor<Self::Evm>,
         tx_env: &TxEnvFor<Self::Evm>,
-    ) -> Result<u64, Self::Error> {
-        let tx: &RecoveredTxEnvelope = tx_env.borrow().borrow();
-        let gas_price = tx.effective_gas_price(None);
-        let balance = db
-            .get_account(&tx.signer())
-            .map_err(Into::into)
-            .map_err(Self::Error::from_eth_err)?
-            .map(|account| account.balance)
-            .unwrap_or_default();
-        let value = tx.value();
-        let allowance = balance.checked_sub(value).ok_or_else(|| {
-            Self::Error::from_eth_err(EthApiError::from(
-                RpcInvalidTransactionError::InsufficientFunds { cost: value, balance },
-            ))
-        })? / U256::from(gas_price);
-
-        Ok(allowance.try_into().unwrap_or(u64::MAX))
-    }
+    ) -> Result<u64, Self::Error>;
 
     /// Executes the closure with the state that corresponds to the given [`BlockId`].
     fn with_state_at_block<F, R>(
@@ -613,7 +593,7 @@ pub trait Call:
         db: DB,
         evm_env: EvmEnvFor<Self::Evm>,
         tx_env: TxEnvFor<Self::Evm>,
-    ) -> Result<TxResultWithState, Self::Error>
+    ) -> Result<TxResultWithStateFor<Self::Evm>, Self::Error>
     where
         DB: DynDatabase + fmt::Debug,
     {
@@ -631,10 +611,10 @@ pub trait Call:
         evm_env: EvmEnvFor<Self::Evm>,
         tx_env: TxEnvFor<Self::Evm>,
         inspector: I,
-    ) -> Result<(I, TxResultWithState), Self::Error>
+    ) -> Result<(I, TxResultWithStateFor<Self::Evm>), Self::Error>
     where
         DB: DynDatabase + fmt::Debug,
-        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static,
+        I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
     {
         let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
         let res = evm
@@ -655,7 +635,7 @@ pub trait Call:
         request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         at: BlockId,
         overrides: EvmOverrides,
-    ) -> impl Future<Output = Result<TxResultWithState, Self::Error>> + Send
+    ) -> impl Future<Output = Result<TxResultWithStateFor<Self::Evm>, Self::Error>> + Send
     where
         Self: LoadPendingBlock,
     {
@@ -747,7 +727,7 @@ pub trait Call:
     ///
     /// Before the transaction is executed, all previous transaction in the block are applied to the
     /// state by executing them first.
-    /// The callback `f` is invoked with the [`TxResultWithState`] after the transaction was
+    /// The callback `f` is invoked with the transaction result after the transaction was
     /// executed and the database that points to the beginning of the transaction.
     ///
     /// Note: Implementers should use a threadpool where blocking is allowed, such as
@@ -759,7 +739,11 @@ pub trait Call:
     ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
     where
         Self: LoadBlock + LoadTransaction,
-        F: FnOnce(TransactionInfo, TxResultWithState, StateCacheDb) -> Result<R, Self::Error>
+        F: FnOnce(
+                TransactionInfo,
+                TxResultWithStateFor<Self::Evm>,
+                StateCacheDb,
+            ) -> Result<R, Self::Error>
             + Send
             + 'static,
         R: Send + 'static,
@@ -942,18 +926,18 @@ pub trait Call:
                 .map_err(EthApiError::from_state_overrides_err)?;
         }
 
+        let gas_price = request_gas_price(request.as_ref(), evm_env.block_base_fee());
         let tx_env =
             self.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut *db))?;
 
         // lower the basefee to 0 to avoid breaking EVM invariants (basefee < gasprice): <https://github.com/ethereum/go-ethereum/blob/355228b011ef9a85ebc0f21e7196f892038d49f0/internal/ethapi/api.go#L700-L704>
-        let transaction: &RecoveredTxEnvelope = tx_env.borrow().borrow();
-        if transaction.effective_gas_price(None) == 0 {
+        if gas_price == 0 {
             evm_env.block_env_mut().basefee = U256::ZERO;
         }
 
         if !request_has_gas_limit {
             // No gas limit was provided in the request, so we need to cap the transaction gas limit
-            if transaction.effective_gas_price(None) > 0 {
+            if gas_price > 0 {
                 // If gas price is specified, cap transaction gas limit with caller allowance
                 trace!(target: "rpc::eth::call", ?request, "Applying gas limit cap with caller allowance");
                 let cap =
@@ -965,5 +949,23 @@ pub trait Call:
 
         let tx_env = self.create_txn_env(&evm_env, request, BorrowedDatabase::new(&mut *db))?;
         Ok((evm_env, tx_env))
+    }
+}
+
+pub(super) fn request_gas_price(
+    request: &alloy_rpc_types_eth::TransactionRequest,
+    block_base_fee: u64,
+) -> u128 {
+    if let Some(gas_price) = request.gas_price {
+        return gas_price
+    }
+
+    match (request.max_fee_per_gas, request.max_priority_fee_per_gas) {
+        (None, None) => 0,
+        (max_fee, priority_fee) => calc_effective_gas_price(
+            max_fee.unwrap_or(u128::MAX),
+            priority_fee.unwrap_or_default(),
+            Some(block_base_fee),
+        ),
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -747,8 +747,8 @@ pub trait Call:
     ///
     /// Before the transaction is executed, all previous transaction in the block are applied to the
     /// state by executing them first.
-    /// The callback `f` is invoked with the [`ResultAndState`] after the transaction was executed
-    /// and the database that points to the beginning of the transaction.
+    /// The callback `f` is invoked with the [`TxResultWithState`] after the transaction was
+    /// executed and the database that points to the beginning of the transaction.
     ///
     /// Note: Implementers should use a threadpool where blocking is allowed, such as
     /// [`BlockingTaskPool`](reth_tasks::pool::BlockingTaskPool).
@@ -818,7 +818,7 @@ pub trait Call:
     /// Replays all the transactions until the target transaction is found.
     ///
     /// All transactions before the target transaction are executed and their changes are written to
-    /// the _runtime_ db ([`State`]).
+    /// the runtime database.
     ///
     /// Note: This assumes the target transaction is in the given iterator.
     /// Returns the index of the target transaction in the given iterator.

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -5,7 +5,10 @@ use super::{LoadBlock, LoadPendingBlock, LoadState, LoadTransaction, SpawnBlocki
 use crate::{
     helpers::estimate::EstimateCall, FromEvmError, FullEthApiTypes, RpcBlock, RpcNodeCore,
 };
-use alloy_consensus::{transaction::TxHashRef, BlockHeader};
+use alloy_consensus::{
+    transaction::{Transaction, TxHashRef},
+    BlockHeader,
+};
 use alloy_eips::{eip1559::calc_effective_gas_price, eip2930::AccessListResult};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256, U256};
@@ -14,10 +17,7 @@ use alloy_rpc_types_eth::{
     state::{EvmOverrides, StateOverride},
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
-use evm2::{
-    ethereum::TransactionExt,
-    evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource},
-};
+use evm2::evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource};
 use evm2_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use futures::Future;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
@@ -565,7 +565,7 @@ pub trait Call:
         tx_env: &TxEnvFor<Self::Evm>,
     ) -> Result<u64, Self::Error> {
         let balance = db
-            .get_account(&tx_env.caller())
+            .get_account(&tx_env.signer())
             .map_err(Into::into)
             .map_err(Self::Error::from_eth_err)?
             .map(|account| account.balance)

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -1,19 +1,46 @@
 //! Loads a pending block from database. Helper trait for `eth_` transaction, call and trace RPC
 //! methods.
 
-use super::{LoadBlock, LoadPendingBlock, LoadState, SpawnBlocking, Trace};
-use crate::{helpers::estimate::EstimateCall, FromEvmError, FullEthApiTypes, RpcBlock};
-use alloy_eips::eip2930::AccessListResult;
-use alloy_primitives::{Bytes, U256};
-use alloy_rpc_types_eth::{
-    simulate::{SimulatePayload, SimulatedBlock},
-    state::{EvmOverrides, StateOverride},
-    BlockId, Bundle, EthCallResponse, StateContext,
+use super::{LoadBlock, LoadPendingBlock, LoadState, LoadTransaction, SpawnBlocking, Trace};
+use crate::{
+    helpers::estimate::EstimateCall, FromEvmError, FullEthApiTypes, RpcBlock, RpcNodeCore,
 };
+use alloy_consensus::{transaction::TxHashRef, BlockHeader};
+use alloy_eips::eip2930::AccessListResult;
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Bytes, B256, U256};
+use alloy_rpc_types_eth::{
+    simulate::{SimBlock, SimulatePayload, SimulatedBlock},
+    state::{EvmOverrides, StateOverride},
+    BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
+};
+use evm2::{
+    ethereum::RecoveredTxEnvelope,
+    evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource},
+    TxResultWithState,
+};
+use evm2_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use futures::Future;
-use reth_errors::ProviderError;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_errors::{ProviderError, RethError};
+use reth_evm::{
+    cancelled::CancelOnDrop,
+    database::{BorrowedDatabase, StateProviderDatabase},
+    execute::{BlockBuilder, BlockExecutorFactory},
+    ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, TxEnvFor,
+};
+use reth_node_api::BlockBody;
+use reth_primitives_traits::Recovered;
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
-use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
+use reth_rpc_eth_types::{
+    cache::db::{apply_block_overrides, apply_state_overrides, StateProviderTraitObjWrapper},
+    error::{AsEthApiError, FromEthApiError},
+    simulate::{self, EthSimulateError},
+    EthApiError, RpcInvalidTransactionError, StateCacheDb,
+};
+use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
+use std::{borrow::Borrow, fmt};
+use tracing::{trace, warn};
 
 /// Result type for `eth_simulateV1` RPC method.
 pub type SimulatedBlocksResult<N, E> = Result<Vec<SimulatedBlock<RpcBlock<N>>>, E>;
@@ -40,42 +67,367 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         payload: SimulatePayload<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>,
         block: Option<BlockId>,
     ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send {
-        let _ = (payload, block);
         async move {
-            Err(Self::Error::from_eth_err(EthApiError::Unsupported(
-                "eth_simulateV1 is unsupported by the active EVM execution path",
-            )))
+            if payload.block_state_calls.len() > self.max_simulate_blocks() as usize {
+                return Err(EthApiError::other(EthSimulateError::TooManyBlocks).into())
+            }
+
+            let block = block.unwrap_or_default();
+
+            let SimulatePayload {
+                block_state_calls,
+                trace_transfers,
+                validation,
+                return_full_transactions,
+            } = payload;
+
+            if block_state_calls.is_empty() {
+                return Err(EthApiError::InvalidParams(String::from("calls are empty.")).into())
+            }
+
+            let _permit = self.acquire_owned_blocking_io().await;
+
+            let base_block = self
+                .recovered_block(block)
+                .await?
+                .ok_or_else(|| EthApiError::other(EthSimulateError::BlockNotFound { block }))?;
+            let parent = base_block.sealed_header().clone();
+            let max_simulate_blocks = self.max_simulate_blocks();
+
+            self.spawn_with_state_at_block(block, move |this, db| {
+                let state_provider = db.db.into_inner().into_inner().0;
+                let mut db =
+                    CacheDB::new(evm2::evm::Db::new(StateProviderDatabase::new(&state_provider)));
+                let mut parent = parent;
+
+                let chain_id = this.provider().chain_spec().chain_id();
+
+                // Validate block ordering and fill gaps with empty blocks so every entry has an
+                // explicit `number` and `time` override and the chain is contiguous (see the
+                // execution-apis spec note: "If the block number is increased more than 1 compared
+                // to the previous block, new empty blocks are generated in between.").
+                let block_state_calls = simulate::sanitize_chain(
+                    block_state_calls,
+                    &parent,
+                    chain_id,
+                    max_simulate_blocks,
+                )?;
+
+                let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
+                    Vec::with_capacity(block_state_calls.len());
+
+                let call_gas_limit = this.call_gas_limit();
+                let mut remaining_call_gas_limit = (call_gas_limit > 0).then_some(call_gas_limit);
+
+                for block in block_state_calls {
+                    let SimBlock { block_overrides, state_overrides, calls } = block;
+
+                    let attributes = this
+                        .pending_env_builder()
+                        .pending_env_attributes(&parent, block_overrides.as_ref())
+                        .map_err(Self::Error::from_eth_err)?;
+
+                    let mut evm_env = this
+                        .evm_config()
+                        .next_evm_env(&parent, &attributes)
+                        .map_err(RethError::other)
+                        .map_err(Self::Error::from_eth_err)?;
+
+                    // Always disable EIP-3607
+                    evm_env.version_mut().features.remove(evm2::EvmFeatures::EIP3607);
+
+                    if !validation {
+                        // If not explicitly required, we disable nonce check <https://github.com/paradigmxyz/reth/issues/16108>
+                        evm_env.version_mut().features.remove(evm2::EvmFeatures::NONCE_CHECK);
+                        evm_env.version_mut().features.remove(evm2::EvmFeatures::BASE_FEE_CHECK);
+                        evm_env.version_mut().tx_gas_limit_cap = u64::MAX;
+                        evm_env.block_env_mut().basefee = U256::ZERO;
+                    }
+
+                    // Set prevrandao to zero for simulated blocks by default,
+                    // matching spec behavior where MixDigest is zero-initialized.
+                    // If user provides an override, it will be applied by apply_block_overrides.
+                    evm_env.block_env_mut().prevrandao = U256::ZERO;
+                    if !this
+                        .provider()
+                        .chain_spec()
+                        .is_paris_active_at_block(evm_env.block_env().number.to())
+                    {
+                        evm_env.block_env_mut().difficulty = parent.difficulty();
+                    }
+
+                    if let Some(block_overrides) = block_overrides {
+                        // ensure we don't allow uncapped gas limit per block
+                        if let Some(gas_limit_override) = block_overrides.gas_limit &&
+                            gas_limit_override > evm_env.block_env().gas_limit.to::<u64>() &&
+                            gas_limit_override > this.call_gas_limit()
+                        {
+                            return Err(EthApiError::other(EthSimulateError::GasLimitReached).into())
+                        }
+                        apply_block_overrides(block_overrides, &mut db, &mut evm_env);
+                    }
+                    if let Some(ref state_overrides) = state_overrides {
+                        apply_state_overrides(state_overrides.clone(), &mut db)
+                            .map_err(Self::Error::from_eth_err)?;
+                    }
+
+                    let chain_id = evm_env.chain_id();
+
+                    let ctx = this
+                        .evm_config()
+                        .context_for_next_block(&parent, attributes)
+                        .map_err(RethError::other)
+                        .map_err(Self::Error::from_eth_err)?;
+                    let map_err = |e: EthApiError| -> Self::Error {
+                        match e.as_simulate_error() {
+                            Some(sim_err) => Self::Error::from_eth_err(EthApiError::other(sim_err)),
+                            None => Self::Error::from_eth_err(e),
+                        }
+                    };
+
+                    let (result, results) = if trace_transfers {
+                        // prepare inspector to capture transfer inside the evm so they are recorded
+                        // and included in logs
+                        let inspector = TransferInspector::new(false).with_logs(true);
+                        let mut evm = this
+                            .evm_config()
+                            .block_executor_factory()
+                            .evm_with_env(BorrowedDatabase::new(&mut db), evm_env.clone());
+                        evm.set_inspector(inspector);
+                        let mut builder =
+                            this.evm_config().create_block_builder(evm, evm_env, &parent, ctx);
+
+                        if let Some(ref state_overrides) = state_overrides {
+                            simulate::apply_precompile_overrides(
+                                state_overrides,
+                                builder.evm_mut(),
+                            )
+                            .map_err(|e| Self::Error::from_eth_err(EthApiError::other(e)))?;
+                        }
+
+                        simulate::execute_transactions(
+                            builder,
+                            &state_provider,
+                            calls,
+                            &mut remaining_call_gas_limit,
+                            chain_id,
+                            this.compute_state_root_for_eth_simulate(),
+                            this.converter(),
+                        )
+                        .map_err(map_err)?
+                    } else {
+                        let evm = this
+                            .evm_config()
+                            .block_executor_factory()
+                            .evm_with_env(BorrowedDatabase::new(&mut db), evm_env.clone());
+                        let mut builder =
+                            this.evm_config().create_block_builder(evm, evm_env, &parent, ctx);
+
+                        if let Some(ref state_overrides) = state_overrides {
+                            simulate::apply_precompile_overrides(
+                                state_overrides,
+                                builder.evm_mut(),
+                            )
+                            .map_err(|e| Self::Error::from_eth_err(EthApiError::other(e)))?;
+                        }
+
+                        simulate::execute_transactions(
+                            builder,
+                            &state_provider,
+                            calls,
+                            &mut remaining_call_gas_limit,
+                            chain_id,
+                            this.compute_state_root_for_eth_simulate(),
+                            this.converter(),
+                        )
+                        .map_err(map_err)?
+                    };
+
+                    let simulated_header = result.block.clone_sealed_header();
+                    db.insert_block_hash(
+                        &U256::from(simulated_header.number()),
+                        &simulated_header.hash(),
+                    );
+                    parent = simulated_header;
+
+                    let block = simulate::build_simulated_block::<Self::Error, _>(
+                        result.block,
+                        results,
+                        return_full_transactions.into(),
+                        this.converter(),
+                    )?;
+
+                    blocks.push(block);
+                }
+
+                Ok(blocks)
+            })
+            .await
         }
     }
 
-    /// Executes the call request (`eth_call`) and returns the output.
+    /// Executes the call request (`eth_call`) and returns the output
     fn call(
         &self,
         request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         block_number: Option<BlockId>,
         overrides: EvmOverrides,
     ) -> impl Future<Output = Result<Bytes, Self::Error>> + Send {
-        let _ = (request, block_number, overrides);
         async move {
-            Err(Self::Error::from_eth_err(EthApiError::Unsupported(
-                "eth_call is unsupported by the active EVM execution path",
-            )))
+            let _permit = self.acquire_owned_blocking_io().await;
+            let res =
+                self.transact_call_at(request, block_number.unwrap_or_default(), overrides).await?;
+
+            Self::Error::ensure_success(res.result)
         }
     }
 
     /// Simulate arbitrary number of transactions at an arbitrary blockchain index, with the
-    /// optionality of state overrides.
+    /// optionality of state overrides
     fn call_many(
         &self,
         bundles: Vec<Bundle<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>>,
         state_context: Option<StateContext>,
-        state_override: Option<StateOverride>,
+        mut state_override: Option<StateOverride>,
     ) -> impl Future<Output = Result<Vec<Vec<EthCallResponse>>, Self::Error>> + Send {
-        let _ = (bundles, state_context, state_override);
         async move {
-            Err(Self::Error::from_eth_err(EthApiError::Unsupported(
-                "eth_callMany is unsupported by the active EVM execution path",
-            )))
+            // Check if the vector of bundles is empty
+            if bundles.is_empty() {
+                return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into());
+            }
+
+            let _permit = self.acquire_owned_blocking_io().await;
+
+            let StateContext { transaction_index, block_number } =
+                state_context.unwrap_or_default();
+            let transaction_index = transaction_index.unwrap_or_default();
+
+            let mut target_block = block_number.unwrap_or_default();
+            let is_block_target_pending = target_block.is_pending();
+
+            // if it's not pending, we should always use block_hash over block_number to ensure that
+            // different provider calls query data related to the same block.
+            if !is_block_target_pending {
+                let Some(block_hash) = self
+                    .provider()
+                    .block_hash_for_id(target_block)
+                    .map_err(Self::Error::from_eth_err::<ProviderError>)?
+                else {
+                    return Err(EthApiError::HeaderNotFound(target_block).into())
+                };
+                target_block = block_hash.into();
+            }
+
+            let block = self
+                .recovered_block(target_block)
+                .await?
+                .ok_or(EthApiError::HeaderNotFound(target_block))?;
+            let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
+
+            // we're essentially replaying the transactions in the block here, hence we need the
+            // state that points to the beginning of the block, which is the state at
+            // the parent block
+            let mut at = block.parent_hash();
+            let mut replay_block_txs = true;
+
+            let num_txs =
+                transaction_index.index().unwrap_or_else(|| block.body().transactions().len());
+            // but if all transactions are to be replayed, we can use the state at the block itself,
+            // however only if we're not targeting the pending block, because for pending we can't
+            // rely on the block's state being available
+            if !is_block_target_pending && num_txs == block.body().transactions().len() {
+                at = block.hash();
+                replay_block_txs = false;
+            }
+
+            self.spawn_with_state_at_block(at, move |this, mut db| {
+                let mut all_results = Vec::with_capacity(bundles.len());
+
+                if replay_block_txs {
+                    let ctx = this
+                        .evm_config()
+                        .context_for_block(block.sealed_block())
+                        .map_err(RethError::other)
+                        .map_err(Self::Error::from_eth_err)?;
+                    let changes = this
+                        .evm_config()
+                        .pre_block_state_changes(
+                            BorrowedDatabase::new(&mut db),
+                            evm_env.clone(),
+                            block.number(),
+                            ctx,
+                        )
+                        .map_err(|err| EthApiError::EvmCustom(err.to_string()))
+                        .map_err(Self::Error::from_eth_err)?;
+                    db.commit_source(&changes);
+                    for tx in block.transactions_recovered().take(num_txs) {
+                        let tx_env = this.evm_config().tx_env(tx.cloned());
+                        let result = this.transact(&mut db, evm_env.clone(), tx_env)?;
+                        db.commit_source(&result.state_changes);
+                    }
+                }
+
+                // transact all bundles
+                for (bundle_index, bundle) in bundles.into_iter().enumerate() {
+                    let Bundle { transactions, block_override } = bundle;
+                    if transactions.is_empty() {
+                        // Skip empty bundles
+                        continue;
+                    }
+
+                    let mut bundle_results = Vec::with_capacity(transactions.len());
+                    let block_overrides = block_override.map(Box::new);
+
+                    // transact all transactions in the bundle
+                    for (tx_index, tx) in transactions.into_iter().enumerate() {
+                        // Apply overrides, state overrides are only applied for the first tx in the
+                        // request
+                        let overrides =
+                            EvmOverrides::new(state_override.take(), block_overrides.clone());
+
+                        let (current_evm_env, prepared_tx) = this
+                            .prepare_call_env(evm_env.clone(), tx, &mut db, overrides)
+                            .map_err(|err| {
+                                Self::Error::from_eth_err(EthApiError::call_many_error(
+                                    bundle_index,
+                                    tx_index,
+                                    err.into(),
+                                ))
+                            })?;
+                        let res = this.transact(&mut db, current_evm_env, prepared_tx).map_err(
+                            |err| {
+                                Self::Error::from_eth_err(EthApiError::call_many_error(
+                                    bundle_index,
+                                    tx_index,
+                                    err.into(),
+                                ))
+                            },
+                        )?;
+
+                        match Self::Error::ensure_success(res.result) {
+                            Ok(output) => {
+                                bundle_results
+                                    .push(EthCallResponse { value: Some(output), error: None });
+                            }
+                            Err(err) => {
+                                bundle_results.push(EthCallResponse {
+                                    value: None,
+                                    error: Some(err.to_string()),
+                                });
+                            }
+                        }
+
+                        // Commit state changes after each transaction to allow subsequent calls to
+                        // see the updates
+                        db.commit_source(&res.state_changes);
+                    }
+
+                    all_results.push(bundle_results);
+                }
+
+                Ok(all_results)
+            })
+            .await
         }
     }
 
@@ -90,12 +442,103 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     where
         Self: Trace,
     {
-        let _ = (request, block_number, state_override);
         async move {
-            Err(Self::Error::from_eth_err(EthApiError::Unsupported(
-                "eth_createAccessList is unsupported by the active EVM execution path",
-            )))
+            let block_id = block_number.unwrap_or_default();
+            let (evm_env, at) = self.evm_env_at(block_id).await?;
+
+            self.spawn_blocking_io_fut(async move |this| {
+                this.create_access_list_with(evm_env, at, request, state_override).await
+            })
+            .await
         }
+    }
+
+    /// Creates [`AccessListResult`] for the [`RpcTxReq`] at the given
+    /// [`BlockId`].
+    fn create_access_list_with(
+        &self,
+        mut evm_env: EvmEnvFor<Self::Evm>,
+        at: BlockId,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        state_override: Option<StateOverride>,
+    ) -> impl Future<Output = Result<AccessListResult, Self::Error>> + Send
+    where
+        Self: Trace,
+    {
+        self.spawn_blocking_io_fut(async move |this| {
+            let state = this.state_at_block_id(at).await?;
+            let mut db = evm2::evm::CacheDB::new(evm2::evm::Db::new(StateProviderDatabase::new(
+                StateProviderTraitObjWrapper(state),
+            )));
+
+            if let Some(state_overrides) = state_override {
+                apply_state_overrides(state_overrides, &mut db)
+                    .map_err(Self::Error::from_eth_err)?;
+            }
+
+            // Read fields from request before consuming it in create_txn_env
+            let request_has_gas_limit = request.as_ref().gas_limit().is_some();
+            let initial = request.as_ref().access_list().cloned().unwrap_or_default();
+
+            let mut request = request;
+
+            // we want to disable this in eth_createAccessList, since this is common practice used
+            // by other node impls and providers <https://github.com/foundry-rs/foundry/issues/4388>
+            evm_env.version_mut().features.remove(evm2::EvmFeatures::BLOCK_GAS_LIMIT_CHECK);
+
+            // The basefee should be ignored for eth_createAccessList
+            // See:
+            // <https://github.com/ethereum/go-ethereum/blob/8990c92aea01ca07801597b00c0d83d4e2d9b811/internal/ethapi/api.go#L1476-L1476>
+            evm_env.version_mut().features.remove(evm2::EvmFeatures::BASE_FEE_CHECK);
+
+            // Disabled because eth_createAccessList is sometimes used with non-eoa senders
+            evm_env.version_mut().features.remove(evm2::EvmFeatures::EIP3607);
+
+            // Disable additional fee charges (e.g. L2 operator fees),
+            // consistent with prepare_call_env and estimate_gas_with.
+            evm_env.version_mut().features.remove(evm2::EvmFeatures::FEE_CHARGE);
+
+            // Disable EIP-7825 transaction gas limit cap so that the gas limit
+            // fallback (block gas limit) is not rejected when it exceeds the
+            // per-tx cap (2^24 ≈ 16.7M post-Osaka).
+            evm_env.version_mut().tx_gas_limit_cap = u64::MAX;
+
+            let tx_env =
+                this.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut db))?;
+            let transaction: &RecoveredTxEnvelope = tx_env.borrow().borrow();
+            if !request_has_gas_limit && transaction.effective_gas_price(None) > 0 {
+                let cap =
+                    this.caller_gas_allowance(BorrowedDatabase::new(&mut db), &evm_env, &tx_env)?;
+                // no gas limit was provided in the request, so we need to cap the request's gas
+                // limit
+                request.as_mut().set_gas_limit(cap.min(evm_env.block_env().gas_limit.to::<u64>()));
+            }
+
+            let inspector = AccessListInspector::new(initial);
+            let tx_env =
+                this.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut db))?;
+
+            let (inspector, result) =
+                this.transact_with_inspector(&mut db, evm_env.clone(), tx_env, inspector)?;
+            let access_list = inspector.into_access_list();
+            let gas_used = result.result.tx_gas_used();
+            if let Err(err) = Self::Error::ensure_success(result.result) {
+                return Ok(AccessListResult {
+                    access_list,
+                    gas_used: U256::from(gas_used),
+                    error: Some(err.to_string()),
+                });
+            }
+
+            // transact again to get the exact gas used
+            request.as_mut().set_access_list(access_list.clone());
+            let tx_env = this.create_txn_env(&evm_env, request, BorrowedDatabase::new(&mut db))?;
+            let result = this.transact(&mut db, evm_env, tx_env)?;
+            let gas_used = result.result.tx_gas_used();
+            let error = Self::Error::ensure_success(result.result).err().map(|e| e.to_string());
+
+            Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
+        })
     }
 }
 
@@ -121,4 +564,406 @@ pub trait Call:
 
     /// Returns the maximum memory the EVM can allocate per RPC request.
     fn evm_memory_limit(&self) -> u64;
+
+    /// Returns the max gas limit that the caller can afford given a transaction environment.
+    fn caller_gas_allowance(
+        &self,
+        mut db: impl Database<Error: Into<EthApiError>>,
+        _evm_env: &EvmEnvFor<Self::Evm>,
+        tx_env: &TxEnvFor<Self::Evm>,
+    ) -> Result<u64, Self::Error> {
+        let tx: &RecoveredTxEnvelope = tx_env.borrow().borrow();
+        let gas_price = tx.effective_gas_price(None);
+        let balance = db
+            .get_account(&tx.signer())
+            .map_err(Into::into)
+            .map_err(Self::Error::from_eth_err)?
+            .map(|account| account.balance)
+            .unwrap_or_default();
+        let value = tx.value();
+        let allowance = balance.checked_sub(value).ok_or_else(|| {
+            Self::Error::from_eth_err(EthApiError::from(
+                RpcInvalidTransactionError::InsufficientFunds { cost: value, balance },
+            ))
+        })? / U256::from(gas_price);
+
+        Ok(allowance.try_into().unwrap_or(u64::MAX))
+    }
+
+    /// Executes the closure with the state that corresponds to the given [`BlockId`].
+    fn with_state_at_block<F, R>(
+        &self,
+        at: BlockId,
+        f: F,
+    ) -> impl Future<Output = Result<R, Self::Error>> + Send
+    where
+        R: Send + 'static,
+        F: FnOnce(Self, StateProviderBox) -> Result<R, Self::Error> + Send + 'static,
+    {
+        self.spawn_blocking_io_fut(async move |this| {
+            let state = this.state_at_block_id(at).await?;
+            f(this, state)
+        })
+    }
+
+    /// Executes the `TxEnv` against the given [Database] without committing state
+    /// changes.
+    fn transact<DB>(
+        &self,
+        db: DB,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
+    ) -> Result<TxResultWithState, Self::Error>
+    where
+        DB: DynDatabase + fmt::Debug,
+    {
+        let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
+        let res = evm.transact(tx_env.borrow()).map_err(Self::Error::from_evm_err)?;
+
+        Ok(res)
+    }
+
+    /// Executes the [`reth_evm::EvmEnv`] against the given [Database] without committing state
+    /// changes.
+    fn transact_with_inspector<DB, I>(
+        &self,
+        db: DB,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
+        inspector: I,
+    ) -> Result<(I, TxResultWithState), Self::Error>
+    where
+        DB: DynDatabase + fmt::Debug,
+        I: evm2::Inspector<evm2::BaseEvmTypes> + 'static,
+    {
+        let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
+        let res = evm
+            .transact_with_inspector(tx_env.borrow(), inspector)
+            .map_err(Self::Error::from_evm_err)?;
+
+        Ok(res)
+    }
+
+    /// Executes the call request at the given [`BlockId`].
+    ///
+    /// This spawns a new task that obtains the state for the given [`BlockId`] and then transacts
+    /// the call [`Self::transact`]. If the future is dropped before the (blocking) transact
+    /// call is invoked, then the task is cancelled early, (for example if the request is terminated
+    /// early client-side).
+    fn transact_call_at(
+        &self,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        at: BlockId,
+        overrides: EvmOverrides,
+    ) -> impl Future<Output = Result<TxResultWithState, Self::Error>> + Send
+    where
+        Self: LoadPendingBlock,
+    {
+        async move {
+            let guard = CancelOnDrop::default();
+            let cancel = guard.clone();
+            let this = self.clone();
+
+            let res = self
+                .spawn_with_call_at(request, at, overrides, move |db, evm_env, tx_env| {
+                    if cancel.is_cancelled() {
+                        // callsite dropped the guard
+                        return Err(EthApiError::InternalEthError.into())
+                    }
+                    this.transact(db, evm_env, tx_env)
+                })
+                .await;
+            drop(guard);
+            res
+        }
+    }
+
+    /// Executes the closure with the state that corresponds to the given [`BlockId`] on a new task
+    fn spawn_with_state_at_block<F, R>(
+        &self,
+        at: impl Into<BlockId>,
+        f: F,
+    ) -> impl Future<Output = Result<R, Self::Error>> + Send
+    where
+        F: FnOnce(Self, StateCacheDb) -> Result<R, Self::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        let at = at.into();
+        self.spawn_blocking_io_fut(async move |this| {
+            let state = this.state_at_block_id(at).await?;
+            let db = evm2::evm::CacheDB::new(evm2::evm::Db::new(StateProviderDatabase::new(
+                StateProviderTraitObjWrapper(state),
+            )));
+            f(this, db)
+        })
+    }
+
+    /// Prepares the state and env for the given [`RpcTxReq`] at the given [`BlockId`] and
+    /// executes the closure on a new task returning the result of the closure.
+    ///
+    /// This returns the configured [`reth_evm::EvmEnv`] for the given [`RpcTxReq`] at
+    /// the given [`BlockId`] and with configured call settings: `prepare_call_env`.
+    ///
+    /// This is primarily used by `eth_call`.
+    ///
+    /// # Blocking behaviour
+    ///
+    /// This assumes executing the call is relatively more expensive on IO than CPU because it
+    /// transacts a single transaction on an empty in memory database. Because `eth_call`s are
+    /// usually allowed to consume a lot of gas, this also allows a lot of memory operations so
+    /// we assume this is not primarily CPU bound and instead spawn the call on a regular tokio task
+    /// instead, where blocking IO is less problematic.
+    fn spawn_with_call_at<F, R>(
+        &self,
+        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        at: BlockId,
+        overrides: EvmOverrides,
+        f: F,
+    ) -> impl Future<Output = Result<R, Self::Error>> + Send
+    where
+        Self: LoadPendingBlock,
+        F: FnOnce(
+                &mut StateCacheDb,
+                EvmEnvFor<Self::Evm>,
+                TxEnvFor<Self::Evm>,
+            ) -> Result<R, Self::Error>
+            + Send
+            + 'static,
+        R: Send + 'static,
+    {
+        async move {
+            let (evm_env, at) = self.evm_env_at(at).await?;
+            self.spawn_with_state_at_block(at, move |this, mut db| {
+                let (evm_env, tx_env) =
+                    this.prepare_call_env(evm_env, request, &mut db, overrides)?;
+
+                f(&mut db, evm_env, tx_env)
+            })
+            .await
+        }
+    }
+
+    /// Retrieves the transaction if it exists and executes it.
+    ///
+    /// Before the transaction is executed, all previous transaction in the block are applied to the
+    /// state by executing them first.
+    /// The callback `f` is invoked with the [`ResultAndState`] after the transaction was executed
+    /// and the database that points to the beginning of the transaction.
+    ///
+    /// Note: Implementers should use a threadpool where blocking is allowed, such as
+    /// [`BlockingTaskPool`](reth_tasks::pool::BlockingTaskPool).
+    fn spawn_replay_transaction<F, R>(
+        &self,
+        hash: B256,
+        f: F,
+    ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
+    where
+        Self: LoadBlock + LoadTransaction,
+        F: FnOnce(TransactionInfo, TxResultWithState, StateCacheDb) -> Result<R, Self::Error>
+            + Send
+            + 'static,
+        R: Send + 'static,
+    {
+        async move {
+            let (transaction, block) = match self.transaction_and_block(hash).await? {
+                None => return Ok(None),
+                Some(res) => res,
+            };
+            let (tx, tx_info) = transaction.split();
+
+            // we need to get the state of the parent block because we're essentially replaying the
+            // block the transaction is included in
+            let parent_block = block.parent_hash();
+            let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
+
+            self.spawn_with_state_at_block(parent_block, move |this, mut db| {
+                let block_txs = block.transactions_recovered();
+
+                let ctx = this
+                    .evm_config()
+                    .context_for_block(block.sealed_block())
+                    .map_err(RethError::other)
+                    .map_err(Self::Error::from_eth_err)?;
+                let changes = this
+                    .evm_config()
+                    .pre_block_state_changes(
+                        BorrowedDatabase::new(&mut db),
+                        evm_env.clone(),
+                        block.number(),
+                        ctx,
+                    )
+                    .map_err(|err| EthApiError::EvmCustom(err.to_string()))
+                    .map_err(Self::Error::from_eth_err)?;
+                db.commit_source(&changes);
+
+                // replay all transactions prior to the targeted transaction
+                for block_tx in block_txs {
+                    if block_tx.tx_hash() == tx.tx_hash() {
+                        break;
+                    }
+                    let tx_env = this.evm_config().tx_env(block_tx.cloned());
+                    let result = this.transact(&mut db, evm_env.clone(), tx_env)?;
+                    db.commit_source(&result.state_changes);
+                }
+
+                let tx_env = RpcNodeCore::evm_config(&this).tx_env(tx);
+                let res = this.transact(&mut db, evm_env, tx_env)?;
+                f(tx_info, res, db)
+            })
+            .await
+            .map(Some)
+        }
+    }
+
+    /// Replays all the transactions until the target transaction is found.
+    ///
+    /// All transactions before the target transaction are executed and their changes are written to
+    /// the _runtime_ db ([`State`]).
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator.
+    fn replay_transactions_until<'a, DB, I>(
+        &self,
+        db: &mut DB,
+        evm_env: EvmEnvFor<Self::Evm>,
+        transactions: I,
+        target_tx_hash: B256,
+    ) -> Result<usize, Self::Error>
+    where
+        DB: DynDatabase + StateChangeSink<Error = core::convert::Infallible> + core::fmt::Debug,
+        I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
+    {
+        let mut index = 0;
+        for tx in transactions {
+            if *tx.tx_hash() == target_tx_hash {
+                // reached the target transaction
+                break
+            }
+
+            let tx_env = self.evm_config().tx_env(tx.cloned());
+            let result = self.transact(&mut *db, evm_env.clone(), tx_env)?;
+            result.state_changes.visit(db).expect("infallible state cache update");
+            index += 1;
+        }
+        Ok(index)
+    }
+
+    ///
+    /// All `TxEnv` fields are derived from the given [`RpcTxReq`], if fields are
+    /// `None`, they fall back to the [`reth_evm::EvmEnv`]'s settings.
+    fn create_txn_env(
+        &self,
+        evm_env: &EvmEnvFor<Self::Evm>,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        mut db: impl Database<Error: Into<EthApiError>>,
+    ) -> Result<TxEnvFor<Self::Evm>, Self::Error> {
+        if request.as_ref().nonce().is_none() {
+            let nonce = db
+                .get_account(&request.as_ref().from().unwrap_or_default())
+                .map_err(Into::into)
+                .map_err(Self::Error::from_eth_err)?
+                .map(|account| account.nonce)
+                .unwrap_or_default();
+            request.as_mut().set_nonce(nonce);
+        }
+
+        Ok(self.converter().tx_env(request, evm_env)?)
+    }
+
+    /// Prepares the [`reth_evm::EvmEnv`] for execution of calls.
+    ///
+    /// Does not commit any changes to the underlying database.
+    ///
+    /// ## EVM settings
+    ///
+    /// This modifies certain EVM settings to mirror geth's `SkipAccountChecks` when transacting requests, see also: <https://github.com/ethereum/go-ethereum/blob/380688c636a654becc8f114438c2a5d93d2db032/core/state_transition.go#L145-L148>:
+    ///
+    ///  - `disable_eip3607` is set to `true`
+    ///  - `disable_base_fee` is set to `true`
+    ///  - `nonce` is set to `None`
+    ///
+    /// In addition, this changes the block's gas limit to the configured [`Self::call_gas_limit`].
+    #[expect(clippy::type_complexity)]
+    fn prepare_call_env<DB>(
+        &self,
+        mut evm_env: EvmEnvFor<Self::Evm>,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        db: &mut CacheDB<DB>,
+        overrides: EvmOverrides,
+    ) -> Result<(EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>), Self::Error>
+    where
+        DB: DynDatabase,
+    {
+        // track whether the request has a gas limit set
+        let request_has_gas_limit = request.as_ref().gas_limit().is_some();
+
+        if let Some(requested_gas) = request.as_ref().gas_limit() {
+            let global_gas_cap = self.call_gas_limit();
+            if global_gas_cap != 0 && global_gas_cap < requested_gas {
+                warn!(target: "rpc::eth::call", ?request, ?global_gas_cap, "Capping gas limit to global gas cap");
+                request.as_mut().set_gas_limit(global_gas_cap);
+            }
+        } else {
+            // cap request's gas limit to call gas limit
+            request.as_mut().set_gas_limit(self.call_gas_limit());
+        }
+
+        // Disable block gas limit check to allow executing transactions with higher gas limit (call
+        // gas limit): https://github.com/paradigmxyz/reth/issues/18577
+        evm_env.version_mut().features.remove(evm2::EvmFeatures::BLOCK_GAS_LIMIT_CHECK);
+
+        // Disabled because eth_call is sometimes used with eoa senders
+        // See <https://github.com/paradigmxyz/reth/issues/1959>
+        evm_env.version_mut().features.remove(evm2::EvmFeatures::EIP3607);
+
+        // The basefee should be ignored for eth_call
+        // See:
+        // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
+        evm_env.version_mut().features.remove(evm2::EvmFeatures::BASE_FEE_CHECK);
+
+        // Disable EIP-7825 transaction gas limit to support larger transactions
+        evm_env.version_mut().tx_gas_limit_cap = u64::MAX;
+
+        // Disable additional fee charges, e.g. opstack operator fee charge
+        // See:
+        // <https://github.com/paradigmxyz/reth/issues/18470>
+        evm_env.version_mut().features.remove(evm2::EvmFeatures::FEE_CHARGE);
+
+        evm_env.version_mut().memory_limit = self.evm_memory_limit();
+
+        // set nonce to None so that the correct nonce is chosen by the EVM
+        request.as_mut().take_nonce();
+
+        if let Some(block_overrides) = overrides.block {
+            apply_block_overrides(*block_overrides, db, &mut evm_env);
+        }
+        if let Some(state_overrides) = overrides.state {
+            apply_state_overrides(state_overrides, db)
+                .map_err(EthApiError::from_state_overrides_err)?;
+        }
+
+        let tx_env =
+            self.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut *db))?;
+
+        // lower the basefee to 0 to avoid breaking EVM invariants (basefee < gasprice): <https://github.com/ethereum/go-ethereum/blob/355228b011ef9a85ebc0f21e7196f892038d49f0/internal/ethapi/api.go#L700-L704>
+        let transaction: &RecoveredTxEnvelope = tx_env.borrow().borrow();
+        if transaction.effective_gas_price(None) == 0 {
+            evm_env.block_env_mut().basefee = U256::ZERO;
+        }
+
+        if !request_has_gas_limit {
+            // No gas limit was provided in the request, so we need to cap the transaction gas limit
+            if transaction.effective_gas_price(None) > 0 {
+                // If gas price is specified, cap transaction gas limit with caller allowance
+                trace!(target: "rpc::eth::call", ?request, "Applying gas limit cap with caller allowance");
+                let cap =
+                    self.caller_gas_allowance(BorrowedDatabase::new(&mut *db), &evm_env, &tx_env)?;
+                // ensure we cap gas_limit to the block's
+                request.as_mut().set_gas_limit(cap.min(evm_env.block_env().gas_limit.to::<u64>()));
+            }
+        }
+
+        let tx_env = self.create_txn_env(&evm_env, request, BorrowedDatabase::new(&mut *db))?;
+        Ok((evm_env, tx_env))
+    }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -14,16 +14,19 @@ use alloy_rpc_types_eth::{
     state::{EvmOverrides, StateOverride},
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
-use evm2::evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource};
+use evm2::{
+    ethereum::TransactionExt,
+    evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource},
+};
 use evm2_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use futures::Future;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     cancelled::CancelOnDrop,
-    database::{BorrowedDatabase, StateProviderDatabase},
+    database::StateProviderDatabase,
     execute::{BlockBuilder, BlockExecutorFactory},
-    ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, EvmTypesFor, TxEnvFor, TxResultWithStateFor,
+    ConfigureEvm, Evm, EvmEnv, EvmEnvFor, EvmTypesFor, TxEnvFor, TxResultWithStateFor,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
@@ -32,10 +35,10 @@ use reth_rpc_eth_types::{
     cache::db::{apply_block_overrides, apply_state_overrides, StateProviderTraitObjWrapper},
     error::{AsEthApiError, FromEthApiError},
     simulate::{self, EthSimulateError},
-    EthApiError, StateCacheDb,
+    EthApiError, RpcInvalidTransactionError, StateCacheDb,
 };
 use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
-use std::{borrow::Borrow, fmt};
+use std::fmt;
 use tracing::{trace, warn};
 
 /// Result type for `eth_simulateV1` RPC method.
@@ -188,7 +191,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         let mut evm = this
                             .evm_config()
                             .block_executor_factory()
-                            .evm_with_env(BorrowedDatabase::new(&mut db), evm_env.clone());
+                            .evm_with_env(&mut db, evm_env.clone());
                         evm.set_inspector(inspector);
                         let mut builder =
                             this.evm_config().create_block_builder(evm, evm_env, &parent, ctx);
@@ -215,7 +218,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         let evm = this
                             .evm_config()
                             .block_executor_factory()
-                            .evm_with_env(BorrowedDatabase::new(&mut db), evm_env.clone());
+                            .evm_with_env(&mut db, evm_env.clone());
                         let mut builder =
                             this.evm_config().create_block_builder(evm, evm_env, &parent, ctx);
 
@@ -347,12 +350,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         .map_err(Self::Error::from_eth_err)?;
                     let changes = this
                         .evm_config()
-                        .pre_block_state_changes(
-                            BorrowedDatabase::new(&mut db),
-                            evm_env.clone(),
-                            block.number(),
-                            ctx,
-                        )
+                        .pre_block_state_changes(&mut db, evm_env.clone(), block.number(), ctx)
                         .map_err(|err| EthApiError::EvmCustom(err.to_string()))
                         .map_err(Self::Error::from_eth_err)?;
                     db.commit_source(&changes);
@@ -499,21 +497,18 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             // per-tx cap (2^24 ≈ 16.7M post-Osaka).
             evm_env.version_mut().tx_gas_limit_cap = u64::MAX;
 
-            let tx_env =
-                this.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut db))?;
+            let tx_env = this.create_txn_env(&evm_env, request.clone(), &mut db)?;
             if !request_has_gas_limit &&
                 request_gas_price(request.as_ref(), evm_env.block_base_fee()) > 0
             {
-                let cap =
-                    this.caller_gas_allowance(BorrowedDatabase::new(&mut db), &evm_env, &tx_env)?;
+                let cap = this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
                 // no gas limit was provided in the request, so we need to cap the request's gas
                 // limit
                 request.as_mut().set_gas_limit(cap.min(evm_env.block_env().gas_limit.to::<u64>()));
             }
 
             let inspector = AccessListInspector::new(initial);
-            let tx_env =
-                this.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut db))?;
+            let tx_env = this.create_txn_env(&evm_env, request.clone(), &mut db)?;
 
             let (inspector, result) =
                 this.transact_with_inspector(&mut db, evm_env.clone(), tx_env, inspector)?;
@@ -529,7 +524,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
             // transact again to get the exact gas used
             request.as_mut().set_access_list(access_list.clone());
-            let tx_env = this.create_txn_env(&evm_env, request, BorrowedDatabase::new(&mut db))?;
+            let tx_env = this.create_txn_env(&evm_env, request, &mut db)?;
             let result = this.transact(&mut db, evm_env, tx_env)?;
             let gas_used = result.result.tx_gas_used();
             let error = Self::Error::ensure_success(result.result).err().map(|e| e.to_string());
@@ -565,10 +560,27 @@ pub trait Call:
     /// Returns the max gas limit that the caller can afford given a transaction environment.
     fn caller_gas_allowance(
         &self,
-        db: impl Database<Error: Into<EthApiError>>,
-        evm_env: &EvmEnvFor<Self::Evm>,
+        mut db: impl DynDatabase,
+        _evm_env: &EvmEnvFor<Self::Evm>,
         tx_env: &TxEnvFor<Self::Evm>,
-    ) -> Result<u64, Self::Error>;
+    ) -> Result<u64, Self::Error> {
+        let balance = match db.get_account(&tx_env.caller()) {
+            Ok(account) => account.map(|account| account.balance).unwrap_or_default(),
+            Err(code) => return Err(Self::Error::from_eth_err(EthApiError::from(db.error(code)))),
+        };
+        let value = tx_env.value();
+        let balance = balance.checked_sub(value).ok_or_else(|| {
+            EthApiError::from(RpcInvalidTransactionError::InsufficientFunds {
+                cost: value,
+                balance,
+            })
+        })?;
+
+        Ok(balance
+            .checked_div(U256::from(tx_env.effective_gas_price(None)))
+            .unwrap_or_default()
+            .saturating_to())
+    }
 
     /// Executes the closure with the state that corresponds to the given [`BlockId`].
     fn with_state_at_block<F, R>(
@@ -586,7 +598,7 @@ pub trait Call:
         })
     }
 
-    /// Executes the `TxEnv` against the given [Database] without committing state
+    /// Executes the `TxEnv` against the given [`DynDatabase`] without committing state
     /// changes.
     fn transact<DB>(
         &self,
@@ -598,12 +610,12 @@ pub trait Call:
         DB: DynDatabase + fmt::Debug,
     {
         let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
-        let res = evm.transact(tx_env.borrow()).map_err(Self::Error::from_evm_err)?;
+        let res = evm.transact(&tx_env).map_err(Self::Error::from_evm_err)?;
 
         Ok(res)
     }
 
-    /// Executes the [`reth_evm::EvmEnv`] against the given [Database] without committing state
+    /// Executes the [`reth_evm::EvmEnv`] against the given [`DynDatabase`] without committing state
     /// changes.
     fn transact_with_inspector<DB, I>(
         &self,
@@ -617,9 +629,8 @@ pub trait Call:
         I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
     {
         let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
-        let res = evm
-            .transact_with_inspector(tx_env.borrow(), inspector)
-            .map_err(Self::Error::from_evm_err)?;
+        let res =
+            evm.transact_with_inspector(&tx_env, inspector).map_err(Self::Error::from_evm_err)?;
 
         Ok(res)
     }
@@ -770,12 +781,7 @@ pub trait Call:
                     .map_err(Self::Error::from_eth_err)?;
                 let changes = this
                     .evm_config()
-                    .pre_block_state_changes(
-                        BorrowedDatabase::new(&mut db),
-                        evm_env.clone(),
-                        block.number(),
-                        ctx,
-                    )
+                    .pre_block_state_changes(&mut db, evm_env.clone(), block.number(), ctx)
                     .map_err(|err| EthApiError::EvmCustom(err.to_string()))
                     .map_err(Self::Error::from_eth_err)?;
                 db.commit_source(&changes);
@@ -839,15 +845,15 @@ pub trait Call:
         &self,
         evm_env: &EvmEnvFor<Self::Evm>,
         mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
-        mut db: impl Database<Error: Into<EthApiError>>,
+        mut db: impl DynDatabase,
     ) -> Result<TxEnvFor<Self::Evm>, Self::Error> {
         if request.as_ref().nonce().is_none() {
-            let nonce = db
-                .get_account(&request.as_ref().from().unwrap_or_default())
-                .map_err(Into::into)
-                .map_err(Self::Error::from_eth_err)?
-                .map(|account| account.nonce)
-                .unwrap_or_default();
+            let nonce = match db.get_account(&request.as_ref().from().unwrap_or_default()) {
+                Ok(account) => account.map(|account| account.nonce).unwrap_or_default(),
+                Err(code) => {
+                    return Err(Self::Error::from_eth_err(EthApiError::from(db.error(code))))
+                }
+            };
             request.as_mut().set_nonce(nonce);
         }
 
@@ -927,8 +933,7 @@ pub trait Call:
         }
 
         let gas_price = request_gas_price(request.as_ref(), evm_env.block_base_fee());
-        let tx_env =
-            self.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut *db))?;
+        let tx_env = self.create_txn_env(&evm_env, request.clone(), &mut *db)?;
 
         // lower the basefee to 0 to avoid breaking EVM invariants (basefee < gasprice): <https://github.com/ethereum/go-ethereum/blob/355228b011ef9a85ebc0f21e7196f892038d49f0/internal/ethapi/api.go#L700-L704>
         if gas_price == 0 {
@@ -940,14 +945,13 @@ pub trait Call:
             if gas_price > 0 {
                 // If gas price is specified, cap transaction gas limit with caller allowance
                 trace!(target: "rpc::eth::call", ?request, "Applying gas limit cap with caller allowance");
-                let cap =
-                    self.caller_gas_allowance(BorrowedDatabase::new(&mut *db), &evm_env, &tx_env)?;
+                let cap = self.caller_gas_allowance(&mut *db, &evm_env, &tx_env)?;
                 // ensure we cap gas_limit to the block's
                 request.as_mut().set_gas_limit(cap.min(evm_env.block_env().gas_limit.to::<u64>()));
             }
         }
 
-        let tx_env = self.create_txn_env(&evm_env, request, BorrowedDatabase::new(&mut *db))?;
+        let tx_env = self.create_txn_env(&evm_env, request, &mut *db)?;
         Ok((evm_env, tx_env))
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -26,7 +26,7 @@ use reth_evm::{
     cancelled::CancelOnDrop,
     database::StateProviderDatabase,
     execute::{BlockBuilder, BlockExecutorFactory},
-    ConfigureEvm, Evm, EvmEnv, EvmEnvFor, EvmTypesFor, TxEnvFor, TxResultWithStateFor,
+    ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, EvmTypesFor, TxEnvFor, TxResultWithStateFor,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
@@ -560,14 +560,16 @@ pub trait Call:
     /// Returns the max gas limit that the caller can afford given a transaction environment.
     fn caller_gas_allowance(
         &self,
-        mut db: impl DynDatabase,
+        mut db: impl Database<Error: Into<EthApiError>>,
         _evm_env: &EvmEnvFor<Self::Evm>,
         tx_env: &TxEnvFor<Self::Evm>,
     ) -> Result<u64, Self::Error> {
-        let balance = match db.get_account(&tx_env.caller()) {
-            Ok(account) => account.map(|account| account.balance).unwrap_or_default(),
-            Err(code) => return Err(Self::Error::from_eth_err(EthApiError::from(db.error(code)))),
-        };
+        let balance = db
+            .get_account(&tx_env.caller())
+            .map_err(Into::into)
+            .map_err(Self::Error::from_eth_err)?
+            .map(|account| account.balance)
+            .unwrap_or_default();
         let value = tx_env.value();
         let balance = balance.checked_sub(value).ok_or_else(|| {
             EthApiError::from(RpcInvalidTransactionError::InsufficientFunds {
@@ -598,7 +600,7 @@ pub trait Call:
         })
     }
 
-    /// Executes the `TxEnv` against the given [`DynDatabase`] without committing state
+    /// Executes the `TxEnv` against the given [`Database`] without committing state
     /// changes.
     fn transact<DB>(
         &self,
@@ -607,15 +609,15 @@ pub trait Call:
         tx_env: TxEnvFor<Self::Evm>,
     ) -> Result<TxResultWithStateFor<Self::Evm>, Self::Error>
     where
-        DB: DynDatabase + fmt::Debug,
+        DB: Database + fmt::Debug,
     {
-        let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
+        let mut evm = self.evm_config().block_executor_factory().evm_with_database(db, evm_env);
         let res = evm.transact(&tx_env).map_err(Self::Error::from_evm_err)?;
 
         Ok(res)
     }
 
-    /// Executes the [`reth_evm::EvmEnv`] against the given [`DynDatabase`] without committing state
+    /// Executes the [`reth_evm::EvmEnv`] against the given [`Database`] without committing state
     /// changes.
     fn transact_with_inspector<DB, I>(
         &self,
@@ -625,10 +627,10 @@ pub trait Call:
         inspector: I,
     ) -> Result<(I, TxResultWithStateFor<Self::Evm>), Self::Error>
     where
-        DB: DynDatabase + fmt::Debug,
+        DB: Database + fmt::Debug,
         I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
     {
-        let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
+        let mut evm = self.evm_config().block_executor_factory().evm_with_database(db, evm_env);
         let res =
             evm.transact_with_inspector(&tx_env, inspector).map_err(Self::Error::from_evm_err)?;
 
@@ -820,7 +822,7 @@ pub trait Call:
         target_tx_hash: B256,
     ) -> Result<usize, Self::Error>
     where
-        DB: DynDatabase + StateChangeSink<Error = core::convert::Infallible> + core::fmt::Debug,
+        DB: Database + StateChangeSink<Error = core::convert::Infallible> + core::fmt::Debug,
         I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
         let mut index = 0;
@@ -845,15 +847,15 @@ pub trait Call:
         &self,
         evm_env: &EvmEnvFor<Self::Evm>,
         mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
-        mut db: impl DynDatabase,
+        mut db: impl Database<Error: Into<EthApiError>>,
     ) -> Result<TxEnvFor<Self::Evm>, Self::Error> {
         if request.as_ref().nonce().is_none() {
-            let nonce = match db.get_account(&request.as_ref().from().unwrap_or_default()) {
-                Ok(account) => account.map(|account| account.nonce).unwrap_or_default(),
-                Err(code) => {
-                    return Err(Self::Error::from_eth_err(EthApiError::from(db.error(code))))
-                }
-            };
+            let nonce = db
+                .get_account(&request.as_ref().from().unwrap_or_default())
+                .map_err(Into::into)
+                .map_err(Self::Error::from_eth_err)?
+                .map(|account| account.nonce)
+                .unwrap_or_default();
             request.as_mut().set_nonce(nonce);
         }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/config.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/config.rs
@@ -163,8 +163,8 @@ where
     }
 }
 
-fn evm_to_precompiles_map(spec_id: evm2::SpecId) -> BTreeMap<String, Address> {
-    let precompiles = evm2::Precompiles::<evm2::BaseEvmTypes>::base(spec_id);
+fn evm_to_precompiles_map(spec_id: impl Into<evm2::SpecId>) -> BTreeMap<String, Address> {
+    let precompiles = evm2::Precompiles::<evm2::BaseEvmTypes>::base(spec_id.into());
     let precompiles = precompiles.as_map();
     precompiles
         .addresses()

--- a/crates/rpc/rpc-eth-api/src/helpers/config.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/config.rs
@@ -6,10 +6,11 @@ use alloy_eips::{
     eip7910::{EthConfig, EthForkConfig, SystemContract},
 };
 use alloy_primitives::Address;
+use evm2::evm::EmptyDB;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks, Head};
 use reth_errors::{ProviderError, RethError};
-use reth_evm::{ConfigureEvm, EvmEnv};
+use reth_evm::{ConfigureEvm, Evm};
 use reth_node_api::NodePrimitives;
 use reth_primitives_traits::header::HeaderMut;
 use reth_rpc_eth_types::EthApiError;
@@ -94,7 +95,7 @@ where
             .into_header();
 
         let current_precompiles = evm_to_precompiles_map(
-            self.evm_config.evm_env(&latest).map_err(RethError::other)?.spec_id(),
+            self.evm_config.evm_for_block(EmptyDB::default(), &latest).map_err(RethError::other)?,
         );
 
         let mut fork_timestamps =
@@ -126,7 +127,9 @@ where
                 header
             };
             let next_precompiles = evm_to_precompiles_map(
-                self.evm_config.evm_env(&fake_header).map_err(RethError::other)?.spec_id(),
+                self.evm_config
+                    .evm_for_block(EmptyDB::default(), &fake_header)
+                    .map_err(RethError::other)?,
             );
 
             config.next = Some(self.build_fork_config_at(next_fork_timestamp, next_precompiles));
@@ -142,7 +145,9 @@ where
             header
         };
         let last_precompiles = evm_to_precompiles_map(
-            self.evm_config.evm_env(&fake_header).map_err(RethError::other)?.spec_id(),
+            self.evm_config
+                .evm_for_block(EmptyDB::default(), &fake_header)
+                .map_err(RethError::other)?,
         );
 
         config.last = Some(self.build_fork_config_at(last_fork_timestamp, last_precompiles));
@@ -163,11 +168,6 @@ where
     }
 }
 
-fn evm_to_precompiles_map(spec_id: impl Into<evm2::SpecId>) -> BTreeMap<String, Address> {
-    let precompiles = evm2::Precompiles::<evm2::BaseEvmTypes>::base(spec_id.into());
-    let precompiles = precompiles.as_map();
-    precompiles
-        .addresses()
-        .filter_map(|address| Some((precompiles.get(&address)?.id().name().to_string(), address)))
-        .collect()
+fn evm_to_precompiles_map(evm: impl Evm) -> BTreeMap<String, Address> {
+    evm.precompile_ids().into_iter().map(|(address, id)| (id.name().to_string(), address)).collect()
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/config.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/config.rs
@@ -1,8 +1,20 @@
 //! Loads chain configuration.
 
-use alloy_eips::eip7910::EthConfig;
+use alloy_consensus::BlockHeader;
+use alloy_eips::{
+    eip7840::BlobParams,
+    eip7910::{EthConfig, EthForkConfig, SystemContract},
+};
+use alloy_primitives::Address;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks, Head};
+use reth_errors::{ProviderError, RethError};
+use reth_evm::{ConfigureEvm, EvmEnv};
+use reth_node_api::NodePrimitives;
+use reth_primitives_traits::header::HeaderMut;
 use reth_rpc_eth_types::EthApiError;
+use reth_storage_api::BlockReaderIdExt;
+use std::collections::BTreeMap;
 
 /// RPC endpoint support for [EIP-7910](https://eips.ethereum.org/EIPS/eip-7910)
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
@@ -18,20 +30,10 @@ pub trait EthConfigApi {
 /// Ref: <https://eips.ethereum.org/EIPS/eip-7910>
 #[derive(Debug, Clone)]
 pub struct EthConfigHandler<Provider, Evm> {
-    #[expect(dead_code)]
     provider: Provider,
-    #[expect(dead_code)]
     evm_config: Evm,
 }
 
-impl<Provider, Evm> EthConfigHandler<Provider, Evm> {
-    /// Creates a new [`EthConfigHandler`].
-    pub const fn new(provider: Provider, evm_config: Evm) -> Self {
-        Self { provider, evm_config }
-    }
-}
-
-#[cfg(any())]
 impl<Provider, Evm> EthConfigHandler<Provider, Evm>
 where
     Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>
@@ -39,6 +41,11 @@ where
         + 'static,
     Evm: ConfigureEvm<Primitives: NodePrimitives<BlockHeader = Provider::Header>> + 'static,
 {
+    /// Creates a new [`EthConfigHandler`].
+    pub const fn new(provider: Provider, evm_config: Evm) -> Self {
+        Self { provider, evm_config }
+    }
+
     /// Returns fork config for specific timestamp.
     fn build_fork_config_at(
         &self,
@@ -87,7 +94,7 @@ where
             .into_header();
 
         let current_precompiles = evm_to_precompiles_map(
-            self.evm_config.evm_for_block(EmptyDB::default(), &latest).map_err(RethError::other)?,
+            self.evm_config.evm_env(&latest).map_err(RethError::other)?.spec_id(),
         );
 
         let mut fork_timestamps =
@@ -119,9 +126,7 @@ where
                 header
             };
             let next_precompiles = evm_to_precompiles_map(
-                self.evm_config
-                    .evm_for_block(EmptyDB::default(), &fake_header)
-                    .map_err(RethError::other)?,
+                self.evm_config.evm_env(&fake_header).map_err(RethError::other)?.spec_id(),
             );
 
             config.next = Some(self.build_fork_config_at(next_fork_timestamp, next_precompiles));
@@ -137,9 +142,7 @@ where
             header
         };
         let last_precompiles = evm_to_precompiles_map(
-            self.evm_config
-                .evm_for_block(EmptyDB::default(), &fake_header)
-                .map_err(RethError::other)?,
+            self.evm_config.evm_env(&fake_header).map_err(RethError::other)?.spec_id(),
         );
 
         config.last = Some(self.build_fork_config_at(last_fork_timestamp, last_precompiles));
@@ -150,24 +153,21 @@ where
 
 impl<Provider, Evm> EthConfigApiServer for EthConfigHandler<Provider, Evm>
 where
-    Provider: Send + Sync + 'static,
-    Evm: Send + Sync + 'static,
+    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks>
+        + BlockReaderIdExt<Header: HeaderMut>
+        + 'static,
+    Evm: ConfigureEvm<Primitives: NodePrimitives<BlockHeader = Provider::Header>> + 'static,
 {
     fn config(&self) -> RpcResult<EthConfig> {
-        Err(EthApiError::Unsupported("eth_config is unsupported by the active EVM execution path")
-            .into())
+        Ok(self.config().map_err(EthApiError::from)?)
     }
 }
 
-#[cfg(any())]
-fn evm_to_precompiles_map(
-    evm: impl Evm<Precompiles = PrecompilesMap>,
-) -> BTreeMap<String, Address> {
-    let precompiles = evm.precompiles();
+fn evm_to_precompiles_map(spec_id: evm2::SpecId) -> BTreeMap<String, Address> {
+    let precompiles = evm2::Precompiles::<evm2::BaseEvmTypes>::base(spec_id);
+    let precompiles = precompiles.as_map();
     precompiles
         .addresses()
-        .filter_map(|address| {
-            Some((precompiles.get(address)?.precompile_id().name().to_string(), *address))
-        })
+        .filter_map(|address| Some((precompiles.get(&address)?.id().name().to_string(), address)))
         .collect()
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -1,28 +1,268 @@
 //! Estimate gas needed implementation
 
 use super::{Call, LoadPendingBlock};
-use crate::FromEthApiError;
-use alloy_primitives::U256;
+use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{TxKind, KECCAK256_EMPTY, U256};
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockId};
+use evm2::{ethereum::RecoveredTxEnvelope, evm::DynDatabase, EvmFeatures, TxResult};
 use futures::Future;
-use reth_evm::EvmEnvFor;
+use reth_chainspec::MIN_TRANSACTION_GAS;
+use reth_evm::{database::BorrowedDatabase, EvmEnv, EvmEnvFor};
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
-use reth_rpc_eth_types::EthApiError;
+use reth_rpc_eth_types::{
+    cache::db::{apply_block_overrides, apply_state_overrides, StateProviderTraitObjWrapper},
+    error::api::{FromEvmHalt, FromRevert},
+    EthApiError, RpcInvalidTransactionError,
+};
+use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO};
+use reth_storage_api::{StateProvider, StateProviderBox};
+use std::borrow::Borrow;
+use tracing::trace;
 
-/// Gas execution estimates.
+/// Gas execution estimates
 pub trait EstimateCall: Call {
     /// Estimates the gas usage of the `request` with the state.
+    ///
+    /// This will execute the [`RpcTxReq`] and find the best gas limit via binary search.
+    ///
+    /// ## EVM settings
+    ///
+    /// This modifies certain EVM settings to mirror geth's `SkipAccountChecks` when transacting requests, see also: <https://github.com/ethereum/go-ethereum/blob/380688c636a654becc8f114438c2a5d93d2db032/core/state_transition.go#L145-L148>:
+    ///
+    ///  - `disable_eip3607` is set to `true`
+    ///  - `disable_base_fee` is set to `true`
+    ///  - `disable_fee_charge` is set to `true`
+    ///  - `nonce` is set to `None`
     fn estimate_gas_with<S>(
         &self,
-        evm_env: EvmEnvFor<Self::Evm>,
-        request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        mut evm_env: EvmEnvFor<Self::Evm>,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
         state: S,
         overrides: EvmOverrides,
-    ) -> Result<U256, Self::Error> {
-        let _ = (evm_env, request, state, overrides);
-        Err(Self::Error::from_eth_err(EthApiError::Unsupported(
-            "eth_estimateGas is unsupported by the active EVM execution path",
-        )))
+    ) -> Result<U256, Self::Error>
+    where
+        S: StateProvider + Send + 'static,
+    {
+        // Disabled because eth_estimateGas is sometimes used with eoa senders
+        // See <https://github.com/paradigmxyz/reth/issues/1959>
+        evm_env.version_mut().features.remove(EvmFeatures::EIP3607);
+
+        // The basefee should be ignored for eth_estimateGas and similar
+        // See:
+        // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
+        evm_env.version_mut().features.remove(EvmFeatures::BASE_FEE_CHECK);
+
+        // Disable additional fee charges (e.g. L2 operator fees) for gas estimation,
+        // consistent with `prepare_call_env` for `eth_call`.
+        evm_env.version_mut().features.remove(EvmFeatures::FEE_CHARGE);
+
+        // set nonce to None so that the correct nonce is chosen by the EVM
+        request.as_mut().take_nonce();
+
+        // Keep a copy of gas related request values
+        let tx_request_gas_limit = request.as_ref().gas_limit();
+        let tx_request_gas_price = request.as_ref().gas_price();
+
+        // Configure the evm env
+        let state: StateProviderBox = Box::new(state);
+        let mut db = evm2::evm::CacheDB::new(evm2::evm::Db::new(
+            reth_evm::database::StateProviderDatabase::new(StateProviderTraitObjWrapper(state)),
+        ));
+
+        // Apply any block overrides before deriving block-derived limits and the tx env so
+        // overrides for `gasLimit`, `baseFee` and `blobBaseFee` are visible to estimation.
+        // Mirrors geth's behavior, see:
+        // <https://github.com/ethereum/go-ethereum/pull/30695>
+        if let Some(block_overrides) = overrides.block {
+            apply_block_overrides(*block_overrides, &mut db, &mut evm_env);
+        }
+
+        // Apply any state overrides if specified.
+        if let Some(state_override) = overrides.state {
+            apply_state_overrides(state_override, &mut db).map_err(Self::Error::from_eth_err)?;
+        }
+
+        // the gas limit of the corresponding block
+        let block_gas_limit = evm_env.block_env().gas_limit.to::<u64>();
+        // If EIP-8037 is enabled, the transaction gas limit cap is not applicable
+        let max_gas_limit = if evm_env.version().feature(EvmFeatures::EIP8037) {
+            block_gas_limit
+        } else {
+            evm_env.version().tx_gas_limit_cap.min(block_gas_limit)
+        };
+
+        // Determine the highest possible gas limit, considering both the request's specified limit
+        // and the block's limit.
+        let mut highest_gas_limit = tx_request_gas_limit
+            .map(|tx_gas_limit| tx_gas_limit.min(max_gas_limit))
+            .unwrap_or(max_gas_limit);
+
+        // Check if this is a basic transfer (no input data to account with no code)
+        let is_basic_transfer = if request.as_ref().input().is_none_or(|input| input.is_empty()) &&
+            let Some(TxKind::Call(to)) = request.as_ref().kind()
+        {
+            match db.get_account(&to) {
+                Ok(Some(account)) => account.code_hash == KECCAK256_EMPTY,
+                _ => true,
+            }
+        } else {
+            false
+        };
+
+        let tx_env =
+            self.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut db))?;
+
+        // Check funds of the sender (only useful to check if transaction gas price is more than 0).
+        //
+        // The caller allowance is check by doing `(account.balance - tx.value) / tx.gas_price`
+        let transaction: &RecoveredTxEnvelope = tx_env.borrow().borrow();
+        if transaction.effective_gas_price(None) > 0 {
+            let allowance =
+                self.caller_gas_allowance(BorrowedDatabase::new(&mut db), &evm_env, &tx_env)?;
+            highest_gas_limit = highest_gas_limit.min(allowance);
+        }
+
+        let mut execute = |gas_limit| {
+            let mut request = request.clone();
+            request.as_mut().set_gas_limit(gas_limit);
+            let tx_env = self.create_txn_env(&evm_env, request, BorrowedDatabase::new(&mut db))?;
+            self.transact(&mut db, evm_env.clone(), tx_env).map(|res| res.result)
+        };
+
+        // For basic transfers, try using minimum gas before running full binary search
+        if is_basic_transfer &&
+            let Ok(res) = execute(MIN_TRANSACTION_GAS) &&
+            res.status
+        {
+            return Ok(U256::from(MIN_TRANSACTION_GAS))
+        }
+
+        trace!(target: "rpc::eth::estimate", ?request, gas_limit = highest_gas_limit, is_basic_transfer, "Starting gas estimation");
+
+        // Execute the transaction with the highest possible gas limit.
+        let mut res = match execute(highest_gas_limit) {
+            // Handle the exceptional case where the transaction initialization uses too much
+            // gas. If the gas price or gas limit was specified in the request,
+            // retry the transaction with the block's gas limit to determine if
+            // the failure was due to insufficient gas.
+            Err(err)
+                if err.is_gas_too_high() &&
+                    (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
+            {
+                let retry = execute(max_gas_limit)?;
+                return map_out_of_gas_result::<Self::Error>(retry, highest_gas_limit)
+            }
+            Err(err) if err.is_gas_too_low() => {
+                // This failed because the configured gas cost of the tx was lower than what
+                // actually consumed by the tx This can happen if the
+                // request provided fee values manually and the resulting gas cost exceeds the
+                // sender's allowance, so we return the appropriate error here
+                return Err(RpcInvalidTransactionError::GasRequiredExceedsAllowance {
+                    gas_limit: highest_gas_limit,
+                }
+                .into_eth_err());
+            }
+            // Propagate other results (successful or other errors).
+            ethres => ethres?,
+        };
+
+        let gas_refund = if res.status {
+            res.refunded
+        } else if res.stop.is_revert() {
+            // if price or limit was included in the request then we can execute the request
+            // again with the block's gas limit to check if revert is gas related or not
+            return if tx_request_gas_limit.is_some() || tx_request_gas_price.is_some() {
+                let retry = execute(max_gas_limit)?;
+                map_out_of_gas_result::<Self::Error>(retry, highest_gas_limit)
+            } else {
+                // the transaction did revert
+                Err(Self::Error::from_revert(res.output))
+            }
+        } else {
+            // here we don't check for invalid opcode because already executed with highest gas
+            // limit
+            return Err(Self::Error::from_evm_halt(res.stop, highest_gas_limit))
+        };
+
+        // At this point we know the call succeeded but want to find the _best_ (lowest) gas the
+        // transaction succeeds with. We find this by doing a binary search over the possible range.
+
+        // NOTE: this is the gas the transaction used, which is less than the
+        // transaction requires to succeed.
+        let mut gas_used = res.tx_gas_used();
+        // the lowest value is capped by the gas used by the unconstrained transaction
+        let mut lowest_gas_limit = gas_used.saturating_sub(1);
+
+        // As stated in Geth, there is a good chance that the transaction will pass if we set the
+        // gas limit to the execution gas used plus the gas refund, so we check this first
+        // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L135
+        //
+        // Calculate the optimistic gas limit by adding gas used and gas refund,
+        // then applying a 64/63 multiplier to account for gas forwarding rules.
+        let optimistic_gas_limit = (gas_used + gas_refund + CALL_STIPEND_GAS) * 64 / 63;
+        if optimistic_gas_limit < highest_gas_limit {
+            // Re-execute the transaction with the new gas limit and update the result and
+            // environment.
+            res = execute(optimistic_gas_limit)?;
+
+            // Update the gas used based on the new result.
+            gas_used = res.tx_gas_used();
+            // Update the gas limit estimates (highest and lowest) based on the execution result.
+            update_estimated_gas_range(
+                res,
+                optimistic_gas_limit,
+                &mut highest_gas_limit,
+                &mut lowest_gas_limit,
+            )?;
+        };
+
+        // Pick a point that's close to the estimated gas
+        let mut mid_gas_limit = std::cmp::min(
+            gas_used * 3,
+            ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64,
+        );
+
+        trace!(target: "rpc::eth::estimate", ?highest_gas_limit, ?lowest_gas_limit, ?mid_gas_limit, "Starting binary search for gas");
+
+        // Binary search narrows the range to find the minimum gas limit needed for the transaction
+        // to succeed.
+        while lowest_gas_limit + 1 < highest_gas_limit {
+            // An estimation error is allowed once the current gas limit range used in the binary
+            // search is small enough (less than 1.5% of the highest gas limit)
+            // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L152
+            let ratio = (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64);
+            if ratio < ESTIMATE_GAS_ERROR_RATIO {
+                break
+            };
+
+            // Execute transaction and handle potential gas errors, adjusting limits accordingly.
+            match execute(mid_gas_limit) {
+                Err(err) if err.is_gas_too_high() => {
+                    // Decrease the highest gas limit if gas is too high
+                    highest_gas_limit = mid_gas_limit;
+                }
+                Err(err) if err.is_gas_too_low() => {
+                    // Increase the lowest gas limit if gas is too low
+                    lowest_gas_limit = mid_gas_limit;
+                }
+                // Handle other cases, including successful transactions.
+                ethres => {
+                    // Update the estimated gas range based on the execution result.
+                    update_estimated_gas_range(
+                        ethres?,
+                        mid_gas_limit,
+                        &mut highest_gas_limit,
+                        &mut lowest_gas_limit,
+                    )?;
+                }
+            }
+
+            // New midpoint
+            mid_gas_limit = ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64;
+        }
+
+        Ok(U256::from(highest_gas_limit))
     }
 
     /// Estimate gas needed for execution of the `request` at the [`BlockId`].
@@ -35,11 +275,60 @@ pub trait EstimateCall: Call {
     where
         Self: LoadPendingBlock,
     {
-        let _ = (request, at, overrides);
         async move {
-            Err(Self::Error::from_eth_err(EthApiError::Unsupported(
-                "eth_estimateGas is unsupported by the active EVM execution path",
-            )))
+            let (evm_env, at) = self.evm_env_at(at).await?;
+
+            self.spawn_blocking_io_fut(async move |this| {
+                let state = this.state_at_block_id(at).await?;
+                EstimateCall::estimate_gas_with(&this, evm_env, request, state, overrides)
+            })
+            .await
         }
     }
+}
+
+fn map_out_of_gas_result<Error>(result: TxResult, requested_gas_limit: u64) -> Result<U256, Error>
+where
+    Error: FromEvmHalt<evm2::interpreter::InstrStop> + FromRevert + FromEthApiError,
+{
+    if result.status {
+        // Transaction succeeded by manually increasing the gas limit,
+        // which means the caller lacks funds to pay for the tx
+        Err(RpcInvalidTransactionError::BasicOutOfGas(requested_gas_limit).into_eth_err())
+    } else if result.stop.is_revert() {
+        // reverted again after bumping the limit
+        Err(Error::from_revert(result.output))
+    } else {
+        Err(Error::from_evm_halt(result.stop, requested_gas_limit))
+    }
+}
+
+/// Updates the highest and lowest gas limits for binary search based on the execution result.
+///
+/// This function refines the gas limit estimates used in a binary search to find the optimal
+/// gas limit for a transaction. It adjusts the highest or lowest gas limits depending on
+/// whether the execution succeeded, reverted, or halted due to specific reasons.
+#[inline]
+pub fn update_estimated_gas_range(
+    result: TxResult,
+    tx_gas_limit: u64,
+    highest_gas_limit: &mut u64,
+    lowest_gas_limit: &mut u64,
+) -> Result<(), EthApiError> {
+    if result.status {
+        // Cap the highest gas limit with the succeeding gas limit.
+        *highest_gas_limit = tx_gas_limit;
+    } else {
+        // We know that transaction succeeded with a higher gas limit before, so any failure
+        // means that we need to increase it.
+        //
+        // We are ignoring all halts here, and not just OOG errors because there are cases when
+        // non-OOG halt might flag insufficient gas limit as well.
+        //
+        // Common usage of invalid opcode in OpenZeppelin:
+        // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/94697be8a3f0dfcd95dfb13ffbd39b5973f5c65d/contracts/metatx/ERC2771Forwarder.sol#L360-L367>
+        *lowest_gas_limit = tx_gas_limit;
+    }
+
+    Ok(())
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -1,11 +1,11 @@
 //! Estimate gas needed implementation
 
-use super::{Call, LoadPendingBlock};
+use super::{call::request_gas_price, Call, LoadPendingBlock};
 use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{TxKind, KECCAK256_EMPTY, U256};
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockId};
-use evm2::{ethereum::RecoveredTxEnvelope, evm::DynDatabase, EvmFeatures, TxResult};
+use evm2::{evm::DynDatabase, EvmFeatures, TxResult};
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_evm::{database::BorrowedDatabase, EvmEnv, EvmEnvFor};
@@ -17,7 +17,6 @@ use reth_rpc_eth_types::{
 };
 use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO};
 use reth_storage_api::{StateProvider, StateProviderBox};
-use std::borrow::Borrow;
 use tracing::trace;
 
 /// Gas execution estimates
@@ -116,8 +115,7 @@ pub trait EstimateCall: Call {
         // Check funds of the sender (only useful to check if transaction gas price is more than 0).
         //
         // The caller allowance is check by doing `(account.balance - tx.value) / tx.gas_price`
-        let transaction: &RecoveredTxEnvelope = tx_env.borrow().borrow();
-        if transaction.effective_gas_price(None) > 0 {
+        if request_gas_price(request.as_ref(), evm_env.block_base_fee()) > 0 {
             let allowance =
                 self.caller_gas_allowance(BorrowedDatabase::new(&mut db), &evm_env, &tx_env)?;
             highest_gas_limit = highest_gas_limit.min(allowance);
@@ -151,7 +149,7 @@ pub trait EstimateCall: Call {
                     (tx_request_gas_limit.is_some() || tx_request_gas_price.is_some()) =>
             {
                 let retry = execute(max_gas_limit)?;
-                return map_out_of_gas_result::<Self::Error>(retry, highest_gas_limit)
+                return map_out_of_gas_result::<Self::Error, _>(retry, highest_gas_limit)
             }
             Err(err) if err.is_gas_too_low() => {
                 // This failed because the configured gas cost of the tx was lower than what
@@ -174,7 +172,7 @@ pub trait EstimateCall: Call {
             // again with the block's gas limit to check if revert is gas related or not
             return if tx_request_gas_limit.is_some() || tx_request_gas_price.is_some() {
                 let retry = execute(max_gas_limit)?;
-                map_out_of_gas_result::<Self::Error>(retry, highest_gas_limit)
+                map_out_of_gas_result::<Self::Error, _>(retry, highest_gas_limit)
             } else {
                 // the transaction did revert
                 Err(Self::Error::from_revert(res.output))
@@ -287,9 +285,13 @@ pub trait EstimateCall: Call {
     }
 }
 
-fn map_out_of_gas_result<Error>(result: TxResult, requested_gas_limit: u64) -> Result<U256, Error>
+fn map_out_of_gas_result<Error, EvmTypes>(
+    result: TxResult<EvmTypes>,
+    requested_gas_limit: u64,
+) -> Result<U256, Error>
 where
     Error: FromEvmHalt<evm2::interpreter::InstrStop> + FromRevert + FromEthApiError,
+    EvmTypes: evm2::EvmTypes,
 {
     if result.status {
         // Transaction succeeded by manually increasing the gas limit,
@@ -309,8 +311,8 @@ where
 /// gas limit for a transaction. It adjusts the highest or lowest gas limits depending on
 /// whether the execution succeeded, reverted, or halted due to specific reasons.
 #[inline]
-pub fn update_estimated_gas_range(
-    result: TxResult,
+pub fn update_estimated_gas_range<EvmTypes: evm2::EvmTypes>(
+    result: TxResult<EvmTypes>,
     tx_gas_limit: u64,
     highest_gas_limit: &mut u64,
     lowest_gas_limit: &mut u64,

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_eth::{state::EvmOverrides, BlockId};
 use evm2::{evm::DynDatabase, EvmFeatures, TxResult};
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
-use reth_evm::{database::BorrowedDatabase, EvmEnv, EvmEnvFor};
+use reth_evm::{EvmEnv, EvmEnvFor};
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
     cache::db::{apply_block_overrides, apply_state_overrides, StateProviderTraitObjWrapper},
@@ -109,22 +109,20 @@ pub trait EstimateCall: Call {
             false
         };
 
-        let tx_env =
-            self.create_txn_env(&evm_env, request.clone(), BorrowedDatabase::new(&mut db))?;
+        let tx_env = self.create_txn_env(&evm_env, request.clone(), &mut db)?;
 
         // Check funds of the sender (only useful to check if transaction gas price is more than 0).
         //
         // The caller allowance is check by doing `(account.balance - tx.value) / tx.gas_price`
         if request_gas_price(request.as_ref(), evm_env.block_base_fee()) > 0 {
-            let allowance =
-                self.caller_gas_allowance(BorrowedDatabase::new(&mut db), &evm_env, &tx_env)?;
+            let allowance = self.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
             highest_gas_limit = highest_gas_limit.min(allowance);
         }
 
         let mut execute = |gas_limit| {
             let mut request = request.clone();
             request.as_mut().set_gas_limit(gas_limit);
-            let tx_env = self.create_txn_env(&evm_env, request, BorrowedDatabase::new(&mut db))?;
+            let tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
             self.transact(&mut db, evm_env.clone(), tx_env).map(|res| res.result)
         };
 

--- a/crates/rpc/rpc-eth-api/src/helpers/mod.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/mod.rs
@@ -41,9 +41,7 @@ pub use signer::EthSigner;
 pub use spec::EthApiSpec;
 pub use state::{EthState, LoadState};
 pub use subscriptions::EthSubscriptions;
-pub use trace::{
-    Trace, TraceBlockEnv, TraceEvmInstance, TraceStateProviderDatabase, TraceTxEnvelope, TracingCtx,
-};
+pub use trace::Trace;
 pub use transaction::{EthTransactions, LoadTransaction};
 
 use crate::FullEthApiTypes;

--- a/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/pending_block.rs
@@ -3,24 +3,40 @@
 
 use super::SpawnBlocking;
 use crate::{EthApiTypes, FromEthApiError, FromEvmError, RpcNodeCore};
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{BlockHeader, Transaction};
+use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockNumberOrTag, BlockOverrides};
 use futures::Future;
-use reth_errors::RethError;
-use reth_evm::{ConfigureEvm, EvmEnvFor, NextBlockEnvAttributes};
-use reth_primitives_traits::{HeaderTy, SealedHeader};
+use reth_chain_state::{BlockState, ExecutedBlock};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError, RethError};
+use reth_evm::{
+    database::StateProviderDatabase,
+    execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionOutput},
+    ConfigureEvm, EvmEnv, EvmEnvFor, NextBlockEnvAttributes,
+};
+use reth_primitives_traits::{transaction::error::InvalidTransactionError, HeaderTy, SealedHeader};
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_types::{
     block::BlockAndReceipts, builder::config::PendingBlockKind, EthApiError, PendingBlock,
     PendingBlockEnv, PendingBlockEnvOrigin,
 };
 use reth_storage_api::{
-    BlockReader, BlockReaderIdExt, ProviderHeader, ProviderTx, StateProviderBox,
+    noop::NoopProvider, BlockReader, BlockReaderIdExt, ProviderHeader, ProviderTx,
+    StateProviderBox, StateProviderFactory,
 };
-use reth_transaction_pool::{PoolTransaction, TransactionPool};
-use std::sync::Arc;
+use reth_transaction_pool::{
+    error::InvalidPoolTransactionError, BestTransactions, BestTransactionsAttributes,
+    PoolTransaction, TransactionPool,
+};
+use reth_trie_common::ComputedTrieData;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::sync::Mutex;
+use tracing::debug;
 
 /// Loads a pending block from database.
 ///
@@ -96,7 +112,20 @@ pub trait LoadPendingBlock:
     where
         Self: SpawnBlocking,
     {
-        async move { Ok(None) }
+        async move {
+            let Some(pending_block) = self.pool_pending_block().await? else {
+                return Ok(None);
+            };
+
+            let latest_historical = self
+                .provider()
+                .history_by_block_hash(pending_block.block().parent_hash())
+                .map_err(Self::Error::from_eth_err)?;
+
+            let state = BlockState::from(pending_block);
+
+            Ok(Some(Box::new(state.state_provider(latest_historical)) as StateProviderBox))
+        }
     }
 
     /// Returns a mem-pool built pending block.
@@ -106,7 +135,18 @@ pub trait LoadPendingBlock:
     where
         Self: SpawnBlocking,
     {
-        async move { Ok(None) }
+        async move {
+            if self.pending_block_kind().is_none() {
+                return Ok(None);
+            }
+            let pending = self.pending_block_env_and_cfg()?;
+            let parent = match pending.origin {
+                PendingBlockEnvOrigin::ActualPending(..) => return Ok(None),
+                PendingBlockEnvOrigin::DerivedFromLatest(parent) => parent,
+            };
+
+            self.build_pool_pending_block(parent, pending.evm_env).await
+        }
     }
 
     /// Builds or returns a cached pending block from the transaction pool.
@@ -122,8 +162,44 @@ pub trait LoadPendingBlock:
         Self: SpawnBlocking,
     {
         async move {
-            let _ = (parent, evm_env);
-            Ok(None)
+            // we couldn't find the real pending block, so we need to build it ourselves
+            let mut lock = self.pending_block().lock().await;
+
+            let now = Instant::now();
+
+            // Is the pending block cached?
+            if let Some(pending_block) = lock.as_ref() {
+                // Is the cached block not expired and latest is its parent?
+                if evm_env.block_env().number.to::<u64>() == pending_block.block().number() &&
+                    parent.hash() == pending_block.block().parent_hash() &&
+                    now <= pending_block.expires_at
+                {
+                    return Ok(Some(pending_block.clone()));
+                }
+            }
+
+            let executed_block = match self
+                .spawn_blocking_io(move |this| {
+                    // we rebuild the block
+                    this.build_block(&parent)
+                })
+                .await
+            {
+                Ok(block) => block,
+                Err(err) => {
+                    debug!(target: "rpc", "Failed to build pending block: {:?}", err);
+                    return Ok(None)
+                }
+            };
+
+            let pending = PendingBlock::with_executed_block(
+                Instant::now() + Duration::from_secs(1),
+                executed_block,
+            );
+
+            *lock = Some(pending.clone());
+
+            Ok(Some(pending))
         }
     }
 
@@ -147,7 +223,10 @@ pub trait LoadPendingBlock:
                 PendingBlockEnvOrigin::ActualPending(block, receipts) => {
                     Some(BlockAndReceipts { block, receipts })
                 }
-                PendingBlockEnvOrigin::DerivedFromLatest(_) => None,
+                PendingBlockEnvOrigin::DerivedFromLatest(parent) => self
+                    .build_pool_pending_block(parent, pending.evm_env)
+                    .await?
+                    .map(PendingBlock::into_block_and_receipts),
             })
         }
     }
@@ -159,7 +238,6 @@ pub trait LoadPendingBlock:
     ///
     /// Withdrawals and any fork-specific behavior (such as EIP-4788 pre-block contract calls) are
     /// determined by the EVM environment and chain specification used during construction.
-    #[cfg(any())]
     fn build_block(
         &self,
         parent: &SealedHeader<ProviderHeader<Self::Provider>>,
@@ -174,23 +252,23 @@ pub trait LoadPendingBlock:
             .history_by_block_hash(parent.hash())
             .map_err(Self::Error::from_eth_err)?;
         let state = StateProviderDatabase::new(state_provider);
-        let mut db = State::builder().with_database(state).with_bundle_update().build();
 
         let mut builder = self
             .evm_config()
-            .builder_for_next_block(&mut db, parent, self.next_env_attributes(parent)?)
+            .builder_for_next_block(state, parent, self.next_env_attributes(parent)?)
             .map_err(RethError::other)
             .map_err(Self::Error::from_eth_err)?;
 
         builder.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
 
-        let block_gas_limit: u64 = builder.evm().block().gas_limit();
-        let is_amsterdam = self
+        let block_gas_limit = builder.evm_env().block_env().gas_limit.to::<u64>();
+        let is_amsterdam = builder.evm_env().uses_separate_block_gas();
+        let basefee = builder.evm_env().block_base_fee();
+        let blob_gasprice = self
             .provider()
             .chain_spec()
-            .is_amsterdam_active_at_timestamp(builder.evm().block().timestamp().saturating_to());
-        let basefee = builder.evm().block().basefee();
-        let blob_gasprice = builder.evm().block().blob_gasprice().map(|p| p as u64);
+            .is_cancun_active_at_timestamp(builder.evm_env().block_env().timestamp.to())
+            .then(|| builder.evm_env().block_blob_base_fee());
 
         let blob_params = self
             .provider()
@@ -201,7 +279,7 @@ pub trait LoadPendingBlock:
         let mut block_regular_gas_used = 0;
         let mut block_state_gas_used = 0;
         let mut sum_blob_gas_used = 0;
-        let tx_gas_limit_cap = builder.evm().cfg_env().tx_gas_limit_cap();
+        let tx_gas_limit_cap = builder.evm_env().regular_gas_limit_cap();
 
         // Only include transactions if not configured as Empty
         if !self.pending_block_kind().is_empty() {
@@ -286,48 +364,44 @@ pub trait LoadPendingBlock:
                     continue
                 }
 
-                let mut tx_regular_gas_used = 0;
-                let gas_output =
-                    match builder.execute_transaction_with_result_closure(tx, |result| {
-                        tx_regular_gas_used = result.result().result.gas().block_regular_gas_used();
-                    }) {
-                        Ok(gas_output) => gas_output,
-                        Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
-                            error,
-                            ..
-                        })) => {
-                            if error.is_nonce_too_low() {
-                                // if the nonce is too low, we can skip this transaction
-                            } else {
-                                // if the transaction is invalid, we can skip it and all of its
-                                // descendants
-                                best_txs.mark_invalid(
-                                    &pool_tx,
-                                    InvalidPoolTransactionError::Consensus(
-                                        InvalidTransactionError::TxTypeNotSupported,
-                                    ),
-                                );
-                            }
-                            continue
-                        }
-                        Err(BlockExecutionError::Validation(
-                            BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
-                                transaction_gas_limit,
-                                block_available_gas,
-                            },
-                        )) => {
+                let gas_output = match builder.execute_transaction(tx) {
+                    Ok(gas_output) => gas_output,
+                    Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                        error,
+                        ..
+                    })) => {
+                        if error.is_nonce_too_low() {
+                            // if the nonce is too low, we can skip this transaction
+                        } else {
+                            // if the transaction is invalid, we can skip it and all of its
+                            // descendants
                             best_txs.mark_invalid(
                                 &pool_tx,
-                                InvalidPoolTransactionError::ExceedsGasLimit(
-                                    transaction_gas_limit,
-                                    block_available_gas,
+                                InvalidPoolTransactionError::Consensus(
+                                    InvalidTransactionError::TxTypeNotSupported,
                                 ),
                             );
-                            continue
                         }
-                        // this is an error that we should treat as fatal for this attempt
-                        Err(err) => return Err(Self::Error::from_eth_err(err)),
-                    };
+                        continue
+                    }
+                    Err(BlockExecutionError::Validation(
+                        BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                            transaction_gas_limit,
+                            block_available_gas,
+                        },
+                    )) => {
+                        best_txs.mark_invalid(
+                            &pool_tx,
+                            InvalidPoolTransactionError::ExceedsGasLimit(
+                                transaction_gas_limit,
+                                block_available_gas,
+                            ),
+                        );
+                        continue
+                    }
+                    // this is an error that we should treat as fatal for this attempt
+                    Err(err) => return Err(Self::Error::from_eth_err(err)),
+                };
 
                 // add to the total blob gas used if the transaction successfully executed
                 if let Some(tx_blob_gas) = tx_blob_gas {
@@ -342,19 +416,22 @@ pub trait LoadPendingBlock:
                 // Track receipt gas and the Amsterdam block-capacity counter separately.
                 let gas_used = gas_output.tx_gas_used();
                 cumulative_tx_gas_used += gas_used;
-                block_regular_gas_used += tx_regular_gas_used;
+                block_regular_gas_used += gas_output.regular_gas_used();
                 block_state_gas_used += gas_output.state_gas_used();
             }
         }
 
-        let BlockBuilderOutcome { execution_result, block, hashed_state, trie_updates, .. } =
-            builder.finish(NoopProvider::default(), None).map_err(Self::Error::from_eth_err)?;
-
-        let block_number = block.number();
-        let execution_outcome = BlockExecutionOutput::new(
+        let BlockBuilderOutcome {
             execution_result,
-            legacy_bundle_to_execution_state(db.take_bundle(), block_number),
-        );
+            execution_state,
+            block,
+            hashed_state,
+            trie_updates,
+            ..
+        } = builder.finish(NoopProvider::default(), None).map_err(Self::Error::from_eth_err)?;
+
+        let execution_outcome =
+            BlockExecutionOutput { state: execution_state, result: execution_result };
 
         Ok(ExecutedBlock::new(
             block.into(),

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -310,7 +310,7 @@ pub trait LoadState:
         }
     }
 
-    /// Returns the EVM env for the given sealed header.
+    /// Returns the EVM environment for the given sealed header.
     fn evm_env_for_header(
         &self,
         header: &SealedHeaderFor<Self::Primitives>,
@@ -321,7 +321,7 @@ pub trait LoadState:
             .map_err(Self::Error::from_eth_err)
     }
 
-    /// Returns the EVM env for the requested [`BlockId`].
+    /// Returns the EVM environment for the requested [`BlockId`]
     ///
     /// If the [`BlockId`] this will return the [`BlockId`] of the block the env was configured
     /// for.
@@ -353,7 +353,8 @@ pub trait LoadState:
         }
     }
 
-    /// Returns the recovered block, EVM env, and state block id for the requested [`BlockId`].
+    /// Returns the recovered block, EVM environment, and state block id for the requested
+    /// [`BlockId`].
     ///
     /// For pending blocks, this preserves the state id returned by [`Self::evm_env_at`], which can
     /// be the pending tag for an actual pending block or the latest block hash when the pending env

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -329,7 +329,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         &self,
         block: &RecoveredBlock<ProviderBlock<Self::Provider>>,
         db: &mut StateCacheDb,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<reth_evm::EvmState, Self::Error> {
         let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
         let ctx = self
             .evm_config()
@@ -342,6 +342,6 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             .map_err(|err| EthApiError::EvmCustom(err.to_string()))
             .map_err(Self::Error::from_eth_err)?;
         db.commit_source(&changes);
-        Ok(())
+        Ok(changes)
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -5,13 +5,13 @@ use crate::{FromEthApiError, FromEvmError};
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
-use evm2::{evm::DynDatabase, BaseEvmTypes, TxResultWithState};
+use evm2::evm::DynDatabase;
 use evm2_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use futures::Future;
 use reth_errors::RethError;
 use reth_evm::{
     database::BorrowedDatabase, execute::BlockExecutorFactory, ConfigureEvm, Evm, EvmEnvFor,
-    TxEnvFor,
+    EvmTypesFor, TxEnvFor, TxResultWithStateFor,
 };
 use reth_primitives_traits::{BlockBody, RecoveredBlock};
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
@@ -19,22 +19,22 @@ use reth_storage_api::ProviderBlock;
 use std::{borrow::Borrow, sync::Arc};
 
 /// Context passed to per-transaction trace callbacks.
-pub struct TracingCtx<'a, Insp> {
+pub struct TracingCtx<'a, Insp, EvmTypes: evm2::EvmTypes> {
     /// Execution result and detached state changes for the transaction.
-    pub result: TxResultWithState,
+    pub result: evm2::TxResultWithState<EvmTypes>,
     /// Database pointing to the transaction pre-state.
     pub db: &'a mut StateCacheDb,
     /// Inspector used while executing the transaction.
     pub inspector: Insp,
 }
 
-impl<Insp> core::fmt::Debug for TracingCtx<'_, Insp> {
+impl<Insp, EvmTypes: evm2::EvmTypes> core::fmt::Debug for TracingCtx<'_, Insp, EvmTypes> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TracingCtx").finish_non_exhaustive()
     }
 }
 
-impl<Insp> TracingCtx<'_, Insp> {
+impl<Insp, EvmTypes: evm2::EvmTypes> TracingCtx<'_, Insp, EvmTypes> {
     /// Consumes this context and returns the inspector.
     pub fn take_inspector(self) -> Insp {
         self.inspector
@@ -50,10 +50,10 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         evm_env: EvmEnvFor<Self::Evm>,
         tx_env: &TxEnvFor<Self::Evm>,
         inspector: I,
-    ) -> Result<(I, TxResultWithState), Self::Error>
+    ) -> Result<(I, TxResultWithStateFor<Self::Evm>), Self::Error>
     where
         DB: DynDatabase,
-        I: evm2::Inspector<BaseEvmTypes> + 'static,
+        I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
     {
         let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
         evm.transact_with_inspector(tx_env.borrow(), inspector).map_err(Self::Error::from_evm_err)
@@ -71,7 +71,9 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     ) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
         R: Send + 'static,
-        F: FnOnce(TracingInspector, TxResultWithState) -> Result<R, Self::Error> + Send + 'static,
+        F: FnOnce(TracingInspector, TxResultWithStateFor<Self::Evm>) -> Result<R, Self::Error>
+            + Send
+            + 'static,
     {
         self.spawn_with_state_at_block(at, move |this, mut db| {
             let (inspector, result) =
@@ -90,7 +92,11 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         f: F,
     ) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
-        F: FnOnce(TracingInspector, TxResultWithState, StateCacheDb) -> Result<R, Self::Error>
+        F: FnOnce(
+                TracingInspector,
+                TxResultWithStateFor<Self::Evm>,
+                StateCacheDb,
+            ) -> Result<R, Self::Error>
             + Send
             + 'static,
         R: Send + 'static,
@@ -114,7 +120,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         F: FnOnce(
                 TransactionInfo,
                 TracingInspector,
-                TxResultWithState,
+                TxResultWithStateFor<Self::Evm>,
                 StateCacheDb,
             ) -> Result<R, Self::Error>
             + Send
@@ -133,10 +139,15 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
     where
         Self: LoadTransaction,
-        F: FnOnce(TransactionInfo, Insp, TxResultWithState, StateCacheDb) -> Result<R, Self::Error>
+        F: FnOnce(
+                TransactionInfo,
+                Insp,
+                TxResultWithStateFor<Self::Evm>,
+                StateCacheDb,
+            ) -> Result<R, Self::Error>
             + Send
             + 'static,
-        Insp: evm2::Inspector<BaseEvmTypes> + Send + 'static,
+        Insp: evm2::Inspector<EvmTypesFor<Self::Evm>> + Send + 'static,
         R: Send + 'static,
     {
         async move {
@@ -178,9 +189,14 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
     where
         Self: LoadBlock,
-        F: Fn(TransactionInfo, TracingCtx<'_, Insp>) -> Result<R, Self::Error> + Send + 'static,
+        F: Fn(
+                TransactionInfo,
+                TracingCtx<'_, Insp, EvmTypesFor<Self::Evm>>,
+            ) -> Result<R, Self::Error>
+            + Send
+            + 'static,
         Setup: FnMut() -> Insp + Send + 'static,
-        Insp: Clone + evm2::Inspector<BaseEvmTypes> + 'static,
+        Insp: Clone + evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
         R: Send + 'static,
     {
         async move {
@@ -241,7 +257,10 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
     where
         Self: LoadBlock,
-        F: Fn(TransactionInfo, TracingCtx<'_, TracingInspector>) -> Result<R, Self::Error>
+        F: Fn(
+                TransactionInfo,
+                TracingCtx<'_, TracingInspector, EvmTypesFor<Self::Evm>>,
+            ) -> Result<R, Self::Error>
             + Send
             + 'static,
         R: Send + 'static,
@@ -265,7 +284,10 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
     where
         Self: LoadBlock,
-        F: Fn(TransactionInfo, TracingCtx<'_, TracingInspector>) -> Result<R, Self::Error>
+        F: Fn(
+                TransactionInfo,
+                TracingCtx<'_, TracingInspector, EvmTypesFor<Self::Evm>>,
+            ) -> Result<R, Self::Error>
             + Send
             + 'static,
         R: Send + 'static,
@@ -289,9 +311,14 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
     where
         Self: LoadBlock,
-        F: Fn(TransactionInfo, TracingCtx<'_, Insp>) -> Result<R, Self::Error> + Send + 'static,
+        F: Fn(
+                TransactionInfo,
+                TracingCtx<'_, Insp, EvmTypesFor<Self::Evm>>,
+            ) -> Result<R, Self::Error>
+            + Send
+            + 'static,
         Setup: FnMut() -> Insp + Send + 'static,
-        Insp: Clone + evm2::Inspector<BaseEvmTypes> + 'static,
+        Insp: Clone + evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
         R: Send + 'static,
     {
         self.trace_block_until_with_inspector(block_id, block, None, insp_setup, f)

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -5,12 +5,11 @@ use crate::{FromEthApiError, FromEvmError};
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
-use evm2::evm::DynDatabase;
 use evm2_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use futures::Future;
 use reth_errors::RethError;
 use reth_evm::{
-    execute::BlockExecutorFactory, ConfigureEvm, Evm, EvmEnvFor, EvmTypesFor, TxEnvFor,
+    execute::BlockExecutorFactory, ConfigureEvm, Database, Evm, EvmEnvFor, EvmTypesFor, TxEnvFor,
     TxResultWithStateFor,
 };
 use reth_primitives_traits::{BlockBody, RecoveredBlock};
@@ -52,10 +51,10 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         inspector: I,
     ) -> Result<(I, TxResultWithStateFor<Self::Evm>), Self::Error>
     where
-        DB: DynDatabase,
+        DB: Database,
         I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
     {
-        let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
+        let mut evm = self.evm_config().block_executor_factory().evm_with_database(db, evm_env);
         evm.transact_with_inspector(tx_env, inspector).map_err(Self::Error::from_evm_err)
     }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -2,50 +2,28 @@
 
 use super::{Call, LoadBlock, LoadState, LoadTransaction};
 use crate::{FromEthApiError, FromEvmError};
-use alloy_consensus::{
-    transaction::{Recovered, TxHashRef},
-    BlockHeader,
-};
-use alloy_eips::BlockId;
+use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_primitives::B256;
-use alloy_rpc_types_eth::TransactionInfo;
-use evm2::{
-    ethereum::RecoveredTxEnvelope,
-    evm::{CacheDB, Db},
-    registry::HandlerError,
-    BaseEvmTypes, ErrorCode, TxResultWithState,
-};
+use alloy_rpc_types_eth::{BlockId, TransactionInfo};
+use evm2::{evm::DynDatabase, BaseEvmTypes, TxResultWithState};
 use evm2_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use futures::Future;
 use reth_errors::RethError;
 use reth_evm::{
-    database::{BorrowedDatabase, StateProviderDatabase},
-    execute::BlockExecutorFactory,
-    ConfigureEvm, EvmEnvFor, TxEnvFor,
+    database::BorrowedDatabase, execute::BlockExecutorFactory, ConfigureEvm, Evm, EvmEnvFor,
+    TxEnvFor,
 };
 use reth_primitives_traits::{BlockBody, RecoveredBlock};
-use reth_rpc_eth_types::EthApiError;
-use reth_storage_api::{ProviderBlock, ProviderTx, StateProviderBox, StateProviderFactory};
-use std::sync::Arc;
-
-/// Cached state database used while tracing transactions sequentially.
-pub type TraceStateProviderDatabase = CacheDB<Db<StateProviderDatabase<StateProviderBox>>>;
-
-/// EVM instance type supported by the current inspector trace path.
-pub type TraceEvmInstance<'a> = evm2::Evm<'a, BaseEvmTypes>;
-
-/// Block environment type supported by the current inspector trace path.
-pub type TraceBlockEnv = evm2::env::BlockEnv;
-
-/// Transaction envelope type supported by the current inspector trace path.
-pub type TraceTxEnvelope = RecoveredTxEnvelope;
+use reth_rpc_eth_types::{EthApiError, StateCacheDb};
+use reth_storage_api::ProviderBlock;
+use std::{borrow::Borrow, sync::Arc};
 
 /// Context passed to per-transaction trace callbacks.
 pub struct TracingCtx<'a, Insp> {
     /// Execution result and detached state changes for the transaction.
     pub result: TxResultWithState,
     /// Database pointing to the transaction pre-state.
-    pub db: &'a mut TraceStateProviderDatabase,
+    pub db: &'a mut StateCacheDb,
     /// Inspector used while executing the transaction.
     pub inspector: Insp,
 }
@@ -66,70 +44,61 @@ impl<Insp> TracingCtx<'_, Insp> {
 /// Executes CPU heavy trace tasks.
 pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     /// Executes a transaction with the provided inspector without committing state changes.
-    fn inspect_with_inspector<I>(
+    fn inspect<DB, I>(
         &self,
-        db: &mut TraceStateProviderDatabase,
+        db: DB,
         evm_env: EvmEnvFor<Self::Evm>,
-        tx_env: TxEnvFor<Self::Evm>,
+        tx_env: &TxEnvFor<Self::Evm>,
         inspector: I,
     ) -> Result<(I, TxResultWithState), Self::Error>
     where
-        I: evm2::Inspector<BaseEvmTypes>,
-        <Self::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<Self::Evm>: AsRef<TraceTxEnvelope>,
+        DB: DynDatabase,
+        I: evm2::Inspector<BaseEvmTypes> + 'static,
     {
-        let mut inspector = inspector;
-
-        enum Resolution {
-            Result(TxResultWithState),
-            DatabaseError(ErrorCode),
-            HandlerError(HandlerError),
-        }
-
-        let result = {
-            let mut evm = self
-                .evm_config()
-                .block_executor_factory()
-                .evm_with_env(BorrowedDatabase::new(&mut *db), evm_env);
-            evm.set_inspector(BorrowedInspector(&mut inspector));
-
-            let resolution = match evm.transact(tx_env.as_ref()) {
-                Ok(executed) => {
-                    if let Some(code) = executed.result().error_code {
-                        let _ = executed.discard();
-                        Resolution::DatabaseError(code)
-                    } else {
-                        Resolution::Result(executed.detach())
-                    }
-                }
-                Err(err) => Resolution::HandlerError(err),
-            };
-
-            match resolution {
-                Resolution::Result(result) => result,
-                Resolution::DatabaseError(code) => return Err(trace_database_error(&mut evm, code)),
-                Resolution::HandlerError(err) => return Err(trace_handler_error(&mut evm, err)),
-            }
-        };
-
-        Ok((inspector, result))
+        let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
+        evm.transact_with_inspector(tx_env.borrow(), inspector).map_err(Self::Error::from_evm_err)
     }
 
-    /// Executes a closure against a shared EVM cache initialized from the requested block state.
-    fn spawn_with_state_at_block<F, R>(
+    /// Executes the transaction on top of the given [`BlockId`] with a tracer configured by the
+    /// config.
+    fn trace_at<F, R>(
         &self,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
+        config: TracingInspectorConfig,
         at: BlockId,
         f: F,
     ) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
-        F: FnOnce(Self, TraceStateProviderDatabase) -> Result<R, Self::Error> + Send + 'static,
+        R: Send + 'static,
+        F: FnOnce(TracingInspector, TxResultWithState) -> Result<R, Self::Error> + Send + 'static,
+    {
+        self.spawn_with_state_at_block(at, move |this, mut db| {
+            let (inspector, result) =
+                this.inspect(&mut db, evm_env, &tx_env, TracingInspector::new(config))?;
+            f(inspector, result)
+        })
+    }
+
+    /// Same as [`trace_at`](Self::trace_at) but also provides the used database to the callback.
+    fn spawn_trace_at_with_state<F, R>(
+        &self,
+        evm_env: EvmEnvFor<Self::Evm>,
+        tx_env: TxEnvFor<Self::Evm>,
+        config: TracingInspectorConfig,
+        at: BlockId,
+        f: F,
+    ) -> impl Future<Output = Result<R, Self::Error>> + Send
+    where
+        F: FnOnce(TracingInspector, TxResultWithState, StateCacheDb) -> Result<R, Self::Error>
+            + Send
+            + 'static,
         R: Send + 'static,
     {
-        self.spawn_tracing(move |this| {
-            let state = this.provider().state_by_block_id(at).map_err(Self::Error::from_eth_err)?;
-            let db = CacheDB::new(Db::new(StateProviderDatabase::new(state)));
-            f(this, db)
+        self.spawn_with_state_at_block(at, move |this, mut db| {
+            let (inspector, result) =
+                this.inspect(&mut db, evm_env, &tx_env, TracingInspector::new(config))?;
+            f(inspector, result, db)
         })
     }
 
@@ -141,20 +110,16 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         f: F,
     ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
     where
-        Self: LoadBlock + LoadTransaction,
+        Self: LoadTransaction,
         F: FnOnce(
                 TransactionInfo,
                 TracingInspector,
                 TxResultWithState,
-                TraceStateProviderDatabase,
+                StateCacheDb,
             ) -> Result<R, Self::Error>
             + Send
             + 'static,
         R: Send + 'static,
-        ProviderTx<Self::Provider>: Clone,
-        <Self::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<Self::Evm>: AsRef<TraceTxEnvelope>,
     {
         self.spawn_trace_transaction_in_block_with_inspector(hash, TracingInspector::new(config), f)
     }
@@ -167,21 +132,12 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         f: F,
     ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
     where
-        Self: LoadBlock + LoadTransaction,
-        F: FnOnce(
-                TransactionInfo,
-                Insp,
-                TxResultWithState,
-                TraceStateProviderDatabase,
-            ) -> Result<R, Self::Error>
+        Self: LoadTransaction,
+        F: FnOnce(TransactionInfo, Insp, TxResultWithState, StateCacheDb) -> Result<R, Self::Error>
             + Send
             + 'static,
         Insp: evm2::Inspector<BaseEvmTypes> + Send + 'static,
         R: Send + 'static,
-        ProviderTx<Self::Provider>: Clone,
-        <Self::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<Self::Evm>: AsRef<TraceTxEnvelope>,
     {
         async move {
             let (transaction, block) = match self.transaction_and_block(hash).await? {
@@ -191,57 +147,24 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             let (target_tx, tx_info) = transaction.split();
             let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
 
-            self.spawn_with_state_at_block(block.parent_hash().into(), move |this, mut db| {
-                this.apply_pre_execution_changes(&block, evm_env.clone(), &mut db)?;
+            self.spawn_with_state_at_block(block.parent_hash(), move |this, mut db| {
+                this.apply_pre_execution_changes(&block, &mut db)?;
 
-                this.replay_transactions_until(
+                Call::replay_transactions_until(
+                    &this,
                     &mut db,
                     evm_env.clone(),
                     block.transactions_recovered(),
                     *target_tx.tx_hash(),
                 )?;
 
-                let tx_env = this.evm_config().tx_env(target_tx.clone());
-                let (inspector, result) =
-                    this.inspect_with_inspector(&mut db, evm_env, tx_env, inspector)?;
+                let tx_env = this.evm_config().tx_env(target_tx);
+                let (inspector, result) = this.inspect(&mut db, evm_env, &tx_env, inspector)?;
                 f(tx_info, inspector, result, db)
             })
             .await
             .map(Some)
         }
-    }
-
-    /// Executes transactions until the target transaction hash, excluding the target itself.
-    fn replay_transactions_until<'a, I>(
-        &self,
-        db: &mut TraceStateProviderDatabase,
-        evm_env: EvmEnvFor<Self::Evm>,
-        transactions: I,
-        target_tx_hash: B256,
-    ) -> Result<u64, Self::Error>
-    where
-        I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
-        ProviderTx<Self::Provider>: Clone + 'a,
-        <Self::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'evm> BlockExecutorFactory<Evm<'evm> = TraceEvmInstance<'evm>>,
-        TxEnvFor<Self::Evm>: AsRef<TraceTxEnvelope>,
-    {
-        for (idx, tx) in transactions.into_iter().enumerate() {
-            if *tx.tx_hash() == target_tx_hash {
-                return Ok(idx as u64)
-            }
-
-            let tx_env = self.evm_config().tx_env(tx.cloned());
-            let (_, result) = self.inspect_with_inspector(
-                db,
-                evm_env.clone(),
-                tx_env,
-                evm2::NoopInspector::default(),
-            )?;
-            db.commit_source(&result.state_changes);
-        }
-
-        Err(EthApiError::TransactionNotFound.into())
     }
 
     /// Executes all transactions of a block up to a given index.
@@ -257,12 +180,8 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         Self: LoadBlock,
         F: Fn(TransactionInfo, TracingCtx<'_, Insp>) -> Result<R, Self::Error> + Send + 'static,
         Setup: FnMut() -> Insp + Send + 'static,
-        Insp: evm2::Inspector<BaseEvmTypes> + Send + 'static,
+        Insp: Clone + evm2::Inspector<BaseEvmTypes> + 'static,
         R: Send + 'static,
-        ProviderTx<Self::Provider>: Clone,
-        <Self::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<Self::Evm>: AsRef<TraceTxEnvelope>,
     {
         async move {
             let block =
@@ -274,13 +193,13 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                 return Ok(Some(Vec::new()))
             }
 
-            self.spawn_with_state_at_block(block.parent_hash().into(), move |this, mut db| {
+            self.spawn_with_state_at_block(block.parent_hash(), move |this, mut db| {
                 let block_hash = block.hash();
                 let block_number = block.number();
                 let block_timestamp = block.timestamp();
                 let base_fee = block.base_fee_per_gas();
 
-                this.apply_pre_execution_changes(&block, evm_env.clone(), &mut db)?;
+                this.apply_pre_execution_changes(&block, &mut db)?;
 
                 let max_transactions = highest_index
                     .map(|highest| highest as usize + 1)
@@ -289,12 +208,8 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
 
                 for (idx, tx) in block.transactions_recovered().take(max_transactions).enumerate() {
                     let tx_env = this.evm_config().tx_env(tx.cloned());
-                    let (inspector, result) = this.inspect_with_inspector(
-                        &mut db,
-                        evm_env.clone(),
-                        tx_env,
-                        inspector_setup(),
-                    )?;
+                    let (inspector, result) =
+                        this.inspect(&mut db, evm_env.clone(), &tx_env, inspector_setup())?;
                     let tx_info = TransactionInfo {
                         hash: Some(*tx.tx_hash()),
                         index: Some(idx as u64),
@@ -315,6 +230,31 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         }
     }
 
+    /// Executes all transactions of a block up to a given index.
+    fn trace_block_until<F, R>(
+        &self,
+        block_id: BlockId,
+        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
+        highest_index: Option<u64>,
+        config: TracingInspectorConfig,
+        f: F,
+    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
+    where
+        Self: LoadBlock,
+        F: Fn(TransactionInfo, TracingCtx<'_, TracingInspector>) -> Result<R, Self::Error>
+            + Send
+            + 'static,
+        R: Send + 'static,
+    {
+        self.trace_block_until_with_inspector(
+            block_id,
+            block,
+            highest_index,
+            move || TracingInspector::new(config),
+            f,
+        )
+    }
+
     /// Executes all transactions of a block with a tracing inspector.
     fn trace_block_with<F, R>(
         &self,
@@ -329,10 +269,6 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             + Send
             + 'static,
         R: Send + 'static,
-        ProviderTx<Self::Provider>: Clone,
-        <Self::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<Self::Evm>: AsRef<TraceTxEnvelope>,
     {
         self.trace_block_until_with_inspector(
             block_id,
@@ -355,12 +291,8 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         Self: LoadBlock,
         F: Fn(TransactionInfo, TracingCtx<'_, Insp>) -> Result<R, Self::Error> + Send + 'static,
         Setup: FnMut() -> Insp + Send + 'static,
-        Insp: evm2::Inspector<BaseEvmTypes> + Send + 'static,
+        Insp: Clone + evm2::Inspector<BaseEvmTypes> + 'static,
         R: Send + 'static,
-        ProviderTx<Self::Provider>: Clone,
-        <Self::Evm as ConfigureEvm>::BlockExecutorFactory:
-            for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-        TxEnvFor<Self::Evm>: AsRef<TraceTxEnvelope>,
     {
         self.trace_block_until_with_inspector(block_id, block, None, insp_setup, f)
     }
@@ -369,9 +301,9 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     fn apply_pre_execution_changes(
         &self,
         block: &RecoveredBlock<ProviderBlock<Self::Provider>>,
-        evm_env: EvmEnvFor<Self::Evm>,
-        db: &mut TraceStateProviderDatabase,
+        db: &mut StateCacheDb,
     ) -> Result<(), Self::Error> {
+        let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
         let ctx = self
             .evm_config()
             .context_for_block(block.sealed_block())
@@ -383,500 +315,6 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             .map_err(|err| EthApiError::EvmCustom(err.to_string()))
             .map_err(Self::Error::from_eth_err)?;
         db.commit_source(&changes);
-        Ok(())
-    }
-}
-
-struct BorrowedInspector<'a, I>(&'a mut I);
-
-impl<I> evm2::Inspector<BaseEvmTypes> for BorrowedInspector<'_, I>
-where
-    I: evm2::Inspector<BaseEvmTypes>,
-{
-    fn initialize_interp(
-        &mut self,
-        interp: &mut evm2::interpreter::Interpreter<'_, '_, BaseEvmTypes>,
-    ) {
-        self.0.initialize_interp(interp);
-    }
-
-    fn step(&mut self, interp: &mut evm2::interpreter::Interpreter<'_, '_, BaseEvmTypes>) {
-        self.0.step(interp);
-    }
-
-    fn step_end(&mut self, interp: &mut evm2::interpreter::Interpreter<'_, '_, BaseEvmTypes>) {
-        self.0.step_end(interp);
-    }
-
-    fn log(&mut self, log: &alloy_primitives::Log, host: &mut evm2::Evm<'_, BaseEvmTypes>) {
-        self.0.log(log, host);
-    }
-
-    fn call(
-        &mut self,
-        interp: &mut evm2::interpreter::Interpreter<'_, '_, BaseEvmTypes>,
-        message: &mut evm2::interpreter::Message<BaseEvmTypes>,
-    ) -> Option<evm2::interpreter::MessageResult<BaseEvmTypes>> {
-        self.0.call(interp, message)
-    }
-
-    fn call_end(
-        &mut self,
-        interp: &mut evm2::interpreter::Interpreter<'_, '_, BaseEvmTypes>,
-        message: &evm2::interpreter::Message<BaseEvmTypes>,
-        result: &mut evm2::interpreter::MessageResult<BaseEvmTypes>,
-    ) {
-        self.0.call_end(interp, message, result);
-    }
-
-    fn create(
-        &mut self,
-        interp: &mut evm2::interpreter::Interpreter<'_, '_, BaseEvmTypes>,
-        message: &mut evm2::interpreter::Message<BaseEvmTypes>,
-    ) -> Option<evm2::interpreter::MessageResult<BaseEvmTypes>> {
-        self.0.create(interp, message)
-    }
-
-    fn create_end(
-        &mut self,
-        interp: &mut evm2::interpreter::Interpreter<'_, '_, BaseEvmTypes>,
-        message: &evm2::interpreter::Message<BaseEvmTypes>,
-        result: &mut evm2::interpreter::MessageResult<BaseEvmTypes>,
-    ) {
-        self.0.create_end(interp, message, result);
-    }
-
-    fn selfdestruct(
-        &mut self,
-        contract: &alloy_primitives::Address,
-        target: &alloy_primitives::Address,
-        value: &alloy_primitives::U256,
-        host: &mut evm2::Evm<'_, BaseEvmTypes>,
-    ) {
-        self.0.selfdestruct(contract, target, value, host);
-    }
-}
-
-fn trace_handler_error<Evm, Error>(
-    evm: &mut evm2::Evm<'_, BaseEvmTypes>,
-    err: HandlerError,
-) -> Error
-where
-    Error: FromEvmError<Evm>,
-{
-    match err {
-        HandlerError::Fatal(code) => trace_database_error::<Evm, Error>(evm, code),
-        err => Error::from_eth_err(EthApiError::EvmCustom(err.to_string())),
-    }
-}
-
-fn trace_database_error<Evm, Error>(evm: &mut evm2::Evm<'_, BaseEvmTypes>, code: ErrorCode) -> Error
-where
-    Error: FromEvmError<Evm>,
-{
-    let err = evm.database_mut().error(code);
-    Error::from_eth_err(EthApiError::EvmCustom(format!("EVM database error {code:?}: {err}")))
-}
-
-#[cfg(any())]
-pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
-    /// Executes the [`TxEnvFor`] with [`reth_evm::EvmEnv`] against the given [Database] without
-    /// committing state changes.
-    fn inspect<DB, I>(
-        &self,
-        db: DB,
-        evm_env: EvmEnvFor<Self::Evm>,
-        tx_env: TxEnvFor<Self::Evm>,
-        inspector: I,
-    ) -> Result<ResultAndState<HaltReasonFor<Self::Evm>>, Self::Error>
-    where
-        DB: Database<Error = EvmDatabaseError<ProviderError>>,
-        I: InspectorFor<Self::Evm, DB>,
-    {
-        let mut evm = self.evm_config().evm_with_env(db, evm_env);
-        evm.set_inspector(inspector);
-        evm.transact(tx_env).map_err(Self::Error::from_evm_err)
-    }
-
-    /// Executes the transaction on top of the given [`BlockId`] with a tracer configured by the
-    /// config.
-    ///
-    /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`reth_evm::EvmEnv`] was inspected.
-    ///
-    /// Caution: this is blocking
-    fn trace_at<F, R>(
-        &self,
-        evm_env: EvmEnvFor<Self::Evm>,
-        tx_env: TxEnvFor<Self::Evm>,
-        config: TracingInspectorConfig,
-        at: BlockId,
-        f: F,
-    ) -> impl Future<Output = Result<R, Self::Error>> + Send
-    where
-        R: Send + 'static,
-        F: FnOnce(
-                TracingInspector,
-                ResultAndState<HaltReasonFor<Self::Evm>>,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-    {
-        self.with_state_at_block(at, move |this, state| {
-            let mut db = State::builder().with_database(StateProviderDatabase::new(state)).build();
-            let mut inspector = TracingInspector::new(config);
-            let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
-            f(inspector, res)
-        })
-    }
-
-    /// Same as [`trace_at`](Self::trace_at) but also provides the used database to the callback.
-    ///
-    /// Executes the transaction on top of the given [`BlockId`] with a tracer configured by the
-    /// config.
-    ///
-    /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`reth_evm::EvmEnv`] was inspected.
-    fn spawn_trace_at_with_state<F, R>(
-        &self,
-        evm_env: EvmEnvFor<Self::Evm>,
-        tx_env: TxEnvFor<Self::Evm>,
-        config: TracingInspectorConfig,
-        at: BlockId,
-        f: F,
-    ) -> impl Future<Output = Result<R, Self::Error>> + Send
-    where
-        F: FnOnce(
-                TracingInspector,
-                ResultAndState<HaltReasonFor<Self::Evm>>,
-                StateCacheDb,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        R: Send + 'static,
-    {
-        self.spawn_with_state_at_block(at, move |this, mut db| {
-            let mut inspector = TracingInspector::new(config);
-            let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
-            f(inspector, res, db)
-        })
-    }
-
-    /// Retrieves the transaction if it exists and returns its trace.
-    ///
-    /// Before the transaction is traced, all previous transaction in the block are applied to the
-    /// state by executing them first.
-    /// The callback `f` is invoked with the [`ResultAndState`] after the transaction was executed
-    /// and the database that points to the beginning of the transaction.
-    ///
-    /// Note: Implementers should use a threadpool where blocking is allowed, such as
-    /// [`BlockingTaskPool`](reth_tasks::pool::BlockingTaskPool).
-    fn spawn_trace_transaction_in_block<F, R>(
-        &self,
-        hash: B256,
-        config: TracingInspectorConfig,
-        f: F,
-    ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
-    where
-        Self: LoadTransaction,
-        F: FnOnce(
-                TransactionInfo,
-                TracingInspector,
-                ResultAndState<HaltReasonFor<Self::Evm>>,
-                StateCacheDb,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        R: Send + 'static,
-    {
-        self.spawn_trace_transaction_in_block_with_inspector(hash, TracingInspector::new(config), f)
-    }
-
-    /// Retrieves the transaction if it exists and returns its trace.
-    ///
-    /// Before the transaction is traced, all previous transaction in the block are applied to the
-    /// state by executing them first.
-    /// The callback `f` is invoked with the [`ResultAndState`] after the transaction was executed
-    /// and the database that points to the beginning of the transaction.
-    ///
-    /// Note: Implementers should use a threadpool where blocking is allowed, such as
-    /// [`BlockingTaskPool`](reth_tasks::pool::BlockingTaskPool).
-    fn spawn_trace_transaction_in_block_with_inspector<Insp, F, R>(
-        &self,
-        hash: B256,
-        mut inspector: Insp,
-        f: F,
-    ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
-    where
-        Self: LoadTransaction,
-        F: FnOnce(
-                TransactionInfo,
-                Insp,
-                ResultAndState<HaltReasonFor<Self::Evm>>,
-                StateCacheDb,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        Insp: for<'a> InspectorFor<Self::Evm, &'a mut StateCacheDb> + Send + 'static,
-        R: Send + 'static,
-    {
-        async move {
-            let (transaction, block) = match self.transaction_and_block(hash).await? {
-                None => return Ok(None),
-                Some(res) => res,
-            };
-            let (tx, tx_info) = transaction.split();
-
-            let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
-
-            // we need to get the state of the parent block because we're essentially replaying the
-            // block the transaction is included in
-            let parent_block = block.parent_hash();
-
-            self.spawn_with_state_at_block(parent_block, move |this, mut db| {
-                let block_txs = block.transactions_recovered();
-
-                this.apply_pre_execution_changes(&block, &mut db)?;
-
-                // replay all transactions prior to the targeted transaction
-                this.replay_transactions_until(&mut db, evm_env.clone(), block_txs, *tx.tx_hash())?;
-
-                let tx_env = this.evm_config().tx_env(tx);
-                let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
-                f(tx_info, inspector, res, db)
-            })
-            .await
-            .map(Some)
-        }
-    }
-
-    /// Executes all transactions of a block up to a given index.
-    ///
-    /// If a `highest_index` is given, this will only execute the first `highest_index`
-    /// transactions, in other words, it will stop executing transactions after the
-    /// `highest_index`th transaction. If `highest_index` is `None`, all transactions
-    /// are executed.
-    fn trace_block_until<F, R>(
-        &self,
-        block_id: BlockId,
-        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
-        highest_index: Option<u64>,
-        config: TracingInspectorConfig,
-        f: F,
-    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
-    where
-        Self: LoadBlock,
-        F: Fn(
-                TransactionInfo,
-                TracingCtx<
-                    '_,
-                    Recovered<&ProviderTx<Self::Provider>>,
-                    EvmFor<Self::Evm, &mut StateCacheDb, TracingInspector>,
-                >,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        R: Send + 'static,
-    {
-        self.trace_block_until_with_inspector(
-            block_id,
-            block,
-            highest_index,
-            move || TracingInspector::new(config),
-            f,
-        )
-    }
-
-    /// Executes all transactions of a block.
-    ///
-    /// If a `highest_index` is given, this will only execute the first `highest_index`
-    /// transactions, in other words, it will stop executing transactions after the
-    /// `highest_index`th transaction.
-    ///
-    /// Note: This expect tx index to be 0-indexed, so the first transaction is at index 0.
-    ///
-    /// This accepts a `inspector_setup` closure that returns the inspector to be used for tracing
-    /// the transactions.
-    fn trace_block_until_with_inspector<Setup, Insp, F, R>(
-        &self,
-        block_id: BlockId,
-        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
-        highest_index: Option<u64>,
-        mut inspector_setup: Setup,
-        f: F,
-    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
-    where
-        Self: LoadBlock,
-        F: Fn(
-                TransactionInfo,
-                TracingCtx<
-                    '_,
-                    Recovered<&ProviderTx<Self::Provider>>,
-                    EvmFor<Self::Evm, &mut StateCacheDb, Insp>,
-                >,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        Setup: FnMut() -> Insp + Send + 'static,
-        Insp: Clone + for<'a> InspectorFor<Self::Evm, &'a mut StateCacheDb>,
-        R: Send + 'static,
-    {
-        async move {
-            let block =
-                if block.is_some() { block } else { self.recovered_block(block_id).await? };
-
-            let Some(block) = block else { return Ok(None) };
-            let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
-
-            if block.body().transactions().is_empty() {
-                // nothing to trace
-                return Ok(Some(Vec::new()))
-            }
-
-            // replay all transactions of the block
-            // we need to get the state of the parent block because we're replaying this block
-            // on top of its parent block's state
-            self.spawn_with_state_at_block(block.parent_hash(), move |this, mut db| {
-                let block_hash = block.hash();
-
-                let block_number = evm_env.block_env.number().saturating_to();
-                let block_timestamp = evm_env.block_env.timestamp().saturating_to();
-                let base_fee = evm_env.block_env.basefee();
-
-                this.apply_pre_execution_changes(&block, &mut db)?;
-
-                // prepare transactions, we do everything upfront to reduce time spent with open
-                // state
-                let max_transactions = highest_index.map_or_else(
-                    || block.body().transaction_count(),
-                    |highest| {
-                        // we need + 1 because the index is 0-based
-                        highest as usize + 1
-                    },
-                );
-
-                let mut idx = 0;
-
-                let results = this
-                    .evm_config()
-                    .evm_factory()
-                    .create_tracer(&mut db, evm_env, inspector_setup())
-                    .try_trace_many(block.transactions_recovered().take(max_transactions), |ctx| {
-                        let tx_info = TransactionInfo {
-                            hash: Some(*ctx.tx.tx_hash()),
-                            index: Some(idx),
-                            block_hash: Some(block_hash),
-                            block_number: Some(block_number),
-                            block_timestamp: Some(block_timestamp),
-                            base_fee: Some(base_fee),
-                        };
-                        idx += 1;
-
-                        f(tx_info, ctx)
-                    })
-                    .collect::<Result<_, _>>()?;
-
-                Ok(Some(results))
-            })
-            .await
-        }
-    }
-
-    /// Executes all transactions of a block and returns a list of callback results invoked for each
-    /// transaction in the block.
-    ///
-    /// This
-    /// 1. fetches all transactions of the block
-    /// 2. configures the EVM env
-    /// 3. loops over all transactions and executes them
-    /// 4. calls the callback with the transaction info, the execution result, the changed state
-    ///    _after_ the transaction [`StateProviderDatabase`] and the database that points to the
-    ///    state right _before_ the transaction.
-    fn trace_block_with<F, R>(
-        &self,
-        block_id: BlockId,
-        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
-        config: TracingInspectorConfig,
-        f: F,
-    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
-    where
-        Self: LoadBlock,
-        // This is the callback that's invoked for each transaction with the inspector, the result,
-        // state and db
-        F: Fn(
-                TransactionInfo,
-                TracingCtx<
-                    '_,
-                    Recovered<&ProviderTx<Self::Provider>>,
-                    EvmFor<Self::Evm, &mut StateCacheDb, TracingInspector>,
-                >,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        R: Send + 'static,
-    {
-        self.trace_block_until(block_id, block, None, config, f)
-    }
-
-    /// Executes all transactions of a block and returns a list of callback results invoked for each
-    /// transaction in the block.
-    ///
-    /// This
-    /// 1. fetches all transactions of the block
-    /// 2. configures the EVM env
-    /// 3. loops over all transactions and executes them
-    /// 4. calls the callback with the transaction info, the execution result, the changed state
-    ///    _after_ the transaction `EvmState` and the database that points to the state right
-    ///    _before_ the transaction, in other words the state the transaction was executed on:
-    ///    `changed_state = tx(cached_state)`
-    ///
-    /// This accepts a `inspector_setup` closure that returns the inspector to be used for tracing
-    /// a transaction. This is invoked for each transaction.
-    fn trace_block_inspector<Setup, Insp, F, R>(
-        &self,
-        block_id: BlockId,
-        block: Option<Arc<RecoveredBlock<ProviderBlock<Self::Provider>>>>,
-        insp_setup: Setup,
-        f: F,
-    ) -> impl Future<Output = Result<Option<Vec<R>>, Self::Error>> + Send
-    where
-        Self: LoadBlock,
-        // This is the callback that's invoked for each transaction with the inspector, the result,
-        // state and db
-        F: Fn(
-                TransactionInfo,
-                TracingCtx<
-                    '_,
-                    Recovered<&ProviderTx<Self::Provider>>,
-                    EvmFor<Self::Evm, &mut StateCacheDb, Insp>,
-                >,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        Setup: FnMut() -> Insp + Send + 'static,
-        Insp: Clone + for<'a> InspectorFor<Self::Evm, &'a mut StateCacheDb>,
-        R: Send + 'static,
-    {
-        self.trace_block_until_with_inspector(block_id, block, None, insp_setup, f)
-    }
-
-    /// Applies chain-specific state transitions required before executing a block.
-    ///
-    /// Note: This should only be called when tracing an entire block vs individual transactions.
-    /// When tracing transactions on top of an already committed block state, those transitions are
-    /// already applied.
-    fn apply_pre_execution_changes(
-        &self,
-        block: &RecoveredBlock<ProviderBlock<Self::Provider>>,
-        db: &mut StateCacheDb,
-    ) -> Result<(), Self::Error> {
-        self.evm_config()
-            .executor_for_block(db, block.sealed_block())
-            .map_err(RethError::other)
-            .map_err(Self::Error::from_eth_err)?
-            .apply_pre_execution_changes()
-            .map_err(reth_errors::BlockExecutionError::other)
-            .map_err(Self::Error::from_eth_err)?;
         Ok(())
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -10,13 +10,13 @@ use evm2_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use futures::Future;
 use reth_errors::RethError;
 use reth_evm::{
-    database::BorrowedDatabase, execute::BlockExecutorFactory, ConfigureEvm, Evm, EvmEnvFor,
-    EvmTypesFor, TxEnvFor, TxResultWithStateFor,
+    execute::BlockExecutorFactory, ConfigureEvm, Evm, EvmEnvFor, EvmTypesFor, TxEnvFor,
+    TxResultWithStateFor,
 };
 use reth_primitives_traits::{BlockBody, RecoveredBlock};
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
 use reth_storage_api::ProviderBlock;
-use std::{borrow::Borrow, sync::Arc};
+use std::sync::Arc;
 
 /// Context passed to per-transaction trace callbacks.
 pub struct TracingCtx<'a, Insp, EvmTypes: evm2::EvmTypes> {
@@ -56,7 +56,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
     {
         let mut evm = self.evm_config().block_executor_factory().evm_with_env(db, evm_env);
-        evm.transact_with_inspector(tx_env.borrow(), inspector).map_err(Self::Error::from_evm_err)
+        evm.transact_with_inspector(tx_env, inspector).map_err(Self::Error::from_evm_err)
     }
 
     /// Executes the transaction on top of the given [`BlockId`] with a tracer configured by the
@@ -338,7 +338,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             .map_err(Self::Error::from_eth_err)?;
         let changes = self
             .evm_config()
-            .pre_block_state_changes(BorrowedDatabase::new(&mut *db), evm_env, block.number(), ctx)
+            .pre_block_state_changes(&mut *db, evm_env, block.number(), ctx)
             .map_err(|err| EthApiError::EvmCustom(err.to_string()))
             .map_err(Self::Error::from_eth_err)?;
         db.commit_source(&changes);

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -51,7 +51,7 @@ use std::{sync::Arc, time::Duration};
 /// There are subtle differences between when transacting [`RpcTxReq`]:
 ///
 /// The endpoints `eth_call` and `eth_estimateGas` and `eth_createAccessList` should always
-/// __disable__ the base fee check in the configured EVM environment.
+/// __disable__ the base fee check in the EVM environment.
 ///
 /// The behaviour for tracing endpoints is not consistent across clients.
 /// Geth also disables the basefee check for tracing: <https://github.com/ethereum/go-ethereum/blob/bc0b87ca196f92e5af49bd33cc190ef0ec32b197/eth/tracers/api.go#L955-L955>

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -21,24 +21,26 @@ reth-metrics.workspace = true
 reth-ethereum-primitives = { workspace = true, features = ["rpc"] }
 reth-primitives-traits = { workspace = true, features = ["rpc-compat"] }
 reth-storage-api.workspace = true
+evm2.workspace = true
 reth-rpc-server-types.workspace = true
 reth-rpc-convert.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
 reth-trie.workspace = true
-evm2.workspace = true
 
 # ethereum
 alloy-chains.workspace = true
-alloy-eips.workspace = true
 alloy-eip7928.workspace = true
+alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
 alloy-transport.workspace = true
 alloy-rpc-client = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
+alloy-network.workspace = true
 alloy-serde.workspace = true
+evm2-inspectors = { workspace = true, features = ["std"] }
 
 # rpc
 jsonrpsee-core.workspace = true
@@ -69,4 +71,4 @@ reth-storage-api = { workspace = true, features = ["std"] }
 serde_json.workspace = true
 
 [features]
-js-tracer = []
+js-tracer = ["evm2-inspectors/js-tracer"]

--- a/crates/rpc/rpc-eth-types/src/cache/config.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/config.rs
@@ -23,7 +23,7 @@ pub struct EthStateCacheConfig {
     ///
     /// Default is 1000.
     pub max_headers: u32,
-    /// Max number of BALs in cache.
+    /// Max number of EVM BALs in cache.
     ///
     /// Default is 1000.
     pub max_bals: u32,

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -2,14 +2,121 @@
 //! <https://github.com/rust-lang/rust/issues/100013> in default implementation of
 //! `reth_rpc_eth_api::helpers::Call`.
 
+use crate::error::StateOverrideError;
 use alloy_primitives::{Address, B256, U256};
+use alloy_rpc_types_eth::{state::StateOverride, BlockOverrides};
+use evm2::{
+    bytecode::Bytecode,
+    evm::{CacheDB, Db, DynDatabase},
+};
 use reth_errors::ProviderResult;
+use reth_evm::{database::StateProviderDatabase, EvmEnv};
 use reth_execution_types::EvmState;
 use reth_storage_api::{BytecodeReader, HashedPostStateProvider, StateProvider, StateProviderBox};
 use reth_trie::{HashedPostState, HashedStorage, MultiProofTargets};
 
 /// Helper alias type for cached state access.
-pub type StateCacheDb = StateProviderTraitObjWrapper;
+pub type StateCacheDb = CacheDB<Db<StateProviderDatabase<StateProviderTraitObjWrapper>>>;
+
+/// Applies RPC block overrides to an evm2 environment and state cache.
+pub fn apply_block_overrides<DB>(
+    overrides: BlockOverrides,
+    db: &mut CacheDB<DB>,
+    evm_env: &mut impl EvmEnv,
+) {
+    let BlockOverrides {
+        number,
+        difficulty,
+        time,
+        gas_limit,
+        coinbase,
+        random,
+        base_fee,
+        blob_base_fee,
+        block_hash,
+        ..
+    } = overrides;
+
+    if let Some(block_hashes) = block_hash {
+        for (number, hash) in block_hashes {
+            db.insert_block_hash(&U256::from(number), &hash);
+        }
+    }
+
+    let block = evm_env.block_env_mut();
+    if let Some(number) = number {
+        block.number = number;
+    }
+    if let Some(difficulty) = difficulty {
+        block.difficulty = difficulty;
+    }
+    if let Some(time) = time {
+        block.timestamp = U256::from(time);
+    }
+    if let Some(gas_limit) = gas_limit {
+        block.gas_limit = U256::from(gas_limit);
+    }
+    if let Some(coinbase) = coinbase {
+        block.beneficiary = coinbase;
+    }
+    if let Some(random) = random {
+        block.prevrandao = U256::from_be_slice(random.as_slice());
+    }
+    if let Some(base_fee) = base_fee {
+        block.basefee = U256::from(base_fee);
+    }
+    if let Some(blob_base_fee) = blob_base_fee {
+        block.blob_basefee = U256::from(blob_base_fee);
+    }
+}
+
+/// Applies RPC state overrides to an evm2 state cache.
+pub fn apply_state_overrides<DB: DynDatabase>(
+    overrides: StateOverride,
+    db: &mut CacheDB<DB>,
+) -> Result<(), StateOverrideError<evm2::AnyError>> {
+    for (address, account_override) in overrides {
+        let mut account = db
+            .get_account(&address)
+            .map_err(|code| StateOverrideError::Database(db.error(code)))?
+            .unwrap_or_default();
+
+        if let Some(nonce) = account_override.nonce {
+            account.nonce = nonce;
+        }
+        if let Some(code) = account_override.code {
+            let code = Bytecode::new_raw_checked(code)?;
+            account.code_hash = code.hash_slow();
+            account.code = Some(code);
+        }
+        if let Some(balance) = account_override.balance {
+            account.balance = balance;
+        }
+
+        let storage = match (account_override.state, account_override.state_diff) {
+            (Some(_), Some(_)) => return Err(StateOverrideError::BothStateAndStateDiff(address)),
+            (Some(state), None) => {
+                db.cache.storage.entry(address).or_default().wipe();
+                Some(state)
+            }
+            (None, Some(state)) => Some(state),
+            (None, None) => None,
+        };
+
+        db.insert_account_info(&address, account);
+        if let Some(storage) = storage {
+            for (key, value) in storage {
+                db.insert_account_storage(
+                    &address,
+                    &U256::from_be_bytes(key.0),
+                    &U256::from_be_bytes(value.0),
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
 
 /// Hack to get around 'higher-ranked lifetime error', see
 /// <https://github.com/rust-lang/rust/issues/100013>

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -60,7 +60,7 @@ type CachedParentBlocksResponseSender<B> = oneshot::Sender<Vec<Arc<RecoveredBloc
 /// The type that can send the response for a transaction hash lookup
 type TransactionHashResponseSender<B, R> = oneshot::Sender<Option<CachedTransaction<B, R>>>;
 
-/// The type that can send the response to a requested BAL.
+/// The type that can send the response to a requested EVM BAL.
 type BalResponseSender = oneshot::Sender<ProviderResult<Option<CachedBal>>>;
 
 type BlockLruCache<B, L> =
@@ -274,7 +274,7 @@ impl<N: NodePrimitives> EthStateCache<N> {
         rx.await.ok()?
     }
 
-    /// Requests the BAL for the block hash.
+    /// Requests the EVM BAL for the block hash.
     ///
     /// Returns `None` if the BAL does not exist.
     pub async fn get_bal(
@@ -341,7 +341,7 @@ pub(crate) struct EthStateCacheService<
     /// Headers are cached because they are required to populate the environment for execution
     /// (evm).
     headers_cache: HeaderLruCache<Provider::Header, LimitHeaders>,
-    /// The LRU cache for BALs grouped by the block hash.
+    /// The LRU cache for EVM BALs grouped by the block hash.
     bal_cache: BalLruCache<LimitBals>,
     /// Sender half of the action channel.
     action_tx: UnboundedSender<CacheAction<Provider::Block, Provider::Receipt>>,
@@ -993,13 +993,24 @@ fn bytecode_heap_size(bytecode: &Bytecode) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::Header;
-    use alloy_primitives::{Address, Signature};
-    use reth_ethereum_primitives::{
-        Block, BlockBody, EthPrimitives, Transaction, TransactionSigned,
+    use alloy_consensus::{transaction::TransactionMeta, Header};
+    use alloy_eip7928::BlockAccessIndex;
+    use alloy_eips::{BlockHashOrNumber, NumHash};
+    use alloy_primitives::{
+        Address, BlockHash, BlockNumber, Bytes, Signature, TxHash, TxNumber, U256,
     };
-    use reth_primitives_traits::RecoveredBlock;
-    use reth_storage_api::noop::NoopProvider;
+    use core::ops::{RangeBounds, RangeInclusive};
+    use reth_db_models::StoredBlockBodyIndices;
+    use reth_ethereum_primitives::{
+        Block, BlockBody, EthPrimitives, Receipt, Transaction, TransactionSigned,
+    };
+    use reth_primitives_traits::{RecoveredBlock, SealedHeader};
+    use reth_storage_api::{
+        noop::NoopProvider, BalProvider, BalStore, BalStoreHandle, BlockBodyIndicesProvider,
+        BlockHashReader, BlockNumReader, BlockReader, BlockSource, HeaderProvider, ReceiptProvider,
+        TransactionVariant, TransactionsProvider,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn test_service() -> EthStateCacheService<NoopProvider, Runtime> {
         let (_cache, service) = EthStateCache::<EthPrimitives>::create(
@@ -1017,6 +1028,10 @@ mod tests {
         service
     }
 
+    fn test_decoded_evm_bal() -> DecodedBal<Arc<EvmBal>> {
+        DecodedBal::new(Arc::new(EvmBal::default()), Bytes::from_static(&[0xc0]))
+    }
+
     fn test_block() -> RecoveredBlock<Block> {
         RecoveredBlock::new_unhashed(
             Block {
@@ -1031,13 +1046,6 @@ mod tests {
             },
             vec![Address::ZERO],
         )
-    }
-
-    fn test_cached_bal() -> CachedBal {
-        CachedBal::new(DecodedBal::new(
-            Arc::new(EvmBal::default()),
-            alloy_primitives::Bytes::from_static(&[0xc0]),
-        ))
     }
 
     #[test]
@@ -1090,7 +1098,7 @@ mod tests {
         let mut service = test_service();
         let block_hash = B256::repeat_byte(0x44);
 
-        assert!(service.bal_cache.insert(block_hash, test_cached_bal()));
+        assert!(service.bal_cache.insert(block_hash, CachedBal::new(test_decoded_evm_bal())));
         assert!(service.bal_cache.get(&block_hash).is_some());
 
         service.on_reorg_bal(block_hash, Ok(None));
@@ -1103,7 +1111,7 @@ mod tests {
         let mut service = test_service();
         let block_hash = B256::repeat_byte(0x55);
         let (response_tx, mut response_rx) = oneshot::channel();
-        let bal = test_cached_bal();
+        let bal = CachedBal::new(test_decoded_evm_bal());
 
         assert!(service.bal_cache.queue(block_hash, response_tx));
 
@@ -1115,34 +1123,28 @@ mod tests {
     }
 
     #[test]
-    fn cached_bal_size_accounts_for_nested_allocations() {
-        let index = alloy_eip7928::BlockAccessIndex::new(1);
+    fn cached_evm_bal_size_accounts_for_nested_allocations() {
+        let index = BlockAccessIndex::new(1);
         let mut account = EvmAccountBal::default();
         account.account_info.nonce.changes.push(alloy_eip7928::NonceChange::new(index, 1));
         account
             .account_info
             .balance
             .changes
-            .push(alloy_eip7928::BalanceChange::new(index, alloy_primitives::U256::from(1)));
+            .push(alloy_eip7928::BalanceChange::new(index, U256::from(1)));
         account.account_info.code.changes.push(EvmBalCodeChange::new(
             index,
-            (
-                B256::repeat_byte(0xaa),
-                Bytecode::new_raw(alloy_primitives::Bytes::from_static(&[0x60, 0x00])),
-            ),
+            (B256::repeat_byte(0xaa), Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00]))),
         ));
         account.storage.storage.insert(
-            alloy_primitives::U256::from(1),
-            EvmBalChanges::new(vec![alloy_eip7928::StorageChange::new(
-                index,
-                alloy_primitives::U256::from(2),
-            )]),
+            U256::from(1),
+            EvmBalChanges::new(vec![alloy_eip7928::StorageChange::new(index, U256::from(2))]),
         );
 
         let mut bal = EvmBal::default();
         bal.accounts.insert(Address::ZERO, account);
 
-        let raw = alloy_primitives::Bytes::from_static(&[0xc0, 0x01, 0x02]);
+        let raw = Bytes::from_static(&[0xc0, 0x01, 0x02]);
         let top_level_estimate = core::mem::size_of::<CachedBal>() +
             core::mem::size_of::<DecodedBal<Arc<EvmBal>>>() +
             raw.len() +
@@ -1151,9 +1153,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_bal_returns_none_when_store_misses() {
+    async fn get_bal_uses_cached_evm_bal() {
+        let fetches = Arc::new(AtomicUsize::default());
+        let provider = TestBalProvider::new(fetches.clone());
         let cache = EthStateCache::<EthPrimitives>::spawn_with(
-            NoopProvider::default(),
+            provider,
+            EthStateCacheConfig {
+                max_blocks: 0,
+                max_receipts: 0,
+                max_headers: 0,
+                max_bals: 4,
+                max_concurrent_db_requests: 1,
+                max_cached_tx_hashes: 0,
+            },
+            Runtime::test(),
+        );
+        let block_hash = B256::repeat_byte(0x66);
+
+        assert!(cache.get_bal(block_hash).await.unwrap().is_some());
+        assert!(cache.get_bal(block_hash).await.unwrap().is_some());
+
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_get_bal_requests_share_fetch() {
+        let fetches = Arc::new(AtomicUsize::default());
+        let provider = TestBalProvider::new(fetches.clone());
+        let cache = EthStateCache::<EthPrimitives>::spawn_with(
+            provider,
             EthStateCacheConfig {
                 max_blocks: 0,
                 max_receipts: 0,
@@ -1166,6 +1194,299 @@ mod tests {
         );
         let block_hash = B256::repeat_byte(0x77);
 
-        assert!(cache.get_bal(block_hash).await.unwrap().is_none());
+        let (first, second) = tokio::join!(cache.get_bal(block_hash), cache.get_bal(block_hash));
+
+        assert!(first.unwrap().is_some());
+        assert!(second.unwrap().is_some());
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct TestBalProvider {
+        bal_store: BalStoreHandle,
+    }
+
+    impl TestBalProvider {
+        fn new(fetches: Arc<AtomicUsize>) -> Self {
+            Self { bal_store: BalStoreHandle::new(TestBalStore { fetches }) }
+        }
+    }
+
+    impl BalProvider for TestBalProvider {
+        fn bal_store(&self) -> &BalStoreHandle {
+            &self.bal_store
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestBalStore {
+        fetches: Arc<AtomicUsize>,
+    }
+
+    impl BalStore for TestBalStore {
+        fn insert(&self, _num_hash: NumHash, _bal: reth_storage_api::RawBal) -> ProviderResult<()> {
+            Ok(())
+        }
+
+        fn prune(&self, _tip: BlockNumber) -> ProviderResult<usize> {
+            Ok(0)
+        }
+
+        fn get_by_hashes(&self, block_hashes: &[BlockHash]) -> ProviderResult<Vec<Option<Bytes>>> {
+            Ok(block_hashes.iter().map(|_| None).collect())
+        }
+
+        fn evm_bal_by_hash(
+            &self,
+            _block_hash: BlockHash,
+        ) -> ProviderResult<Option<DecodedBal<Arc<EvmBal>>>> {
+            self.fetches.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(test_decoded_evm_bal()))
+        }
+
+        fn bal_stream(&self) -> reth_storage_api::BalNotificationStream {
+            reth_storage_api::NoopBalStore.bal_stream()
+        }
+    }
+
+    impl BlockHashReader for TestBalProvider {
+        fn block_hash(&self, _number: BlockNumber) -> ProviderResult<Option<B256>> {
+            Ok(None)
+        }
+
+        fn canonical_hashes_range(
+            &self,
+            _start: BlockNumber,
+            _end: BlockNumber,
+        ) -> ProviderResult<Vec<B256>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl BlockNumReader for TestBalProvider {
+        fn chain_info(&self) -> ProviderResult<reth_chainspec::ChainInfo> {
+            Ok(reth_chainspec::ChainInfo::default())
+        }
+
+        fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+            Ok(0)
+        }
+
+        fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+            Ok(0)
+        }
+
+        fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
+            Ok(None)
+        }
+    }
+
+    impl HeaderProvider for TestBalProvider {
+        type Header = Header;
+
+        fn header(&self, _block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+            Ok(None)
+        }
+
+        fn header_by_number(&self, _num: u64) -> ProviderResult<Option<Self::Header>> {
+            Ok(None)
+        }
+
+        fn headers_range(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+        ) -> ProviderResult<Vec<Self::Header>> {
+            Ok(Vec::new())
+        }
+
+        fn sealed_header(
+            &self,
+            _number: BlockNumber,
+        ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+            Ok(None)
+        }
+
+        fn sealed_headers_while(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+            _predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+        ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl BlockBodyIndicesProvider for TestBalProvider {
+        fn block_body_indices(&self, _num: u64) -> ProviderResult<Option<StoredBlockBodyIndices>> {
+            Ok(None)
+        }
+
+        fn block_body_indices_range(
+            &self,
+            _range: RangeInclusive<BlockNumber>,
+        ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl TransactionsProvider for TestBalProvider {
+        type Transaction = TransactionSigned;
+
+        fn transaction_id(&self, _tx_hash: TxHash) -> ProviderResult<Option<TxNumber>> {
+            Ok(None)
+        }
+
+        fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<Self::Transaction>> {
+            Ok(None)
+        }
+
+        fn transaction_by_id_unhashed(
+            &self,
+            _id: TxNumber,
+        ) -> ProviderResult<Option<Self::Transaction>> {
+            Ok(None)
+        }
+
+        fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Self::Transaction>> {
+            Ok(None)
+        }
+
+        fn transaction_by_hash_with_meta(
+            &self,
+            _hash: TxHash,
+        ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+            Ok(None)
+        }
+
+        fn transactions_by_block(
+            &self,
+            _block: BlockHashOrNumber,
+        ) -> ProviderResult<Option<Vec<Self::Transaction>>> {
+            Ok(None)
+        }
+
+        fn transactions_by_block_range(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+        ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
+            Ok(Vec::new())
+        }
+
+        fn transactions_by_tx_range(
+            &self,
+            _range: impl RangeBounds<TxNumber>,
+        ) -> ProviderResult<Vec<Self::Transaction>> {
+            Ok(Vec::new())
+        }
+
+        fn senders_by_tx_range(
+            &self,
+            _range: impl RangeBounds<TxNumber>,
+        ) -> ProviderResult<Vec<Address>> {
+            Ok(Vec::new())
+        }
+
+        fn transaction_sender(&self, _id: TxNumber) -> ProviderResult<Option<Address>> {
+            Ok(None)
+        }
+    }
+
+    impl ReceiptProvider for TestBalProvider {
+        type Receipt = Receipt;
+
+        fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Self::Receipt>> {
+            Ok(None)
+        }
+
+        fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Self::Receipt>> {
+            Ok(None)
+        }
+
+        fn receipts_by_block(
+            &self,
+            _block: BlockHashOrNumber,
+        ) -> ProviderResult<Option<Vec<Self::Receipt>>> {
+            Ok(None)
+        }
+
+        fn receipts_by_tx_range(
+            &self,
+            _range: impl RangeBounds<TxNumber>,
+        ) -> ProviderResult<Vec<Self::Receipt>> {
+            Ok(Vec::new())
+        }
+
+        fn receipts_by_block_range(
+            &self,
+            _block_range: RangeInclusive<BlockNumber>,
+        ) -> ProviderResult<Vec<Vec<Self::Receipt>>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl BlockReader for TestBalProvider {
+        type Block = Block;
+
+        fn find_block_by_hash(
+            &self,
+            _hash: B256,
+            _source: BlockSource,
+        ) -> ProviderResult<Option<Self::Block>> {
+            Ok(None)
+        }
+
+        fn block(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
+            Ok(None)
+        }
+
+        fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+            Ok(None)
+        }
+
+        fn pending_block_and_receipts(
+            &self,
+        ) -> ProviderResult<Option<(RecoveredBlock<Self::Block>, Vec<Self::Receipt>)>> {
+            Ok(None)
+        }
+
+        fn recovered_block(
+            &self,
+            _id: BlockHashOrNumber,
+            _transaction_kind: TransactionVariant,
+        ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+            Ok(None)
+        }
+
+        fn sealed_block_with_senders(
+            &self,
+            _id: BlockHashOrNumber,
+            _transaction_kind: TransactionVariant,
+        ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
+            Ok(None)
+        }
+
+        fn block_range(
+            &self,
+            _range: RangeInclusive<BlockNumber>,
+        ) -> ProviderResult<Vec<Self::Block>> {
+            Ok(Vec::new())
+        }
+
+        fn block_with_senders_range(
+            &self,
+            _range: RangeInclusive<BlockNumber>,
+        ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+            Ok(Vec::new())
+        }
+
+        fn recovered_block_range(
+            &self,
+            _range: RangeInclusive<BlockNumber>,
+        ) -> ProviderResult<Vec<RecoveredBlock<Self::Block>>> {
+            Ok(Vec::new())
+        }
+
+        fn block_by_transaction_id(&self, _id: TxNumber) -> ProviderResult<Option<BlockNumber>> {
+            Ok(None)
+        }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -1,7 +1,10 @@
 //! Helper traits to wrap generic l1 errors, in network specific error type configured in
 //! `reth_rpc_eth_api::EthApiTypes`.
 
-use crate::{simulate::EthSimulateError, EthApiError};
+use crate::{simulate::EthSimulateError, EthApiError, RevertError};
+use alloy_primitives::Bytes;
+use evm2::{interpreter::InstrStop, TxResult};
+use reth_evm::{BlockExecutionError, ConfigureEvm};
 
 use super::RpcInvalidTransactionError;
 
@@ -106,6 +109,55 @@ impl AsEthApiError for EthApiError {
 }
 
 /// Helper trait to convert from EVM errors.
-pub trait FromEvmError<Evm>: FromEthApiError {}
+pub trait FromEvmError<Evm: ConfigureEvm>:
+    FromEthApiError + FromEvmHalt<InstrStop> + FromRevert
+{
+    /// Converts from EVM error to this type.
+    fn from_evm_err(err: BlockExecutionError) -> Self {
+        Self::from_eth_err(err)
+    }
 
-impl<T, Evm> FromEvmError<Evm> for T where T: FromEthApiError {}
+    /// Ensures the execution result is successful or returns an error.
+    fn ensure_success(result: TxResult) -> Result<Bytes, Self> {
+        if result.status {
+            Ok(result.output)
+        } else if result.stop.is_revert() {
+            Err(Self::from_revert(result.output))
+        } else {
+            Err(Self::from_evm_halt(result.stop, result.tx_gas_used()))
+        }
+    }
+}
+
+impl<T, Evm> FromEvmError<Evm> for T
+where
+    T: FromEthApiError + FromEvmHalt<InstrStop> + FromRevert,
+    Evm: ConfigureEvm,
+{
+}
+
+/// Helper trait to convert from EVM halts.
+pub trait FromEvmHalt<Halt> {
+    /// Converts from EVM halt to this type.
+    fn from_evm_halt(halt: Halt, gas_limit: u64) -> Self;
+}
+
+impl FromEvmHalt<InstrStop> for EthApiError {
+    fn from_evm_halt(halt: InstrStop, gas_limit: u64) -> Self {
+        RpcInvalidTransactionError::halt(halt, gas_limit).into()
+    }
+}
+
+/// Helper trait to construct errors from unexpected reverts.
+pub trait FromRevert {
+    /// Constructs an error from revert bytes.
+    ///
+    /// This is only invoked when revert was unexpected (`eth_call`, `eth_estimateGas`, etc).
+    fn from_revert(output: Bytes) -> Self;
+}
+
+impl FromRevert for EthApiError {
+    fn from_revert(output: Bytes) -> Self {
+        RpcInvalidTransactionError::Revert(RevertError::new(output)).into()
+    }
+}

--- a/crates/rpc/rpc-eth-types/src/error/api.rs
+++ b/crates/rpc/rpc-eth-types/src/error/api.rs
@@ -118,7 +118,7 @@ pub trait FromEvmError<Evm: ConfigureEvm>:
     }
 
     /// Ensures the execution result is successful or returns an error.
-    fn ensure_success(result: TxResult) -> Result<Bytes, Self> {
+    fn ensure_success<EvmTypes: evm2::EvmTypes>(result: TxResult<EvmTypes>) -> Result<Bytes, Self> {
         if result.status {
             Ok(result.output)
         } else if result.stop.is_revert() {

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -8,9 +8,11 @@ use alloy_sol_types::{ContractError, RevertReason};
 use alloy_transport::{RpcError, TransportErrorKind};
 pub use api::{AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError};
 use core::time::Duration;
+use evm2::{interpreter::InstrStop, registry::HandlerError};
+use evm2_inspectors::tracing::{DebugInspectorError, MuxError};
 use reth_errors::{BlockExecutionError, BlockValidationError, RethError};
 use reth_primitives_traits::transaction::{error::InvalidTransactionError, signed::RecoveryError};
-use reth_rpc_convert::TransactionConversionError;
+use reth_rpc_convert::{CallFeesError, EthTxEnvError, TransactionConversionError};
 use reth_rpc_server_types::result::{
     block_id_to_str, internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code,
 };
@@ -20,16 +22,6 @@ use reth_transaction_pool::error::{
 };
 use std::convert::Infallible;
 use tokio::sync::oneshot::error::RecvError;
-
-#[cfg(any())]
-enum EvmDatabaseError<E> {
-    Bal(BalError),
-    Database(E),
-}
-
-#[cfg(any())]
-#[derive(Debug)]
-struct BalError;
 
 /// A trait to convert an error to an RPC error.
 pub trait ToRpcError: core::error::Error + Send + Sync + 'static {
@@ -179,6 +171,9 @@ pub enum EthApiError {
     /// Error encountered when converting a transaction type
     #[error(transparent)]
     TransactionConversionError(#[from] TransactionConversionError),
+    /// Error thrown when tracing with a muxTracer fails.
+    #[error(transparent)]
+    MuxTracerError(#[from] MuxError),
     /// Error thrown when waiting for transaction confirmation times out
     #[error(
         "Transaction {hash} was added to the mempool but wasn't confirmed within {duration:?}."
@@ -211,6 +206,41 @@ pub enum EthApiError {
     /// Any other error
     #[error("{0}")]
     Other(Box<dyn ToRpcError>),
+}
+
+/// Insufficient funds error.
+#[derive(Debug, thiserror::Error)]
+#[error("insufficient funds: cost {cost} > balance {balance}")]
+pub struct InsufficientFundsError {
+    /// Transaction cost.
+    pub cost: U256,
+    /// Account balance.
+    pub balance: U256,
+}
+
+/// Error type for call utilities.
+#[derive(Debug, thiserror::Error)]
+pub enum CallError<E> {
+    /// Database error.
+    #[error(transparent)]
+    Database(E),
+    /// Insufficient funds error.
+    #[error(transparent)]
+    InsufficientFunds(#[from] InsufficientFundsError),
+}
+
+/// Errors that can occur while applying state overrides.
+#[derive(Debug, thiserror::Error)]
+pub enum StateOverrideError<E> {
+    /// Invalid bytecode provided in an override.
+    #[error(transparent)]
+    InvalidBytecode(#[from] evm2::bytecode::BytecodeDecodeError),
+    /// Both state and state diff were provided for an account.
+    #[error("Both 'state' and 'stateDiff' fields are set for account {0}")]
+    BothStateAndStateDiff(Address),
+    /// Database error.
+    #[error(transparent)]
+    Database(E),
 }
 
 impl EthApiError {
@@ -250,6 +280,22 @@ impl EthApiError {
             Self::InvalidTransaction(e) => Some(e),
             _ => None,
         }
+    }
+
+    /// Converts the given [`StateOverrideError`] into a new [`EthApiError`] instance.
+    pub fn from_state_overrides_err<E>(err: StateOverrideError<E>) -> Self
+    where
+        E: Into<Self>,
+    {
+        err.into()
+    }
+
+    /// Converts the given [`CallError`] into a new [`EthApiError`] instance.
+    pub fn from_call_err<E>(err: CallError<E>) -> Self
+    where
+        E: Into<Self>,
+    {
+        err.into()
     }
 
     /// Converts this error into the rpc error object.
@@ -315,6 +361,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             err @ EthApiError::TransactionInputError(_) => invalid_params_rpc_err(err.to_string()),
             EthApiError::PrunedHistoryUnavailable => rpc_error_with_code(4444, error.to_string()),
             EthApiError::Other(err) => err.to_rpc_error(),
+            EthApiError::MuxTracerError(msg) => internal_rpc_err(msg.to_string()),
             EthApiError::BatchTxRecvError(err) => internal_rpc_err(err.to_string()),
             EthApiError::BatchTxSendError => {
                 internal_rpc_err("Batch transaction sender channel closed".to_string())
@@ -336,23 +383,98 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
     }
 }
 
-#[cfg(any())]
-impl<E> From<EvmDatabaseError<E>> for EthApiError
+impl<E> From<CallError<E>> for EthApiError
 where
     E: Into<Self>,
 {
-    fn from(value: EvmDatabaseError<E>) -> Self {
+    fn from(value: CallError<E>) -> Self {
         match value {
-            EvmDatabaseError::Bal(err) => err.into(),
-            EvmDatabaseError::Database(err) => err.into(),
+            CallError::Database(err) => err.into(),
+            CallError::InsufficientFunds(err) => {
+                Self::InvalidTransaction(RpcInvalidTransactionError::InsufficientFunds {
+                    cost: err.cost,
+                    balance: err.balance,
+                })
+            }
         }
     }
 }
 
-#[cfg(any())]
-impl From<BalError> for EthApiError {
-    fn from(err: BalError) -> Self {
-        Self::EvmCustom(format!("bal error: {:?}", err))
+impl<E> From<StateOverrideError<E>> for EthApiError
+where
+    E: Into<Self>,
+{
+    fn from(value: StateOverrideError<E>) -> Self {
+        match value {
+            StateOverrideError::InvalidBytecode(err) => Self::InvalidBytecode(err.to_string()),
+            StateOverrideError::BothStateAndStateDiff(address) => {
+                Self::BothStateAndStateDiffInOverride(address)
+            }
+            StateOverrideError::Database(err) => err.into(),
+        }
+    }
+}
+
+impl From<EthTxEnvError> for EthApiError {
+    fn from(value: EthTxEnvError) -> Self {
+        match value {
+            EthTxEnvError::CallFees(CallFeesError::BlobTransactionMissingBlobHashes) => {
+                Self::InvalidTransaction(
+                    RpcInvalidTransactionError::BlobTransactionMissingBlobHashes,
+                )
+            }
+            EthTxEnvError::CallFees(CallFeesError::FeeCapTooLow) => {
+                Self::InvalidTransaction(RpcInvalidTransactionError::FeeCapTooLow)
+            }
+            EthTxEnvError::CallFees(CallFeesError::ConflictingFeeFieldsInRequest) => {
+                Self::ConflictingFeeFieldsInRequest
+            }
+            EthTxEnvError::CallFees(CallFeesError::TipAboveFeeCap) => {
+                Self::InvalidTransaction(RpcInvalidTransactionError::TipAboveFeeCap)
+            }
+            EthTxEnvError::CallFees(CallFeesError::TipVeryHigh) => {
+                Self::InvalidTransaction(RpcInvalidTransactionError::TipVeryHigh)
+            }
+            EthTxEnvError::Input(err) => Self::TransactionInputError(err),
+            EthTxEnvError::BlobTransactionIsCreate => {
+                Self::InvalidTransaction(RpcInvalidTransactionError::BlobTransactionIsCreate)
+            }
+            EthTxEnvError::AuthorizationListInvalidFields => {
+                Self::InvalidTransaction(RpcInvalidTransactionError::AuthorizationListInvalidFields)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "js-tracer")]
+impl From<evm2_inspectors::tracing::js::JsInspectorError> for EthApiError {
+    fn from(error: evm2_inspectors::tracing::js::JsInspectorError) -> Self {
+        match error {
+            err @ evm2_inspectors::tracing::js::JsInspectorError::JsError(_) => {
+                Self::InternalJsTracerError(err.to_string())
+            }
+            err => Self::InvalidParams(err.to_string()),
+        }
+    }
+}
+
+impl From<DebugInspectorError> for EthApiError {
+    fn from(error: DebugInspectorError) -> Self {
+        match error {
+            DebugInspectorError::InvalidTracerConfig => Self::InvalidTracerConfig,
+            DebugInspectorError::UnsupportedTracer => Self::Unsupported("unsupported tracer"),
+            DebugInspectorError::JsTracerNotEnabled => {
+                Self::Unsupported("JS Tracer is not enabled")
+            }
+            DebugInspectorError::MuxInspector(err) => err.into(),
+            DebugInspectorError::Database(err) => {
+                Self::Internal(RethError::msg(format!("{err:?}")))
+            }
+            #[cfg(feature = "js-tracer")]
+            DebugInspectorError::JsInspector(err) => err.into(),
+            #[allow(unreachable_patterns)]
+            _ => Self::Unsupported("unsupported tracer error"),
+        }
     }
 }
 
@@ -385,6 +507,12 @@ impl From<BlockExecutionError> for EthApiError {
                         ))
                     }
                 }
+                BlockValidationError::Other(error) => match error.downcast::<HandlerError>() {
+                    Ok(error) => Self::InvalidTransaction((*error).into()),
+                    Err(error) => Self::Internal(RethError::Execution(
+                        BlockExecutionError::Validation(BlockValidationError::Other(error)),
+                    )),
+                },
                 _ => Self::Internal(RethError::Execution(BlockExecutionError::Validation(
                     validation_error,
                 ))),
@@ -393,6 +521,12 @@ impl From<BlockExecutionError> for EthApiError {
                 Self::Internal(RethError::Execution(BlockExecutionError::Internal(internal_error)))
             }
         }
+    }
+}
+
+impl From<evm2::AnyError> for EthApiError {
+    fn from(error: evm2::AnyError) -> Self {
+        Self::EvmCustom(error.to_string())
     }
 }
 
@@ -611,6 +745,19 @@ impl RpcInvalidTransactionError {
         Self::Other(Box::new(err))
     }
 
+    /// Converts the halt error.
+    pub fn halt(reason: InstrStop, gas_limit: u64) -> Self {
+        match reason {
+            InstrStop::OutOfGas | InstrStop::ReentrancySentryOOG => Self::BasicOutOfGas(gas_limit),
+            InstrStop::MemoryOOG => Self::MemoryOutOfGas(gas_limit),
+            InstrStop::MemoryLimitOOG => Self::MemoryLimitOutOfGas,
+            InstrStop::PrecompileOOG => Self::PrecompileOutOfGas(gas_limit),
+            InstrStop::InvalidOperandOOG => Self::InvalidOperandOutOfGas(gas_limit),
+            InstrStop::NonceOverflow => Self::NonceMaxValue,
+            err => Self::EvmHalt(format!("{err:?}")),
+        }
+    }
+
     /// Returns the rpc error code for this error.
     pub const fn error_code(&self) -> i32 {
         match self {
@@ -679,6 +826,42 @@ impl From<InvalidTransactionError> for RpcInvalidTransactionError {
             InvalidTransactionError::FeeCapTooLow => Self::FeeCapTooLow,
             InvalidTransactionError::SignerAccountHasBytecode => Self::SenderNoEOA,
             InvalidTransactionError::GasLimitTooHigh => Self::GasLimitTooHigh,
+        }
+    }
+}
+
+impl From<HandlerError> for RpcInvalidTransactionError {
+    fn from(err: HandlerError) -> Self {
+        match err {
+            HandlerError::InvalidNonce { expected, got } if got < expected => {
+                Self::NonceTooLow { tx: got, state: expected }
+            }
+            HandlerError::InvalidNonce { .. } => Self::NonceTooHigh,
+            HandlerError::InvalidChainId { .. } | HandlerError::MissingChainId => {
+                Self::InvalidChainId
+            }
+            HandlerError::IntrinsicGasTooLow { .. } => Self::GasTooLow,
+            HandlerError::InsufficientFunds | HandlerError::OutOfFunds => {
+                Self::InsufficientFundsForTransfer
+            }
+            HandlerError::RejectCallerWithCode => Self::SenderNoEOA,
+            HandlerError::NonceOverflow => Self::NonceMaxValue,
+            HandlerError::GasLimitMoreThanBlock { .. } |
+            HandlerError::TxGasLimitGreaterThanCap { .. } => Self::GasTooHigh,
+            HandlerError::CreateInitCodeSizeLimit { .. } => Self::MaxInitCodeSizeExceeded,
+            HandlerError::UnsupportedTransactionType(_) |
+            HandlerError::WrongTransactionType { .. } => Self::TxTypeNotSupported,
+            HandlerError::FeeCapLessThanBaseFee { .. } => Self::FeeCapTooLow,
+            HandlerError::EmptyAuthorizationList => Self::AuthorizationListInvalidFields,
+            HandlerError::BlobFeeCapLessThanBlobBaseFee { .. } => Self::BlobFeeCapTooLow,
+            HandlerError::EmptyBlobs => Self::BlobTransactionMissingBlobHashes,
+            HandlerError::TooManyBlobs { have, .. } => Self::TooManyBlobs { have },
+            HandlerError::BlobVersionNotSupported => Self::BlobHashVersionMismatch,
+            HandlerError::PriorityFeeGreaterThanMaxFee => Self::TipAboveFeeCap,
+            err => Self::other(rpc_error_with_code(
+                EthRpcErrorCode::TransactionRejected.code(),
+                err.to_string(),
+            )),
         }
     }
 }

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -1,17 +1,47 @@
 //! Utilities for serving `eth_simulateV1`
 
-use crate::{error::ToRpcError, EthApiError};
+use crate::{
+    error::{api::FromEthApiError, FromEvmError, ToRpcError},
+    EthApiError,
+};
 use alloy_chains::Chain;
-use alloy_consensus::BlockHeader;
-use alloy_primitives::U256;
-use alloy_rpc_types_eth::{simulate::SimBlock, BlockId, BlockOverrides};
+use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
+use alloy_eips::eip2718::WithEncoded;
+use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_rpc_types_eth::{
+    simulate::{SimBlock, SimCallResult, SimulateError, SimulatedBlock},
+    state::StateOverride,
+    BlockId, BlockOverrides, BlockTransactionsKind,
+};
+use evm2::{precompiles::MovePrecompileError, EvmFeatures, TxResult};
 use jsonrpsee_types::{error::INTERNAL_ERROR_CODE, ErrorObject};
-use reth_primitives_traits::SealedHeader;
+use reth_evm::{
+    execute::{BlockBuilder, BlockBuilderOutcome},
+    Database, Evm as RethEvm, EvmEnv,
+};
+use reth_primitives_traits::{
+    BlockBody as _, BlockTy, NodePrimitives, Recovered, RecoveredBlock, SealedHeader,
+};
+use reth_rpc_convert::{RpcBlock, RpcConvert, RpcTxReq};
 use reth_rpc_server_types::result::{block_id_to_str, rpc_err};
+use reth_storage_api::{noop::NoopProvider, StateProvider};
 
 /// Fallback seconds added between simulated block timestamps when neither the user nor the chain
 /// hint provides a value.
 const SIMULATE_FALLBACK_TIMESTAMP_INCREMENT: u64 = 12;
+
+/// Error code for execution reverted in `eth_simulateV1`.
+///
+/// Consistent with `eth_call` revert error code.
+///
+/// <https://github.com/ethereum/execution-apis/pull/748>
+pub const SIMULATE_REVERT_CODE: i32 = 3;
+
+/// Error code for VM execution errors (e.g., out of gas) in `eth_simulateV1`.
+///
+/// <https://github.com/ethereum/execution-apis>
+pub const SIMULATE_VM_ERROR_CODE: i32 = -32015;
 
 /// Errors which may occur during `eth_simulateV1` execution.
 #[derive(Debug, thiserror::Error)]
@@ -81,6 +111,12 @@ pub enum EthSimulateError {
     /// Max init code size exceeded.
     #[error("max initcode size exceeded")]
     MaxInitCodeSizeExceeded,
+    /// Attempted to move a non-precompile address.
+    #[error("account {0} is not a precompile")]
+    NotAPrecompile(Address),
+    /// Attempted to move a precompile to its own address.
+    #[error("cannot move precompile {0} to itself")]
+    MovePrecompileToSelf(Address),
 }
 
 impl EthSimulateError {
@@ -99,7 +135,8 @@ impl EthSimulateError {
             Self::SenderNotEOA => -38024,
             Self::MaxInitCodeSizeExceeded => -38025,
             Self::TooManyBlocks | Self::GasLimitReached => -38026,
-            Self::BlockNotFound { .. } => -32000,
+            Self::MovePrecompileToSelf(_) => -38022,
+            Self::BlockNotFound { .. } | Self::NotAPrecompile(_) => -32000,
         }
     }
 }
@@ -211,15 +248,394 @@ where
     Ok(out)
 }
 
+/// Applies precompile move overrides from state overrides to the EVM's precompiles map.
+///
+/// This function processes `movePrecompileToAddress` entries from the state overrides and
+/// moves precompiles from their original addresses to new addresses. The original address
+/// is cleared (precompile removed) and the precompile is installed at the destination address.
+pub fn apply_precompile_overrides(
+    state_overrides: &StateOverride,
+    evm: &mut impl RethEvm,
+) -> Result<(), EthSimulateError> {
+    let moves: Vec<_> = state_overrides
+        .iter()
+        .filter_map(|(source, account_override)| {
+            account_override.move_precompile_to.map(|dest| (*source, dest))
+        })
+        .collect();
+    if moves.is_empty() {
+        return Ok(())
+    }
+
+    for (source, dest) in &moves {
+        if source == dest {
+            if !evm.has_precompile(source) {
+                return Err(EthSimulateError::NotAPrecompile(*source))
+            }
+            return Err(EthSimulateError::MovePrecompileToSelf(*source))
+        }
+    }
+
+    evm.move_precompiles(moves).map_err(|MovePrecompileError::NotAPrecompile(addr)| {
+        EthSimulateError::NotAPrecompile(addr)
+    })?;
+
+    Ok(())
+}
+
+/// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the
+/// given [`BlockExecutor`].
+///
+/// Returns all executed transactions and the result of the execution.
+///
+/// For each call without an explicit `gas` field, the remaining block gas is used as the default.
+/// The RPC gas cap is tracked as a request-wide remaining budget and caps each call before
+/// execution. This matches the spec rule `"gasLimit: blockGasLimit - soFarUsedGasInBlock"` and
+/// geth's per-call `sanitizeCall` behavior.
+///
+/// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
+pub fn execute_transactions<S, T>(
+    mut builder: S,
+    state_provider: impl StateProvider,
+    calls: Vec<RpcTxReq<T::Network>>,
+    remaining_call_gas_limit: &mut Option<u64>,
+    chain_id: u64,
+    compute_state_root: bool,
+    converter: &T,
+) -> Result<(BlockBuilderOutcome<S::Primitives>, Vec<TxResult>), EthApiError>
+where
+    S: BlockBuilder,
+    T: RpcConvert<Primitives = S::Primitives>,
+{
+    builder.apply_pre_execution_changes()?;
+
+    let mut results = Vec::with_capacity(calls.len());
+    let mut cumulative_tx_gas_used: u64 = 0;
+    let mut block_regular_gas_used: u64 = 0;
+    let mut block_state_gas_used: u64 = 0;
+    let block_gas_limit = builder.evm_env().block_env().gas_limit.to::<u64>();
+    let is_amsterdam = builder.evm_env().version().feature(EvmFeatures::EIP8037);
+    let tx_gas_limit_cap = builder.evm_env().version().tx_gas_limit_cap;
+    for mut call in calls {
+        let block_gas_remaining = if is_amsterdam {
+            block_gas_limit
+                .saturating_sub(block_regular_gas_used)
+                .min(block_gas_limit.saturating_sub(block_state_gas_used))
+        } else {
+            block_gas_limit.saturating_sub(cumulative_tx_gas_used)
+        };
+        let mut default_gas_limit = block_gas_remaining;
+
+        if let Some(gas_limit) = call.as_ref().gas_limit() {
+            let exceeds_gas_limit = if is_amsterdam {
+                let regular_available_gas = block_gas_limit.saturating_sub(block_regular_gas_used);
+                let state_available_gas = block_gas_limit.saturating_sub(block_state_gas_used);
+                let regular_tx_gas_limit = gas_limit.min(tx_gas_limit_cap);
+
+                regular_tx_gas_limit > regular_available_gas || gas_limit > state_available_gas
+            } else {
+                gas_limit > block_gas_remaining
+            };
+
+            if exceeds_gas_limit {
+                return Err(EthApiError::other(EthSimulateError::BlockGasLimitExceeded))
+            }
+        }
+
+        if let Some(remaining_call_gas_limit) = *remaining_call_gas_limit {
+            if let Some(gas_limit) = call.as_ref().gas_limit() {
+                if gas_limit > remaining_call_gas_limit {
+                    call.as_mut().set_gas_limit(remaining_call_gas_limit);
+                }
+            } else {
+                default_gas_limit = default_gas_limit.min(remaining_call_gas_limit);
+            }
+        }
+
+        // Resolve transaction, populate missing fields and enforce calls
+        // correctness.
+        let tx = resolve_transaction_with_evm(
+            call,
+            default_gas_limit,
+            builder.evm_env().block_base_fee(),
+            chain_id,
+            !builder.evm_env().version().feature(EvmFeatures::NONCE_CHECK),
+            builder.evm_mut(),
+            converter,
+        )?;
+        // Create transaction with an empty envelope.
+        // The effect for a layer-2 execution client is that it does not charge L1 cost.
+        let tx = WithEncoded::new(Default::default(), tx);
+
+        let mut tx_regular_gas_used = 0;
+        let gas_output = builder.execute_transaction_with_result_closure(tx, |result| {
+            tx_regular_gas_used = result.regular_gas_spent();
+            results.push(result.clone())
+        })?;
+
+        let gas_used = gas_output.tx_gas_used();
+        if let Some(remaining_call_gas_limit) = remaining_call_gas_limit.as_mut() {
+            if gas_used > *remaining_call_gas_limit {
+                return Err(EthApiError::other(EthSimulateError::GasLimitReached))
+            }
+            *remaining_call_gas_limit -= gas_used;
+        }
+
+        cumulative_tx_gas_used = cumulative_tx_gas_used.saturating_add(gas_used);
+        block_regular_gas_used = block_regular_gas_used.saturating_add(tx_regular_gas_used);
+        block_state_gas_used = block_state_gas_used.saturating_add(gas_output.state_gas_used());
+    }
+
+    let result = if compute_state_root {
+        builder.finish(state_provider, None)?
+    } else {
+        builder.finish(NoopProvider::default(), None)?
+    };
+
+    Ok((result, results))
+}
+
+/// Goes over the list of [`TransactionRequest`]s and populates missing fields trying to resolve
+/// them into primitive transactions.
+///
+/// This will set the defaults as defined in <https://github.com/ethereum/execution-apis/blob/e56d3208789259d0b09fa68e9d8594aa4d73c725/docs/ethsimulatev1-notes.md#default-values-for-transactions>
+///
+/// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
+pub fn resolve_transaction<DB: Database, Tx, T>(
+    tx: RpcTxReq<T::Network>,
+    default_gas_limit: u64,
+    block_base_fee_per_gas: u64,
+    chain_id: u64,
+    disable_nonce_check: bool,
+    db: &mut DB,
+    converter: &T,
+) -> Result<Recovered<Tx>, EthApiError>
+where
+    DB::Error: Into<EthApiError>,
+    T: RpcConvert<Primitives: NodePrimitives<SignedTx = Tx>>,
+{
+    resolve_transaction_with_account(
+        tx,
+        default_gas_limit,
+        block_base_fee_per_gas,
+        chain_id,
+        disable_nonce_check,
+        |address| db.get_account(address).map_err(Into::into),
+        converter,
+    )
+}
+
+fn resolve_transaction_with_evm<Tx, T, E>(
+    tx: RpcTxReq<T::Network>,
+    default_gas_limit: u64,
+    block_base_fee_per_gas: u64,
+    chain_id: u64,
+    disable_nonce_check: bool,
+    evm: &mut E,
+    converter: &T,
+) -> Result<Recovered<Tx>, EthApiError>
+where
+    T: RpcConvert<Primitives: NodePrimitives<SignedTx = Tx>>,
+    E: RethEvm,
+{
+    resolve_transaction_with_account(
+        tx,
+        default_gas_limit,
+        block_base_fee_per_gas,
+        chain_id,
+        disable_nonce_check,
+        |address| evm.account_info(address).map_err(Into::into),
+        converter,
+    )
+}
+
+fn resolve_transaction_with_account<Tx, T, F>(
+    mut tx: RpcTxReq<T::Network>,
+    default_gas_limit: u64,
+    block_base_fee_per_gas: u64,
+    chain_id: u64,
+    disable_nonce_check: bool,
+    mut account: F,
+    converter: &T,
+) -> Result<Recovered<Tx>, EthApiError>
+where
+    T: RpcConvert<Primitives: NodePrimitives<SignedTx = Tx>>,
+    F: FnMut(&Address) -> Result<Option<evm2::evm::AccountInfo>, EthApiError>,
+{
+    // If we're missing any fields we try to fill nonce, gas and
+    // gas price.
+    let tx_type = tx.as_ref().output_tx_type();
+
+    let from = if let Some(from) = tx.as_ref().from() {
+        from
+    } else {
+        tx.as_mut().set_from(Address::ZERO);
+        Address::ZERO
+    };
+
+    if tx.as_ref().nonce().is_none() {
+        tx.as_mut().set_nonce(account(&from)?.map(|acc| acc.nonce).unwrap_or_default());
+    }
+    // eth_simulateV1 validation-off mode behaves like eth_call; avoid the EVM's max-nonce guard.
+    if disable_nonce_check && tx.as_ref().nonce() == Some(u64::MAX) {
+        tx.as_mut().set_nonce(0);
+    }
+
+    if tx.as_ref().gas_limit().is_none() {
+        tx.as_mut().set_gas_limit(default_gas_limit);
+    }
+
+    if tx.as_ref().chain_id().is_none() {
+        tx.as_mut().set_chain_id(chain_id);
+    }
+
+    if tx.as_ref().kind().is_none() {
+        tx.as_mut().set_kind(TxKind::Create);
+    }
+
+    // if we can't build the _entire_ transaction yet, fill the fee fields.
+    //
+    // Per the eth_simulateV1 spec, unspecified fee fields default to 0 (not the block base fee),
+    // matching geth's `CallDefaults` behavior. This lets simulation behave like a free-gas
+    // `eth_call` when validation is off, and surfaces "max fee per gas less than block base fee"
+    // errors when validation is on with a real base fee.
+    let _ = block_base_fee_per_gas;
+    if tx.as_ref().output_tx_type_checked().is_none() {
+        if tx_type.is_legacy() || tx_type.is_eip2930() {
+            if tx.as_ref().gas_price().is_none() {
+                tx.as_mut().set_gas_price(0);
+            }
+        } else {
+            if tx.as_ref().max_fee_per_gas().is_none() {
+                tx.as_mut().set_max_fee_per_gas(0);
+            }
+            if tx.as_ref().max_priority_fee_per_gas().is_none() {
+                tx.as_mut().set_max_priority_fee_per_gas(0);
+            }
+        }
+    }
+
+    let tx =
+        converter.build_simulate_v1_transaction(tx).map_err(|e| EthApiError::other(e.into()))?;
+
+    Ok(Recovered::new_unchecked(tx, from))
+}
+
+/// Handles outputs of the calls execution and builds a [`SimulatedBlock`].
+pub fn build_simulated_block<Err, T>(
+    block: RecoveredBlock<BlockTy<T::Primitives>>,
+    results: Vec<TxResult>,
+    txs_kind: BlockTransactionsKind,
+    converter: &T,
+) -> Result<SimulatedBlock<RpcBlock<T::Network>>, Err>
+where
+    Err: std::error::Error
+        + FromEthApiError
+        + FromEvmError<T::Evm>
+        + From<T::Error>
+        + Into<jsonrpsee_types::ErrorObject<'static>>,
+    T: RpcConvert,
+{
+    let mut calls: Vec<SimCallResult> = Vec::with_capacity(results.len());
+
+    let mut log_index = 0;
+    for (index, (result, tx)) in results.into_iter().zip(block.body().transactions()).enumerate() {
+        let gas_used = result.tx_gas_used();
+        let max_used_gas = Some(result.total_gas_spent.max(result.floor_gas));
+        let call = if result.status {
+            SimCallResult {
+                return_data: result.output,
+                error: None,
+                gas_used,
+                max_used_gas,
+                logs: result
+                    .logs
+                    .into_iter()
+                    .map(|log| {
+                        log_index += 1;
+                        alloy_rpc_types_eth::Log {
+                            inner: log,
+                            log_index: Some(log_index - 1),
+                            transaction_index: Some(index as u64),
+                            transaction_hash: Some(*tx.tx_hash()),
+                            block_hash: Some(block.hash()),
+                            block_number: Some(block.header().number()),
+                            block_timestamp: Some(block.header().timestamp()),
+                            ..Default::default()
+                        }
+                    })
+                    .collect(),
+                status: true,
+            }
+        } else if result.stop.is_revert() {
+            let error = Err::from_revert(result.output.clone());
+            SimCallResult {
+                return_data: Bytes::new(),
+                error: Some(SimulateError {
+                    message: error.to_string(),
+                    code: SIMULATE_REVERT_CODE,
+                    data: Some(result.output),
+                }),
+                gas_used,
+                max_used_gas,
+                status: false,
+                logs: Vec::new(),
+            }
+        } else {
+            let error = Err::from_evm_halt(result.stop, tx.gas_limit());
+            SimCallResult {
+                return_data: Bytes::new(),
+                error: Some(SimulateError {
+                    message: error.to_string(),
+                    code: SIMULATE_VM_ERROR_CODE,
+                    ..SimulateError::invalid_params()
+                }),
+                gas_used,
+                max_used_gas,
+                logs: Vec::new(),
+                status: false,
+            }
+        };
+
+        calls.push(call);
+    }
+
+    let block = block.into_rpc_block(
+        txs_kind,
+        |tx, tx_info| converter.fill(tx, tx_info),
+        |header, size| converter.convert_header(header, size),
+    )?;
+    Ok(SimulatedBlock { inner: block, calls })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_chain, EthSimulateError, INTERNAL_ERROR_CODE};
+    use super::{
+        apply_precompile_overrides, sanitize_chain, EthSimulateError, INTERNAL_ERROR_CODE,
+    };
     use crate::{error::ToRpcError, EthApiError};
     use alloy_chains::Chain;
     use alloy_consensus::Header;
-    use alloy_primitives::U256;
-    use alloy_rpc_types_eth::{simulate::SimBlock, BlockOverrides, TransactionRequest};
+    use alloy_primitives::{address, U256};
+    use alloy_rpc_types_eth::{
+        simulate::SimBlock,
+        state::{AccountOverride, StateOverride},
+        BlockOverrides, TransactionRequest,
+    };
+    use evm2::{
+        ethereum::ethereum_tx_registry, evm::EmptyDB, BaseEvmTypes, Evm, Precompiles, SpecId,
+    };
     use reth_primitives_traits::SealedHeader;
+
+    fn test_evm() -> Evm<'static, BaseEvmTypes> {
+        Evm::new(
+            SpecId::PRAGUE,
+            Default::default(),
+            ethereum_tx_registry(SpecId::PRAGUE),
+            EmptyDB::default(),
+            Precompiles::base(SpecId::PRAGUE),
+        )
+    }
 
     #[test]
     fn nonce_max_value_error_uses_internal_error_code() {
@@ -249,6 +665,54 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn precompile_self_move_requires_existing_precompile() {
+        let address = address!("c100000000000000000000000000000000000000");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            address,
+            AccountOverride { move_precompile_to: Some(address), ..Default::default() },
+        );
+        let mut evm = test_evm();
+
+        let err = apply_precompile_overrides(&state_overrides, &mut evm).unwrap_err();
+
+        assert!(matches!(err, EthSimulateError::NotAPrecompile(addr) if addr == address));
+    }
+
+    #[test]
+    fn precompile_self_move_errors_for_existing_precompile() {
+        let address = address!("0000000000000000000000000000000000000001");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            address,
+            AccountOverride { move_precompile_to: Some(address), ..Default::default() },
+        );
+        let mut evm = test_evm();
+
+        let err = apply_precompile_overrides(&state_overrides, &mut evm).unwrap_err();
+
+        assert!(matches!(err, EthSimulateError::MovePrecompileToSelf(addr) if addr == address));
+    }
+
+    #[test]
+    fn moved_precompile_is_callable() {
+        let source = address!("0000000000000000000000000000000000000001");
+        let dest = address!("0000000000000000000000000000000000123456");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            source,
+            AccountOverride { move_precompile_to: Some(dest), ..Default::default() },
+        );
+        let mut evm = test_evm();
+
+        apply_precompile_overrides(&state_overrides, &mut evm).unwrap();
+
+        let precompiles = evm.precompiles_as::<Precompiles>().unwrap().as_map();
+        assert!(!precompiles.contains(&source));
+        assert!(precompiles.contains(&dest));
     }
 
     #[test]

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -294,7 +294,8 @@ pub fn apply_precompile_overrides(
 /// geth's per-call `sanitizeCall` behavior.
 ///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
-pub fn execute_transactions<S, T>(
+#[expect(clippy::type_complexity)]
+pub fn execute_transactions<S, T, EvmTypes>(
     mut builder: S,
     state_provider: impl StateProvider,
     calls: Vec<RpcTxReq<T::Network>>,
@@ -302,10 +303,16 @@ pub fn execute_transactions<S, T>(
     chain_id: u64,
     compute_state_root: bool,
     converter: &T,
-) -> Result<(BlockBuilderOutcome<S::Primitives>, Vec<TxResult>), EthApiError>
+) -> Result<(BlockBuilderOutcome<S::Primitives>, Vec<TxResult<EvmTypes>>), EthApiError>
 where
-    S: BlockBuilder,
+    S: BlockBuilder<
+        Executor: reth_evm::BlockExecutor<
+            Evm: RethEvm<EvmTypes = EvmTypes>,
+            TransactionResult = TxResult<EvmTypes>,
+        >,
+    >,
     T: RpcConvert<Primitives = S::Primitives>,
+    EvmTypes: evm2::EvmTypes,
 {
     builder.apply_pre_execution_changes()?;
 
@@ -522,9 +529,9 @@ where
 }
 
 /// Handles outputs of the calls execution and builds a [`SimulatedBlock`].
-pub fn build_simulated_block<Err, T>(
+pub fn build_simulated_block<Err, T, EvmTypes>(
     block: RecoveredBlock<BlockTy<T::Primitives>>,
-    results: Vec<TxResult>,
+    results: Vec<TxResult<EvmTypes>>,
     txs_kind: BlockTransactionsKind,
     converter: &T,
 ) -> Result<SimulatedBlock<RpcBlock<T::Network>>, Err>
@@ -535,6 +542,7 @@ where
         + From<T::Error>
         + Into<jsonrpsee_types::ErrorObject<'static>>,
     T: RpcConvert,
+    EvmTypes: evm2::EvmTypes,
 {
     let mut calls: Vec<SimCallResult> = Vec::with_capacity(results.len());
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -284,7 +284,7 @@ pub fn apply_precompile_overrides(
 }
 
 /// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the
-/// given [`BlockExecutor`].
+/// given [`BlockBuilder`].
 ///
 /// Returns all executed transactions and the result of the execution.
 ///

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -123,7 +123,7 @@ pub mod cache {
     /// Default cache size for the header cache: 1000 headers.
     pub const DEFAULT_HEADER_CACHE_MAX_LEN: u32 = 1000;
 
-    /// Default cache size for the BAL cache: 1000 block access lists.
+    /// Default cache size for the EVM BAL cache: 1000 block access lists.
     pub const DEFAULT_BAL_CACHE_MAX_LEN: u32 = 1000;
 
     /// Default number of concurrent database requests.

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 # reth
 reth-chainspec.workspace = true
-reth-consensus-common.workspace = true
 reth-primitives-traits.workspace = true
 reth-rpc-api.workspace = true
 reth-rpc-eth-api.workspace = true
@@ -22,12 +21,15 @@ reth-engine-primitives.workspace = true
 reth-errors.workspace = true
 reth-metrics.workspace = true
 reth-storage-api.workspace = true
+reth-execution-types = { workspace = true, features = ["serde"] }
 reth-chain-state.workspace = true
 reth-transaction-pool.workspace = true
 reth-network-api.workspace = true
 reth-rpc-engine-api.workspace = true
+evm2.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }
 reth-rpc-convert.workspace = true
+evm2-inspectors = { workspace = true, features = ["std"] }
 reth-network-peers = { workspace = true, features = ["secp256k1"] }
 reth-evm.workspace = true
 reth-evm-ethereum = { workspace = true, features = ["std"] }
@@ -35,11 +37,12 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-types.workspace = true
 reth-consensus.workspace = true
+reth-consensus-common.workspace = true
+reth-ethereum-primitives.workspace = true
+reth-ethereum-engine-primitives.workspace = true
 reth-node-api.workspace = true
 reth-payload-primitives.workspace = true
 reth-trie-common.workspace = true
-evm2.workspace = true
-evm2-inspectors = { workspace = true, features = ["std"] }
 
 # ethereum
 alloy-consensus.workspace = true
@@ -92,7 +95,6 @@ reth-testing-utils.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-db-api.workspace = true
-reth-ethereum-primitives.workspace = true
 
 rand.workspace = true
 
@@ -100,7 +102,7 @@ jsonrpsee = { workspace = true, features = ["client"] }
 
 [features]
 js-tracer = [
+    "evm2-inspectors/js-tracer",
     "reth-rpc-eth-types/js-tracer",
     "reth-rpc-eth-api/js-tracer",
-    "evm2-inspectors/js-tracer",
 ]

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -12,7 +12,11 @@ use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use async_trait::async_trait;
-use evm2::evm::{BlockStateAccumulator, DynDatabase, StateChangeSource};
+use evm2::{
+    ethereum::RecoveredTxEnvelope,
+    evm::{BlockStateAccumulator, DynDatabase, NonStaticAny, StateChangeSource},
+    EvmTypes, TxResultWithState,
+};
 use evm2_inspectors::tracing::{DebugInspector, TransactionContext};
 use futures::Stream;
 use jsonrpsee::core::RpcResult;
@@ -102,6 +106,27 @@ where
     }
 }
 
+fn debug_result<T: EvmTypes>(
+    inspector: &mut DebugInspector,
+    tx_context: Option<TransactionContext>,
+    tx: &T::Tx,
+    block_env: &evm2::env::BlockEnv<T>,
+    result: &TxResultWithState<T>,
+    db: &mut dyn DynDatabase,
+) -> Result<GethTrace, EthApiError> {
+    if NonStaticAny::type_id(tx) != core::any::TypeId::of::<RecoveredTxEnvelope>() ||
+        NonStaticAny::type_id(block_env) != core::any::TypeId::of::<evm2::env::BlockEnv>()
+    {
+        return Err(EthApiError::Unsupported("debug tracing for custom EVM types"))
+    }
+
+    // SAFETY: The type IDs above verify both erased values have the target concrete types.
+    let tx = unsafe { &*core::ptr::from_ref(tx).cast::<RecoveredTxEnvelope>() };
+    // SAFETY: The type IDs above verify both erased values have the target concrete types.
+    let block_env = unsafe { &*core::ptr::from_ref(block_env).cast::<evm2::env::BlockEnv>() };
+    inspector.get_result(tx_context, tx, block_env, result, db).map_err(Into::into)
+}
+
 // === impl DebugApi ===
 
 impl<Eth> DebugApi<Eth>
@@ -135,19 +160,19 @@ where
                     let (next_inspector, res) =
                         eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
                     inspector = next_inspector;
-                    let result = inspector
-                        .get_result(
-                            Some(TransactionContext {
-                                block_hash: Some(block.hash()),
-                                tx_hash: Some(tx_hash),
-                                tx_index: Some(index),
-                            }),
-                            tx_env.borrow().borrow(),
-                            evm_env.block_env(),
-                            &res,
-                            &mut db,
-                        )
-                        .map_err(Eth::Error::from_eth_err)?;
+                    let result = debug_result(
+                        &mut inspector,
+                        Some(TransactionContext {
+                            block_hash: Some(block.hash()),
+                            tx_hash: Some(tx_hash),
+                            tx_index: Some(index),
+                        }),
+                        tx_env.borrow(),
+                        evm_env.block_env(),
+                        &res,
+                        &mut db,
+                    )
+                    .map_err(Eth::Error::from_eth_err)?;
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {
@@ -254,19 +279,19 @@ where
                 let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
                 let (mut inspector, res) =
                     eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
-                let trace = inspector
-                    .get_result(
-                        Some(TransactionContext {
-                            block_hash: Some(block_hash),
-                            tx_index: Some(index),
-                            tx_hash: Some(tx_hash),
-                        }),
-                        tx_env.borrow().borrow(),
-                        evm_env.block_env(),
-                        &res,
-                        &mut db,
-                    )
-                    .map_err(Eth::Error::from_eth_err)?;
+                let trace = debug_result(
+                    &mut inspector,
+                    Some(TransactionContext {
+                        block_hash: Some(block_hash),
+                        tx_index: Some(index),
+                        tx_hash: Some(tx_hash),
+                    }),
+                    tx_env.borrow(),
+                    evm_env.block_env(),
+                    &res,
+                    &mut db,
+                )
+                .map_err(Eth::Error::from_eth_err)?;
 
                 Ok(trace)
             })
@@ -311,9 +336,15 @@ where
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
                 let (mut inspector, res) =
                     this.eth_api().inspect(&mut *db, evm_env.clone(), &tx_env, inspector)?;
-                let trace = inspector
-                    .get_result(None, tx_env.borrow().borrow(), evm_env.block_env(), &res, db)
-                    .map_err(Eth::Error::from_eth_err)?;
+                let trace = debug_result(
+                    &mut inspector,
+                    None,
+                    tx_env.borrow(),
+                    evm_env.block_env(),
+                    &res,
+                    db,
+                )
+                .map_err(Eth::Error::from_eth_err)?;
                 Ok(trace)
             })
             .await
@@ -373,9 +404,15 @@ where
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
                 let (mut inspector, res) =
                     eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
-                let trace = inspector
-                    .get_result(None, tx_env.borrow().borrow(), evm_env.block_env(), &res, &mut db)
-                    .map_err(Eth::Error::from_eth_err)?;
+                let trace = debug_result(
+                    &mut inspector,
+                    None,
+                    tx_env.borrow(),
+                    evm_env.block_env(),
+                    &res,
+                    &mut db,
+                )
+                .map_err(Eth::Error::from_eth_err)?;
 
                 Ok(trace)
             })
@@ -468,15 +505,15 @@ where
                         let (next_inspector, res) =
                             eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
                         inspector = next_inspector;
-                        let trace = inspector
-                            .get_result(
-                                None,
-                                tx_env.borrow().borrow(),
-                                evm_env.block_env(),
-                                &res,
-                                &mut db,
-                            )
-                            .map_err(Eth::Error::from_eth_err)?;
+                        let trace = debug_result(
+                            &mut inspector,
+                            None,
+                            tx_env.borrow(),
+                            evm_env.block_env(),
+                            &res,
+                            &mut db,
+                        )
+                        .map_err(Eth::Error::from_eth_err)?;
 
                         // If there is more transactions, commit the database
                         // If there is no transactions, but more bundles, commit to the database too

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -24,11 +24,7 @@ use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::ConsensusEngineEvent;
 use reth_errors::RethError;
-use reth_evm::{
-    database::BorrowedDatabase,
-    execute::{BlockExecutor, Executor},
-    ConfigureEvm, EvmEnv, EvmEnvFor,
-};
+use reth_evm::{database::BorrowedDatabase, execute::Executor, ConfigureEvm, EvmEnv, EvmEnvFor};
 use reth_primitives_traits::{
     Account as PrimitiveAccount, Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom,
     RecoveredBlock,
@@ -705,21 +701,17 @@ where
             ))
             .into())
         }
+        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
 
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
-                let mut executor = eth_api
-                    .evm_config()
-                    .executor_for_block(BorrowedDatabase::new(&mut db), block.sealed_block())
-                    .map_err(RethError::other)
-                    .map_err(Eth::Error::from_eth_err)?;
-                executor.apply_pre_execution_changes().map_err(Eth::Error::from_eth_err)?;
+                eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
                 for tx in block.transactions_recovered().take(tx_index + 1) {
                     let tx_env = eth_api.evm_config().tx_env(tx.cloned());
-                    executor.execute_transaction(tx_env).map_err(Eth::Error::from_eth_err)?;
+                    let result = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
+                    db.commit_source(&result.state_changes);
                 }
-                drop(executor);
 
                 f(&mut db)
             })

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -14,7 +14,7 @@ use alloy_rpc_types_trace::geth::{
 use async_trait::async_trait;
 use evm2::{
     ethereum::RecoveredTxEnvelope,
-    evm::{BlockStateAccumulator, DynDatabase, NonStaticAny, StateChangeSource},
+    evm::{DynDatabase, NonStaticAny, StateChangeSource},
     EvmTypes, TxResultWithState,
 };
 use evm2_inspectors::tracing::{DebugInspector, TransactionContext};
@@ -591,7 +591,7 @@ where
                     .contracts
                     .values()
                     .map(|code| code.original_bytes())
-                    .filter(|code| !mode.is_canonical() || !code.is_empty())
+                    .filter(|code| !code.is_empty())
                     .collect::<Vec<_>>();
                 if mode.is_canonical() {
                     codes.sort_unstable();
@@ -818,10 +818,8 @@ where
 
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
-
                 let mut roots = Vec::with_capacity(block.body().transactions().len());
-                let mut state = BlockStateAccumulator::new();
+                let mut state = eth_api.apply_pre_execution_changes(&block, &mut db)?;
                 for tx in block.transactions_recovered() {
                     let tx_env = eth_api.evm_config().tx_env(tx.cloned());
                     let result = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,42 +1,55 @@
-use alloy_consensus::{transaction::TxHashRef, BlockHeader};
+use alloy_consensus::{constants::KECCAK_EMPTY, transaction::TxHashRef, BlockHeader};
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
-use alloy_primitives::{hex::decode, Address, Bytes, B256, U64};
+use alloy_primitives::{hex::decode, keccak256, uint, Address, Bytes, B256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
 use alloy_rpc_types_debug::ExecutionWitness;
-use alloy_rpc_types_eth::{Account, AccountInfo, BlockError, Bundle, Index, StateContext};
+use alloy_rpc_types_eth::{
+    state::EvmOverrides, Account, AccountInfo, BlockError, Bundle, Index, StateContext,
+};
 use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use async_trait::async_trait;
-use evm2_inspectors::tracing::{DebugInspector, DebugInspectorError, TransactionContext};
+use evm2::evm::{BlockStateAccumulator, DynDatabase, StateChangeSource};
+use evm2_inspectors::tracing::{DebugInspector, TransactionContext};
 use futures::Stream;
 use jsonrpsee::core::RpcResult;
 use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::ConsensusEngineEvent;
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, EvmEnvFor, TxEnvFor};
+use reth_errors::RethError;
+use reth_evm::{
+    database::BorrowedDatabase,
+    execute::{BlockExecutor, Executor},
+    ConfigureEvm, EvmEnv, EvmEnvFor,
+};
 use reth_primitives_traits::{
-    Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom, RecoveredBlock,
+    Account as PrimitiveAccount, Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom,
+    RecoveredBlock,
 };
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
-    helpers::{EthTransactions, TraceBlockEnv, TraceEvmInstance, TraceExt, TraceTxEnvelope},
+    helpers::{EthTransactions, TraceExt},
     FromEthApiError, RpcConvert, RpcNodeCore,
 };
-use reth_rpc_eth_types::EthApiError;
+use reth_rpc_eth_types::{EthApiError, StateCacheDb};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
-    BlockIdReader, BlockReaderIdExt, HeaderProvider, ProviderBlock, ReceiptProviderIdExt,
-    StateProviderFactory, TransactionVariant,
+    BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
+    ReceiptProviderIdExt, StateProofProvider, StateProviderFactory, StateRootProvider,
+    StorageRootProvider, TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_transaction_pool::TransactionPool;
-use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
+use reth_trie_common::{
+    updates::TrieUpdates, ExecutionWitnessMode, HashedPostState, HashedStorage,
+};
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, sync::Arc};
+use std::{borrow::Borrow, collections::VecDeque, sync::Arc};
+use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 
 /// `debug` API implementation.
@@ -95,47 +108,6 @@ impl<Eth> DebugApi<Eth>
 where
     Eth: TraceExt,
 {
-    /// Returns the code associated with a given hash at the specified block ID. If no code is
-    /// found, it returns None. If no block ID is provided, it defaults to the latest block.
-    pub async fn debug_code_by_hash(
-        &self,
-        hash: B256,
-        block_id: Option<BlockId>,
-    ) -> Result<Option<Bytes>, Eth::Error> {
-        Ok(self
-            .provider()
-            .state_by_block_id(block_id.unwrap_or_default())
-            .map_err(Eth::Error::from_eth_err)?
-            .bytecode_by_hash(&hash)
-            .map_err(Eth::Error::from_eth_err)?
-            .map(|b| b.original_bytes()))
-    }
-
-    /// Returns the state root of the `HashedPostState` on top of the state for the given block with
-    /// trie updates.
-    async fn debug_state_root_with_updates(
-        &self,
-        hashed_state: HashedPostState,
-        block_id: Option<BlockId>,
-    ) -> Result<(B256, TrieUpdates), Eth::Error> {
-        self.inner
-            .eth_api
-            .spawn_blocking_io(move |this| {
-                let state = this
-                    .provider()
-                    .state_by_block_id(block_id.unwrap_or_default())
-                    .map_err(Eth::Error::from_eth_err)?;
-                state.state_root_with_updates(hashed_state).map_err(Eth::Error::from_eth_err)
-            })
-            .await
-    }
-}
-
-#[cfg(any())]
-impl<Eth> DebugApi<Eth>
-where
-    Eth: TraceExt,
-{
     /// Acquires a permit to execute a tracing call.
     async fn acquire_trace_permit(&self) -> Result<OwnedSemaphorePermit, AcquireError> {
         self.inner.blocking_task_guard.clone().acquire_owned().await
@@ -158,14 +130,11 @@ where
                 let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
                 while let Some((index, tx)) = transactions.next() {
                     let tx_hash = *tx.tx_hash();
-                    let tx_env = eth_api.evm_config().tx_env(tx);
+                    let tx_env = eth_api.evm_config().tx_env(tx.cloned());
 
-                    let res = eth_api.inspect(
-                        &mut db,
-                        evm_env.clone(),
-                        tx_env.clone(),
-                        &mut inspector,
-                    )?;
+                    let (next_inspector, res) =
+                        eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
+                    inspector = next_inspector;
                     let result = inspector
                         .get_result(
                             Some(TransactionContext {
@@ -173,8 +142,8 @@ where
                                 tx_hash: Some(tx_hash),
                                 tx_index: Some(index),
                             }),
-                            &tx_env,
-                            &evm_env.block_env,
+                            tx_env.borrow().borrow(),
+                            evm_env.block_env(),
                             &res,
                             &mut db,
                         )
@@ -185,7 +154,7 @@ where
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit(res.state)
+                        db.commit_source(&res.state_changes)
                     }
                 }
 
@@ -268,6 +237,7 @@ where
 
                 // configure env for the target transaction
                 let tx = transaction.into_recovered();
+                let tx_hash = *tx.tx_hash();
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
@@ -276,23 +246,23 @@ where
                     &mut db,
                     evm_env.clone(),
                     block_txs,
-                    *tx.tx_hash(),
+                    tx_hash,
                 )?;
 
-                let tx_env = eth_api.evm_config().tx_env(&tx);
+                let tx_env = eth_api.evm_config().tx_env(tx);
 
-                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                let res =
-                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
+                let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
+                let (mut inspector, res) =
+                    eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
                 let trace = inspector
                     .get_result(
                         Some(TransactionContext {
                             block_hash: Some(block_hash),
                             tx_index: Some(index),
-                            tx_hash: Some(*tx.tx_hash()),
+                            tx_hash: Some(tx_hash),
                         }),
-                        &tx_env,
-                        &evm_env.block_env,
+                        tx_env.borrow().borrow(),
+                        evm_env.block_env(),
                         &res,
                         &mut db,
                     )
@@ -337,16 +307,12 @@ where
         let this = self.clone();
         self.eth_api()
             .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                let mut inspector =
+                let inspector =
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
-                let res = this.eth_api().inspect(
-                    &mut *db,
-                    evm_env.clone(),
-                    tx_env.clone(),
-                    &mut inspector,
-                )?;
+                let (mut inspector, res) =
+                    this.eth_api().inspect(&mut *db, evm_env.clone(), &tx_env, inspector)?;
                 let trace = inspector
-                    .get_result(None, &tx_env, &evm_env.block_env, &res, db)
+                    .get_result(None, tx_env.borrow().borrow(), evm_env.block_env(), &res, db)
                     .map_err(Eth::Error::from_eth_err)?;
                 Ok(trace)
             })
@@ -403,12 +369,12 @@ where
                 let (evm_env, tx_env) =
                     eth_api.prepare_call_env(evm_env, call, &mut db, overrides)?;
 
-                let mut inspector =
+                let inspector =
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
-                let res =
-                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
+                let (mut inspector, res) =
+                    eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
                 let trace = inspector
-                    .get_result(None, &tx_env, &evm_env.block_env, &res, &mut db)
+                    .get_result(None, tx_env.borrow().borrow(), evm_env.block_env(), &res, &mut db)
                     .map_err(Eth::Error::from_eth_err)?;
 
                 Ok(trace)
@@ -474,9 +440,9 @@ where
 
                     // Execute all transactions until index
                     for tx in transactions {
-                        let tx_env = eth_api.evm_config().tx_env(tx);
+                        let tx_env = eth_api.evm_config().tx_env(tx.cloned());
                         let res = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit(res.state);
+                        db.commit_source(&res.state_changes);
                     }
                 }
 
@@ -499,27 +465,30 @@ where
                         let (evm_env, tx_env) =
                             eth_api.prepare_call_env(evm_env.clone(), tx, &mut db, overrides)?;
 
-                        let res = eth_api.inspect(
-                            &mut db,
-                            evm_env.clone(),
-                            tx_env.clone(),
-                            &mut inspector,
-                        )?;
+                        let (next_inspector, res) =
+                            eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
+                        inspector = next_inspector;
                         let trace = inspector
-                            .get_result(None, &tx_env, &evm_env.block_env, &res, &mut db)
+                            .get_result(
+                                None,
+                                tx_env.borrow().borrow(),
+                                evm_env.block_env(),
+                                &res,
+                                &mut db,
+                            )
                             .map_err(Eth::Error::from_eth_err)?;
 
                         // If there is more transactions, commit the database
                         // If there is no transactions, but more bundles, commit to the database too
                         if transactions.peek().is_some() || bundles.peek().is_some() {
                             inspector.fuse().map_err(Eth::Error::from_eth_err)?;
-                            db.commit(res.state);
+                            db.commit_source(&res.state_changes);
                         }
                         results.push(trace);
                     }
                     // Increment block_env number and timestamp for the next bundle
-                    evm_env.block_env.inner_mut().number += uint!(1_U256);
-                    evm_env.block_env.inner_mut().timestamp += uint!(12_U256);
+                    evm_env.block_env_mut().number += uint!(1_U256);
+                    evm_env.block_env_mut().timestamp += uint!(12_U256);
 
                     all_bundles.push(results);
                 }
@@ -570,40 +539,84 @@ where
         block: Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>,
         mode: ExecutionWitnessMode,
     ) -> Result<ExecutionWitness, Eth::Error> {
-        #[cfg(not(any()))]
-        {
-            let _ = (block, mode);
-            return Err(Eth::Error::from_eth_err(EthApiError::Unsupported(
-                "debug execution witnesses are unsupported by the active EVM execution path",
-            )))
-        }
+        let block_number = block.header().number();
+        self.eth_api()
+            .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
+                let output = eth_api
+                    .evm_config()
+                    .executor(BorrowedDatabase::new(&mut db))
+                    .execute(&block)
+                    .map_err(|err| EthApiError::Internal(err.into()))?;
+                db.commit_source(output.state.inner());
 
-        #[cfg(any())]
-        {
-            let block_number = block.header().number();
-            self.eth_api()
-                .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
-                    let block_executor = eth_api.evm_config().executor(&mut db);
+                let mut codes = db
+                    .cache
+                    .contracts
+                    .values()
+                    .map(|code| code.original_bytes())
+                    .filter(|code| !mode.is_canonical() || !code.is_empty())
+                    .collect::<Vec<_>>();
+                if mode.is_canonical() {
+                    codes.sort_unstable();
+                }
+                let mut hashed_state = HashedPostState::default();
+                let mut keys = Vec::new();
+                for (address, account) in &db.cache.accounts {
+                    let hashed_address = keccak256(address);
+                    hashed_state.accounts.insert(
+                        hashed_address,
+                        account.as_ref().map(|account| PrimitiveAccount {
+                            nonce: account.nonce,
+                            balance: account.balance,
+                            bytecode_hash: (!account.code_hash.is_zero() &&
+                                account.code_hash != KECCAK_EMPTY)
+                                .then_some(account.code_hash),
+                        }),
+                    );
+                    if account.is_some() {
+                        keys.push(address.to_vec().into());
+                    }
 
-                    let mut witness_record = ExecutionWitnessRecord::default();
+                    if let Some(storage) = db.cache.storage.get(address) {
+                        let hashed_storage = hashed_state
+                            .storages
+                            .entry(hashed_address)
+                            .or_insert_with(|| HashedStorage::new(storage.wiped));
+                        for (slot, value) in &storage.slots {
+                            let slot = B256::from(*slot);
+                            hashed_storage.storage.insert(keccak256(slot), *value);
+                            keys.push(slot.into());
+                        }
+                    }
+                }
 
-                    let _ = block_executor
-                        .execute_with_state_closure(&block, |statedb: &State<_>| {
-                            witness_record.record_executed_state(statedb, mode);
-                        })
-                        .map_err(|err| EthApiError::Internal(err.into()))?;
+                let state = db
+                    .db
+                    .inner()
+                    .witness(Default::default(), hashed_state, mode)
+                    .map_err(EthApiError::from)?;
+                let lowest_block_number = db
+                    .cache
+                    .block_hashes
+                    .keys()
+                    .map(|number| number.saturating_to::<u64>())
+                    .min()
+                    .unwrap_or_else(|| block_number.saturating_sub(1));
+                let headers = eth_api
+                    .provider()
+                    .headers_range(lowest_block_number..block_number)
+                    .map_err(EthApiError::from)?
+                    .into_iter()
+                    .map(|header| {
+                        let mut encoded = Vec::new();
+                        header.encode(&mut encoded);
+                        encoded.into()
+                    })
+                    .collect();
 
-                    Ok(witness_record
-                        .into_execution_witness(
-                            &db.database.0,
-                            eth_api.provider(),
-                            block_number,
-                            mode,
-                        )
-                        .map_err(EthApiError::from)?)
-                })
-                .await
-        }
+                Ok(ExecutionWitness { state, codes, keys, headers })
+            })
+            .await
     }
 
     /// Returns account information, including the storage root, after replaying the block through
@@ -614,15 +627,6 @@ where
         tx_index: Index,
         address: Address,
     ) -> Result<Option<Account>, Eth::Error> {
-        #[cfg(not(any()))]
-        {
-            let _ = (block_id, tx_index, address);
-            return Err(Eth::Error::from_eth_err(EthApiError::Unsupported(
-                "debug account replay is unsupported by the active EVM execution path",
-            )))
-        }
-
-        #[cfg(any())]
         self.replay_block_until(block_id, tx_index, move |db| Self::account(db, address))
             .await
             .map(Option::flatten)
@@ -636,21 +640,11 @@ where
         tx_index: Index,
         address: Address,
     ) -> Result<Option<AccountInfo>, Eth::Error> {
-        #[cfg(not(any()))]
-        {
-            let _ = (block_id, tx_index, address);
-            return Err(Eth::Error::from_eth_err(EthApiError::Unsupported(
-                "debug account replay is unsupported by the active EVM execution path",
-            )))
-        }
-
-        #[cfg(any())]
         self.replay_block_until(block_id, tx_index, move |db| Self::account_info(db, address)).await
     }
 
     /// Replays a block through the transaction at the given index and calls `f` with the resulting
     /// state.
-    #[cfg(any())]
     async fn replay_block_until<F, R>(
         &self,
         block_id: BlockId,
@@ -679,19 +673,14 @@ where
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let mut executor = eth_api
                     .evm_config()
-                    .executor_for_block(&mut db, block.sealed_block())
+                    .executor_for_block(BorrowedDatabase::new(&mut db), block.sealed_block())
                     .map_err(RethError::other)
                     .map_err(Eth::Error::from_eth_err)?;
-                executor
-                    .apply_pre_execution_changes()
-                    .map_err(reth_errors::BlockExecutionError::other)
-                    .map_err(Eth::Error::from_eth_err)?;
+                executor.apply_pre_execution_changes().map_err(Eth::Error::from_eth_err)?;
 
                 for tx in block.transactions_recovered().take(tx_index + 1) {
-                    executor
-                        .execute_transaction(tx)
-                        .map_err(reth_errors::BlockExecutionError::other)
-                        .map_err(Eth::Error::from_eth_err)?;
+                    let tx_env = eth_api.evm_config().tx_env(tx.cloned());
+                    executor.execute_transaction(tx_env).map_err(Eth::Error::from_eth_err)?;
                 }
                 drop(executor);
 
@@ -702,47 +691,45 @@ where
     }
 
     /// Retrieves the account's balance, nonce, code hash, and storage root from the given state.
-    #[cfg(any())]
     fn account(db: &mut StateCacheDb, address: Address) -> Result<Option<Account>, Eth::Error> {
-        let account = db.basic(address).map_err(Eth::Error::from_eth_err)?;
+        let account = db
+            .get_account(&address)
+            .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+            .map_err(Eth::Error::from_eth_err)?;
         let Some(account) = account else { return Ok(None) };
 
         let balance = account.balance;
         let nonce = account.nonce;
         let code_hash = account.code_hash;
-        let hashed_storage = db
-            .cache
-            .accounts
-            .get(&address)
-            .and_then(|account| {
-                account.account.as_ref().map(|plain_account| {
-                    HashedStorage::from_plain_storage(
-                        account.status.was_destroyed(),
-                        plain_account.storage.iter(),
-                    )
-                })
-            })
-            .unwrap_or_default();
-        let storage_root =
-            db.database.storage_root(address, hashed_storage).map_err(Eth::Error::from_eth_err)?;
+        let hashed_storage =
+            db.cache.storage.get(&address).map_or_else(HashedStorage::default, |s| {
+                HashedStorage::from_plain_storage(s.wiped, s.slots.iter())
+            });
+        let storage_root = db
+            .db
+            .inner()
+            .storage_root(address, hashed_storage)
+            .map_err(Eth::Error::from_eth_err)?;
 
         Ok(Some(Account { balance, nonce, code_hash, storage_root }))
     }
 
     /// Retrieves the account's balance, nonce, and code from the given state.
-    #[cfg(any())]
-    fn account_info<DB>(db: &mut DB, address: Address) -> Result<AccountInfo, Eth::Error>
-    where
-        DB: Database,
-        EthApiError: From<DB::Error>,
-    {
-        let account = db.basic(address).map_err(Eth::Error::from_eth_err)?.unwrap_or_default();
+    fn account_info(db: &mut StateCacheDb, address: Address) -> Result<AccountInfo, Eth::Error> {
+        let account = db
+            .get_account(&address)
+            .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+            .map_err(Eth::Error::from_eth_err)?
+            .unwrap_or_default();
         let code = if account.code_hash == KECCAK_EMPTY {
             Default::default()
         } else if let Some(code) = account.code {
             code.original_bytes()
         } else {
-            db.code_by_hash(account.code_hash).map_err(Eth::Error::from_eth_err)?.original_bytes()
+            db.get_code_by_hash(&account.code_hash)
+                .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+                .map_err(Eth::Error::from_eth_err)?
+                .original_bytes()
         };
 
         Ok(AccountInfo { balance: account.balance, nonce: account.nonce, code })
@@ -785,189 +772,36 @@ where
 
     /// Executes a block and returns the state root after each transaction.
     pub async fn intermediate_roots(&self, block_hash: B256) -> Result<Vec<B256>, Eth::Error> {
-        let _ = block_hash;
-        Err(Eth::Error::from_eth_err(EthApiError::Unsupported(
-            "debug intermediate roots are unsupported by the active EVM execution path",
-        )))
-    }
-}
-
-impl<Eth> DebugApi<Eth>
-where
-    Eth: TraceExt,
-    Eth::Evm: ConfigureEvm,
-    EvmEnvFor<Eth::Evm>: AsRef<TraceBlockEnv>,
-    <Eth::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-    TxEnvFor<Eth::Evm>: AsRef<TraceTxEnvelope> + Clone,
-{
-    async fn trace_block_impl(
-        &self,
-        block: Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>,
-        evm_env: EvmEnvFor<Eth::Evm>,
-        opts: GethDebugTracingOptions,
-    ) -> Result<Vec<TraceResult>, Eth::Error> {
-        self.eth_api()
-            .spawn_with_state_at_block(block.parent_hash().into(), move |eth_api, mut db| {
-                let mut results = Vec::with_capacity(block.body().transactions().len());
-                eth_api.apply_pre_execution_changes(&block, evm_env.clone(), &mut db)?;
-
-                let mut transactions = block.transactions_recovered().enumerate().peekable();
-                let mut inspector =
-                    DebugInspector::new(opts).map_err(debug_inspector_error::<Eth::Error>)?;
-
-                while let Some((index, tx)) = transactions.next() {
-                    let tx_hash = *tx.tx_hash();
-                    let tx_env = eth_api.evm_config().tx_env(tx.cloned());
-                    let (mut returned_inspector, result) = eth_api.inspect_with_inspector(
-                        &mut db,
-                        evm_env.clone(),
-                        tx_env.clone(),
-                        inspector,
-                    )?;
-                    let trace = returned_inspector
-                        .get_result(
-                            Some(TransactionContext {
-                                block_hash: Some(block.hash()),
-                                tx_index: Some(index),
-                                tx_hash: Some(tx_hash),
-                            }),
-                            tx_env.as_ref(),
-                            evm_env.as_ref(),
-                            &result,
-                            &mut db,
-                        )
-                        .map_err(debug_inspector_error::<Eth::Error>)?;
-
-                    results.push(TraceResult::Success { result: trace, tx_hash: Some(tx_hash) });
-                    db.commit_source(&result.state_changes);
-
-                    if transactions.peek().is_some() {
-                        returned_inspector.fuse().map_err(debug_inspector_error::<Eth::Error>)?;
-                    }
-                    inspector = returned_inspector;
-                }
-
-                Ok(results)
-            })
-            .await
-    }
-
-    async fn debug_trace_raw_block_impl(
-        &self,
-        rlp_block: Bytes,
-        opts: GethDebugTracingOptions,
-    ) -> Result<Vec<TraceResult>, Eth::Error> {
-        let block: ProviderBlock<Eth::Provider> = Decodable::decode(&mut rlp_block.as_ref())
-            .map_err(BlockError::RlpDecodeRawBlock)
-            .map_err(Eth::Error::from_eth_err)?;
-
-        let evm_env = self
-            .eth_api()
-            .evm_config()
-            .evm_env(block.header())
-            .map_err(reth_errors::RethError::other)
-            .map_err(Eth::Error::from_eth_err)?;
-
-        let senders =
-            if self.provider().chain_spec().is_homestead_active_at_block(block.header().number()) {
-                block.body().recover_signers()
-            } else {
-                block.body().recover_signers_unchecked()
-            }
-            .map_err(Eth::Error::from_eth_err)?;
-
-        self.trace_block_impl(Arc::new(block.into_recovered_with_signers(senders)), evm_env, opts)
-            .await
-    }
-
-    async fn debug_trace_block_impl(
-        &self,
-        block_id: BlockId,
-        opts: GethDebugTracingOptions,
-    ) -> Result<Vec<TraceResult>, Eth::Error> {
         let block = self
             .eth_api()
-            .recovered_block(block_id)
+            .recovered_block(block_hash.into())
             .await?
-            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+            .ok_or(EthApiError::HeaderNotFound(block_hash.into()))?;
         let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
-
-        self.trace_block_impl(block, evm_env, opts).await
-    }
-
-    async fn debug_trace_transaction_impl(
-        &self,
-        tx_hash: B256,
-        opts: GethDebugTracingOptions,
-    ) -> Result<GethTrace, Eth::Error> {
-        let (transaction, block) = match self.eth_api().transaction_and_block(tx_hash).await? {
-            None => return Err(EthApiError::TransactionNotFound.into()),
-            Some(res) => res,
-        };
-        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
-        let (tx, _) = transaction.split();
-        let block_hash = block.hash();
 
         self.eth_api()
-            .spawn_with_state_at_block(block.parent_hash().into(), move |eth_api, mut db| {
-                eth_api.apply_pre_execution_changes(&block, evm_env.clone(), &mut db)?;
-                let index = eth_api.replay_transactions_until(
-                    &mut db,
-                    evm_env.clone(),
-                    block.transactions_recovered(),
-                    *tx.tx_hash(),
-                )?;
+            .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
+                eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
-                let tx_env = eth_api.evm_config().tx_env(tx.clone());
-                let inspector =
-                    DebugInspector::new(opts).map_err(debug_inspector_error::<Eth::Error>)?;
-                let (mut inspector, result) = eth_api.inspect_with_inspector(
-                    &mut db,
-                    evm_env.clone(),
-                    tx_env.clone(),
-                    inspector,
-                )?;
-                inspector
-                    .get_result(
-                        Some(TransactionContext {
-                            block_hash: Some(block_hash),
-                            tx_index: Some(index as usize),
-                            tx_hash: Some(*tx.tx_hash()),
-                        }),
-                        tx_env.as_ref(),
-                        evm_env.as_ref(),
-                        &result,
-                        &mut db,
-                    )
-                    .map_err(debug_inspector_error::<Eth::Error>)
+                let mut roots = Vec::with_capacity(block.body().transactions().len());
+                let mut state = BlockStateAccumulator::new();
+                for tx in block.transactions_recovered() {
+                    let tx_env = eth_api.evm_config().tx_env(tx.cloned());
+                    let result = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
+                    result
+                        .state_changes
+                        .visit(&mut state)
+                        .expect("state accumulator is infallible");
+                    db.commit_source(&result.state_changes);
+                    let hashed_state = db.db.inner().hashed_post_state(&state);
+                    let root =
+                        db.db.inner().state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;
+                    roots.push(root);
+                }
+
+                Ok(roots)
             })
             .await
-    }
-}
-
-fn unsupported_debug<T>() -> RpcResult<T> {
-    Err(EthApiError::Unsupported(
-        "debug execution API is unsupported by the active EVM execution path",
-    )
-    .into())
-}
-
-fn debug_inspector_error<E>(err: DebugInspectorError) -> E
-where
-    E: FromEthApiError,
-{
-    match err {
-        DebugInspectorError::InvalidTracerConfig => {
-            E::from_eth_err(EthApiError::InvalidTracerConfig)
-        }
-        DebugInspectorError::UnsupportedTracer => {
-            E::from_eth_err(EthApiError::Unsupported("unsupported tracer"))
-        }
-        DebugInspectorError::JsTracerNotEnabled => {
-            E::from_eth_err(EthApiError::Unsupported("JS tracer is not enabled"))
-        }
-        err => E::from_eth_err(EthApiError::EvmCustom(err.to_string())),
     }
 }
 
@@ -975,11 +809,6 @@ where
 impl<Eth> DebugApiServer<RpcTxReq<Eth::NetworkTypes>> for DebugApi<Eth>
 where
     Eth: EthTransactions + TraceExt,
-    Eth::Evm: ConfigureEvm,
-    EvmEnvFor<Eth::Evm>: AsRef<TraceBlockEnv>,
-    <Eth::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-    TxEnvFor<Eth::Evm>: AsRef<TraceTxEnvelope> + Clone,
 {
     /// Handler for `debug_getRawHeader`
     async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes> {
@@ -1092,11 +921,10 @@ where
     /// Handler for `debug_traceChain`
     async fn debug_trace_chain(
         &self,
-        start_exclusive: BlockNumberOrTag,
-        end_inclusive: BlockNumberOrTag,
+        _start_exclusive: BlockNumberOrTag,
+        _end_inclusive: BlockNumberOrTag,
     ) -> RpcResult<Vec<BlockTraceResult>> {
-        let _ = (start_exclusive, end_inclusive);
-        unsupported_debug()
+        Err(internal_rpc_err("unimplemented"))
     }
 
     /// Handler for `debug_traceBlock`
@@ -1105,7 +933,8 @@ where
         rlp_block: Bytes,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
-        self.debug_trace_raw_block_impl(rlp_block, opts.unwrap_or_default())
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_raw_block(self, rlp_block, opts.unwrap_or_default())
             .await
             .map_err(Into::into)
     }
@@ -1116,7 +945,8 @@ where
         block: B256,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
-        self.debug_trace_block_impl(block.into(), opts.unwrap_or_default())
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_block(self, block.into(), opts.unwrap_or_default())
             .await
             .map_err(Into::into)
     }
@@ -1127,7 +957,8 @@ where
         block: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
-        self.debug_trace_block_impl(block.into(), opts.unwrap_or_default())
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_block(self, block.into(), opts.unwrap_or_default())
             .await
             .map_err(Into::into)
     }
@@ -1138,7 +969,8 @@ where
         tx_hash: B256,
         opts: Option<GethDebugTracingOptions>,
     ) -> RpcResult<GethTrace> {
-        self.debug_trace_transaction_impl(tx_hash, opts.unwrap_or_default())
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_transaction(self, tx_hash, opts.unwrap_or_default())
             .await
             .map_err(Into::into)
     }
@@ -1150,8 +982,10 @@ where
         block_id: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<GethTrace> {
-        let _ = (request, block_id, opts);
-        unsupported_debug()
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_call(self, request, block_id, opts.unwrap_or_default())
+            .await
+            .map_err(Into::into)
     }
 
     async fn debug_trace_call_many(
@@ -1160,8 +994,8 @@ where
         state_context: Option<StateContext>,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<Vec<GethTrace>>> {
-        let _ = (bundles, state_context, opts);
-        unsupported_debug()
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_trace_call_many(self, bundles, state_context, opts).await.map_err(Into::into)
     }
 
     /// Handler for `debug_executionWitness`
@@ -1170,8 +1004,8 @@ where
         block: BlockNumberOrTag,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
-        let _ = (block, mode);
-        unsupported_debug()
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_execution_witness(self, block, mode).await.map_err(Into::into)
     }
 
     /// Handler for `debug_executionWitnessByBlockHash`
@@ -1180,8 +1014,8 @@ where
         hash: B256,
         mode: Option<ExecutionWitnessMode>,
     ) -> RpcResult<ExecutionWitness> {
-        let _ = (hash, mode);
-        unsupported_debug()
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_execution_witness_by_block_hash(self, hash, mode).await.map_err(Into::into)
     }
 
     /// Handler for `debug_accountAt`
@@ -1191,8 +1025,8 @@ where
         tx_index: Index,
         address: Address,
     ) -> RpcResult<Option<Account>> {
-        let _ = (block_id, tx_index, address);
-        unsupported_debug()
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_account_at(self, block_id, tx_index, address).await.map_err(Into::into)
     }
 
     /// Handler for `debug_accountInfoAt`
@@ -1202,8 +1036,8 @@ where
         tx_index: Index,
         address: Address,
     ) -> RpcResult<Option<AccountInfo>> {
-        let _ = (block_id, tx_index, address);
-        unsupported_debug()
+        let _permit = self.acquire_trace_permit().await;
+        Self::debug_account_info_at(self, block_id, tx_index, address).await.map_err(Into::into)
     }
 
     async fn debug_account_range(
@@ -1321,8 +1155,8 @@ where
         block_hash: B256,
         _opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<B256>> {
-        let _ = block_hash;
-        unsupported_debug()
+        let _permit = self.acquire_trace_permit().await;
+        self.intermediate_roots(block_hash).await.map_err(Into::into)
     }
 
     async fn debug_mem_stats(&self) -> RpcResult<()> {
@@ -1393,19 +1227,22 @@ where
         block_hash: B256,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<TraceResult>> {
-        let block = self
+        let _permit = self.acquire_trace_permit().await;
+        let entry = self
             .inner
             .bad_block_store
             .get(block_hash)
-            .ok_or(EthApiError::HeaderNotFound(block_hash.into()))?
-            .block;
+            .ok_or_else(|| internal_rpc_err("bad block not found in cache"))?;
+
         let evm_env = self
             .eth_api()
-            .evm_env_for_header(block.sealed_block().sealed_header())
-            .map_err(Into::into)?;
-        let opts = opts.map(|opts| opts.tracing_options).unwrap_or_default();
+            .evm_config()
+            .evm_env(entry.block.header())
+            .map_err(RethError::other)
+            .to_rpc_result()?;
 
-        self.trace_block_impl(block, evm_env, opts).await.map_err(Into::into)
+        let opts = opts.map(|o| o.tracing_options).unwrap_or_default();
+        self.trace_block(entry.block.clone(), evm_env, opts).await.map_err(Into::into)
     }
 }
 
@@ -1425,7 +1262,6 @@ struct DebugApiInner<Eth: RpcNodeCore> {
     /// The implementation of `eth` API
     eth_api: Eth,
     // restrict the number of concurrent calls to blocking calls
-    #[expect(dead_code)]
     blocking_task_guard: BlockingTaskGuard,
     /// Cache for bad blocks.
     bad_block_store: BadBlockStore<BlockTy<Eth::Primitives>>,

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -591,7 +591,7 @@ where
                     .contracts
                     .values()
                     .map(|code| code.original_bytes())
-                    .filter(|code| !code.is_empty())
+                    .filter(|code| !mode.is_canonical() || !code.is_empty())
                     .collect::<Vec<_>>();
                 if mode.is_canonical() {
                     codes.sort_unstable();

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -12,11 +12,7 @@ use alloy_rpc_types_trace::geth::{
     BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use async_trait::async_trait;
-use evm2::{
-    ethereum::RecoveredTxEnvelope,
-    evm::{DynDatabase, NonStaticAny, StateChangeSource},
-    EvmTypes, TxResultWithState,
-};
+use evm2::evm::StateChangeSource;
 use evm2_inspectors::tracing::{DebugInspector, TransactionContext};
 use futures::Stream;
 use jsonrpsee::core::RpcResult;
@@ -24,7 +20,7 @@ use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::ConsensusEngineEvent;
 use reth_errors::RethError;
-use reth_evm::{database::BorrowedDatabase, execute::Executor, ConfigureEvm, EvmEnv, EvmEnvFor};
+use reth_evm::{execute::Executor, ConfigureEvm, DynDatabase, EvmEnv, EvmEnvFor};
 use reth_primitives_traits::{
     Account as PrimitiveAccount, Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom,
     RecoveredBlock,
@@ -48,7 +44,7 @@ use reth_trie_common::{
     updates::TrieUpdates, ExecutionWitnessMode, HashedPostState, HashedStorage,
 };
 use serde::{Deserialize, Serialize};
-use std::{borrow::Borrow, collections::VecDeque, sync::Arc};
+use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 
@@ -102,27 +98,6 @@ where
     }
 }
 
-fn debug_result<T: EvmTypes>(
-    inspector: &mut DebugInspector,
-    tx_context: Option<TransactionContext>,
-    tx: &T::Tx,
-    block_env: &evm2::env::BlockEnv<T>,
-    result: &TxResultWithState<T>,
-    db: &mut dyn DynDatabase,
-) -> Result<GethTrace, EthApiError> {
-    if NonStaticAny::type_id(tx) != core::any::TypeId::of::<RecoveredTxEnvelope>() ||
-        NonStaticAny::type_id(block_env) != core::any::TypeId::of::<evm2::env::BlockEnv>()
-    {
-        return Err(EthApiError::Unsupported("debug tracing for custom EVM types"))
-    }
-
-    // SAFETY: The type IDs above verify both erased values have the target concrete types.
-    let tx = unsafe { &*core::ptr::from_ref(tx).cast::<RecoveredTxEnvelope>() };
-    // SAFETY: The type IDs above verify both erased values have the target concrete types.
-    let block_env = unsafe { &*core::ptr::from_ref(block_env).cast::<evm2::env::BlockEnv>() };
-    inspector.get_result(tx_context, tx, block_env, result, db).map_err(Into::into)
-}
-
 // === impl DebugApi ===
 
 impl<Eth> DebugApi<Eth>
@@ -156,19 +131,19 @@ where
                     let (next_inspector, res) =
                         eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
                     inspector = next_inspector;
-                    let result = debug_result(
-                        &mut inspector,
-                        Some(TransactionContext {
-                            block_hash: Some(block.hash()),
-                            tx_hash: Some(tx_hash),
-                            tx_index: Some(index),
-                        }),
-                        tx_env.borrow(),
-                        evm_env.block_env(),
-                        &res,
-                        &mut db,
-                    )
-                    .map_err(Eth::Error::from_eth_err)?;
+                    let result = inspector
+                        .get_result(
+                            Some(TransactionContext {
+                                block_hash: Some(block.hash()),
+                                tx_hash: Some(tx_hash),
+                                tx_index: Some(index),
+                            }),
+                            &tx_env,
+                            evm_env.block_env(),
+                            &res,
+                            &mut db,
+                        )
+                        .map_err(Eth::Error::from_eth_err)?;
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {
@@ -275,19 +250,19 @@ where
                 let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
                 let (mut inspector, res) =
                     eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
-                let trace = debug_result(
-                    &mut inspector,
-                    Some(TransactionContext {
-                        block_hash: Some(block_hash),
-                        tx_index: Some(index),
-                        tx_hash: Some(tx_hash),
-                    }),
-                    tx_env.borrow(),
-                    evm_env.block_env(),
-                    &res,
-                    &mut db,
-                )
-                .map_err(Eth::Error::from_eth_err)?;
+                let trace = inspector
+                    .get_result(
+                        Some(TransactionContext {
+                            block_hash: Some(block_hash),
+                            tx_index: Some(index),
+                            tx_hash: Some(tx_hash),
+                        }),
+                        &tx_env,
+                        evm_env.block_env(),
+                        &res,
+                        &mut db,
+                    )
+                    .map_err(Eth::Error::from_eth_err)?;
 
                 Ok(trace)
             })
@@ -332,15 +307,9 @@ where
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
                 let (mut inspector, res) =
                     this.eth_api().inspect(&mut *db, evm_env.clone(), &tx_env, inspector)?;
-                let trace = debug_result(
-                    &mut inspector,
-                    None,
-                    tx_env.borrow(),
-                    evm_env.block_env(),
-                    &res,
-                    db,
-                )
-                .map_err(Eth::Error::from_eth_err)?;
+                let trace = inspector
+                    .get_result(None, &tx_env, evm_env.block_env(), &res, db)
+                    .map_err(Eth::Error::from_eth_err)?;
                 Ok(trace)
             })
             .await
@@ -400,15 +369,9 @@ where
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
                 let (mut inspector, res) =
                     eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
-                let trace = debug_result(
-                    &mut inspector,
-                    None,
-                    tx_env.borrow(),
-                    evm_env.block_env(),
-                    &res,
-                    &mut db,
-                )
-                .map_err(Eth::Error::from_eth_err)?;
+                let trace = inspector
+                    .get_result(None, &tx_env, evm_env.block_env(), &res, &mut db)
+                    .map_err(Eth::Error::from_eth_err)?;
 
                 Ok(trace)
             })
@@ -501,15 +464,9 @@ where
                         let (next_inspector, res) =
                             eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
                         inspector = next_inspector;
-                        let trace = debug_result(
-                            &mut inspector,
-                            None,
-                            tx_env.borrow(),
-                            evm_env.block_env(),
-                            &res,
-                            &mut db,
-                        )
-                        .map_err(Eth::Error::from_eth_err)?;
+                        let trace = inspector
+                            .get_result(None, &tx_env, evm_env.block_env(), &res, &mut db)
+                            .map_err(Eth::Error::from_eth_err)?;
 
                         // If there is more transactions, commit the database
                         // If there is no transactions, but more bundles, commit to the database too
@@ -577,7 +534,7 @@ where
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let output = eth_api
                     .evm_config()
-                    .executor(BorrowedDatabase::new(&mut db))
+                    .executor(&mut db)
                     .execute(&block)
                     .map_err(|err| EthApiError::Internal(err.into()))?;
                 db.commit_source(output.state.inner());

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -1,10 +1,22 @@
 //! `Eth` bundle implementation and helpers.
 
-use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
+use alloy_consensus::{transaction::TxHashRef, EnvKzgSettings, Transaction as _};
+use alloy_eips::eip7840::BlobParams;
+use alloy_primitives::{uint, Keccak256, U256};
+use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
+use evm2::evm::DynDatabase;
 use jsonrpsee::core::RpcResult;
-use reth_rpc_eth_api::{helpers::EthTransactions, EthCallBundleApiServer};
-use reth_rpc_eth_types::EthApiError;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
+use reth_evm::{ConfigureEvm, EvmEnv};
+use reth_rpc_eth_api::{
+    helpers::{Call, EthTransactions, LoadPendingBlock},
+    EthCallBundleApiServer, FromEthApiError,
+};
+use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError, RpcInvalidTransactionError};
 use reth_tasks::pool::BlockingTaskGuard;
+use reth_transaction_pool::{
+    EthBlobTransactionSidecar, EthPoolTransaction, PoolPooledTx, PoolTransaction, TransactionPool,
+};
 use std::sync::Arc;
 
 /// `Eth` bundle implementation.
@@ -27,7 +39,7 @@ impl<Eth> EthBundle<Eth> {
 
 impl<Eth> EthBundle<Eth>
 where
-    Eth: EthTransactions + 'static,
+    Eth: EthTransactions + LoadPendingBlock + Call + 'static,
 {
     /// Simulates a bundle of transactions at the top of a given block number with the state of
     /// another (or the same) block. This can be used to simulate future blocks with the current
@@ -37,18 +49,222 @@ where
         &self,
         bundle: EthCallBundle,
     ) -> Result<EthCallBundleResponse, Eth::Error> {
-        let _ = bundle;
-        Err(EthApiError::Unsupported(
-            "eth_callBundle is unsupported by the active EVM execution path",
-        )
-        .into())
+        let EthCallBundle {
+            txs,
+            block_number,
+            coinbase,
+            state_block_number,
+            timeout: _,
+            timestamp,
+            gas_limit,
+            difficulty,
+            base_fee,
+            ..
+        } = bundle;
+        if txs.is_empty() {
+            return Err(EthApiError::InvalidParams(
+                EthBundleError::EmptyBundleTransactions.to_string(),
+            )
+            .into())
+        }
+        if block_number == 0 {
+            return Err(EthApiError::InvalidParams(
+                EthBundleError::BundleMissingBlockNumber.to_string(),
+            )
+            .into())
+        }
+
+        // Validate gas limit against the configured call gas limit before any DB calls
+        let call_gas_limit = self.inner.eth_api.call_gas_limit();
+        if let Some(gas_limit) = gas_limit &&
+            gas_limit > call_gas_limit
+        {
+            return Err(
+                EthApiError::InvalidTransaction(RpcInvalidTransactionError::GasTooHigh).into()
+            )
+        }
+
+        let transactions = txs
+            .into_iter()
+            .map(|tx| recover_raw_transaction::<PoolPooledTx<Eth::Pool>>(&tx))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let block_id: alloy_rpc_types_eth::BlockId = state_block_number.into();
+        // Note: the block number is considered the `parent` block: <https://github.com/flashbots/mev-geth/blob/fddf97beec5877483f879a77b7dea2e58a58d653/internal/ethapi/api.go#L2104>
+        let (mut evm_env, at) = self.eth_api().evm_env_at(block_id).await?;
+
+        if let Some(coinbase) = coinbase {
+            evm_env.block_env_mut().beneficiary = coinbase;
+        }
+
+        // need to adjust the timestamp for the next block
+        if let Some(timestamp) = timestamp {
+            evm_env.block_env_mut().timestamp = U256::from(timestamp);
+        } else {
+            evm_env.block_env_mut().timestamp += uint!(12_U256);
+        }
+
+        if let Some(difficulty) = difficulty {
+            evm_env.block_env_mut().difficulty = U256::from(difficulty);
+        }
+
+        // Validate that the bundle does not contain more than MAX_BLOB_NUMBER_PER_BLOCK blob
+        // transactions.
+        let blob_gas_used = transactions.iter().filter_map(|tx| tx.blob_gas_used()).sum::<u64>();
+        if blob_gas_used > 0 {
+            let blob_params = self
+                .eth_api()
+                .provider()
+                .chain_spec()
+                .blob_params_at_timestamp(evm_env.block_env().timestamp.to())
+                .unwrap_or_else(BlobParams::cancun);
+            if blob_gas_used > blob_params.max_blob_gas_per_block() {
+                return Err(EthApiError::InvalidParams(
+                    EthBundleError::Eip4844BlobGasExceeded(blob_params.max_blob_gas_per_block())
+                        .to_string(),
+                )
+                .into())
+            }
+        }
+
+        // Apply gas limit: default to call gas limit unless user requests a smaller limit
+        evm_env.block_env_mut().gas_limit = U256::from(gas_limit.unwrap_or(call_gas_limit));
+
+        if let Some(base_fee) = base_fee {
+            evm_env.block_env_mut().basefee = U256::from(base_fee);
+        }
+
+        let state_block_number = evm_env.block_env().number;
+        // use the block number of the request
+        evm_env.block_env_mut().number = U256::from(block_number);
+
+        self.eth_api()
+            .spawn_with_state_at_block(at, move |eth_api, mut db| {
+                let coinbase = evm_env.block_env().beneficiary;
+                let basefee = evm_env.block_base_fee();
+
+                let initial_coinbase = db
+                    .get_account(&coinbase)
+                    .map_err(|code| {
+                        Eth::Error::from_eth_err(EthApiError::EvmCustom(db.error(code).to_string()))
+                    })?
+                    .map(|acc| acc.balance)
+                    .unwrap_or_default();
+                let mut coinbase_balance_before_tx = initial_coinbase;
+                let mut coinbase_balance_after_tx = initial_coinbase;
+                let mut total_gas_used = 0u64;
+                let mut total_gas_fees = U256::ZERO;
+                let mut hasher = Keccak256::new();
+
+                let mut results = Vec::with_capacity(transactions.len());
+                let mut transactions = transactions.into_iter().peekable();
+
+                while let Some(tx) = transactions.next() {
+                    let signer = tx.signer();
+                    let tx = {
+                        let mut tx = <Eth::Pool as TransactionPool>::Transaction::from_pooled(tx);
+
+                        if let EthBlobTransactionSidecar::Present(sidecar) = tx.take_blob() {
+                            tx.validate_blob(&sidecar, EnvKzgSettings::Default.get()).map_err(
+                                |e| {
+                                    Eth::Error::from_eth_err(EthApiError::InvalidParams(
+                                        e.to_string(),
+                                    ))
+                                },
+                            )?;
+                        }
+
+                        tx.into_consensus()
+                    };
+
+                    hasher.update(*tx.tx_hash());
+                    let tx_env = eth_api.evm_config().tx_env(tx.clone());
+                    let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
+                    let result = result_and_state.result;
+                    let state = result_and_state.state_changes;
+
+                    let gas_price = tx
+                        .effective_tip_per_gas(basefee)
+                        .expect("fee is always valid; execution succeeded");
+                    let gas_used = result.tx_gas_used();
+                    total_gas_used += gas_used;
+
+                    let gas_fees = U256::from(gas_used) * U256::from(gas_price);
+                    total_gas_fees += gas_fees;
+
+                    // coinbase is always present in the result state
+                    coinbase_balance_after_tx = state
+                        .accounts
+                        .get(&coinbase)
+                        .and_then(|acc| acc.current.as_ref())
+                        .map(|acc| acc.balance)
+                        .unwrap_or(coinbase_balance_before_tx);
+                    let coinbase_diff =
+                        coinbase_balance_after_tx.saturating_sub(coinbase_balance_before_tx);
+                    let eth_sent_to_coinbase = coinbase_diff.saturating_sub(gas_fees);
+
+                    // update the coinbase balance
+                    coinbase_balance_before_tx = coinbase_balance_after_tx;
+
+                    // set the return data for the response
+                    let (value, revert) = if result.status {
+                        let value = result.output;
+                        (Some(value), None)
+                    } else {
+                        let revert = result.output;
+                        (None, Some(revert))
+                    };
+
+                    let tx_res = EthCallBundleTransactionResult {
+                        coinbase_diff,
+                        eth_sent_to_coinbase,
+                        from_address: signer,
+                        gas_fees,
+                        gas_price: U256::from(gas_price),
+                        gas_used,
+                        to_address: tx.inner().to(),
+                        tx_hash: *tx.tx_hash(),
+                        value,
+                        revert,
+                    };
+                    results.push(tx_res);
+
+                    // need to apply the state changes of this call before executing the
+                    // next call
+                    if transactions.peek().is_some() {
+                        // need to apply the state changes of this call before executing
+                        // the next call
+                        db.commit_source(&state);
+                    }
+                }
+
+                // populate the response
+
+                let coinbase_diff = coinbase_balance_after_tx.saturating_sub(initial_coinbase);
+                let eth_sent_to_coinbase = coinbase_diff.saturating_sub(total_gas_fees);
+                let bundle_gas_price =
+                    coinbase_diff.checked_div(U256::from(total_gas_used)).unwrap_or_default();
+                let res = EthCallBundleResponse {
+                    bundle_gas_price,
+                    bundle_hash: hasher.finalize(),
+                    coinbase_diff,
+                    eth_sent_to_coinbase,
+                    gas_fees: total_gas_fees,
+                    results,
+                    state_block_number: state_block_number.to(),
+                    total_gas_used,
+                };
+
+                Ok(res)
+            })
+            .await
     }
 }
 
 #[async_trait::async_trait]
 impl<Eth> EthCallBundleApiServer for EthBundle<Eth>
 where
-    Eth: EthTransactions + 'static,
+    Eth: EthTransactions + LoadPendingBlock + Call + 'static,
 {
     async fn call_bundle(&self, request: EthCallBundle) -> RpcResult<EthCallBundleResponse> {
         Self::call_bundle(self, request).await.map_err(Into::into)

--- a/crates/rpc/rpc/src/eth/helpers/bal.rs
+++ b/crates/rpc/rpc/src/eth/helpers/bal.rs
@@ -1,7 +1,10 @@
 //! Contains RPC handler implementations specific to block access lists.
 
 use reth_rpc_convert::RpcConvert;
-use reth_rpc_eth_api::{helpers::bal::GetBlockAccessList, FromEvmError, RpcNodeCore};
+use reth_rpc_eth_api::{
+    helpers::{bal::GetBlockAccessList, Trace},
+    FromEvmError, RpcNodeCore,
+};
 use reth_rpc_eth_types::EthApiError;
 
 use crate::EthApi;
@@ -11,5 +14,6 @@ where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
+    Self: Trace,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -1,23 +1,18 @@
 //! Contains RPC handler implementations specific to endpoints that call/execute within evm.
 
 use crate::EthApi;
-use alloy_primitives::U256;
-use evm2::ethereum::RecoveredTxEnvelope;
-use reth_evm::{Database, EvmEnvFor, TxEnvFor};
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall},
     FromEvmError, RpcNodeCore,
 };
-use reth_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
-use std::borrow::Borrow;
+use reth_rpc_eth_types::EthApiError;
 
 impl<N, Rpc> EthCall for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
-    TxEnvFor<N::Evm>: Borrow<RecoveredTxEnvelope>,
 {
 }
 
@@ -26,7 +21,6 @@ where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
-    TxEnvFor<N::Evm>: Borrow<RecoveredTxEnvelope>,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -47,30 +41,6 @@ where
     fn evm_memory_limit(&self) -> u64 {
         self.inner.evm_memory_limit()
     }
-
-    fn caller_gas_allowance(
-        &self,
-        mut db: impl Database<Error: Into<EthApiError>>,
-        _evm_env: &EvmEnvFor<Self::Evm>,
-        tx_env: &TxEnvFor<Self::Evm>,
-    ) -> Result<u64, Self::Error> {
-        let tx = tx_env.borrow();
-        let gas_price = tx.effective_gas_price(None);
-        let balance = db
-            .get_account(&tx.signer())
-            .map_err(Into::into)?
-            .map(|account| account.balance)
-            .unwrap_or_default();
-        let value = tx.value();
-        let allowance = balance.checked_sub(value).ok_or_else(|| {
-            EthApiError::from(RpcInvalidTransactionError::InsufficientFunds {
-                cost: value,
-                balance,
-            })
-        })? / U256::from(gas_price);
-
-        Ok(allowance.try_into().unwrap_or(u64::MAX))
-    }
 }
 
 impl<N, Rpc> EstimateCall for EthApi<N, Rpc>
@@ -78,6 +48,5 @@ where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
-    TxEnvFor<N::Evm>: Borrow<RecoveredTxEnvelope>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/call.rs
+++ b/crates/rpc/rpc/src/eth/helpers/call.rs
@@ -1,18 +1,23 @@
 //! Contains RPC handler implementations specific to endpoints that call/execute within evm.
 
 use crate::EthApi;
+use alloy_primitives::U256;
+use evm2::ethereum::RecoveredTxEnvelope;
+use reth_evm::{Database, EvmEnvFor, TxEnvFor};
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall},
     FromEvmError, RpcNodeCore,
 };
-use reth_rpc_eth_types::EthApiError;
+use reth_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
+use std::borrow::Borrow;
 
 impl<N, Rpc> EthCall for EthApi<N, Rpc>
 where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
+    TxEnvFor<N::Evm>: Borrow<RecoveredTxEnvelope>,
 {
 }
 
@@ -21,6 +26,7 @@ where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
+    TxEnvFor<N::Evm>: Borrow<RecoveredTxEnvelope>,
 {
     #[inline]
     fn call_gas_limit(&self) -> u64 {
@@ -41,6 +47,30 @@ where
     fn evm_memory_limit(&self) -> u64 {
         self.inner.evm_memory_limit()
     }
+
+    fn caller_gas_allowance(
+        &self,
+        mut db: impl Database<Error: Into<EthApiError>>,
+        _evm_env: &EvmEnvFor<Self::Evm>,
+        tx_env: &TxEnvFor<Self::Evm>,
+    ) -> Result<u64, Self::Error> {
+        let tx = tx_env.borrow();
+        let gas_price = tx.effective_gas_price(None);
+        let balance = db
+            .get_account(&tx.signer())
+            .map_err(Into::into)?
+            .map(|account| account.balance)
+            .unwrap_or_default();
+        let value = tx.value();
+        let allowance = balance.checked_sub(value).ok_or_else(|| {
+            EthApiError::from(RpcInvalidTransactionError::InsufficientFunds {
+                cost: value,
+                balance,
+            })
+        })? / U256::from(gas_price);
+
+        Ok(allowance.try_into().unwrap_or(u64::MAX))
+    }
 }
 
 impl<N, Rpc> EstimateCall for EthApi<N, Rpc>
@@ -48,5 +78,6 @@ where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
+    TxEnvFor<N::Evm>: Borrow<RecoveredTxEnvelope>,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/trace.rs
+++ b/crates/rpc/rpc/src/eth/helpers/trace.rs
@@ -1,7 +1,10 @@
 //! Contains RPC handler implementations specific to tracing.
 
 use reth_rpc_convert::RpcConvert;
-use reth_rpc_eth_api::{helpers::Trace, FromEvmError, RpcNodeCore};
+use reth_rpc_eth_api::{
+    helpers::{Call, Trace},
+    FromEvmError, RpcNodeCore,
+};
 use reth_rpc_eth_types::EthApiError;
 
 use crate::EthApi;
@@ -11,5 +14,6 @@ where
     N: RpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, Evm = N::Evm>,
+    Self: Call,
 {
 }

--- a/crates/rpc/rpc/src/eth/helpers/types.rs
+++ b/crates/rpc/rpc/src/eth/helpers/types.rs
@@ -8,3 +8,76 @@ use reth_rpc_eth_types::receipt::EthReceiptConverter;
 /// An [`RpcConverter`] with its generics set to Ethereum specific.
 pub type EthRpcConverter<ChainSpec> =
     RpcConverter<Ethereum, EthEvmConfig, EthReceiptConverter<ChainSpec>>;
+
+//tests for simulate
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{Transaction, TxType};
+    use alloy_rpc_types_eth::TransactionRequest;
+    use evm2::evm::EmptyDB;
+    use reth_chainspec::MAINNET;
+    use reth_rpc_eth_types::simulate::resolve_transaction;
+
+    #[test]
+    fn test_resolve_transaction_empty_request() {
+        let builder = EthRpcConverter::new(EthReceiptConverter::new(MAINNET.clone()));
+        let mut db = EmptyDB::default();
+        let tx = TransactionRequest::default();
+        let result = resolve_transaction(tx, 21000, 0, 1, false, &mut db, &builder).unwrap();
+
+        // For an empty request, we should get a valid transaction with defaults
+        let tx = result.into_inner();
+        assert_eq!(tx.max_fee_per_gas(), 0);
+        assert_eq!(tx.max_priority_fee_per_gas(), Some(0));
+        assert_eq!(tx.gas_price(), None);
+    }
+
+    #[test]
+    fn test_resolve_transaction_legacy() {
+        let mut db = EmptyDB::default();
+        let builder = EthRpcConverter::new(EthReceiptConverter::new(MAINNET.clone()));
+
+        let tx = TransactionRequest { gas_price: Some(100), ..Default::default() };
+
+        let tx = resolve_transaction(tx, 21000, 0, 1, false, &mut db, &builder).unwrap();
+
+        assert_eq!(tx.tx_type(), TxType::Legacy);
+
+        let tx = tx.into_inner();
+        assert_eq!(tx.gas_price(), Some(100));
+        assert_eq!(tx.max_priority_fee_per_gas(), None);
+    }
+
+    #[test]
+    fn test_resolve_transaction_partial_eip1559() {
+        let mut db = EmptyDB::default();
+        let rpc_converter = EthRpcConverter::new(EthReceiptConverter::new(MAINNET.clone()));
+
+        let tx = TransactionRequest {
+            max_fee_per_gas: Some(200),
+            max_priority_fee_per_gas: Some(10),
+            ..Default::default()
+        };
+
+        let result = resolve_transaction(tx, 21000, 0, 1, false, &mut db, &rpc_converter).unwrap();
+
+        assert_eq!(result.tx_type(), TxType::Eip1559);
+        let tx = result.into_inner();
+        assert_eq!(tx.max_fee_per_gas(), 200);
+        assert_eq!(tx.max_priority_fee_per_gas(), Some(10));
+        assert_eq!(tx.gas_price(), None);
+    }
+
+    #[test]
+    fn test_resolve_transaction_wraps_max_nonce_when_nonce_check_disabled() {
+        let mut db = EmptyDB::default();
+        let rpc_converter = EthRpcConverter::new(EthReceiptConverter::new(MAINNET.clone()));
+
+        let tx = TransactionRequest { nonce: Some(u64::MAX), ..Default::default() };
+
+        let result = resolve_transaction(tx, 21000, 0, 1, true, &mut db, &rpc_converter).unwrap();
+
+        assert_eq!(result.nonce(), 0);
+    }
+}

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -1,18 +1,22 @@
 //! `Eth` Sim bundle implementation and helpers.
 
-use alloy_consensus::transaction::Recovered;
-#[cfg(test)]
-use alloy_rpc_types_eth::Log;
-#[cfg(test)]
-use alloy_rpc_types_mev::SimBundleLogs;
+use alloy_consensus::{transaction::TxHashRef, BlockHeader};
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::U256;
+use alloy_rpc_types_eth::{BlockId, Log};
 use alloy_rpc_types_mev::{
-    BundleItem, Inclusion, MevSendBundle, Privacy, RefundConfig, SimBundleOverrides,
+    BundleItem, Inclusion, MevSendBundle, Privacy, RefundConfig, SimBundleLogs, SimBundleOverrides,
     SimBundleResponse, Validity,
 };
+use evm2::evm::DynDatabase;
 use jsonrpsee::core::RpcResult;
+use reth_evm::{ConfigureEvm, EvmEnv};
+use reth_primitives_traits::Recovered;
 use reth_rpc_api::MevSimApiServer;
 use reth_rpc_eth_api::helpers::{block::LoadBlock, Call, EthTransactions};
-use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError};
+use reth_rpc_eth_types::{
+    cache::db::apply_block_overrides, utils::recover_raw_transaction, EthApiError,
+};
 use reth_storage_api::ProviderTx;
 use reth_tasks::pool::BlockingTaskGuard;
 use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionPool};
@@ -32,7 +36,6 @@ const DEFAULT_SIM_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_SIM_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Maximum payout cost
-#[expect(dead_code)]
 const SBUNDLE_PAYOUT_MAX_COST: u64 = 30_000;
 
 /// A flattened representation of a bundle item containing transaction and associated metadata.
@@ -72,7 +75,6 @@ impl<Eth> EthSimBundle<Eth> {
     }
 
     /// Builds a hierarchical `SimBundleLogs` structure from flattened transaction logs.
-    #[cfg(test)]
     fn build_bundle_logs(
         bundle: &MevSendBundle,
         flat_logs: &[Vec<Log>],
@@ -142,7 +144,6 @@ where
     /// `FlattenedBundleItem` with their associated metadata. This handles recursive bundle
     /// processing up to `MAX_NESTED_BUNDLE_DEPTH` and `MAX_BUNDLE_BODY_SIZE`, preserving
     /// inclusion, validity and privacy settings from parent bundles.
-    #[expect(dead_code)]
     fn parse_and_flatten_bundle(
         &self,
         request: &MevSendBundle,
@@ -278,11 +279,194 @@ where
         overrides: SimBundleOverrides,
         logs: bool,
     ) -> Result<SimBundleResponse, Eth::Error> {
-        let _ = (request, overrides, logs);
-        Err(EthApiError::Unsupported(
-            "mev_simBundle is unsupported by the active EVM execution path",
-        )
-        .into())
+        let SimBundleOverrides { parent_block, block_overrides, .. } = overrides;
+
+        // Parse and validate bundle
+        // Also, flatten the bundle here so that its easier to process
+        let flattened_bundle = self.parse_and_flatten_bundle(&request)?;
+
+        let block_id = parent_block.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let (current_block, mut evm_env, current_block_id) =
+            self.eth_api().evm_env_and_recovered_block_at(block_id).await?;
+
+        let eth_api = self.inner.eth_api.clone();
+
+        let sim_response = self
+            .inner
+            .eth_api
+            .spawn_with_state_at_block(current_block_id, move |_, mut db| {
+                // Setup environment
+                let current_block_number = current_block.number();
+                let coinbase = evm_env.block_env().beneficiary;
+                let basefee = evm_env.block_base_fee();
+
+                // apply overrides
+                apply_block_overrides(block_overrides, &mut db, &mut evm_env);
+
+                let initial_coinbase_balance = db
+                    .get_account(&coinbase)
+                    .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))?
+                    .map(|acc| acc.balance)
+                    .unwrap_or_default();
+
+                let mut coinbase_balance_before_tx = initial_coinbase_balance;
+                let mut total_gas_used = 0;
+                let mut total_profit = U256::ZERO;
+                let mut refundable_value = U256::ZERO;
+                let mut flat_logs: Vec<Vec<Log>> = Vec::new();
+
+                let mut log_index = 0;
+
+                for (tx_index, item) in flattened_bundle.iter().enumerate() {
+                    // Check inclusion constraints
+                    let block_number = item.inclusion.block_number();
+                    let max_block_number =
+                        item.inclusion.max_block_number().unwrap_or(block_number);
+
+                    if current_block_number < block_number ||
+                        current_block_number > max_block_number
+                    {
+                        return Err(EthApiError::InvalidParams(
+                            EthSimBundleError::InvalidInclusion.to_string(),
+                        )
+                        .into());
+                    }
+
+                    let tx_env = eth_api.evm_config().tx_env(item.tx.clone());
+                    let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
+                    let result = result_and_state.result;
+                    let state = result_and_state.state_changes;
+
+                    if !result.status && !item.can_revert {
+                        return Err(EthApiError::InvalidParams(
+                            EthSimBundleError::BundleTransactionFailed.to_string(),
+                        )
+                        .into());
+                    }
+
+                    let gas_used = result.tx_gas_used();
+                    total_gas_used += gas_used;
+
+                    // coinbase is always present in the result state
+                    let coinbase_balance_after_tx = state
+                        .accounts
+                        .get(&coinbase)
+                        .and_then(|acc| acc.current.as_ref())
+                        .map(|acc| acc.balance)
+                        .unwrap_or(coinbase_balance_before_tx);
+
+                    let coinbase_diff =
+                        coinbase_balance_after_tx.saturating_sub(coinbase_balance_before_tx);
+                    total_profit += coinbase_diff;
+
+                    // Add to refundable value if this tx does not have a refund percent
+                    if item.refund_percent.is_none() {
+                        refundable_value += coinbase_diff;
+                    }
+
+                    // Update coinbase balance before next tx
+                    coinbase_balance_before_tx = coinbase_balance_after_tx;
+
+                    // Keep one log entry per executed transaction so we can rebuild the bundle
+                    // tree in execution order after simulation.
+                    if logs {
+                        let tx_logs: Vec<Log> = result
+                            .logs
+                            .into_iter()
+                            .map(|inner| {
+                                let full_log = Log {
+                                    inner,
+                                    block_hash: Some(current_block.hash()),
+                                    block_number: Some(current_block.number()),
+                                    block_timestamp: Some(current_block.timestamp()),
+                                    transaction_hash: Some(*item.tx.tx_hash()),
+                                    transaction_index: Some(tx_index as u64),
+                                    log_index: Some(log_index),
+                                    removed: false,
+                                };
+                                log_index += 1;
+                                full_log
+                            })
+                            .collect();
+                        flat_logs.push(tx_logs);
+                    }
+
+                    // Apply state changes
+                    db.commit_source(&state);
+                }
+
+                let body_logs =
+                    if logs { Self::build_bundle_logs(&request, &flat_logs)? } else { vec![] };
+
+                // After processing all transactions, process refunds
+                // Store the original refundable value to calculate all payouts correctly
+                let original_refundable_value = refundable_value;
+                for item in &flattened_bundle {
+                    if let Some(refund_percent) = item.refund_percent {
+                        let refund_configs = item.refund_configs.clone().unwrap_or_else(|| {
+                            vec![RefundConfig { address: item.tx.signer(), percent: 100 }]
+                        });
+
+                        // Calculate payout transaction fee
+                        let payout_tx_fee = U256::from(basefee) *
+                            U256::from(SBUNDLE_PAYOUT_MAX_COST) *
+                            U256::from(refund_configs.len() as u64);
+
+                        // Add gas used for payout transactions
+                        total_gas_used += SBUNDLE_PAYOUT_MAX_COST * refund_configs.len() as u64;
+
+                        // Calculate allocated refundable value (payout value) based on ORIGINAL
+                        // refundable value. This ensures all refund_percent values are
+                        // calculated from the same base.
+                        let payout_value = original_refundable_value * U256::from(refund_percent) /
+                            U256::from(100);
+
+                        if payout_tx_fee > payout_value {
+                            return Err(EthApiError::InvalidParams(
+                                EthSimBundleError::NegativeProfit.to_string(),
+                            )
+                            .into());
+                        }
+
+                        // Subtract payout value from total profit
+                        total_profit = total_profit.checked_sub(payout_value).ok_or(
+                            EthApiError::InvalidParams(
+                                EthSimBundleError::NegativeProfit.to_string(),
+                            ),
+                        )?;
+
+                        // Adjust refundable value
+                        refundable_value = refundable_value.checked_sub(payout_value).ok_or(
+                            EthApiError::InvalidParams(
+                                EthSimBundleError::NegativeProfit.to_string(),
+                            ),
+                        )?;
+                    }
+                }
+
+                // Calculate mev gas price
+                let mev_gas_price = if total_gas_used != 0 {
+                    total_profit / U256::from(total_gas_used)
+                } else {
+                    U256::ZERO
+                };
+
+                Ok(SimBundleResponse {
+                    success: true,
+                    state_block: current_block_number,
+                    error: None,
+                    logs: Some(body_logs),
+                    gas_used: total_gas_used,
+                    mev_gas_price,
+                    profit: total_profit,
+                    refundable_value,
+                    exec_error: None,
+                    revert: None,
+                })
+            })
+            .await?;
+
+        Ok(sim_response)
     }
 }
 

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -41,8 +41,6 @@ mod txpool;
 mod validation;
 mod web3;
 
-use alloy_eip7928 as _;
-
 pub use admin::AdminApi;
 pub use aliases::*;
 pub use debug::DebugApi;

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -11,19 +11,16 @@ use alloy_rpc_types_trace::{
     parity::{Action, CreateAction, CreateOutput, TraceOutput},
 };
 use async_trait::async_trait;
-use evm2::{interpreter::InstrStop, NoopInspector};
 use evm2_inspectors::{
-    tracing::TracingInspectorConfig,
+    tracing::{types::CallTraceNode, TracingInspectorConfig},
     transfer::{TransferInspector, TransferKind},
 };
-use jsonrpsee::core::RpcResult;
-use jsonrpsee_types::ErrorObjectOwned;
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, TxEnvFor};
+use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
 use reth_primitives_traits::TxTy;
 use reth_rpc_api::{EthApiServer, OtterscanServer};
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
-    helpers::{EthTransactions, TraceEvmInstance, TraceExt, TraceTxEnvelope},
+    helpers::{EthTransactions, TraceExt},
     FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
 };
 use reth_rpc_eth_types::{utils::binary_search, EthApiError};
@@ -80,10 +77,6 @@ where
         > + EthTransactions
         + TraceExt
         + 'static,
-    Eth::Evm: ConfigureEvm,
-    <Eth::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-    TxEnvFor<Eth::Evm>: AsRef<TraceTxEnvelope>,
 {
     /// Handler for `ots_getHeaderByNumber` and `erigon_getHeaderByNumber`
     async fn get_header_by_number(
@@ -138,13 +131,9 @@ where
     async fn get_transaction_error(&self, tx_hash: TxHash) -> RpcResult<Option<Bytes>> {
         let maybe_revert = self
             .eth
-            .spawn_trace_transaction_in_block_with_inspector(
-                tx_hash,
-                NoopInspector::default(),
-                |_tx_info, _inspector, res, _| {
-                    Ok((res.result.stop == InstrStop::Revert).then_some(res.result.output))
-                },
-            )
+            .spawn_replay_transaction(tx_hash, |_tx_info, res, _| {
+                Ok((!res.result.status && res.result.stop.is_revert()).then_some(res.result.output))
+            })
             .await
             .map(Option::flatten)
             .map_err(Into::into)?;
@@ -165,21 +154,18 @@ where
             .map(|traces| {
                 traces
                     .into_iter()
-                    .map(|node| {
-                        let trace = node.trace;
-                        TraceEntry {
-                            r#type: if trace.is_selfdestruct() {
-                                "SELFDESTRUCT".to_string()
-                            } else {
-                                trace.kind.to_string()
-                            },
-                            depth: trace.depth as u32,
-                            from: trace.caller,
-                            to: trace.address,
-                            value: Some(trace.value),
-                            input: trace.data,
-                            output: trace.output,
-                        }
+                    .map(|CallTraceNode { trace, .. }| TraceEntry {
+                        r#type: if trace.is_selfdestruct() {
+                            "SELFDESTRUCT".to_string()
+                        } else {
+                            trace.kind.to_string()
+                        },
+                        depth: trace.depth as u32,
+                        from: trace.caller,
+                        to: trace.address,
+                        value: Some(trace.value),
+                        input: trace.data,
+                        output: trace.output,
                     })
                     .collect::<Vec<_>>()
             });
@@ -330,7 +316,7 @@ where
     /// Handler for `ots_getContractCreator`
     async fn get_contract_creator(&self, address: Address) -> RpcResult<Option<ContractCreator>> {
         if !self.has_code(address, None).await? {
-            return Ok(None)
+            return Ok(None);
         }
 
         let num = binary_search::<_, _, ErrorObjectOwned>(

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -11,11 +11,14 @@ use reth_chain_state::{
     PersistedBlockSubscriptions,
 };
 use reth_errors::{RethError, RethResult};
-use reth_evm::ConfigureEvm;
+use reth_evm::{database::StateProviderDatabase, execute::Executor, ConfigureEvm};
+use reth_execution_types::ExecutionOutcome;
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
 use reth_rpc_api::{RethApiServer, RethJitAction};
 use reth_rpc_eth_types::{EthApiError, EthResult};
-use reth_storage_api::{BlockReader, BlockReaderIdExt, ChangeSetReader, StateProviderFactory};
+use reth_storage_api::{
+    BlockReader, BlockReaderIdExt, ChangeSetReader, StateProviderFactory, TransactionVariant,
+};
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use serde::Serialize;
 use tokio::sync::oneshot;
@@ -102,7 +105,6 @@ where
     }
 }
 
-#[cfg(any())]
 impl<N, Provider, EvmConfig> RethApi<Provider, EvmConfig>
 where
     N: NodePrimitives,
@@ -148,18 +150,39 @@ where
         block_id: BlockId,
         block_count: u64,
     ) -> EthResult<Option<ExecutionOutcome<N::Receipt>>> {
-        let _ = (block_id, block_count);
-        Err(EthApiError::Unsupported(
-            "reth_getBlockExecutionOutcome is unsupported by the active EVM execution path",
-        ))
-    }
-}
+        let Some(start_block) = self.provider().block_number_for_id(block_id)? else {
+            return Ok(None)
+        };
 
-fn unsupported_block_execution_outcome<T>() -> RpcResult<T> {
-    Err(EthApiError::Unsupported(
-        "reth_getBlockExecutionOutcome is unsupported by the active EVM execution path",
-    )
-    .into())
+        if start_block == 0 {
+            return Ok(Some(ExecutionOutcome::default()))
+        }
+
+        let state_provider = self.provider().history_by_block_number(start_block - 1)?;
+        let db = StateProviderDatabase::new(&state_provider);
+
+        let mut blocks = Vec::with_capacity(block_count as usize);
+        for block_number in start_block..start_block + block_count {
+            let Some(block) = self
+                .provider()
+                .recovered_block(block_number.into(), TransactionVariant::WithHash)?
+            else {
+                if block_number == start_block {
+                    return Ok(None)
+                }
+                break;
+            };
+            blocks.push(block);
+        }
+
+        let outcome = self.evm_config().executor(db).execute_batch(&blocks).map_err(
+            |e: reth_evm::execute::BlockExecutionError| {
+                EthApiError::Internal(reth_errors::RethError::Other(e.into()))
+            },
+        )?;
+
+        Ok(Some(outcome))
+    }
 }
 
 #[async_trait]
@@ -173,7 +196,7 @@ where
         + ForkChoiceSubscriptions<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>
         + PersistedBlockSubscriptions
         + 'static,
-    EvmConfig: ConfigureEvm<Primitives = Provider::Primitives> + Send + Sync + 'static,
+    EvmConfig: ConfigureEvm<Primitives = Provider::Primitives> + 'static,
 {
     /// Handler for `reth_getBalanceChangesInBlock`
     async fn reth_get_balance_changes_in_block(
@@ -189,8 +212,16 @@ where
         block_id: BlockId,
         count: Option<U64>,
     ) -> RpcResult<Option<serde_json::Value>> {
-        let _ = (block_id, count);
-        unsupported_block_execution_outcome()
+        let outcome = Self::block_execution_outcome(self, block_id, count).await?;
+        match outcome {
+            Some(outcome) => {
+                let value = serde_json::to_value(&outcome).map_err(|e| {
+                    EthApiError::Internal(reth_errors::RethError::msg(e.to_string()))
+                })?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
     }
 
     /// Handler for `reth_jit`
@@ -369,7 +400,6 @@ struct RethApiInner<Provider, EvmConfig> {
     /// The EVM configuration used to create block executors.
     evm_config: EvmConfig,
     /// Guard to restrict the number of concurrent block re-execution requests.
-    #[expect(dead_code)]
     blocking_task_guard: BlockingTaskGuard,
     /// The type that can spawn tasks which would otherwise block.
     task_spawner: Runtime,

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -31,7 +31,7 @@ use reth_errors::RethError;
 use reth_ethereum_engine_primitives::EthBuiltPayload;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::{
-    database::{BorrowedDatabase, StateProviderDatabase},
+    database::StateProviderDatabase,
     execute::{BlockBuilder, BlockExecutor},
     ConfigureEvm, EvmEnv, NextBlockEnvAttributes,
 };
@@ -158,7 +158,7 @@ where
                 };
 
                 let mut builder = evm_config
-                    .builder_for_next_block(BorrowedDatabase::new(&mut state), &parent, env_attrs)
+                    .builder_for_next_block(&mut state, &parent, env_attrs)
                     .map_err(RethError::other)
                     .map_err(Eth::Error::from_eth_err)?;
                 if is_amsterdam {

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -14,26 +14,51 @@
 //! **Warning:** This namespace allows building arbitrary blocks. Never expose it
 //! on public-facing RPC endpoints without proper authentication.
 
-use alloy_primitives::{Bytes, B256};
-use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV5, PayloadAttributes};
+use alloy_consensus::{Header, Transaction};
+use alloy_eips::{eip1559::calculate_block_gas_limit, eip2718::Decodable2718};
+use alloy_primitives::{
+    map::{DefaultHashBuilder, HashSet},
+    Address, Bytes, B256, U256,
+};
+use alloy_rlp::Encodable;
+use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV5, ForkchoiceState, PayloadAttributes};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
+use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_consensus_common::validation::MAX_RLP_BLOCK_SIZE;
 use reth_engine_primitives::ConsensusEngineHandle;
+use reth_errors::RethError;
+use reth_ethereum_engine_primitives::EthBuiltPayload;
+use reth_ethereum_primitives::EthPrimitives;
+use reth_evm::{
+    database::{BorrowedDatabase, StateProviderDatabase},
+    execute::{BlockBuilder, BlockExecutor},
+    ConfigureEvm, EvmEnv, NextBlockEnvAttributes,
+};
 use reth_payload_primitives::PayloadTypes;
-use reth_rpc_api::TestingApiServer;
+use reth_primitives_traits::{
+    transaction::{recover::try_recover_signers, signed::RecoveryError},
+    AlloyBlockHeader as BlockTrait, TxTy,
+};
+use reth_rpc_api::{TestingApiServer, TestingBuildBlockRequestV1};
+use reth_rpc_eth_api::{helpers::Call, FromEthApiError};
 use reth_rpc_eth_types::EthApiError;
+use reth_storage_api::{BlockReader, BlockReaderIdExt, HeaderProvider};
+use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
+use std::sync::Arc;
+use tracing::debug;
 
 /// Testing API handler.
 #[derive(Debug, Clone)]
-pub struct TestingApi<Eth, Evm, Payload: PayloadTypes> {
-    #[expect(dead_code)]
+pub struct TestingApi<
+    Eth,
+    Evm,
+    Payload: PayloadTypes = reth_ethereum_engine_primitives::EthEngineTypes,
+> {
     eth_api: Eth,
-    #[expect(dead_code)]
     evm_config: Evm,
     /// Desired gas limit to move toward while respecting the consensus gas limit bounds.
-    #[expect(dead_code)]
     desired_gas_limit: u64,
-    #[expect(dead_code)]
     engine_handle: ConsensusEngineHandle<Payload>,
     /// If true, skip invalid transactions instead of failing.
     skip_invalid_transactions: bool,
@@ -74,19 +99,292 @@ impl<Eth, Evm, Payload: PayloadTypes> TestingApi<Eth, Evm, Payload> {
     }
 }
 
-fn unsupported_testing<T>() -> RpcResult<T> {
-    Err(EthApiError::Unsupported("testing RPC is unsupported by the active EVM execution path")
-        .into())
+impl<Eth, Evm, Payload> TestingApi<Eth, Evm, Payload>
+where
+    Payload: PayloadTypes,
+    Payload::ExecutionData: From<EthBuiltPayload>,
+    Eth: Call<
+        Provider: BlockReader<Header = Header>
+                      + BlockReaderIdExt<Header = Header>
+                      + ChainSpecProvider<ChainSpec: EthereumHardforks>,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Evm::Primitives>>>,
+    >,
+    Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes, Primitives = EthPrimitives>
+        + 'static,
+{
+    async fn build_payload_v1(
+        &self,
+        request: TestingBuildBlockRequestV1,
+        skip_invalid_transactions: bool,
+        use_pool_transactions: bool,
+    ) -> Result<EthBuiltPayload, Eth::Error> {
+        let evm_config = self.evm_config.clone();
+        let desired_gas_limit = self.desired_gas_limit;
+        let gas_limit_override = self.gas_limit_override;
+        self.eth_api
+            .spawn_with_state_at_block(request.parent_block_hash, move |eth_api, state| {
+                let state_provider = state.db.into_inner().into_inner().0;
+                let mut state = evm2::evm::CacheDB::new(evm2::evm::Db::new(
+                    StateProviderDatabase::new(&state_provider),
+                ));
+                let parent = eth_api
+                    .provider()
+                    .sealed_header_by_hash(request.parent_block_hash)?
+                    .ok_or_else(|| {
+                    EthApiError::HeaderNotFound(request.parent_block_hash.into())
+                })?;
+
+                let chain_spec = eth_api.provider().chain_spec();
+                let is_amsterdam = chain_spec
+                    .is_amsterdam_active_at_timestamp(request.payload_attributes.timestamp);
+                let is_cancun =
+                    chain_spec.is_cancun_active_at_timestamp(request.payload_attributes.timestamp);
+                let is_osaka =
+                    chain_spec.is_osaka_active_at_timestamp(request.payload_attributes.timestamp);
+                let withdrawals = request.payload_attributes.withdrawals.clone();
+                let withdrawals_rlp_length = withdrawals.as_ref().map(|w| w.length()).unwrap_or(0);
+
+                let env_attrs = NextBlockEnvAttributes {
+                    timestamp: request.payload_attributes.timestamp,
+                    suggested_fee_recipient: request.payload_attributes.suggested_fee_recipient,
+                    prev_randao: request.payload_attributes.prev_randao,
+                    gas_limit: gas_limit_override.unwrap_or_else(|| {
+                        calculate_block_gas_limit(parent.gas_limit(), desired_gas_limit)
+                    }),
+                    parent_beacon_block_root: request.payload_attributes.parent_beacon_block_root,
+                    withdrawals: withdrawals.map(Into::into),
+                    extra_data: request.extra_data.unwrap_or_default(),
+                    slot_number: request.payload_attributes.slot_number,
+                };
+
+                let mut builder = evm_config
+                    .builder_for_next_block(BorrowedDatabase::new(&mut state), &parent, env_attrs)
+                    .map_err(RethError::other)
+                    .map_err(Eth::Error::from_eth_err)?;
+                if is_amsterdam {
+                    builder.executor_mut().enable_block_access_list_builder();
+                }
+                builder.apply_pre_execution_changes().map_err(Eth::Error::from_eth_err)?;
+
+                let mut total_fees = U256::ZERO;
+                let base_fee = builder.evm_env().block_base_fee();
+
+                let mut invalid_senders: HashSet<Address, DefaultHashBuilder> = HashSet::default();
+                let mut block_transactions_rlp_length = 0usize;
+
+                // If no transactions are provided in the request, use transactions from the pool.
+                let recovered_txs = if use_pool_transactions {
+                    let mut best_txs = eth_api.pool().best_transactions_with_attributes(
+                        BestTransactionsAttributes::new(
+                            base_fee,
+                            is_cancun.then(|| builder.evm_env().block_blob_base_fee()),
+                        ),
+                    );
+                    best_txs.no_updates();
+                    best_txs.map(|tx| tx.to_consensus()).collect()
+                } else {
+                    // Decode and recover all transactions in parallel
+                    try_recover_signers(&request.transactions, |tx| {
+                        TxTy::<Evm::Primitives>::decode_2718_exact(tx.as_ref())
+                            .map_err(RecoveryError::from_source)
+                    })
+                    .or(Err(EthApiError::InvalidTransactionSignature))?
+                };
+                let allow_skip_invalid_transactions =
+                    skip_invalid_transactions || use_pool_transactions;
+
+                for (idx, tx) in recovered_txs.into_iter().enumerate() {
+                    let signer = tx.signer();
+                    if allow_skip_invalid_transactions && invalid_senders.contains(&signer) {
+                        continue;
+                    }
+
+                    // EIP-7934: Check estimated block size before adding transaction
+                    let tx_rlp_len = tx.inner().length();
+                    if is_osaka {
+                        // 1KB overhead for block header
+                        let estimated_block_size = block_transactions_rlp_length +
+                            tx_rlp_len +
+                            withdrawals_rlp_length +
+                            1024;
+                        if estimated_block_size > MAX_RLP_BLOCK_SIZE {
+                            if allow_skip_invalid_transactions {
+                                debug!(
+                                    target: "rpc::testing",
+                                    tx_idx = idx,
+                                    ?signer,
+                                    estimated_block_size,
+                                    max_size = MAX_RLP_BLOCK_SIZE,
+                                    "Skipping transaction: would exceed block size limit"
+                                );
+                                invalid_senders.insert(signer);
+                                continue;
+                            }
+                            return Err(Eth::Error::from_eth_err(EthApiError::InvalidParams(
+                                format!(
+                                    "transaction at index {} would exceed max block size: {} > {}",
+                                    idx, estimated_block_size, MAX_RLP_BLOCK_SIZE
+                                ),
+                            )));
+                        }
+                    }
+
+                    let tip = tx.effective_tip_per_gas(base_fee).unwrap_or_default();
+                    let gas_used = match builder.execute_transaction(tx) {
+                        Ok(gas_used) => gas_used.tx_gas_used(),
+                        Err(err) => {
+                            if allow_skip_invalid_transactions {
+                                debug!(
+                                    target: "rpc::testing",
+                                    tx_idx = idx,
+                                    ?signer,
+                                    error = ?err,
+                                    "Skipping invalid transaction"
+                                );
+                                invalid_senders.insert(signer);
+                                continue;
+                            }
+                            debug!(
+                                target: "rpc::testing",
+                                tx_idx = idx,
+                                ?signer,
+                                error = ?err,
+                                "Transaction execution failed"
+                            );
+                            return Err(Eth::Error::from_eth_err(err));
+                        }
+                    };
+
+                    block_transactions_rlp_length += tx_rlp_len;
+                    total_fees += U256::from(tip) * U256::from(gas_used);
+                }
+                let outcome =
+                    builder.finish(&state_provider, None).map_err(Eth::Error::from_eth_err)?;
+
+                let has_requests = outcome.block.requests_hash().is_some();
+                let requests = has_requests.then_some(outcome.execution_result.requests);
+                let block_access_list = outcome
+                    .block_access_list
+                    .map(|block_access_list| alloy_rlp::encode(&block_access_list).into());
+
+                Ok(EthBuiltPayload::new(
+                    Arc::new(outcome.block),
+                    total_fees,
+                    requests,
+                    block_access_list,
+                ))
+            })
+            .await
+    }
+
+    async fn build_block_v1(
+        &self,
+        request: TestingBuildBlockRequestV1,
+        use_pool_transactions: bool,
+    ) -> Result<ExecutionPayloadEnvelopeV5, Eth::Error> {
+        self.build_payload_v1(request, self.skip_invalid_transactions, use_pool_transactions)
+            .await?
+            .try_into_v5()
+            .map_err(RethError::other)
+            .map_err(Eth::Error::from_eth_err)
+    }
+
+    async fn commit_block_v1(
+        &self,
+        payload_attributes: PayloadAttributes,
+        transactions: Option<Vec<Bytes>>,
+        extra_data: Option<Bytes>,
+    ) -> Result<B256, Eth::Error> {
+        let parent = self
+            .eth_api
+            .provider()
+            .latest_header()
+            .map_err(EthApiError::from)?
+            .ok_or_else(|| EthApiError::HeaderNotFound(alloy_eips::BlockId::latest()))?;
+        let safe_block_hash = self
+            .eth_api
+            .provider()
+            .safe_header()
+            .map_err(EthApiError::from)?
+            .map(|header| header.hash())
+            .unwrap_or_else(|| parent.hash());
+        let finalized_block_hash = self
+            .eth_api
+            .provider()
+            .finalized_header()
+            .map_err(EthApiError::from)?
+            .map(|header| header.hash())
+            .unwrap_or_else(|| parent.hash());
+
+        let use_pool_transactions = transactions.is_none();
+        let payload = self
+            .build_payload_v1(
+                TestingBuildBlockRequestV1 {
+                    parent_block_hash: parent.hash(),
+                    payload_attributes,
+                    transactions: transactions.unwrap_or_default(),
+                    extra_data,
+                },
+                false,
+                use_pool_transactions,
+            )
+            .await?;
+
+        let block_hash = payload.block().hash();
+        let execution_data: Payload::ExecutionData = payload.into();
+        let status = self
+            .engine_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(RethError::other)
+            .map_err(Eth::Error::from_eth_err)?;
+        if !status.is_valid() {
+            return Err(Eth::Error::from_eth_err(EthApiError::InvalidParams(format!(
+                "new payload returned non-valid status: {:?}",
+                status.status
+            ))));
+        }
+
+        let fcu = self
+            .engine_handle
+            .fork_choice_updated(
+                ForkchoiceState {
+                    head_block_hash: block_hash,
+                    safe_block_hash,
+                    finalized_block_hash,
+                },
+                None,
+            )
+            .await
+            .map_err(RethError::other)
+            .map_err(Eth::Error::from_eth_err)?;
+        if !fcu.is_valid() {
+            return Err(Eth::Error::from_eth_err(EthApiError::InvalidParams(format!(
+                "forkchoice update returned non-valid status: {:?}",
+                fcu.payload_status.status
+            ))));
+        }
+
+        Ok(block_hash)
+    }
 }
 
 #[async_trait]
 impl<Eth, Evm, Payload> TestingApiServer for TestingApi<Eth, Evm, Payload>
 where
-    Eth: Send + Sync + 'static,
-    Evm: Send + Sync + 'static,
-    Payload: PayloadTypes + Send + Sync + 'static,
+    Payload: PayloadTypes,
+    Payload::ExecutionData: From<EthBuiltPayload>,
+    Eth: Call<
+        Provider: BlockReader<Header = Header>
+                      + BlockReaderIdExt<Header = Header>
+                      + ChainSpecProvider<ChainSpec: EthereumHardforks>,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Evm::Primitives>>>,
+    >,
+    Evm: ConfigureEvm<NextBlockEnvCtx = NextBlockEnvAttributes, Primitives = EthPrimitives>
+        + 'static,
 {
-    /// Handles `testing_buildBlockV1`.
+    /// Handles `testing_buildBlockV1` by gating concurrency via a semaphore and offloading heavy
+    /// work to the blocking pool to avoid stalling the async runtime.
     async fn build_block_v1(
         &self,
         parent_block_hash: B256,
@@ -94,18 +392,24 @@ where
         transactions: Option<Vec<Bytes>>,
         extra_data: Option<Bytes>,
     ) -> RpcResult<ExecutionPayloadEnvelopeV5> {
-        let _ = (parent_block_hash, payload_attributes, transactions, extra_data);
-        unsupported_testing()
+        let use_pool_transactions = transactions.is_none();
+        let request = TestingBuildBlockRequestV1 {
+            parent_block_hash,
+            payload_attributes,
+            transactions: transactions.unwrap_or_default(),
+            extra_data,
+        };
+        self.build_block_v1(request, use_pool_transactions).await.map_err(Into::into)
     }
 
-    /// Handles `testing_commitBlockV1`.
+    /// Handles `testing_commitBlockV1` by building on the current canonical head, then submitting
+    /// the payload and advancing forkchoice through the same engine handle used by the Engine API.
     async fn commit_block_v1(
         &self,
         payload_attributes: PayloadAttributes,
         transactions: Option<Vec<Bytes>>,
         extra_data: Option<Bytes>,
     ) -> RpcResult<B256> {
-        let _ = (payload_attributes, transactions, extra_data);
-        unsupported_testing()
+        self.commit_block_v1(payload_attributes, transactions, extra_data).await.map_err(Into::into)
     }
 }

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -1,35 +1,44 @@
-use alloy_consensus::{constants::ETH_TO_WEI, BlockHeader};
+use alloy_consensus::{constants::ETH_TO_WEI, BlockHeader as _};
 use alloy_eips::BlockId;
-#[cfg(any())]
-use alloy_primitives::{map::HashMap, Address, BlockHash};
-use alloy_primitives::{map::HashSet, BlockHash, Bytes, B256, U256};
-use alloy_rpc_types_eth::{state::StateOverride, BlockOverrides, Index};
+use alloy_primitives::{
+    map::{HashMap, HashSet},
+    Address, BlockHash, Bytes, B256, U256,
+};
+use alloy_rpc_types_eth::{
+    state::{EvmOverrides, StateOverride},
+    BlockOverrides, Index,
+};
 use alloy_rpc_types_trace::{
     filter::TraceFilter,
     opcode::{BlockOpcodeGas, TransactionOpcodeGas},
     parity::*,
+    tracerequest::TraceCallRequest,
 };
 use async_trait::async_trait;
-use evm2_inspectors::{opcode::OpcodeGasInspector, tracing::TracingInspectorConfig};
+use evm2::evm::DynDatabase;
+use evm2_inspectors::{
+    opcode::OpcodeGasInspector,
+    storage::StorageInspector,
+    tracing::{parity::populate_state_diff, TracingInspector, TracingInspectorConfig},
+};
 use futures::StreamExt;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, TxEnvFor};
-use reth_primitives_traits::BlockBody;
-#[cfg(any())]
-use reth_primitives_traits::BlockHeader;
+use reth_evm::ConfigureEvm;
+use reth_primitives_traits::{BlockBody, BlockHeader};
 use reth_rpc_api::TraceApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
-    helpers::{TraceEvmInstance, TraceExt, TraceTxEnvelope, TracingCtx},
-    FromEthApiError,
+    helpers::{Call, LoadPendingBlock, LoadTransaction, Trace, TraceExt},
+    FromEthApiError, RpcNodeCore,
 };
-use reth_rpc_eth_types::{EthApiError, EthConfig};
+use reth_rpc_eth_types::{error::EthApiError, utils::recover_raw_transaction, EthConfig};
 use reth_storage_api::{BlockNumReader, BlockReader};
 use reth_tasks::pool::BlockingTaskGuard;
-#[cfg(any())]
+use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionPool};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 
 /// Maximum number of `trace_filter` blocks replayed concurrently.
 const TRACE_FILTER_BLOCK_BUFFER_SIZE: usize = 4;
@@ -56,20 +65,28 @@ impl<Eth> TraceApi<Eth> {
         Self { inner }
     }
 
+    /// Acquires a permit to execute a tracing call.
+    async fn acquire_trace_permit(
+        &self,
+    ) -> std::result::Result<OwnedSemaphorePermit, AcquireError> {
+        self.inner.blocking_task_guard.clone().acquire_owned().await
+    }
+
     /// Access the underlying `Eth` API.
     pub fn eth_api(&self) -> &Eth {
         &self.inner.eth_api
     }
 }
 
-fn unsupported_trace<T>() -> RpcResult<T> {
-    Err(EthApiError::Unsupported("trace API is unsupported by the active EVM execution path")
-        .into())
+impl<Eth: RpcNodeCore> TraceApi<Eth> {
+    /// Access the underlying provider.
+    pub fn provider(&self) -> &Eth::Provider {
+        self.inner.eth_api.provider()
+    }
 }
 
 // === impl TraceApi === //
 
-#[cfg(any())]
 impl<Eth> TraceApi<Eth>
 where
     // tracing methods do _not_ read from mempool, hence no `LoadBlock` trait
@@ -85,14 +102,19 @@ where
         let config = TracingInspectorConfig::from_parity_config(&trace_request.trace_types);
         let overrides =
             EvmOverrides::new(trace_request.state_overrides, trace_request.block_overrides);
-        let mut inspector = TracingInspector::new(config);
         let this = self.clone();
         self.eth_api()
             .spawn_with_call_at(trace_request.call, at, overrides, move |db, evm_env, tx_env| {
-                let res = this.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
+                let (inspector, res) = this.eth_api().inspect(
+                    &mut *db,
+                    evm_env,
+                    &tx_env,
+                    TracingInspector::new(config),
+                )?;
                 let trace_res = inspector
                     .into_parity_builder()
-                    .into_trace_results_with_state(&res, &trace_request.trace_types, &db)
+                    .into_trace_results_with_state(&res, &trace_request.trace_types, &mut *db)
+                    .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
                     .map_err(Eth::Error::from_eth_err)?;
                 Ok(trace_res)
             })
@@ -110,17 +132,23 @@ where
             .map(<Eth::Pool as TransactionPool>::Transaction::pooled_into_consensus);
 
         let (evm_env, at) = self.eth_api().evm_env_at(block_id.unwrap_or_default()).await?;
-        let tx_env = self.eth_api().evm_config().tx_env(tx);
-
         let config = TracingInspectorConfig::from_parity_config(&trace_types);
 
+        let tx_env = self.eth_api().evm_config().tx_env(tx);
         self.eth_api()
-            .spawn_trace_at_with_state(evm_env, tx_env, config, at, move |inspector, res, db| {
-                inspector
-                    .into_parity_builder()
-                    .into_trace_results_with_state(&res, &trace_types, &db)
-                    .map_err(Eth::Error::from_eth_err)
-            })
+            .spawn_trace_at_with_state(
+                evm_env,
+                tx_env,
+                config,
+                at,
+                move |inspector, res, mut db| {
+                    inspector
+                        .into_parity_builder()
+                        .into_trace_results_with_state(&res, &trace_types, &mut db)
+                        .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+                        .map_err(Eth::Error::from_eth_err)
+                },
+            )
             .await
     }
 
@@ -150,12 +178,17 @@ where
                         Default::default(),
                     )?;
                     let config = TracingInspectorConfig::from_parity_config(&trace_types);
-                    let mut inspector = TracingInspector::new(config);
-                    let res = eth_api.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
+                    let (inspector, res) = eth_api.inspect(
+                        &mut db,
+                        evm_env,
+                        &tx_env,
+                        TracingInspector::new(config),
+                    )?;
 
                     let trace_res = inspector
                         .into_parity_builder()
-                        .into_trace_results_with_state(&res, &trace_types, &db)
+                        .into_trace_results_with_state(&res, &trace_types, &mut db)
+                        .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
                         .map_err(Eth::Error::from_eth_err)?;
 
                     results.push(trace_res);
@@ -163,7 +196,7 @@ where
                     // need to apply the state changes of this call before executing the
                     // next call
                     if calls.peek().is_some() {
-                        db.commit(res.state)
+                        db.commit_source(&res.state_changes)
                     }
                 }
 
@@ -180,10 +213,11 @@ where
     ) -> Result<TraceResults, Eth::Error> {
         let config = TracingInspectorConfig::from_parity_config(&trace_types);
         self.eth_api()
-            .spawn_trace_transaction_in_block(hash, config, move |_, inspector, res, db| {
+            .spawn_trace_transaction_in_block(hash, config, move |_, inspector, res, mut db| {
                 let trace_res = inspector
                     .into_parity_builder()
-                    .into_trace_results_with_state(&res, &trace_types, &db)
+                    .into_trace_results_with_state(&res, &trace_types, &mut db)
+                    .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
                     .map_err(Eth::Error::from_eth_err)?;
                 Ok(trace_res)
             })
@@ -319,7 +353,6 @@ where
     }
 }
 
-#[cfg(any())]
 impl<Eth> TraceApi<Eth>
 where
     // tracing methods read from mempool, hence `LoadBlock` trait bound via
@@ -409,7 +442,7 @@ where
                                 Some(block.clone()),
                                 None,
                                 TracingInspectorConfig::default_parity(),
-                                move |tx_info, mut ctx| {
+                                move |tx_info, ctx| {
                                     // Keep the block replay permit inside the spawned replay task.
                                     let _block_replay_permit = &permit;
                                     let mut traces = ctx
@@ -491,7 +524,7 @@ where
                 block_id,
                 Some(block.clone()),
                 TracingInspectorConfig::default_parity(),
-                |tx_info, mut ctx| {
+                |tx_info, ctx| {
                     let traces = ctx
                         .take_inspector()
                         .into_parity_builder()
@@ -527,16 +560,19 @@ where
                 block_id,
                 None,
                 TracingInspectorConfig::from_parity_config(&trace_types),
-                move |tx_info, mut ctx| {
+                move |tx_info, ctx| {
+                    let result = ctx.result;
+                    let db = ctx.db;
                     let mut full_trace = ctx
-                        .take_inspector()
+                        .inspector
                         .into_parity_builder()
-                        .into_trace_results(&ctx.result, &trace_types);
+                        .into_trace_results(&result.result, &trace_types);
 
                     // If statediffs were requested, populate them with the account balance and
                     // nonce from pre-state
                     if let Some(ref mut state_diff) = full_trace.state_diff {
-                        populate_state_diff(state_diff, &ctx.db, ctx.state.iter())
+                        populate_state_diff(state_diff, db, &result.state_changes)
+                            .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
                             .map_err(Eth::Error::from_eth_err)?;
                     }
 
@@ -604,7 +640,7 @@ where
                 block_id,
                 Some(block.clone()),
                 StorageInspector::default,
-                move |tx_info, mut ctx| {
+                move |tx_info, ctx| {
                     let unique_loads = ctx.inspector.unique_loads();
                     let warm_loads = ctx.inspector.warm_loads();
                     let trace = TransactionStorageAccess {
@@ -661,10 +697,6 @@ fn apply_trace_filter_pagination(
 impl<Eth> TraceApiServer<RpcTxReq<Eth::NetworkTypes>> for TraceApi<Eth>
 where
     Eth: TraceExt + 'static,
-    Eth::Evm: ConfigureEvm,
-    <Eth::Evm as ConfigureEvm>::BlockExecutorFactory:
-        for<'a> BlockExecutorFactory<Evm<'a> = TraceEvmInstance<'a>>,
-    TxEnvFor<Eth::Evm>: AsRef<TraceTxEnvelope>,
 {
     /// Executes the given call and returns a number of possible traces for it.
     ///
@@ -677,8 +709,10 @@ where
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
     ) -> RpcResult<TraceResults> {
-        let _ = (call, trace_types, block_id, state_overrides, block_overrides);
-        unsupported_trace()
+        let _permit = self.acquire_trace_permit().await;
+        let request =
+            TraceCallRequest { call, trace_types, block_id, state_overrides, block_overrides };
+        Ok(Self::trace_call(self, request).await.map_err(Into::into)?)
     }
 
     /// Handler for `trace_callMany`
@@ -687,8 +721,8 @@ where
         calls: Vec<(RpcTxReq<Eth::NetworkTypes>, HashSet<TraceType>)>,
         block_id: Option<BlockId>,
     ) -> RpcResult<Vec<TraceResults>> {
-        let _ = (calls, block_id);
-        unsupported_trace()
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_call_many(self, calls, block_id).await.map_err(Into::into)?)
     }
 
     /// Handler for `trace_rawTransaction`
@@ -698,8 +732,10 @@ where
         trace_types: HashSet<TraceType>,
         block_id: Option<BlockId>,
     ) -> RpcResult<TraceResults> {
-        let _ = (data, trace_types, block_id);
-        unsupported_trace()
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_raw_transaction(self, data, trace_types, block_id)
+            .await
+            .map_err(Into::into)?)
     }
 
     /// Handler for `trace_replayBlockTransactions`
@@ -708,30 +744,10 @@ where
         block_id: BlockId,
         trace_types: HashSet<TraceType>,
     ) -> RpcResult<Option<Vec<TraceResultsWithTransactionHash>>> {
-        self.eth_api()
-            .trace_block_with(
-                block_id,
-                None,
-                TracingInspectorConfig::from_parity_config(&trace_types),
-                move |tx_info, ctx| {
-                    let TracingCtx { result, db, inspector } = ctx;
-                    let full_trace = inspector
-                        .into_parity_builder()
-                        .into_trace_results_with_state(&result, &trace_types, db)
-                        .map_err(|err| {
-                            Eth::Error::from_eth_err(EthApiError::EvmCustom(format!(
-                                "EVM database error: {err:?}"
-                            )))
-                        })?;
-
-                    Ok(TraceResultsWithTransactionHash {
-                        transaction_hash: tx_info.hash.expect("tx hash is set"),
-                        full_trace,
-                    })
-                },
-            )
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::replay_block_transactions(self, block_id, trace_types)
             .await
-            .map_err(Into::into)
+            .map_err(Into::into)?)
     }
 
     /// Handler for `trace_replayTransaction`
@@ -740,26 +756,8 @@ where
         transaction: B256,
         trace_types: HashSet<TraceType>,
     ) -> RpcResult<TraceResults> {
-        let config = TracingInspectorConfig::from_parity_config(&trace_types);
-        self.eth_api()
-            .spawn_trace_transaction_in_block(
-                transaction,
-                config,
-                move |_, inspector, res, mut db| {
-                    inspector
-                        .into_parity_builder()
-                        .into_trace_results_with_state(&res, &trace_types, &mut db)
-                        .map_err(|err| {
-                            Eth::Error::from_eth_err(EthApiError::EvmCustom(format!(
-                                "EVM database error: {err:?}"
-                            )))
-                        })
-                },
-            )
-            .await
-            .transpose()
-            .ok_or(EthApiError::TransactionNotFound)?
-            .map_err(Into::into)
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::replay_transaction(self, transaction, trace_types).await.map_err(Into::into)?)
     }
 
     /// Handler for `trace_block`
@@ -767,43 +765,8 @@ where
         &self,
         block_id: BlockId,
     ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>> {
-        let Some(block) = self.eth_api().recovered_block(block_id).await.map_err(Into::into)?
-        else {
-            return Err(EthApiError::HeaderNotFound(block_id).into());
-        };
-
-        let mut traces = self
-            .eth_api()
-            .trace_block_with(
-                block_id,
-                Some(block.clone()),
-                TracingInspectorConfig::default_parity(),
-                |tx_info, ctx| {
-                    Ok(ctx
-                        .take_inspector()
-                        .into_parity_builder()
-                        .into_localized_transaction_traces(tx_info))
-                },
-            )
-            .await
-            .map_err(Into::into)?
-            .map(|traces| traces.into_iter().flatten().collect::<Vec<_>>());
-
-        if let Some(traces) = traces.as_mut() &&
-            let Some(base_block_reward) = calculate_base_block_reward(
-                self.eth_api().provider().chain_spec().as_ref(),
-                block.number(),
-            )
-        {
-            traces.extend(extract_reward_traces(
-                block.hash(),
-                block.header(),
-                block.body().ommers(),
-                base_block_reward,
-            ));
-        }
-
-        Ok(traces)
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_block(self, block_id).await.map_err(Into::into)?)
     }
 
     /// Handler for `trace_filter`
@@ -813,138 +776,7 @@ where
     /// # Limitations
     /// This currently requires block filter fields, since reth does not have address indices yet.
     async fn trace_filter(&self, filter: TraceFilter) -> RpcResult<Vec<LocalizedTransactionTrace>> {
-        let matcher = Arc::new(filter.matcher());
-        let TraceFilter { from_block, to_block, mut after, count, .. } = filter;
-        let start = from_block.unwrap_or(0);
-
-        let latest_block =
-            self.eth_api().provider().best_block_number().map_err(EthApiError::from)?;
-        if start > latest_block {
-            return Err(EthApiError::HeaderNotFound(start.into()).into());
-        }
-        let end = to_block.unwrap_or(latest_block);
-        if end > latest_block {
-            return Err(EthApiError::HeaderNotFound(end.into()).into());
-        }
-
-        let earliest_block =
-            self.eth_api().provider().earliest_block_number().map_err(EthApiError::from)?;
-        if start < earliest_block {
-            return Err(EthApiError::PrunedHistoryUnavailable.into());
-        }
-
-        if start > end {
-            return Err(EthApiError::InvalidParams(
-                "invalid parameters: fromBlock cannot be greater than toBlock".to_string(),
-            )
-            .into());
-        }
-
-        let distance = end.saturating_sub(start);
-        if distance > self.inner.eth_config.max_trace_filter_blocks {
-            return Err(EthApiError::InvalidParams(format!(
-                "Block range too large; currently limited to {} blocks",
-                self.inner.eth_config.max_trace_filter_blocks
-            ))
-            .into());
-        }
-
-        let mut all_traces = Vec::new();
-        let block_buffer_size =
-            self.inner.eth_config.max_tracing_requests.clamp(1, TRACE_FILTER_BLOCK_BUFFER_SIZE);
-        let mut include_reward_traces = true;
-
-        for chunk_start in (start..=end).step_by(TRACE_FILTER_FETCH_CHUNK_SIZE) {
-            let chunk_end = (chunk_start + TRACE_FILTER_FETCH_CHUNK_SIZE as u64 - 1).min(end);
-
-            let blocks = self
-                .eth_api()
-                .spawn_blocking_io(move |this| {
-                    Ok(this
-                        .provider()
-                        .recovered_block_range(chunk_start..=chunk_end)
-                        .map_err(Eth::Error::from_eth_err)?
-                        .into_iter()
-                        .map(Arc::new)
-                        .collect::<Vec<_>>())
-                })
-                .await
-                .map_err(Into::into)?;
-
-            let mut block_replays = futures::stream::iter(blocks)
-                .map(|block| {
-                    let this = self.clone();
-                    let matcher = matcher.clone();
-
-                    async move {
-                        let traces = this
-                            .eth_api()
-                            .trace_block_with(
-                                block.hash().into(),
-                                Some(block.clone()),
-                                TracingInspectorConfig::default_parity(),
-                                move |tx_info, ctx| {
-                                    let mut traces = ctx
-                                        .take_inspector()
-                                        .into_parity_builder()
-                                        .into_localized_transaction_traces(tx_info);
-                                    traces.retain(|trace| matcher.matches(&trace.trace));
-                                    Ok(Some(traces))
-                                },
-                            )
-                            .await?;
-
-                        Ok::<_, Eth::Error>((block, traces))
-                    }
-                })
-                .buffered(block_buffer_size);
-
-            while let Some(block_replay) = block_replays.next().await {
-                let (block, traces) = block_replay.map_err(Into::into)?;
-                if let Some(traces) = traces {
-                    all_traces.extend(traces.into_iter().flatten().flatten());
-                }
-
-                let reward_traces = if include_reward_traces {
-                    if let Some(base_block_reward) = calculate_base_block_reward(
-                        self.eth_api().provider().chain_spec().as_ref(),
-                        block.number(),
-                    ) {
-                        extract_reward_traces(
-                            block.hash(),
-                            block.header(),
-                            block.body().ommers(),
-                            base_block_reward,
-                        )
-                        .into_iter()
-                        .filter(|trace| matcher.matches(&trace.trace))
-                        .collect::<Vec<_>>()
-                    } else {
-                        // Blocks are processed in ascending order, so once a historical range
-                        // reaches post-Paris blocks, later blocks in the range have no rewards.
-                        include_reward_traces = false;
-                        Vec::new()
-                    }
-                } else {
-                    Vec::new()
-                };
-                all_traces.extend(reward_traces);
-
-                if let Some(traces) =
-                    apply_trace_filter_pagination(&mut all_traces, &mut after, count)
-                {
-                    return Ok(traces)
-                }
-            }
-        }
-
-        if let Some(cutoff) = after.map(|a| a as usize) &&
-            cutoff >= all_traces.len()
-        {
-            return Ok(vec![])
-        }
-
-        Ok(all_traces)
+        Ok(Self::trace_filter(self, filter).await.map_err(Into::into)?)
     }
 
     /// Returns transaction trace at given index.
@@ -954,12 +786,10 @@ where
         hash: B256,
         indices: Vec<Index>,
     ) -> RpcResult<Option<LocalizedTransactionTrace>> {
-        if indices.len() != 1 {
-            return Ok(None)
-        }
-
-        let index = usize::from(indices[0]);
-        Ok(self.trace_transaction(hash).await?.and_then(|traces| traces.into_iter().nth(index)))
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_get(self, hash, indices.into_iter().map(Into::into).collect())
+            .await
+            .map_err(Into::into)?)
     }
 
     /// Handler for `trace_transaction`
@@ -967,16 +797,8 @@ where
         &self,
         hash: B256,
     ) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>> {
-        self.eth_api()
-            .spawn_trace_transaction_in_block(
-                hash,
-                TracingInspectorConfig::default_parity(),
-                move |tx_info, inspector, _, _| {
-                    Ok(inspector.into_parity_builder().into_localized_transaction_traces(tx_info))
-                },
-            )
-            .await
-            .map_err(Into::into)
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_transaction(self, hash).await.map_err(Into::into)?)
     }
 
     /// Handler for `trace_transactionOpcodeGas`
@@ -984,52 +806,14 @@ where
         &self,
         tx_hash: B256,
     ) -> RpcResult<Option<TransactionOpcodeGas>> {
-        self.eth_api()
-            .spawn_trace_transaction_in_block_with_inspector(
-                tx_hash,
-                OpcodeGasInspector::default(),
-                move |_tx_info, inspector, _res, _| {
-                    Ok(TransactionOpcodeGas {
-                        transaction_hash: tx_hash,
-                        opcode_gas: inspector.opcode_gas_iter().collect(),
-                    })
-                },
-            )
-            .await
-            .map_err(Into::into)
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_transaction_opcode_gas(self, tx_hash).await.map_err(Into::into)?)
     }
 
     /// Handler for `trace_blockOpcodeGas`
     async fn trace_block_opcode_gas(&self, block_id: BlockId) -> RpcResult<Option<BlockOpcodeGas>> {
-        let Some(block) = self.eth_api().recovered_block(block_id).await.map_err(Into::into)?
-        else {
-            return Err(EthApiError::HeaderNotFound(block_id).into());
-        };
-
-        let Some(transactions) = self
-            .eth_api()
-            .trace_block_inspector(
-                block_id,
-                Some(block.clone()),
-                OpcodeGasInspector::default,
-                move |tx_info, ctx| {
-                    Ok(TransactionOpcodeGas {
-                        transaction_hash: tx_info.hash.expect("tx hash is set"),
-                        opcode_gas: ctx.inspector.opcode_gas_iter().collect(),
-                    })
-                },
-            )
-            .await
-            .map_err(Into::into)?
-        else {
-            return Ok(None);
-        };
-
-        Ok(Some(BlockOpcodeGas {
-            block_hash: block.hash(),
-            block_number: block.number(),
-            transactions,
-        }))
+        let _permit = self.acquire_trace_permit().await;
+        Ok(Self::trace_block_opcode_gas(self, block_id).await.map_err(Into::into)?)
     }
 }
 
@@ -1048,24 +832,18 @@ struct TraceApiInner<Eth> {
     /// Access to commonly used code of the `eth` namespace
     eth_api: Eth,
     // restrict the number of concurrent calls to `trace_*`
-    #[expect(dead_code)]
     blocking_task_guard: BlockingTaskGuard,
     // eth config settings
     eth_config: EthConfig,
 }
 
-fn calculate_base_block_reward<C>(chain_spec: &C, block_number: u64) -> Option<u128>
-where
-    C: EthereumHardforks,
-{
-    if chain_spec.is_paris_active_at_block(block_number) {
-        None
-    } else if chain_spec.is_constantinople_active_at_block(block_number) {
-        Some(2 * ETH_TO_WEI)
-    } else if chain_spec.is_byzantium_active_at_block(block_number) {
-        Some(3 * ETH_TO_WEI)
+fn base_block_reward_pre_merge(spec: impl EthereumHardforks, block_number: u64) -> u128 {
+    if spec.is_constantinople_active_at_block(block_number) {
+        ETH_TO_WEI * 2
+    } else if spec.is_byzantium_active_at_block(block_number) {
+        ETH_TO_WEI * 3
     } else {
-        Some(5 * ETH_TO_WEI)
+        ETH_TO_WEI * 5
     }
 }
 
@@ -1073,70 +851,12 @@ const fn block_reward(base_block_reward: u128, ommers: usize) -> u128 {
     base_block_reward + (base_block_reward >> 5) * ommers as u128
 }
 
-fn ommer_reward(base_block_reward: u128, block_number: u64, ommer_block_number: u64) -> u128 {
-    let distance = 8 + ommer_block_number - block_number;
-    (u128::from(distance) * base_block_reward) >> 3
-}
-
-fn extract_reward_traces<H: BlockHeader>(
-    block_hash: BlockHash,
-    header: &H,
-    ommers: Option<&[H]>,
-    base_block_reward: u128,
-) -> Vec<LocalizedTransactionTrace> {
-    let ommers_cnt = ommers.map(|o| o.len()).unwrap_or_default();
-    let mut traces = Vec::with_capacity(ommers_cnt + 1);
-
-    traces.push(reward_trace(
-        block_hash,
-        header,
-        RewardAction {
-            author: header.beneficiary(),
-            reward_type: RewardType::Block,
-            value: U256::from(block_reward(base_block_reward, ommers_cnt)),
-        },
-    ));
-
-    let Some(ommers) = ommers else { return traces };
-
-    for ommer in ommers {
-        traces.push(reward_trace(
-            block_hash,
-            header,
-            RewardAction {
-                author: ommer.beneficiary(),
-                reward_type: RewardType::Uncle,
-                value: U256::from(ommer_reward(base_block_reward, header.number(), ommer.number())),
-            },
-        ));
-    }
-
-    traces
-}
-
-fn reward_trace<H: BlockHeader>(
-    block_hash: BlockHash,
-    header: &H,
-    reward: RewardAction,
-) -> LocalizedTransactionTrace {
-    LocalizedTransactionTrace {
-        block_hash: Some(block_hash),
-        block_number: Some(header.number()),
-        transaction_hash: None,
-        transaction_position: None,
-        trace: TransactionTrace {
-            trace_address: vec![],
-            subtraces: 0,
-            action: Action::Reward(reward),
-            error: None,
-            result: None,
-        },
-    }
+const fn ommer_reward(base_block_reward: u128, block_number: u64, ommer_block_number: u64) -> u128 {
+    ((8 + ommer_block_number - block_number) as u128 * base_block_reward) >> 3
 }
 
 /// Response type for storage tracing that contains all accessed storage slots
 /// for a transaction.
-#[cfg(any())]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionStorageAccess {
@@ -1151,7 +871,6 @@ pub struct TransactionStorageAccess {
 }
 
 /// Response type for storage tracing that contains all accessed storage slots
-#[cfg(any())]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockStorageAccess {
@@ -1165,7 +884,6 @@ pub struct BlockStorageAccess {
 
 /// Helper to construct a [`LocalizedTransactionTrace`] that describes a reward to the block
 /// beneficiary.
-#[cfg(any())]
 fn reward_trace<H: BlockHeader>(
     block_hash: BlockHash,
     header: &H,
@@ -1189,7 +907,6 @@ fn reward_trace<H: BlockHeader>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::Address;
 
     fn localized_transaction_trace(
         block_number: u64,

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -1,10 +1,8 @@
 use alloy_consensus::{
     BlobTransactionValidationError, BlockHeader, EnvKzgSettings, Transaction, TxReceipt,
 };
-use alloy_eips::{
-    eip7685::RequestsOrHash,
-    eip7928::{bal::DecodedBal, compute_block_access_list_hash},
-};
+use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash};
+use alloy_eips::eip7685::RequestsOrHash;
 use alloy_primitives::{map::AddressSet, Address, B256, U256};
 use alloy_rpc_types_beacon::relay::{
     BidTrace, BuilderBlockValidationRequest, BuilderBlockValidationRequestV2,
@@ -552,11 +550,9 @@ where
         + ChainSpecProvider<ChainSpec: EthereumHardforks>
         + StateProviderFactory
         + Clone
-        + Send
-        + Sync
         + 'static,
-    E: ConfigureEvm + Send + Sync + 'static,
-    T: PayloadTypes<ExecutionData = ExecutionData> + Send + Sync + 'static,
+    E: ConfigureEvm + 'static,
+    T: PayloadTypes<ExecutionData = ExecutionData>,
 {
     async fn validate_builder_submission_v1(
         &self,

--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -36,7 +36,7 @@ impl<N: NodeTypesWithDB> DbTool<N> {
     pub fn list<T: Table>(&self, filter: &ListFilter) -> Result<(Vec<TableRow<T>>, usize)> {
         let bmb = Rc::new(BMByte::from(&filter.search));
         if bmb.is_none() && filter.has_search() {
-            eyre::bail!("Invalid search.")
+            eyre::bail!("Invalid search.");
         }
 
         let mut hits = 0;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1741,9 +1741,20 @@ mod tests {
                 .first()
                 .map(|block| {
                     let senders = block.senders().expect("failed to recover senders");
+                    let original_accounts = in_memory_changesets
+                        .iter()
+                        .map(|(address, account, _)| (*address, *account))
+                        .collect::<AddressMap<_>>();
                     let state = execution_state_from_init(
                         in_memory_state.into_iter().map(|(address, (account, _))| {
-                            (address, (None, Some(account), BTreeMap::default()))
+                            (
+                                address,
+                                (
+                                    original_accounts.get(&address).copied(),
+                                    Some(account),
+                                    BTreeMap::default(),
+                                ),
+                            )
                         }),
                         [],
                     );

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1916,9 +1916,20 @@ mod tests {
                 .first()
                 .map(|block| {
                     let senders = block.senders().expect("failed to recover senders");
+                    let original_accounts = in_memory_changesets
+                        .iter()
+                        .map(|(address, account, _)| (*address, *account))
+                        .collect::<AddressMap<_>>();
                     let state = execution_state_from_init(
                         in_memory_state.into_iter().map(|(address, (account, _))| {
-                            (address, (None, Some(account), BTreeMap::default()))
+                            (
+                                address,
+                                (
+                                    original_accounts.get(&address).copied(),
+                                    Some(account),
+                                    BTreeMap::default(),
+                                ),
+                            )
                         }),
                         [],
                     );

--- a/examples/custom-evm/src/config.rs
+++ b/examples/custom-evm/src/config.rs
@@ -64,6 +64,7 @@ impl EvmTypesHost for CustomTypes {
     type ConfigSelector = CustomConfigSelector;
     type SpecId = CustomSpecId;
     type Tx = CustomEnvelope;
+    type EvmExt = ();
     type MessageExt = CustomMessageExt;
     type MessageResultExt = CustomMessageResultExt;
     type TxEnvExt = CustomTxEnvExt;

--- a/examples/custom-evm/src/main.rs
+++ b/examples/custom-evm/src/main.rs
@@ -14,6 +14,7 @@
 #![allow(missing_docs, clippy::missing_const_for_fn)]
 #![warn(unused_crate_dependencies)]
 
+use alloy_consensus::transaction::Recovered;
 use alloy_eips::eip2718::Typed2718;
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, Bytes, U256};
@@ -108,12 +109,15 @@ fn custom_precompile() -> HandlerResult<()> {
         InMemoryDB::default(),
         factory.precompiles(spec),
     );
-    let result = evm.transact(&CustomEnvelope::ExecuteCode(ExecuteCodeTx {
-        caller: Address::ZERO,
-        target,
-        code: code.into(),
-        gas_limit: 100_000,
-    }))?;
+    let tx = Recovered::new_unchecked(
+        CustomEnvelope::ExecuteCode(ExecuteCodeTx {
+            target,
+            code: code.into(),
+            gas_limit: 100_000,
+        }),
+        Address::ZERO,
+    );
+    let result = evm.transact(&tx)?;
     let status = result.result().status;
     drop(result);
     assert!(status);
@@ -149,12 +153,20 @@ fn custom_transaction() -> HandlerResult<()> {
     let mut database = InMemoryDB::default();
     database.insert_account_info(&target, AccountInfo::default().with_nonce(1));
     let mut evm = custom_evm_with_database(database);
-    let tx = CustomEnvelope::ExecuteCode(ExecuteCodeTx {
-        caller: Address::ZERO,
-        target,
-        gas_limit: 100_000,
-        code: Bytes::from_static(&[opcode::CUSTOM_OPCODE, op::PUSH1, 0x01, op::SSTORE, op::STOP]),
-    });
+    let tx = Recovered::new_unchecked(
+        CustomEnvelope::ExecuteCode(ExecuteCodeTx {
+            target,
+            gas_limit: 100_000,
+            code: Bytes::from_static(&[
+                opcode::CUSTOM_OPCODE,
+                op::PUSH1,
+                0x01,
+                op::SSTORE,
+                op::STOP,
+            ]),
+        }),
+        Address::ZERO,
+    );
 
     let result = evm.transact(&tx)?.commit();
     assert!(result.status);
@@ -192,21 +204,23 @@ fn custom_wire_transaction() -> HandlerResult<()> {
     let recovered = recover_wire_transaction(decoded).unwrap();
     let caller = recovered.signer();
     let evm_tx = into_evm_transaction(recovered);
-    let CustomEnvelope::ExecuteCode(tx) = evm_tx;
-    assert_eq!(tx.caller, caller);
+    assert_eq!(evm_tx.signer(), caller);
+    let CustomEnvelope::ExecuteCode(tx) = evm_tx.inner();
     assert_eq!(tx.target, Address::from([0xcc; 20]));
     assert_eq!(tx.code, Bytes::from_static(&[op::STOP]));
     println!("custom wire transaction: type=0x{:02x} roundtrip=true", WireTx::tx_type());
     Ok(())
 }
 
-fn custom_opcode_tx(code: Bytes) -> CustomEnvelope {
-    CustomEnvelope::ExecuteCode(ExecuteCodeTx {
-        caller: Address::ZERO,
-        target: Address::from([0xcc; 20]),
-        code,
-        gas_limit: 100_000,
-    })
+fn custom_opcode_tx(code: Bytes) -> Recovered<CustomEnvelope> {
+    Recovered::new_unchecked(
+        CustomEnvelope::ExecuteCode(ExecuteCodeTx {
+            target: Address::from([0xcc; 20]),
+            code,
+            gas_limit: 100_000,
+        }),
+        Address::ZERO,
+    )
 }
 
 fn custom_evm() -> Evm<'static, CustomTypes> {

--- a/examples/custom-evm/src/tx.rs
+++ b/examples/custom-evm/src/tx.rs
@@ -42,8 +42,6 @@ impl CustomEnvelope {
 /// Payload for [`CustomEnvelope::ExecuteCode`].
 #[derive(Debug)]
 pub struct ExecuteCodeTx {
-    /// Recovered sender used as the message caller.
-    pub caller: Address,
     /// Message destination.
     pub target: Address,
     /// Code executed by the message.
@@ -68,7 +66,7 @@ pub fn execute_code(
         gas_limit: req.tx.gas_limit,
         destination: req.tx.target,
         code_address: req.tx.target,
-        caller: req.tx.caller,
+        caller: req.tx.signer(),
         ext: CustomMessageExt { is_system: false },
         ..Message::default()
     };

--- a/examples/custom-evm/src/wire.rs
+++ b/examples/custom-evm/src/wire.rs
@@ -210,13 +210,17 @@ pub fn recover_wire_transaction(
 }
 
 /// Converts a recovered wire transaction into the evm2 transaction registry envelope.
-pub fn into_evm_transaction(transaction: Recovered<SignedCustomTransaction>) -> CustomEnvelope {
+pub fn into_evm_transaction(
+    transaction: Recovered<SignedCustomTransaction>,
+) -> Recovered<CustomEnvelope> {
     let (transaction, caller) = transaction.into_parts();
     let tx = transaction.strip_signature();
-    CustomEnvelope::ExecuteCode(ExecuteCodeTx {
+    Recovered::new_unchecked(
+        CustomEnvelope::ExecuteCode(ExecuteCodeTx {
+            target: tx.target,
+            code: tx.code,
+            gas_limit: tx.gas_limit,
+        }),
         caller,
-        target: tx.target,
-        code: tx.code,
-        gas_limit: tx.gas_limit,
-    })
+    )
 }

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -81,12 +81,8 @@ fn main() {
                         let tx_env = EthTxEnv::from(tx.to_consensus());
 
                         let mut db = CacheDB::new(Db::new(StateProviderDatabase::new(state)));
-                        let result = eth_api.inspect_with_inspector(
-                            &mut db,
-                            evm_env,
-                            tx_env,
-                            DummyInspector::default(),
-                        );
+                        let result =
+                            eth_api.inspect(&mut db, evm_env, &tx_env, DummyInspector::default());
 
                         if let Ok((inspector, _)) = result {
                             let hash = tx.hash();

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -20,10 +20,7 @@ use evm2::{
 use futures_util::StreamExt;
 use reth_ethereum::{
     cli::{chainspec::EthereumChainSpecParser, interface::Cli},
-    evm::{
-        primitives::{database::StateProviderDatabase, ConfigureEvm},
-        EthTxEnv,
-    },
+    evm::primitives::{database::StateProviderDatabase, ConfigureEvm},
     node::{builder::NodeHandle, EthereumNode},
     pool::TransactionPool,
     rpc::api::eth::helpers::Trace,
@@ -78,7 +75,7 @@ fn main() {
                             Ok(env) => env,
                             Err(err) => match err {},
                         };
-                        let tx_env = EthTxEnv::from(tx.to_consensus());
+                        let tx_env = node.evm_config.tx_env(tx.to_consensus());
 
                         let mut db = CacheDB::new(Db::new(StateProviderDatabase::new(state)));
                         let result =

--- a/examples/custom-state-root/Cargo.toml
+++ b/examples/custom-state-root/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 
 [dependencies]
 reth-ethereum = { workspace = true, features = ["node", "test-utils"] }
-reth-evm.workspace = true
 reth-engine-tree.workspace = true
+reth-evm.workspace = true
 reth-chain-state.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true

--- a/examples/custom-state-root/src/main.rs
+++ b/examples/custom-state-root/src/main.rs
@@ -33,7 +33,6 @@ use reth_engine_tree::tree::{
 };
 use reth_ethereum::{
     chainspec::ChainSpec,
-    evm::EthEvmEnv,
     node::{
         builder::{
             rpc::{
@@ -48,7 +47,7 @@ use reth_ethereum::{
     tasks::Runtime,
     EthPrimitives,
 };
-use reth_evm::{BlockExecutorFactory, ConfigureEvm, TxEnvFor};
+use reth_evm::{ConfigureEvm, EvmEnv};
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock};
 use reth_provider::{BlockExecutionOutput, ProviderResult};
 use reth_trie::updates::TrieUpdates;
@@ -67,14 +66,13 @@ impl<N, P, Evm> StateRootStrategy<N, P, Evm> for ZeroStateRootStrategy
 where
     N: NodePrimitives,
     Evm: ConfigureEvm<Primitives = N>,
-    Evm::BlockExecutorFactory: BlockExecutorFactory<EvmEnv = EthEvmEnv>,
     DefaultStateRootStrategy: StateRootStrategy<N, P, Evm>,
 {
     fn prepare(
         &self,
         ctx: StateRootJobContext<'_, N, P, Evm>,
     ) -> ProviderResult<PreparedStateRootJob<N>> {
-        let timestamp: u64 = ctx.env().evm_env.block.timestamp.saturating_to();
+        let timestamp: u64 = ctx.env().evm_env.block_env().timestamp.saturating_to();
         if timestamp < self.activation_timestamp {
             return self.default.prepare(ctx)
         }
@@ -139,8 +137,6 @@ where
             alloy_rpc_types_engine::ExecutionData,
         >,
     >,
-    <N::Evm as ConfigureEvm>::BlockExecutorFactory: BlockExecutorFactory<EvmEnv = EthEvmEnv>,
-    TxEnvFor<N::Evm>: Clone + Send + 'static,
 {
     type EngineValidator = BasicEngineValidator<
         N::Provider,

--- a/examples/txpool-tracing/Cargo.toml
+++ b/examples/txpool-tracing/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 reth-ethereum = { workspace = true, features = ["node", "pool", "cli", "rpc"] }
-reth-rpc-api.workspace = true
 
 alloy-primitives.workspace = true
 alloy-rpc-types-trace.workspace = true

--- a/examples/txpool-tracing/src/main.rs
+++ b/examples/txpool-tracing/src/main.rs
@@ -10,8 +10,8 @@
 
 #![warn(unused_crate_dependencies)]
 
-use alloy_primitives::{map::HashSet, Address};
-use alloy_rpc_types_trace::parity::TraceType;
+use alloy_primitives::Address;
+use alloy_rpc_types_trace::{parity::TraceType, tracerequest::TraceCallRequest};
 use clap::Parser;
 use futures_util::StreamExt;
 use reth_ethereum::{
@@ -20,7 +20,6 @@ use reth_ethereum::{
     pool::TransactionPool,
     rpc::eth::primitives::TransactionRequest,
 };
-use reth_rpc_api::TraceApiServer;
 
 mod submit;
 
@@ -51,10 +50,9 @@ fn main() {
                         // trace the transaction with `trace_call`
                         let callrequest =
                             TransactionRequest::from_recovered_transaction(tx.to_consensus());
-                        let trace_types = HashSet::from_iter([TraceType::Trace]);
-                        if let Ok(trace_result) =
-                            traceapi.trace_call(callrequest, trace_types, None, None, None).await
-                        {
+                        let tracerequest =
+                            TraceCallRequest::new(callrequest).with_trace_type(TraceType::Trace);
+                        if let Ok(trace_result) = traceapi.trace_call(tracerequest).await {
                             let hash = tx.hash();
                             println!("trace result for transaction {hash}: {trace_result:?}");
                         }


### PR DESCRIPTION
# Per-file diff stats

Files are selected from `origin/codex/excise-revm...HEAD`. Each line shows `origin/main...origin/codex/excise-revm` -> `origin/main...HEAD`.

## Full diff vs main

- 🟢 `216 files, +16123 / -15195` -> `221 files, +16211 / -12763`
- Difference: `+5 files`, `+88 insertions`, `-2432 deletions`, and `-2344 total changed lines`

🟢 means the total changed-line count went down, 🔴 means it went up, and ⚪ means it stayed equal.

- 🔴 `Cargo.lock` — `+1087 / -1230` -> `+1091 / -1229`
- ⚪ `Cargo.toml` — `+14 / -12` -> `+14 / -12`
- 🔴 `crates/cli/commands/src/config_cmd.rs` — `+0 / -0` -> `+3 / -1`
- 🔴 `crates/cli/commands/src/download/archive.rs` — `+0 / -0` -> `+1 / -1`
- 🔴 `crates/cli/commands/src/download/manifest.rs` — `+0 / -0` -> `+1 / -1`
- 🔴 `crates/cli/commands/src/download/manifest_cmd.rs` — `+0 / -0` -> `+1 / -1`
- 🔴 `crates/cli/commands/src/p2p/bootnode.rs` — `+0 / -0` -> `+6 / -2`
- 🔴 `crates/cli/commands/src/p2p/mod.rs` — `+0 / -0` -> `+2 / -2`
- 🔴 `crates/cli/commands/src/stage/unwind.rs` — `+0 / -0` -> `+1 / -1`
- 🟢 `crates/e2e-test-utils/src/rpc.rs` — `+20 / -1` -> `+0 / -0`
- 🔴 `crates/engine/local/src/miner.rs` — `+0 / -0` -> `+4 / -4`
- ⚪ `crates/engine/tree/src/tree/payload_processor/bal/execute.rs` — `+362 / -823` -> `+362 / -823`
- ⚪ `crates/engine/tree/src/tree/payload_processor/mod.rs` — `+39 / -50` -> `+37 / -52`
- 🔴 `crates/engine/tree/src/tree/payload_processor/prewarm.rs` — `+60 / -49` -> `+61 / -49`
- 🟢 `crates/engine/tree/src/tree/payload_validator.rs` — `+112 / -177` -> `+106 / -176`
- 🟢 `crates/ethereum/evm/src/convert.rs` — `+237 / -0` -> `+203 / -0`
- 🟢 `crates/ethereum/evm/src/execution.rs` — `+1944 / -0` -> `+1943 / -0`
- ⚪ `crates/ethereum/evm/src/executor.rs` — `+1143 / -0` -> `+1143 / -0`
- 🔴 `crates/ethereum/evm/src/factory.rs` — `+489 / -146` -> `+492 / -146`
- 🔴 `crates/ethereum/evm/src/lib.rs` — `+481 / -338` -> `+507 / -338`
- 🟢 `crates/ethereum/node/src/node.rs` — `+48 / -59` -> `+36 / -58`
- 🔴 `crates/evm/evm/src/aliases.rs` — `+19 / -42` -> `+30 / -40`
- 🟢 `crates/evm/evm/src/database.rs` — `+189 / -0` -> `+143 / -0`
- 🔴 `crates/evm/evm/src/engine.rs` — `+4 / -5` -> `+5 / -6`
- 🔴 `crates/evm/evm/src/execute.rs` — `+1035 / -488` -> `+1152 / -467`
- 🔴 `crates/evm/evm/src/lib.rs` — `+298 / -373` -> `+320 / -373`
- 🟢 `crates/node/builder/src/components/mod.rs` — `+1 / -1` -> `+0 / -0`
- 🔴 `crates/node/builder/src/launch/invalid_block_hook.rs` — `+0 / -0` -> `+1 / -1`
- 🟢 `crates/node/builder/src/rpc.rs` — `+15 / -2` -> `+0 / -0`
- 🔴 `crates/node/core/src/utils.rs` — `+0 / -0` -> `+2 / -2`
- 🟢 `crates/rpc/rpc-builder/src/lib.rs` — `+33 / -4` -> `+0 / -0`
- 🔴 `crates/rpc/rpc-convert/Cargo.toml` — `+0 / -1` -> `+1 / -1`
- 🔴 `crates/rpc/rpc-convert/src/fees.rs` — `+0 / -0` -> `+106 / -0`
- 🔴 `crates/rpc/rpc-convert/src/lib.rs` — `+0 / -2` -> `+5 / -3`
- 🔴 `crates/rpc/rpc-convert/src/transaction.rs` — `+13 / -22` -> `+161 / -7`
- 🟢 `crates/rpc/rpc-eth-api/Cargo.toml` — `+6 / -5` -> `+3 / -5`
- ⚪ `crates/rpc/rpc-eth-api/src/helpers/bal.rs` — `+53 / -31` -> `+53 / -31`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/call.rs` — `+26 / -824` -> `+176 / -121`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/config.rs` — `+16 / -25` -> `+4 / -13`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/estimate.rs` — `+16 / -363` -> `+101 / -159`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/mod.rs` — `+3 / -1` -> `+0 / -0`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/pending_block.rs` — `+19 / -96` -> `+55 / -55`
- 🔴 `crates/rpc/rpc-eth-api/src/helpers/state.rs` — `+3 / -3` -> `+4 / -3`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/trace.rs` — `+474 / -16` -> `+143 / -221`
- ⚪ `crates/rpc/rpc-eth-api/src/helpers/transaction.rs` — `+1 / -1` -> `+1 / -1`
- 🟢 `crates/rpc/rpc-eth-types/Cargo.toml` — `+3 / -7` -> `+3 / -5`
- ⚪ `crates/rpc/rpc-eth-types/src/cache/config.rs` — `+1 / -1` -> `+1 / -1`
- 🔴 `crates/rpc/rpc-eth-types/src/cache/db.rs` — `+6 / -7` -> `+113 / -7`
- 🟢 `crates/rpc/rpc-eth-types/src/cache/mod.rs` — `+95 / -429` -> `+84 / -78`
- 🟢 `crates/rpc/rpc-eth-types/src/error/api.rs` — `+4 / -62` -> `+18 / -24`
- 🔴 `crates/rpc/rpc-eth-types/src/error/mod.rs` — `+22 / -257` -> `+126 / -178`
- 🟢 `crates/rpc/rpc-eth-types/src/simulate.rs` — `+9 / -425` -> `+145 / -89`
- ⚪ `crates/rpc/rpc-server-types/src/constants.rs` — `+1 / -1` -> `+1 / -1`
- 🟢 `crates/rpc/rpc/Cargo.toml` — `+6 / -10` -> `+4 / -6`
- 🟢 `crates/rpc/rpc/src/debug.rs` — `+326 / -101` -> `+147 / -102`
- 🟢 `crates/rpc/rpc/src/eth/bundle.rs` — `+10 / -224` -> `+34 / -32`
- 🔴 `crates/rpc/rpc/src/eth/helpers/bal.rs` — `+0 / -0` -> `+5 / -1`
- 🔴 `crates/rpc/rpc/src/eth/helpers/trace.rs` — `+0 / -0` -> `+5 / -1`
- 🟢 `crates/rpc/rpc/src/eth/helpers/types.rs` — `+0 / -73` -> `+5 / -5`
- 🟢 `crates/rpc/rpc/src/eth/sim_bundle.rs` — `+15 / -198` -> `+24 / -23`
- 🟢 `crates/rpc/rpc/src/lib.rs` — `+2 / -0` -> `+0 / -0`
- 🟢 `crates/rpc/rpc/src/otterscan.rs` — `+37 / -25` -> `+7 / -9`
- 🟢 `crates/rpc/rpc/src/reth.rs` — `+18 / -48` -> `+2 / -2`
- 🟢 `crates/rpc/rpc/src/testing.rs` — `+20 / -324` -> `+20 / -20`
- 🟢 `crates/rpc/rpc/src/trace.rs` — `+384 / -64` -> `+69 / -32`
- 🟢 `crates/rpc/rpc/src/validation.rs` — `+61 / -44` -> `+53 / -40`
- 🔴 `crates/storage/db-common/src/db_tool/mod.rs` — `+0 / -0` -> `+1 / -1`
- 🔴 `crates/storage/provider/src/providers/blockchain_provider.rs` — `+56 / -42` -> `+67 / -42`
- 🔴 `crates/storage/provider/src/providers/consistent.rs` — `+174 / -155` -> `+185 / -155`
- 🔴 `examples/custom-evm/src/config.rs` — `+167 / -0` -> `+168 / -0`
- 🔴 `examples/custom-evm/src/main.rs` — `+245 / -101` -> `+259 / -101`
- 🟢 `examples/custom-evm/src/tx.rs` — `+96 / -0` -> `+94 / -0`
- 🔴 `examples/custom-evm/src/wire.rs` — `+222 / -0` -> `+226 / -0`
- 🟢 `examples/custom-inspector/src/main.rs` — `+55 / -61` -> `+50 / -63`
- 🟢 `examples/custom-state-root/Cargo.toml` — `+1 / -1` -> `+0 / -0`
- 🟢 `examples/custom-state-root/src/main.rs` — `+6 / -2` -> `+2 / -2`
- 🟢 `examples/txpool-tracing/Cargo.toml` — `+1 / -0` -> `+0 / -0`
- 🟢 `examples/txpool-tracing/src/main.rs` — `+7 / -5` -> `+0 / -0`
