### PR TITLE
fix(trie): continue prefix-set traversal after cached descendant

### DIFF
--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -1,7 +1,7 @@
 use crate::Nibbles;
 use alloc::{sync::Arc, vec::Vec};
 use alloy_primitives::map::{B256Map, B256Set};
-use core::ops::Range;
+use core::ops::{Bound, RangeBounds};
 
 /// Collection of mutable prefix sets.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
@@ -261,28 +261,48 @@ impl PrefixSet {
         false
     }
 
-    /// Returns `true` if any key in the set falls within the given half-open range
-    /// `[start, end)`.
+    /// Returns `true` if any key in the set falls within the given range bounds.
     ///
     /// Like [`Self::contains`], this method maintains the internal index for sequential access
     /// optimization.
     #[inline]
-    pub fn contains_range(&mut self, range: Range<&Nibbles>) -> bool {
+    pub fn contains_range<'a>(&mut self, range: impl RangeBounds<&'a Nibbles>) -> bool {
         if self.all {
             return true
         }
 
-        while self.index > 0 && &self.keys[self.index] >= range.end {
+        let start_bound = match range.start_bound() {
+            Bound::Included(bound) => Bound::Included(*bound),
+            Bound::Excluded(bound) => Bound::Excluded(*bound),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let end_bound = match range.end_bound() {
+            Bound::Included(bound) => Bound::Included(*bound),
+            Bound::Excluded(bound) => Bound::Excluded(*bound),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let satisfies_start = |key: &Nibbles| match start_bound {
+            Bound::Included(start) => key >= start,
+            Bound::Excluded(start) => key > start,
+            Bound::Unbounded => true,
+        };
+        let satisfies_end = |key: &Nibbles| match end_bound {
+            Bound::Included(end) => key <= end,
+            Bound::Excluded(end) => key < end,
+            Bound::Unbounded => true,
+        };
+
+        while self.index > 0 && !satisfies_end(&self.keys[self.index]) {
             self.index -= 1;
         }
 
         for (idx, key) in self.keys[self.index..].iter().enumerate() {
-            if key >= range.start && key < range.end {
+            if satisfies_start(key) && satisfies_end(key) {
                 self.index += idx;
                 return true
             }
 
-            if key >= range.end {
+            if !satisfies_end(key) {
                 self.index += idx;
                 return false
             }
@@ -402,6 +422,21 @@ mod tests {
 
         let prefix_set = prefix_set_mut.freeze();
         assert_eq!(prefix_set.slice(), &[path_a, path_b]);
+    }
+
+    #[test]
+    fn test_contains_range_bounds() {
+        let first = Nibbles::from_nibbles([1, 2, 3]);
+        let middle = Nibbles::from_nibbles([1, 2, 4]);
+        let last = Nibbles::from_nibbles([4, 5, 6]);
+        let mut prefix_set = PrefixSetMut::from([first, middle, last]).freeze();
+
+        assert!(prefix_set.contains_range(&first..&middle));
+        assert!(!prefix_set.contains_range((Bound::Excluded(&first), Bound::Excluded(&middle))));
+        assert!(prefix_set.contains_range(&middle..));
+        assert!(prefix_set.contains_range(..=&first));
+        assert!(!prefix_set.contains_range(..&first));
+        assert!(prefix_set.contains_range((Bound::Excluded(&middle), Bound::Included(&last))));
     }
 
     #[test]

--- a/crates/trie/common/src/prefix_set.rs
+++ b/crates/trie/common/src/prefix_set.rs
@@ -271,24 +271,14 @@ impl PrefixSet {
             return true
         }
 
-        let start_bound = match range.start_bound() {
-            Bound::Included(bound) => Bound::Included(*bound),
-            Bound::Excluded(bound) => Bound::Excluded(*bound),
-            Bound::Unbounded => Bound::Unbounded,
-        };
-        let end_bound = match range.end_bound() {
-            Bound::Included(bound) => Bound::Included(*bound),
-            Bound::Excluded(bound) => Bound::Excluded(*bound),
-            Bound::Unbounded => Bound::Unbounded,
-        };
-        let satisfies_start = |key: &Nibbles| match start_bound {
-            Bound::Included(start) => key >= start,
-            Bound::Excluded(start) => key > start,
+        let satisfies_start = |key: &Nibbles| match range.start_bound() {
+            Bound::Included(start) => key >= *start,
+            Bound::Excluded(start) => key > *start,
             Bound::Unbounded => true,
         };
-        let satisfies_end = |key: &Nibbles| match end_bound {
-            Bound::Included(end) => key <= end,
-            Bound::Excluded(end) => key < end,
+        let satisfies_end = |key: &Nibbles| match range.end_bound() {
+            Bound::Included(end) => key <= *end,
+            Bound::Excluded(end) => key < *end,
             Bound::Unbounded => true,
         };
 

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1104,6 +1104,33 @@ where
                         }
                     }
                 }
+
+                // A cached branch can be a strict descendant of this branch's child. In that
+                // case the child's bit is set before later prefix-set paths in the same child
+                // range have been processed.
+                if uncalculated_lower_bound_ref.starts_with(&self.branch_path) &&
+                    uncalculated_lower_bound_ref.len() > branch_path_len + 1
+                {
+                    let child_nibble = uncalculated_lower_bound_ref.get_unchecked(branch_path_len);
+                    if curr_state_mask.is_bit_set(child_nibble) {
+                        let child_path = self.child_path_at(child_nibble);
+                        let contains_remaining = match child_path.next_without_prefix() {
+                            None => {
+                                self.prefix_set.contains(uncalculated_lower_bound_ref) ||
+                                    self.prefix_set
+                                        .iter()
+                                        .next_back()
+                                        .is_some_and(|key| key >= uncalculated_lower_bound_ref)
+                            }
+                            Some(upper) => {
+                                self.prefix_set.contains_range(uncalculated_lower_bound_ref..&upper)
+                            }
+                        };
+                        if contains_remaining {
+                            next_child_nibbles.set_bit(child_nibble);
+                        }
+                    }
+                }
             }
 
             let _orig_next_child_nibbles = next_child_nibbles;
@@ -1240,11 +1267,18 @@ where
             // branch node may be the node at this child directly, or this child may be an
             // extension and the cached branch is the child of that extension.
 
-            // All trie nodes prior to `child_path` will not be modified further, so we can seek the
-            // trie cursor to the next cached node at-or-after `child_path`.
-            if trie_cursor_state.path().is_some_and(|path| path < &child_path) {
-                trace!(target: TRACE_TARGET, ?child_path, "Seeking trie cursor to child path");
-                *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(child_path)?);
+            let child_lower_bound = if uncalculated_lower_bound_ref.starts_with(&child_path) {
+                *uncalculated_lower_bound_ref
+            } else {
+                child_path
+            };
+
+            // All trie nodes prior to `child_lower_bound` have been processed, so seek the trie
+            // cursor to the next cached node at-or-after it.
+            if trie_cursor_state.path().is_some_and(|path| path < &child_lower_bound) {
+                trace!(target: TRACE_TARGET, ?child_lower_bound, "Seeking trie cursor to child path");
+                *trie_cursor_state =
+                    TrieCursorState::seeked(self.trie_cursor_seek(child_lower_bound)?);
             }
 
             // If the next cached branch node is a child of `child_path` then we can assume it is
@@ -1284,7 +1318,7 @@ where
             let child_path_upper = child_path.next_without_prefix();
             trace!(
                 target: TRACE_TARGET,
-                lower=?child_path,
+                lower=?child_lower_bound,
                 upper=?child_path_upper,
                 "Returning sub-trie's key range to calculate",
             );
@@ -1292,7 +1326,7 @@ where
             // Push the current cached branch back onto the stack before returning.
             self.cached_branch_stack.push((cached_path, cached_branch));
 
-            return Ok(Some((child_path, child_path_upper)));
+            return Ok(Some((child_lower_bound, child_path_upper)));
         }
     }
 
@@ -2799,6 +2833,54 @@ mod tests {
             .expect("root hash should succeed")
             .expect("root should get hashed");
         pretty_assertions::assert_eq!(expected_root, got_root);
+    }
+
+    #[test]
+    fn test_prefix_set_root_proof_processes_sibling_after_cached_descendant() {
+        reth_tracing::init_test_tracing();
+
+        fn b256(s: &str) -> B256 {
+            B256::from_slice(&alloy_primitives::hex::decode(s).expect("valid hex string"))
+        }
+
+        let storage: BTreeMap<B256, U256> = [
+            ("1022c69e9d900e40775cd387c134899f465f291dbc3c97899ff6bfb8dc972b37", 45u64),
+            ("1111ad8083c8a3a398b2b781217b989ff4d1ed182f46cc765eda49a7b316139d", 60),
+            ("12012d20943649899b2fc0f87b9840b70ef68e93613aac17c269bf8c5a78a712", 17),
+            ("12014b57b9a162c03d072eb6acd4e936f1c4bc23b803a054347c5ee9a9bcfb9a", 49),
+            ("1203f800840af3f898ab4572f2750106a7c4bd2b3e844b6e7fa72704673cc2c6", 76),
+            ("12208f18fbcd6971c92808721392acbf11d5af58e9143a374cc86e70bdd1f097", 10),
+        ]
+        .into_iter()
+        .map(|(key, value)| (b256(key), U256::from(value)))
+        .collect();
+
+        let dirty = b256("12208f18fbcd6971c92808721392acbf11d5af58e9143a374cc86e70bdd1f097");
+        let harness = ProofTestHarness::new(storage);
+        let expected_root = harness.original_root();
+
+        let mut prefix_set = PrefixSetMut::default();
+        prefix_set.insert(Nibbles::unpack(dirty));
+
+        let trie_cursor =
+            harness.trie_cursor_factory().storage_trie_cursor(harness.hashed_address()).unwrap();
+        let hashed_cursor = harness
+            .hashed_cursor_factory()
+            .hashed_storage_cursor(harness.hashed_address())
+            .unwrap();
+        let mut calculator = StorageProofCalculator::new_storage(trie_cursor, hashed_cursor)
+            .with_prefix_set(prefix_set.freeze());
+
+        let mut targets = vec![ProofV2Target::new(B256::ZERO)];
+        let proof = calculator.storage_proof(harness.hashed_address(), &mut targets).unwrap();
+        let actual_root = calculator.compute_root_hash(&proof).unwrap();
+
+        pretty_assertions::assert_eq!(
+            Some(expected_root),
+            actual_root,
+            "root proof must process a prefix-set sibling after a cached descendant: expected \
+             {expected_root:?}, got {actual_root:?}"
+        );
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1107,9 +1107,19 @@ where
 
                 // A cached branch can be a strict descendant of this branch's child. In that
                 // case the child's bit is set before later prefix-set paths in the same child
-                // range have been processed. For example, after cached branch `0x120` is processed
-                // while building branch `0x1`, child `0x12` is set and the lower bound is `0x121`,
-                // but a prefix-set path under `0x122` still needs to be processed.
+                // range have been processed.
+                //
+                // For example:
+                // - Branch at 0x1 is being built
+                // - Cached branch 0x120 is processed
+                //   - Child bit 2 on branch 0x1 is set
+                //   - uncalculated_lower_bound ends up at 0x121
+                // - 0x122 is set in the prefix set
+                //
+                // Once the calculator pops back to 0x1, next_child_nibbles won't have child nibble
+                // 2 set, because the processing of 0x120 will have set that nibble on the
+                // state_mask. We set the child nibble on next_child_nibbles here to indicate that
+                // there might be more work to do at that prefix.
                 if uncalculated_lower_bound_ref.starts_with(&self.branch_path) &&
                     uncalculated_lower_bound_ref.len() > branch_path_len + 1
                 {

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -2902,6 +2902,62 @@ mod tests {
     }
 
     #[test]
+    fn test_prefix_set_root_proof_preserves_clean_sibling_after_cached_branch_collapse() {
+        reth_tracing::init_test_tracing();
+
+        let dirty = B256::right_padding_from(&[0x10, 0x00, 0x10]);
+        let clean_sibling = B256::right_padding_from(&[0x10, 0x10]);
+        let storage = [
+            B256::right_padding_from(&[0x10]),
+            dirty,
+            B256::right_padding_from(&[0x10, 0x01]),
+            B256::right_padding_from(&[0x10, 0x02]),
+            clean_sibling,
+            B256::right_padding_from(&[0x11]),
+            B256::right_padding_from(&[0x12]),
+        ]
+        .into_iter()
+        .map(|key| (key, U256::from(1u64)))
+        .collect();
+
+        let harness = ProofTestHarness::new(storage);
+        let expected_root = harness.original_root();
+
+        let root_with = |prefix_set: PrefixSet| {
+            let trie_cursor = harness
+                .trie_cursor_factory()
+                .storage_trie_cursor(harness.hashed_address())
+                .unwrap();
+            let hashed_cursor = harness
+                .hashed_cursor_factory()
+                .hashed_storage_cursor(harness.hashed_address())
+                .unwrap();
+            let mut calculator = StorageProofCalculator::new_storage(trie_cursor, hashed_cursor)
+                .with_prefix_set(prefix_set);
+
+            let mut targets = vec![ProofV2Target::new(B256::ZERO)];
+            let proof = calculator.storage_proof(harness.hashed_address(), &mut targets).unwrap();
+            calculator.compute_root_hash(&proof).unwrap()
+        };
+
+        let mut prefix_set = PrefixSetMut::default();
+        prefix_set.insert(Nibbles::unpack(dirty));
+        let actual_root = root_with(prefix_set.freeze());
+
+        let mut prefix_set_with_sibling = PrefixSetMut::default();
+        prefix_set_with_sibling.insert(Nibbles::unpack(dirty));
+        prefix_set_with_sibling.insert(Nibbles::unpack(clean_sibling));
+        let control_root = root_with(prefix_set_with_sibling.freeze());
+
+        pretty_assertions::assert_eq!(Some(expected_root), control_root);
+        pretty_assertions::assert_eq!(
+            Some(expected_root),
+            actual_root,
+            "a dirty prefix must not omit a clean sibling after collapsing a cached branch",
+        );
+    }
+
+    #[test]
     fn test_cached_hash_with_deleted_leaf() {
         reth_tracing::init_test_tracing();
 

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1107,7 +1107,9 @@ where
 
                 // A cached branch can be a strict descendant of this branch's child. In that
                 // case the child's bit is set before later prefix-set paths in the same child
-                // range have been processed.
+                // range have been processed. For example, after cached branch `0x120` is processed
+                // while building branch `0x1`, child `0x12` is set and the lower bound is `0x121`,
+                // but a prefix-set path under `0x122` still needs to be processed.
                 if uncalculated_lower_bound_ref.starts_with(&self.branch_path) &&
                     uncalculated_lower_bound_ref.len() > branch_path_len + 1
                 {

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1100,6 +1100,12 @@ where
                         child_path.truncate(branch_path_len);
                         child_path.push_unchecked(nibble);
                         if self.prefix_set.contains(&child_path) {
+                            trace!(
+                                target: TRACE_TARGET,
+                                branch_path = ?self.branch_path,
+                                ?nibble,
+                                "Setting child nibble from prefix set on next_child_nibbles",
+                            );
                             next_child_nibbles.set_bit(nibble);
                         }
                     }
@@ -1132,6 +1138,13 @@ where
                             child_path_upper.as_ref().map_or(Bound::Unbounded, Bound::Excluded),
                         ));
                         if contains_remaining {
+                            trace!(
+                                target: TRACE_TARGET,
+                                branch_path = ?self.branch_path,
+                                ?uncalculated_lower_bound,
+                                nibble = ?child_nibble,
+                                "Setting child nibble from uncalculated lower bound on next_child_nibbles",
+                            );
                             next_child_nibbles.set_bit(child_nibble);
                         }
                     }

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -19,7 +19,7 @@ use reth_trie_common::{
     prefix_set::PrefixSet, BranchNodeMasks, BranchNodeRef, BranchNodeV2, Nibbles, ProofTrieNodeV2,
     ProofV2Target, RlpNode, TrieNodeV2,
 };
-use std::cmp::Ordering;
+use std::{cmp::Ordering, ops::Bound};
 use tracing::{error, instrument, trace};
 
 mod value;
@@ -1116,18 +1116,11 @@ where
                     let child_nibble = uncalculated_lower_bound_ref.get_unchecked(branch_path_len);
                     if curr_state_mask.is_bit_set(child_nibble) {
                         let child_path = self.child_path_at(child_nibble);
-                        let contains_remaining = match child_path.next_without_prefix() {
-                            None => {
-                                self.prefix_set.contains(uncalculated_lower_bound_ref) ||
-                                    self.prefix_set
-                                        .iter()
-                                        .next_back()
-                                        .is_some_and(|key| key >= uncalculated_lower_bound_ref)
-                            }
-                            Some(upper) => {
-                                self.prefix_set.contains_range(uncalculated_lower_bound_ref..&upper)
-                            }
-                        };
+                        let child_path_upper = child_path.next_without_prefix();
+                        let contains_remaining = self.prefix_set.contains_range((
+                            Bound::Included(uncalculated_lower_bound_ref),
+                            child_path_upper.as_ref().map_or(Bound::Unbounded, Bound::Excluded),
+                        ));
                         if contains_remaining {
                             next_child_nibbles.set_bit(child_nibble);
                         }


### PR DESCRIPTION
Fixes proof v2 traversal when a skipped branch exposes a cached descendant before another prefix-set path. Traversal now resumes from its current lower bound, preserving valid cached hashes while processing later invalidated paths.

This fix is only relevant for usages of the ProofCalculator which pass a prefix set, e.g. TrieWitness. Normal payload validation is not affected.

Adds the deterministic storage-root regression found while reviewing #26357.