### PR TITLE
fix(ci): run x86_64 macOS release build on Intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
             rustflags: ""
             native: true
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-15-intel
             profile: maxperf
             allow_fail: false
             rustflags: "-C target-cpu=x86-64-v3 -C target-feature=+pclmulqdq"


### PR DESCRIPTION
Runs the x86_64 macOS release build on GitHub’s Intel runner instead of cross-compiling from the ARM64 macos-14 runner.

Fixes the gmp-mpfr-sys failure in release run https://github.com/paradigmxyz/reth/actions/runs/29331749800.