### PR TITLE
chore: bump revmc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10883,7 +10883,7 @@ dependencies = [
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10903,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 dependencies = [
  "eyre",
  "ruint",
@@ -10912,12 +10912,12 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 dependencies = [
  "paste",
  "revm-bytecode",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 dependencies = [
  "revm-context",
  "revm-context-interface",
@@ -10978,7 +10978,7 @@ dependencies = [
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=main#520462a463523a3bcd0a47226ddbc3200d62232e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -509,6 +509,7 @@ fn jit_runtime_config(jit: &JitArgs) -> RuntimeConfig {
         dump_dir: default_config.dump_dir,
         debug_assertions: jit.debug,
         blocking: jit.blocking,
+        single_error: default_config.single_error,
         no_dedup: default_config.no_dedup,
         no_dse: default_config.no_dse,
         gas_params: default_config.gas_params,


### PR DESCRIPTION
Bumps revmc from `7e3536d` to the latest `main` revision, `520462a`.

Validation:
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

Note: a full dependency fetch was blocked by the sandbox GitHub credential path returning HTTP 401 for public git dependencies.

Prompted by: @DaniPopes