### PR TITLE
feat(rpc): add ephemeral admin tracing directives

### DIFF
--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -393,10 +393,7 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, SubCmd: Subcommand + fmt:
     /// This is used to determine whether to enable runtime log level changes.
     pub fn tracing_reload_enabled(&self) -> bool {
         match self {
-            Self::Node(cmd) => {
-                cmd.rpc.is_namespace_enabled(RethRpcModule::Debug) ||
-                    cmd.rpc.is_namespace_enabled(RethRpcModule::Admin)
-            }
+            Self::Node(cmd) => cmd.rpc.is_namespace_enabled(RethRpcModule::Admin),
             _ => false,
         }
     }

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -253,15 +253,6 @@ impl<
         // Enable reload support if an RPC namespace with runtime tracing controls is available.
         let enable_reload = self.command.tracing_reload_enabled();
         let guards = self.logs.init_tracing_with_layers(layers, enable_reload)?;
-        if enable_reload {
-            let directive = self.logs.verbosity.directive().to_string();
-            let baseline = if self.logs.log_stdout_filter.is_empty() {
-                directive
-            } else {
-                format!("{directive},{}", self.logs.log_stdout_filter)
-            };
-            reth_tracing::set_startup_log_directives(baseline);
-        }
         info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
 
         match otlp_status {

--- a/crates/ethereum/cli/src/interface.rs
+++ b/crates/ethereum/cli/src/interface.rs
@@ -250,9 +250,18 @@ impl<
         let otlp_status = runner.block_on(self.traces.init_otlp_tracing(&mut layers))?;
         let otlp_logs_status = runner.block_on(self.traces.init_otlp_logs(&mut layers))?;
 
-        // Enable reload support if debug RPC namespace is available
-        let enable_reload = self.command.debug_namespace_enabled();
+        // Enable reload support if an RPC namespace with runtime tracing controls is available.
+        let enable_reload = self.command.tracing_reload_enabled();
         let guards = self.logs.init_tracing_with_layers(layers, enable_reload)?;
+        if enable_reload {
+            let directive = self.logs.verbosity.directive().to_string();
+            let baseline = if self.logs.log_stdout_filter.is_empty() {
+                directive
+            } else {
+                format!("{directive},{}", self.logs.log_stdout_filter)
+            };
+            reth_tracing::set_startup_log_directives(baseline);
+        }
         info!(target: "reth::cli", "Initialized tracing, debug log directory: {}", self.logs.log_file_directory);
 
         match otlp_status {
@@ -379,12 +388,15 @@ impl<C: ChainSpecParser, Ext: clap::Args + fmt::Debug, SubCmd: Subcommand + fmt:
         }
     }
 
-    /// Returns `true` if this is a node command with debug RPC namespace enabled.
+    /// Returns `true` if this is a node command with runtime tracing RPCs enabled.
     ///
     /// This is used to determine whether to enable runtime log level changes.
-    pub fn debug_namespace_enabled(&self) -> bool {
+    pub fn tracing_reload_enabled(&self) -> bool {
         match self {
-            Self::Node(cmd) => cmd.rpc.is_namespace_enabled(RethRpcModule::Debug),
+            Self::Node(cmd) => {
+                cmd.rpc.is_namespace_enabled(RethRpcModule::Debug) ||
+                    cmd.rpc.is_namespace_enabled(RethRpcModule::Admin)
+            }
             _ => false,
         }
     }

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -25,7 +25,9 @@ pub struct TracingDirectivesResponse {
     pub applied: String,
     /// Number of seconds before the override is reverted, or `None` for an indefinite override.
     pub ttl_secs: Option<u64>,
-    /// The startup tracing directives that will be restored.
+    /// The startup stdout directives that will be restored.
+    ///
+    /// Other reloadable layers restore their respective startup directives.
     pub reverts_to: String,
 }
 

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -3,6 +3,20 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_network_peers::{AnyNode, NodeRecord};
 use serde::{Deserialize, Serialize};
 
+/// Reloadable tracing output targeted by an override.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TracingTarget {
+    /// Standard output logs.
+    Stdout,
+    /// File logs.
+    File,
+    /// OTLP traces.
+    OtlpTraces,
+    /// OTLP logs.
+    OtlpLogs,
+}
+
 /// Request parameters for [`AdminApi::tracing_directives`].
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -10,6 +24,8 @@ pub struct TracingDirectivesRequest {
     /// `RUST_LOG`-style tracing directives. Ignored when `ttlSecs` is `0`.
     #[serde(default)]
     pub directives: String,
+    /// Outputs to override. If omitted, all reloadable outputs are targeted.
+    pub targets: Option<Vec<TracingTarget>>,
     /// Number of seconds before the startup tracing configuration is restored.
     ///
     /// If omitted, the override remains active until explicitly reset. Set to `0` to reset
@@ -25,10 +41,8 @@ pub struct TracingDirectivesResponse {
     pub applied: String,
     /// Number of seconds before the override is reverted, or `None` for an indefinite override.
     pub ttl_secs: Option<u64>,
-    /// The startup stdout directives that will be restored.
-    ///
-    /// Other reloadable layers restore their respective startup directives.
-    pub reverts_to: String,
+    /// Outputs affected by the override.
+    pub targets: Vec<TracingTarget>,
 }
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
@@ -109,5 +123,17 @@ mod tests {
             serde_json::from_value(serde_json::json!({ "ttlSecs": 0 })).unwrap();
         assert!(request.directives.is_empty());
         assert_eq!(request.ttl_secs, Some(0));
+        assert!(request.targets.is_none());
+    }
+
+    #[test]
+    fn scoped_override_deserializes_targets() {
+        let request: TracingDirectivesRequest = serde_json::from_value(serde_json::json!({
+            "directives": "reth=trace",
+            "targets": ["otlpTraces"]
+        }))
+        .unwrap();
+        assert_eq!(request.targets, Some(vec![TracingTarget::OtlpTraces]));
+        assert_eq!(request.ttl_secs, None);
     }
 }

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -7,10 +7,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TracingDirectivesRequest {
-    /// `RUST_LOG`-style tracing directives.
+    /// `RUST_LOG`-style tracing directives. Ignored when `ttlSecs` is `0`.
+    #[serde(default)]
     pub directives: String,
     /// Number of seconds before the startup tracing configuration is restored.
-    pub ttl_secs: u64,
+    ///
+    /// If omitted, the override remains active until explicitly reset. Set to `0` to reset
+    /// immediately.
+    pub ttl_secs: Option<u64>,
 }
 
 /// Result returned by [`AdminApi::tracing_directives`].
@@ -19,8 +23,8 @@ pub struct TracingDirectivesRequest {
 pub struct TracingDirectivesResponse {
     /// The tracing directives that were applied.
     pub applied: String,
-    /// Number of seconds before the override is reverted.
-    pub ttl_secs: u64,
+    /// Number of seconds before the override is reverted, or `None` for an indefinite override.
+    pub ttl_secs: Option<u64>,
     /// The startup tracing directives that will be restored.
     pub reverts_to: String,
 }
@@ -84,10 +88,24 @@ pub trait AdminApi {
 
     /// Temporarily overrides the node's tracing directives.
     ///
-    /// The startup tracing configuration is restored after `ttlSecs`.
+    /// The startup tracing configuration is restored after `ttlSecs`. If `ttlSecs` is omitted,
+    /// the override remains active until reset by calling this method with `ttlSecs: 0`.
     #[method(name = "tracingDirectives")]
     async fn tracing_directives(
         &self,
         request: TracingDirectivesRequest,
     ) -> RpcResult<TracingDirectivesResponse>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_request_only_requires_ttl() {
+        let request: TracingDirectivesRequest =
+            serde_json::from_value(serde_json::json!({ "ttlSecs": 0 })).unwrap();
+        assert!(request.directives.is_empty());
+        assert_eq!(request.ttl_secs, Some(0));
+    }
 }

--- a/crates/rpc/rpc-api/src/admin.rs
+++ b/crates/rpc/rpc-api/src/admin.rs
@@ -1,6 +1,29 @@
 use alloy_rpc_types_admin::{NodeInfo, PeerInfo};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_network_peers::{AnyNode, NodeRecord};
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for [`AdminApi::tracing_directives`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TracingDirectivesRequest {
+    /// `RUST_LOG`-style tracing directives.
+    pub directives: String,
+    /// Number of seconds before the startup tracing configuration is restored.
+    pub ttl_secs: u64,
+}
+
+/// Result returned by [`AdminApi::tracing_directives`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TracingDirectivesResponse {
+    /// The tracing directives that were applied.
+    pub applied: String,
+    /// Number of seconds before the override is reverted.
+    pub ttl_secs: u64,
+    /// The startup tracing directives that will be restored.
+    pub reverts_to: String,
+}
 
 /// Admin namespace rpc interface that gives access to several non-standard RPC methods.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "admin"))]
@@ -58,4 +81,13 @@ pub trait AdminApi {
     /// Returns the number of transactions that were removed from the pool.
     #[method(name = "clearTxpool")]
     async fn clear_txpool(&self) -> RpcResult<u64>;
+
+    /// Temporarily overrides the node's tracing directives.
+    ///
+    /// The startup tracing configuration is restored after `ttlSecs`.
+    #[method(name = "tracingDirectives")]
+    async fn tracing_directives(
+        &self,
+        request: TracingDirectivesRequest,
+    ) -> RpcResult<TracingDirectivesResponse>;
 }

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -32,6 +32,7 @@ mod txpool;
 mod validation;
 mod web3;
 
+pub use admin::{TracingDirectivesRequest, TracingDirectivesResponse};
 pub use reth::RethJitAction;
 pub use testing::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1, TESTING_COMMIT_BLOCK_V1};
 

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -32,7 +32,7 @@ mod txpool;
 mod validation;
 mod web3;
 
-pub use admin::{TracingDirectivesRequest, TracingDirectivesResponse};
+pub use admin::{TracingDirectivesRequest, TracingDirectivesResponse, TracingTarget};
 pub use reth::RethJitAction;
 pub use testing::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1, TESTING_COMMIT_BLOCK_V1};
 

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -43,6 +43,7 @@ reth-ethereum-engine-primitives.workspace = true
 reth-node-api.workspace = true
 reth-payload-primitives.workspace = true
 reth-trie-common.workspace = true
+reth-tracing.workspace = true
 
 # ethereum
 alloy-evm = { workspace = true, features = ["overrides"] }

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -248,7 +248,7 @@ where
         let mut state = TRACING_REVERT.lock().await;
 
         let directives = if ttl_secs == Some(0) {
-            reth_tracing::set_log_vmodule(&baseline).map_err(internal_rpc_err)?;
+            reth_tracing::reset_log_filters().map_err(internal_rpc_err)?;
             baseline.clone()
         } else {
             let directives = request.directives.trim().to_string();
@@ -263,16 +263,15 @@ where
         let generation = state.generation;
 
         if let Some(ttl_secs @ 1..=MAX_TRACING_TTL_SECS) = ttl_secs {
-            let revert_baseline = baseline.clone();
             state.task = Some(tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
                 let mut state = TRACING_REVERT.lock().await;
                 if state.generation != generation {
                     return;
                 }
-                match reth_tracing::set_log_vmodule(&revert_baseline) {
+                match reth_tracing::reset_log_filters() {
                     Ok(()) => {
-                        info!(target: "reth::rpc::admin", %revert_baseline, "Reverted tracing directives after TTL")
+                        info!(target: "reth::rpc::admin", "Reverted tracing directives after TTL")
                     }
                     Err(err) => {
                         warn!(target: "reth::rpc::admin", %err, "Failed to revert tracing directives after TTL")

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use alloy_genesis::ChainConfig;
 use alloy_primitives::keccak256;
@@ -21,7 +18,7 @@ use reth_rpc_server_types::{
     ToRpcResult,
 };
 use reth_transaction_pool::TransactionPool;
-use tokio::task::JoinHandle;
+use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{info, warn};
 
 /// Maximum duration of a tracing override.
@@ -36,7 +33,7 @@ struct TracingRevertState {
 }
 
 static TRACING_REVERT: Mutex<TracingRevertState> =
-    Mutex::new(TracingRevertState { generation: 0, task: None });
+    Mutex::const_new(TracingRevertState { generation: 0, task: None });
 
 /// `admin` API implementation.
 ///
@@ -248,7 +245,7 @@ where
 
         let baseline = reth_tracing::startup_log_directives().unwrap_or_default().to_string();
         let ttl_secs = request.ttl_secs;
-        let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
+        let mut state = TRACING_REVERT.lock().await;
 
         let directives = if ttl_secs == Some(0) {
             reth_tracing::set_log_vmodule(&baseline).map_err(internal_rpc_err)?;
@@ -269,7 +266,7 @@ where
             let revert_baseline = baseline.clone();
             state.task = Some(tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
-                let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
+                let mut state = TRACING_REVERT.lock().await;
                 if state.generation != generation {
                     return;
                 }

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -239,7 +239,7 @@ where
         &self,
         request: TracingDirectivesRequest,
     ) -> RpcResult<TracingDirectivesResponse> {
-        let directives = validate_tracing_directives(&request)?.to_string();
+        validate_tracing_directives(&request)?;
         if !reth_tracing::log_handle_available() {
             return Err(internal_rpc_err(
                 "tracing reload is not active; enable the admin RPC namespace at startup",
@@ -250,42 +250,55 @@ where
         let ttl_secs = request.ttl_secs;
         let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
 
-        reth_tracing::set_log_vmodule(&directives).map_err(invalid_params_rpc_err)?;
+        let directives = if ttl_secs == Some(0) {
+            reth_tracing::set_log_vmodule(&baseline).map_err(internal_rpc_err)?;
+            baseline.clone()
+        } else {
+            let directives = request.directives.trim().to_string();
+            reth_tracing::set_log_vmodule(&directives).map_err(invalid_params_rpc_err)?;
+            directives
+        };
+
         if let Some(previous) = state.task.take() {
             previous.abort();
         }
         state.generation = state.generation.wrapping_add(1);
         let generation = state.generation;
 
-        let revert_baseline = baseline.clone();
-        state.task = Some(tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
-            let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
-            if state.generation != generation {
-                return;
-            }
-            match reth_tracing::set_log_vmodule(&revert_baseline) {
-                Ok(()) => {
-                    info!(target: "reth::rpc::admin", %revert_baseline, "Reverted tracing directives after TTL")
+        if let Some(ttl_secs @ 1..=MAX_TRACING_TTL_SECS) = ttl_secs {
+            let revert_baseline = baseline.clone();
+            state.task = Some(tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
+                let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
+                if state.generation != generation {
+                    return;
                 }
-                Err(err) => {
-                    warn!(target: "reth::rpc::admin", %err, "Failed to revert tracing directives after TTL")
+                match reth_tracing::set_log_vmodule(&revert_baseline) {
+                    Ok(()) => {
+                        info!(target: "reth::rpc::admin", %revert_baseline, "Reverted tracing directives after TTL")
+                    }
+                    Err(err) => {
+                        warn!(target: "reth::rpc::admin", %err, "Failed to revert tracing directives after TTL")
+                    }
                 }
-            }
-            state.task = None;
-        }));
+                state.task = None;
+            }));
+        }
         drop(state);
 
-        info!(target: "reth::rpc::admin", %directives, ttl_secs, "Applied ephemeral tracing directives");
+        info!(target: "reth::rpc::admin", %directives, ?ttl_secs, "Applied tracing directives");
         Ok(TracingDirectivesResponse { applied: directives, ttl_secs, reverts_to: baseline })
     }
 }
 
-fn validate_tracing_directives(request: &TracingDirectivesRequest) -> RpcResult<&str> {
-    if request.ttl_secs == 0 || request.ttl_secs > MAX_TRACING_TTL_SECS {
+fn validate_tracing_directives(request: &TracingDirectivesRequest) -> RpcResult<()> {
+    if request.ttl_secs.is_some_and(|ttl| ttl > MAX_TRACING_TTL_SECS) {
         return Err(invalid_params_rpc_err(format!(
-            "ttlSecs must be in 1..={MAX_TRACING_TTL_SECS}"
+            "ttlSecs must be in 0..={MAX_TRACING_TTL_SECS}"
         )));
+    }
+    if request.ttl_secs == Some(0) {
+        return Ok(())
     }
     let directives = request.directives.trim();
     if directives.is_empty() {
@@ -296,7 +309,7 @@ fn validate_tracing_directives(request: &TracingDirectivesRequest) -> RpcResult<
             "directives must be at most {MAX_TRACING_DIRECTIVES_LEN} characters"
         )));
     }
-    Ok(directives)
+    Ok(())
 }
 
 impl<N, ChainSpec, Pool> std::fmt::Debug for AdminApi<N, ChainSpec, Pool> {
@@ -313,23 +326,32 @@ mod tests {
     fn validates_tracing_directives() {
         let request = TracingDirectivesRequest {
             directives: "  info,reth::net=trace  ".to_string(),
-            ttl_secs: 30,
+            ttl_secs: Some(30),
         };
-        assert_eq!(validate_tracing_directives(&request).unwrap(), "info,reth::net=trace");
+        validate_tracing_directives(&request).unwrap();
+        validate_tracing_directives(&TracingDirectivesRequest {
+            directives: "trace".to_string(),
+            ttl_secs: None,
+        })
+        .unwrap();
+        validate_tracing_directives(&TracingDirectivesRequest {
+            directives: String::new(),
+            ttl_secs: Some(0),
+        })
+        .unwrap();
     }
 
     #[test]
     fn rejects_invalid_tracing_directives() {
         for request in [
-            TracingDirectivesRequest { directives: "info".to_string(), ttl_secs: 0 },
             TracingDirectivesRequest {
                 directives: "info".to_string(),
-                ttl_secs: MAX_TRACING_TTL_SECS + 1,
+                ttl_secs: Some(MAX_TRACING_TTL_SECS + 1),
             },
-            TracingDirectivesRequest { directives: "  ".to_string(), ttl_secs: 30 },
+            TracingDirectivesRequest { directives: "  ".to_string(), ttl_secs: Some(30) },
             TracingDirectivesRequest {
                 directives: "x".repeat(MAX_TRACING_DIRECTIVES_LEN + 1),
-                ttl_secs: 30,
+                ttl_secs: None,
             },
         ] {
             assert_eq!(

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use alloy_genesis::ChainConfig;
 use alloy_primitives::keccak256;
@@ -7,14 +10,30 @@ use alloy_rpc_types_admin::{
     Ports, ProtocolInfo,
 };
 use async_trait::async_trait;
-use jsonrpsee::core::RpcResult;
+use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::{AnyNode, NodeRecord};
 use reth_network_types::PeerKind;
-use reth_rpc_api::AdminApiServer;
+use reth_rpc_api::{AdminApiServer, TracingDirectivesRequest, TracingDirectivesResponse};
 use reth_rpc_server_types::ToRpcResult;
 use reth_transaction_pool::TransactionPool;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+/// Maximum duration of a tracing override.
+const MAX_TRACING_TTL_SECS: u64 = 3600;
+/// Maximum accepted tracing directive length.
+const MAX_TRACING_DIRECTIVES_LEN: usize = 1024;
+
+#[derive(Debug, Default)]
+struct TracingRevertState {
+    generation: u64,
+    task: Option<JoinHandle<()>>,
+}
+
+static TRACING_REVERT: Mutex<TracingRevertState> =
+    Mutex::new(TracingRevertState { generation: 0, task: None });
 
 /// `admin` API implementation.
 ///
@@ -211,10 +230,119 @@ where
         let _ = self.pool.remove_transactions(all_hashes);
         Ok(count)
     }
+
+    /// Handler for `admin_tracingDirectives`.
+    async fn tracing_directives(
+        &self,
+        request: TracingDirectivesRequest,
+    ) -> RpcResult<TracingDirectivesResponse> {
+        let directives = validate_tracing_directives(&request)?.to_string();
+        if !reth_tracing::log_handle_available() {
+            return Err(ErrorObjectOwned::owned(
+                jsonrpsee_types::error::INTERNAL_ERROR_CODE,
+                "tracing reload is not active; enable the admin RPC namespace at startup",
+                None::<()>,
+            ));
+        }
+
+        let baseline = reth_tracing::startup_log_directives().unwrap_or_default().to_string();
+        let ttl_secs = request.ttl_secs;
+        let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
+
+        reth_tracing::set_log_vmodule(&directives).map_err(invalid_params)?;
+        if let Some(previous) = state.task.take() {
+            previous.abort();
+        }
+        state.generation = state.generation.wrapping_add(1);
+        let generation = state.generation;
+
+        let revert_baseline = baseline.clone();
+        state.task = Some(tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
+            let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
+            if state.generation != generation {
+                return;
+            }
+            match reth_tracing::set_log_vmodule(&revert_baseline) {
+                Ok(()) => {
+                    info!(target: "reth::rpc::admin", %revert_baseline, "Reverted tracing directives after TTL")
+                }
+                Err(err) => {
+                    warn!(target: "reth::rpc::admin", %err, "Failed to revert tracing directives after TTL")
+                }
+            }
+            state.task = None;
+        }));
+        drop(state);
+
+        info!(target: "reth::rpc::admin", %directives, ttl_secs, "Applied ephemeral tracing directives");
+        Ok(TracingDirectivesResponse { applied: directives, ttl_secs, reverts_to: baseline })
+    }
+}
+
+fn invalid_params(message: impl ToString) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        jsonrpsee_types::error::INVALID_PARAMS_CODE,
+        message.to_string(),
+        None::<()>,
+    )
+}
+
+fn validate_tracing_directives(
+    request: &TracingDirectivesRequest,
+) -> Result<&str, ErrorObjectOwned> {
+    if request.ttl_secs == 0 || request.ttl_secs > MAX_TRACING_TTL_SECS {
+        return Err(invalid_params(format!("ttlSecs must be in 1..={MAX_TRACING_TTL_SECS}")));
+    }
+    let directives = request.directives.trim();
+    if directives.is_empty() {
+        return Err(invalid_params("directives must not be empty"));
+    }
+    if directives.len() > MAX_TRACING_DIRECTIVES_LEN {
+        return Err(invalid_params(format!(
+            "directives must be at most {MAX_TRACING_DIRECTIVES_LEN} characters"
+        )));
+    }
+    Ok(directives)
 }
 
 impl<N, ChainSpec, Pool> std::fmt::Debug for AdminApi<N, ChainSpec, Pool> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AdminApi").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_tracing_directives() {
+        let request = TracingDirectivesRequest {
+            directives: "  info,reth::net=trace  ".to_string(),
+            ttl_secs: 30,
+        };
+        assert_eq!(validate_tracing_directives(&request).unwrap(), "info,reth::net=trace");
+    }
+
+    #[test]
+    fn rejects_invalid_tracing_directives() {
+        for request in [
+            TracingDirectivesRequest { directives: "info".to_string(), ttl_secs: 0 },
+            TracingDirectivesRequest {
+                directives: "info".to_string(),
+                ttl_secs: MAX_TRACING_TTL_SECS + 1,
+            },
+            TracingDirectivesRequest { directives: "  ".to_string(), ttl_secs: 30 },
+            TracingDirectivesRequest {
+                directives: "x".repeat(MAX_TRACING_DIRECTIVES_LEN + 1),
+                ttl_secs: 30,
+            },
+        ] {
+            assert_eq!(
+                validate_tracing_directives(&request).unwrap_err().code(),
+                jsonrpsee_types::error::INVALID_PARAMS_CODE
+            );
+        }
     }
 }

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -12,7 +12,9 @@ use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCond
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::{AnyNode, NodeRecord};
 use reth_network_types::PeerKind;
-use reth_rpc_api::{AdminApiServer, TracingDirectivesRequest, TracingDirectivesResponse};
+use reth_rpc_api::{
+    AdminApiServer, TracingDirectivesRequest, TracingDirectivesResponse, TracingTarget,
+};
 use reth_rpc_server_types::{
     result::{internal_rpc_err, invalid_params_rpc_err},
     ToRpcResult,
@@ -27,13 +29,36 @@ const MAX_TRACING_TTL_SECS: u64 = 3600;
 const MAX_TRACING_DIRECTIVES_LEN: usize = 1024;
 
 #[derive(Debug, Default)]
-struct TracingRevertState {
+struct TargetRevertState {
     generation: u64,
     task: Option<JoinHandle<()>>,
 }
 
-static TRACING_REVERT: Mutex<TracingRevertState> =
-    Mutex::const_new(TracingRevertState { generation: 0, task: None });
+#[derive(Debug, Default)]
+struct TracingRevertState {
+    stdout: TargetRevertState,
+    file: TargetRevertState,
+    otlp_traces: TargetRevertState,
+    otlp_logs: TargetRevertState,
+}
+
+impl TracingRevertState {
+    fn target_mut(&mut self, target: TracingTarget) -> &mut TargetRevertState {
+        match target {
+            TracingTarget::Stdout => &mut self.stdout,
+            TracingTarget::File => &mut self.file,
+            TracingTarget::OtlpTraces => &mut self.otlp_traces,
+            TracingTarget::OtlpLogs => &mut self.otlp_logs,
+        }
+    }
+}
+
+static TRACING_REVERT: Mutex<TracingRevertState> = Mutex::const_new(TracingRevertState {
+    stdout: TargetRevertState { generation: 0, task: None },
+    file: TargetRevertState { generation: 0, task: None },
+    otlp_traces: TargetRevertState { generation: 0, task: None },
+    otlp_logs: TargetRevertState { generation: 0, task: None },
+});
 
 /// `admin` API implementation.
 ///
@@ -243,48 +268,97 @@ where
             ));
         }
 
-        let baseline = reth_tracing::startup_log_directives().unwrap_or_default().to_string();
+        let targets = resolve_tracing_targets(&request)?;
+        let filter_targets = targets.iter().copied().map(log_filter_target).collect::<Vec<_>>();
         let ttl_secs = request.ttl_secs;
         let mut state = TRACING_REVERT.lock().await;
 
         let directives = if ttl_secs == Some(0) {
-            reth_tracing::reset_log_filters().map_err(internal_rpc_err)?;
-            baseline.clone()
+            reth_tracing::reset_log_filters_for_targets(&filter_targets)
+                .map_err(internal_rpc_err)?;
+            "startup configuration".to_string()
         } else {
             let directives = request.directives.trim().to_string();
-            reth_tracing::set_log_vmodule(&directives).map_err(invalid_params_rpc_err)?;
+            reth_tracing::set_log_vmodule_for_targets(&directives, &filter_targets)
+                .map_err(invalid_params_rpc_err)?;
             directives
         };
 
-        if let Some(previous) = state.task.take() {
-            previous.abort();
-        }
-        state.generation = state.generation.wrapping_add(1);
-        let generation = state.generation;
+        for target in targets.iter().copied() {
+            let target_state = state.target_mut(target);
+            if let Some(previous) = target_state.task.take() {
+                previous.abort();
+            }
+            target_state.generation = target_state.generation.wrapping_add(1);
+            let generation = target_state.generation;
 
-        if let Some(ttl_secs @ 1..=MAX_TRACING_TTL_SECS) = ttl_secs {
-            state.task = Some(tokio::spawn(async move {
-                tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
-                let mut state = TRACING_REVERT.lock().await;
-                if state.generation != generation {
-                    return;
-                }
-                match reth_tracing::reset_log_filters() {
-                    Ok(()) => {
-                        info!(target: "reth::rpc::admin", "Reverted tracing directives after TTL")
+            if let Some(ttl_secs @ 1..=MAX_TRACING_TTL_SECS) = ttl_secs {
+                target_state.task = Some(tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
+                    let mut state = TRACING_REVERT.lock().await;
+                    if state.target_mut(target).generation != generation {
+                        return;
                     }
-                    Err(err) => {
-                        warn!(target: "reth::rpc::admin", %err, "Failed to revert tracing directives after TTL")
+                    let filter_target = log_filter_target(target);
+                    match reth_tracing::reset_log_filters_for_targets(&[filter_target]) {
+                        Ok(()) => {
+                            info!(target: "reth::rpc::admin", ?target, "Reverted tracing directives after TTL")
+                        }
+                        Err(err) => {
+                            warn!(target: "reth::rpc::admin", ?target, %err, "Failed to revert tracing directives after TTL")
+                        }
                     }
-                }
-                state.task = None;
-            }));
+                    state.target_mut(target).task = None;
+                }));
+            }
         }
         drop(state);
 
-        info!(target: "reth::rpc::admin", %directives, ?ttl_secs, "Applied tracing directives");
-        Ok(TracingDirectivesResponse { applied: directives, ttl_secs, reverts_to: baseline })
+        info!(target: "reth::rpc::admin", %directives, ?targets, ?ttl_secs, "Applied tracing directives");
+        Ok(TracingDirectivesResponse { applied: directives, ttl_secs, targets })
     }
+}
+
+const fn log_filter_target(target: TracingTarget) -> reth_tracing::LogFilterTarget {
+    match target {
+        TracingTarget::Stdout => reth_tracing::LogFilterTarget::Stdout,
+        TracingTarget::File => reth_tracing::LogFilterTarget::File,
+        TracingTarget::OtlpTraces => reth_tracing::LogFilterTarget::OtlpTraces,
+        TracingTarget::OtlpLogs => reth_tracing::LogFilterTarget::OtlpLogs,
+    }
+}
+
+const fn tracing_target(target: reth_tracing::LogFilterTarget) -> TracingTarget {
+    match target {
+        reth_tracing::LogFilterTarget::Stdout => TracingTarget::Stdout,
+        reth_tracing::LogFilterTarget::File => TracingTarget::File,
+        reth_tracing::LogFilterTarget::OtlpTraces => TracingTarget::OtlpTraces,
+        reth_tracing::LogFilterTarget::OtlpLogs => TracingTarget::OtlpLogs,
+    }
+}
+
+fn resolve_tracing_targets(request: &TracingDirectivesRequest) -> RpcResult<Vec<TracingTarget>> {
+    let available = reth_tracing::available_log_filter_targets();
+    let requested = request
+        .targets
+        .clone()
+        .unwrap_or_else(|| available.iter().copied().map(tracing_target).collect());
+    if requested.is_empty() {
+        return Err(invalid_params_rpc_err("targets must not be empty"));
+    }
+
+    let mut targets = Vec::with_capacity(requested.len());
+    for target in requested {
+        if !available.contains(&log_filter_target(target)) {
+            return Err(invalid_params_rpc_err(format!(
+                "tracing target {target:?} is not configured"
+            )));
+        }
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
+    }
+    Ok(targets)
 }
 
 fn validate_tracing_directives(request: &TracingDirectivesRequest) -> RpcResult<()> {
@@ -322,16 +396,19 @@ mod tests {
     fn validates_tracing_directives() {
         let request = TracingDirectivesRequest {
             directives: "  info,reth::net=trace  ".to_string(),
+            targets: None,
             ttl_secs: Some(30),
         };
         validate_tracing_directives(&request).unwrap();
         validate_tracing_directives(&TracingDirectivesRequest {
             directives: "trace".to_string(),
+            targets: Some(vec![TracingTarget::OtlpTraces]),
             ttl_secs: None,
         })
         .unwrap();
         validate_tracing_directives(&TracingDirectivesRequest {
             directives: String::new(),
+            targets: None,
             ttl_secs: Some(0),
         })
         .unwrap();
@@ -342,11 +419,17 @@ mod tests {
         for request in [
             TracingDirectivesRequest {
                 directives: "info".to_string(),
+                targets: None,
                 ttl_secs: Some(MAX_TRACING_TTL_SECS + 1),
             },
-            TracingDirectivesRequest { directives: "  ".to_string(), ttl_secs: Some(30) },
+            TracingDirectivesRequest {
+                directives: "  ".to_string(),
+                targets: None,
+                ttl_secs: Some(30),
+            },
             TracingDirectivesRequest {
                 directives: "x".repeat(MAX_TRACING_DIRECTIVES_LEN + 1),
+                targets: None,
                 ttl_secs: None,
             },
         ] {

--- a/crates/rpc/rpc/src/admin.rs
+++ b/crates/rpc/rpc/src/admin.rs
@@ -10,13 +10,16 @@ use alloy_rpc_types_admin::{
     Ports, ProtocolInfo,
 };
 use async_trait::async_trait;
-use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
+use jsonrpsee::core::RpcResult;
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, ForkCondition};
 use reth_network_api::{NetworkInfo, Peers};
 use reth_network_peers::{AnyNode, NodeRecord};
 use reth_network_types::PeerKind;
 use reth_rpc_api::{AdminApiServer, TracingDirectivesRequest, TracingDirectivesResponse};
-use reth_rpc_server_types::ToRpcResult;
+use reth_rpc_server_types::{
+    result::{internal_rpc_err, invalid_params_rpc_err},
+    ToRpcResult,
+};
 use reth_transaction_pool::TransactionPool;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -238,10 +241,8 @@ where
     ) -> RpcResult<TracingDirectivesResponse> {
         let directives = validate_tracing_directives(&request)?.to_string();
         if !reth_tracing::log_handle_available() {
-            return Err(ErrorObjectOwned::owned(
-                jsonrpsee_types::error::INTERNAL_ERROR_CODE,
+            return Err(internal_rpc_err(
                 "tracing reload is not active; enable the admin RPC namespace at startup",
-                None::<()>,
             ));
         }
 
@@ -249,7 +250,7 @@ where
         let ttl_secs = request.ttl_secs;
         let mut state = TRACING_REVERT.lock().expect("tracing revert mutex poisoned");
 
-        reth_tracing::set_log_vmodule(&directives).map_err(invalid_params)?;
+        reth_tracing::set_log_vmodule(&directives).map_err(invalid_params_rpc_err)?;
         if let Some(previous) = state.task.take() {
             previous.abort();
         }
@@ -280,26 +281,18 @@ where
     }
 }
 
-fn invalid_params(message: impl ToString) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(
-        jsonrpsee_types::error::INVALID_PARAMS_CODE,
-        message.to_string(),
-        None::<()>,
-    )
-}
-
-fn validate_tracing_directives(
-    request: &TracingDirectivesRequest,
-) -> Result<&str, ErrorObjectOwned> {
+fn validate_tracing_directives(request: &TracingDirectivesRequest) -> RpcResult<&str> {
     if request.ttl_secs == 0 || request.ttl_secs > MAX_TRACING_TTL_SECS {
-        return Err(invalid_params(format!("ttlSecs must be in 1..={MAX_TRACING_TTL_SECS}")));
+        return Err(invalid_params_rpc_err(format!(
+            "ttlSecs must be in 1..={MAX_TRACING_TTL_SECS}"
+        )));
     }
     let directives = request.directives.trim();
     if directives.is_empty() {
-        return Err(invalid_params("directives must not be empty"));
+        return Err(invalid_params_rpc_err("directives must not be empty"));
     }
     if directives.len() > MAX_TRACING_DIRECTIVES_LEN {
-        return Err(invalid_params(format!(
+        return Err(invalid_params_rpc_err(format!(
             "directives must be at most {MAX_TRACING_DIRECTIVES_LEN} characters"
         )));
     }

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -1,4 +1,6 @@
-use crate::{formatter::LogFormat, LayerInfo, LogFilterReloadHandle};
+use crate::{
+    formatter::LogFormat, install_log_handle_with_baseline, LayerInfo, LogFilterReloadHandle,
+};
 #[cfg(feature = "otlp-logs")]
 use reth_tracing_otlp::{log_layer, OtlpLogsConfig};
 #[cfg(feature = "otlp")]
@@ -133,7 +135,7 @@ impl Layers {
         filters: &str,
         color: Option<String>,
         reloadable: bool,
-    ) -> eyre::Result<Option<LogFilterReloadHandle>> {
+    ) -> eyre::Result<Option<(LogFilterReloadHandle, EnvFilter)>> {
         let filter = build_env_filter(Some(default_directive), filters)?;
 
         // When reloadable, always show target since the user may switch to DEBUG/TRACE
@@ -143,10 +145,11 @@ impl Layers {
             filter.max_level_hint().is_none_or(|max_level| max_level > tracing::Level::INFO);
 
         if reloadable {
+            let startup_filter = filter.clone();
             let (reloadable_filter, handle) = reload::Layer::new(filter);
             let layer = format.apply(reloadable_filter, color, show_target, None);
             self.add_layer(layer);
-            Ok(Some(handle))
+            Ok(Some((handle, startup_filter)))
         } else {
             let layer = format.apply(filter, color, show_target, None);
             self.add_layer(layer);
@@ -172,14 +175,15 @@ impl Layers {
         filter: &str,
         file_info: FileInfo,
         reloadable: bool,
-    ) -> eyre::Result<(FileWorkerGuard, Option<LogFilterReloadHandle>)> {
+    ) -> eyre::Result<(FileWorkerGuard, Option<(LogFilterReloadHandle, EnvFilter)>)> {
         let (writer, guard) = file_info.create_log_writer()?;
         let file_filter = build_env_filter(None, filter)?;
 
         if reloadable {
+            let startup_filter = file_filter.clone();
             let (reloadable_filter, handle) = reload::Layer::new(file_filter);
             self.add_layer(format.apply(reloadable_filter, None, true, Some(writer)));
-            Ok((guard, Some(handle)))
+            Ok((guard, Some((handle, startup_filter))))
         } else {
             self.add_layer(format.apply(file_filter, None, true, Some(writer)));
             Ok((guard, None))
@@ -262,11 +266,14 @@ impl Layers {
     ) -> eyre::Result<()> {
         // Create the span provider
 
+        let startup_filter = filter.clone();
+        let (filter, handle) = reload::Layer::new(filter);
         let span_layer = span_layer(otlp_config)
             .map_err(|e| eyre::eyre!("Failed to build OTLP span exporter {}", e))?
             .with_filter(filter);
 
         self.add_layer(span_layer);
+        install_log_handle_with_baseline(handle, startup_filter);
 
         Ok(())
     }
@@ -278,11 +285,14 @@ impl Layers {
         otlp_config: OtlpLogsConfig,
         filter: EnvFilter,
     ) -> eyre::Result<()> {
+        let startup_filter = filter.clone();
+        let (filter, handle) = reload::Layer::new(filter);
         let log_layer = log_layer(otlp_config)
             .map_err(|e| eyre::eyre!("Failed to build OTLP log exporter {}", e))?
             .with_filter(filter);
 
         self.add_layer(log_layer);
+        install_log_handle_with_baseline(handle, startup_filter);
 
         Ok(())
     }

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -1,6 +1,6 @@
-use crate::{
-    formatter::LogFormat, install_log_handle_with_baseline, LayerInfo, LogFilterReloadHandle,
-};
+use crate::{formatter::LogFormat, LayerInfo, LogFilterReloadHandle};
+#[cfg(any(feature = "otlp", feature = "otlp-logs"))]
+use crate::{install_log_handle_with_target, LogFilterTarget};
 #[cfg(feature = "otlp-logs")]
 use reth_tracing_otlp::{log_layer, OtlpLogsConfig};
 #[cfg(feature = "otlp")]
@@ -273,7 +273,7 @@ impl Layers {
             .with_filter(filter);
 
         self.add_layer(span_layer);
-        install_log_handle_with_baseline(handle, startup_filter);
+        install_log_handle_with_target(LogFilterTarget::OtlpTraces, handle, startup_filter);
 
         Ok(())
     }
@@ -292,7 +292,7 @@ impl Layers {
             .with_filter(filter);
 
         self.add_layer(log_layer);
-        install_log_handle_with_baseline(handle, startup_filter);
+        install_log_handle_with_target(LogFilterTarget::OtlpLogs, handle, startup_filter);
 
         Ok(())
     }

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -60,9 +60,10 @@ pub use formatter::LogFormat;
 pub use layers::{FileInfo, FileWorkerGuard, Layers, TracingGuards};
 #[cfg(feature = "std")]
 pub use log_handle::{
-    install_log_handle, install_log_handle_with_baseline, log_handle_available, reset_log_filters,
-    set_log_verbosity, set_log_vmodule, set_startup_log_directives, startup_log_directives,
-    LogFilterReloadHandle,
+    available_log_filter_targets, install_log_handle, install_log_handle_with_baseline,
+    install_log_handle_with_target, log_handle_available, reset_log_filters,
+    reset_log_filters_for_targets, set_log_verbosity, set_log_vmodule, set_log_vmodule_for_targets,
+    LogFilterReloadHandle, LogFilterTarget,
 };
 #[cfg(feature = "std")]
 pub use test_tracer::TestTracer;
@@ -282,7 +283,7 @@ impl Tracer for RethTracer {
             self.stdout.color,
             self.enable_reload,
         )? {
-            install_log_handle_with_baseline(handle, startup_filter);
+            install_log_handle_with_target(LogFilterTarget::Stdout, handle, startup_filter);
         }
 
         if let Some(config) = self.journald {
@@ -293,7 +294,7 @@ impl Tracer for RethTracer {
             let (guard, handle) =
                 layers.file(config.format, &config.filters, file_info, self.enable_reload)?;
             if let Some((handle, startup_filter)) = handle {
-                install_log_handle_with_baseline(handle, startup_filter);
+                install_log_handle_with_target(LogFilterTarget::File, handle, startup_filter);
             }
             Some(guard)
         } else {

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -61,7 +61,7 @@ pub use layers::{FileInfo, FileWorkerGuard, Layers, TracingGuards};
 #[cfg(feature = "std")]
 pub use log_handle::{
     install_log_handle, log_handle_available, set_log_verbosity, set_log_vmodule,
-    LogFilterReloadHandle,
+    set_startup_log_directives, startup_log_directives, LogFilterReloadHandle,
 };
 #[cfg(feature = "std")]
 pub use test_tracer::TestTracer;

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -60,8 +60,9 @@ pub use formatter::LogFormat;
 pub use layers::{FileInfo, FileWorkerGuard, Layers, TracingGuards};
 #[cfg(feature = "std")]
 pub use log_handle::{
-    install_log_handle, log_handle_available, set_log_verbosity, set_log_vmodule,
-    set_startup_log_directives, startup_log_directives, LogFilterReloadHandle,
+    install_log_handle, install_log_handle_with_baseline, log_handle_available, reset_log_filters,
+    set_log_verbosity, set_log_vmodule, set_startup_log_directives, startup_log_directives,
+    LogFilterReloadHandle,
 };
 #[cfg(feature = "std")]
 pub use test_tracer::TestTracer;
@@ -274,14 +275,14 @@ pub trait Tracer: Sized {
 impl Tracer for RethTracer {
     fn init_with_layers(self, mut layers: Layers) -> eyre::Result<TracingGuards> {
         // Configure stdout layer - reloadable if requested for runtime log level changes
-        if let Some(handle) = layers.stdout(
+        if let Some((handle, startup_filter)) = layers.stdout(
             self.stdout.format,
             self.stdout.default_directive.parse()?,
             &self.stdout.filters,
             self.stdout.color,
             self.enable_reload,
         )? {
-            install_log_handle(handle);
+            install_log_handle_with_baseline(handle, startup_filter);
         }
 
         if let Some(config) = self.journald {
@@ -291,8 +292,8 @@ impl Tracer for RethTracer {
         let file_guard = if let Some((config, file_info)) = self.file {
             let (guard, handle) =
                 layers.file(config.format, &config.filters, file_info, self.enable_reload)?;
-            if let Some(handle) = handle {
-                install_log_handle(handle);
+            if let Some((handle, startup_filter)) = handle {
+                install_log_handle_with_baseline(handle, startup_filter);
             }
             Some(guard)
         } else {

--- a/crates/tracing/src/log_handle.rs
+++ b/crates/tracing/src/log_handle.rs
@@ -1,8 +1,8 @@
 //! Global log handle for runtime filter changes.
 //!
 //! Provides a single global [`LogFilterHandle`] that collects reload handles from all
-//! reloadable layers (stdout, file, etc.). `set_log_verbosity` and `set_log_vmodule`
-//! update every registered layer in one shot.
+//! reloadable layers (stdout, file, OTLP traces, and OTLP logs). `set_log_verbosity` and
+//! `set_log_vmodule` update every registered layer in one shot.
 
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{reload, EnvFilter, Registry};
@@ -13,26 +13,32 @@ static STARTUP_LOG_DIRECTIVES: std::sync::OnceLock<String> = std::sync::OnceLock
 /// Type alias for a single layer's reload handle.
 pub type LogFilterReloadHandle = reload::Handle<EnvFilter, Registry>;
 
+#[derive(Debug)]
+struct ReloadableFilter {
+    handle: LogFilterReloadHandle,
+    startup_filter: EnvFilter,
+}
+
 /// Collects reload handles so all layers can be updated together.
 #[derive(Debug)]
 pub struct LogFilterHandle {
-    handles: Vec<LogFilterReloadHandle>,
+    filters: Vec<ReloadableFilter>,
 }
 
 impl LogFilterHandle {
     /// Creates a new, empty handle collection.
     const fn new() -> Self {
-        Self { handles: Vec::new() }
+        Self { filters: Vec::new() }
     }
 
     /// Adds a reload handle for a layer.
-    fn push(&mut self, handle: LogFilterReloadHandle) {
-        self.handles.push(handle);
+    fn push(&mut self, handle: LogFilterReloadHandle, startup_filter: EnvFilter) {
+        self.filters.push(ReloadableFilter { handle, startup_filter });
     }
 
     /// Returns `true` if at least one handle is registered.
     const fn is_available(&self) -> bool {
-        !self.handles.is_empty()
+        !self.filters.is_empty()
     }
 
     /// Reloads every registered layer with a fresh filter built by `make_filter`.
@@ -40,9 +46,20 @@ impl LogFilterHandle {
         &self,
         make_filter: impl Fn() -> Result<EnvFilter, String>,
     ) -> Result<(), String> {
-        for handle in &self.handles {
+        for reloadable in &self.filters {
             let filter = make_filter()?;
-            handle.reload(filter).map_err(|e| e.to_string())?;
+            reloadable.handle.reload(filter).map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+
+    /// Restores every registered layer to its own startup directives.
+    fn reset_all(&self) -> Result<(), String> {
+        for reloadable in &self.filters {
+            reloadable
+                .handle
+                .reload(reloadable.startup_filter.clone())
+                .map_err(|e| e.to_string())?;
         }
         Ok(())
     }
@@ -52,11 +69,19 @@ impl LogFilterHandle {
 static LOG_HANDLE: std::sync::Mutex<LogFilterHandle> =
     std::sync::Mutex::new(LogFilterHandle::new());
 
-/// Registers a reload handle for a layer (stdout, file, etc.).
+/// Registers a reload handle for a layer with an INFO reset baseline.
 ///
 /// Can be called multiple times — each handle is appended.
 pub fn install_log_handle(handle: LogFilterReloadHandle) {
-    LOG_HANDLE.lock().expect("log handle poisoned").push(handle);
+    install_log_handle_with_baseline(
+        handle,
+        EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).parse_lossy(""),
+    );
+}
+
+/// Registers a reload handle and the filter that should be restored on reset.
+pub fn install_log_handle_with_baseline(handle: LogFilterReloadHandle, startup_filter: EnvFilter) {
+    LOG_HANDLE.lock().expect("log handle poisoned").push(handle, startup_filter);
 }
 
 /// Returns `true` if at least one global log handle is available.
@@ -76,6 +101,15 @@ pub fn startup_log_directives() -> Option<&'static str> {
     STARTUP_LOG_DIRECTIVES.get().map(String::as_str)
 }
 
+/// Restores every reloadable layer to the tracing directives it started with.
+pub fn reset_log_filters() -> Result<(), String> {
+    let guard = LOG_HANDLE.lock().expect("log handle poisoned");
+    if !guard.is_available() {
+        return Err("Log filter reload not available".to_string());
+    }
+    guard.reset_all()
+}
+
 /// Sets the global log verbosity level.
 ///
 /// - 0: OFF
@@ -85,7 +119,7 @@ pub fn startup_log_directives() -> Option<&'static str> {
 /// - 4: DEBUG
 /// - 5+: TRACE
 ///
-/// Updates all reloadable layers (stdout, file, etc.).
+/// Updates all reloadable tracing layers.
 ///
 /// Returns an error if no log handle is installed or if the reload fails.
 pub fn set_log_verbosity(level: usize) -> Result<(), String> {
@@ -118,7 +152,7 @@ pub fn set_log_verbosity(level: usize) -> Result<(), String> {
 ///
 /// An empty string resets the filter to the default level (INFO).
 ///
-/// Updates all reloadable layers (stdout, file, etc.).
+/// Updates all reloadable tracing layers.
 ///
 /// Returns an error if no log handle is installed or if parsing fails.
 pub fn set_log_vmodule(pattern: &str) -> Result<(), String> {
@@ -140,5 +174,35 @@ pub fn set_log_vmodule(pattern: &str) -> Result<(), String> {
         guard.reload_all(|| {
             EnvFilter::try_new(pattern).map_err(|e| format!("Invalid filter pattern: {e}"))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_restores_each_layers_startup_directives() {
+        let (_stdout_layer, stdout_handle): (_, LogFilterReloadHandle) =
+            reload::Layer::new(EnvFilter::try_new("info,reth=debug").unwrap());
+        let (_otlp_layer, otlp_handle): (_, LogFilterReloadHandle) =
+            reload::Layer::new(EnvFilter::try_new("warn,reth=trace").unwrap());
+        let stdout_baseline = stdout_handle.with_current(Clone::clone).unwrap();
+        let otlp_baseline = otlp_handle.with_current(Clone::clone).unwrap();
+
+        let mut filters = LogFilterHandle::new();
+        filters.push(stdout_handle.clone(), stdout_baseline.clone());
+        filters.push(otlp_handle.clone(), otlp_baseline.clone());
+        filters.reload_all(|| EnvFilter::try_new("trace").map_err(|err| err.to_string())).unwrap();
+        filters.reset_all().unwrap();
+
+        assert_eq!(
+            stdout_handle.with_current(ToString::to_string).unwrap(),
+            stdout_baseline.to_string()
+        );
+        assert_eq!(
+            otlp_handle.with_current(ToString::to_string).unwrap(),
+            otlp_baseline.to_string()
+        );
     }
 }

--- a/crates/tracing/src/log_handle.rs
+++ b/crates/tracing/src/log_handle.rs
@@ -7,6 +7,9 @@
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{reload, EnvFilter, Registry};
 
+/// Tracing directives in effect when the node started.
+static STARTUP_LOG_DIRECTIVES: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
 /// Type alias for a single layer's reload handle.
 pub type LogFilterReloadHandle = reload::Handle<EnvFilter, Registry>;
 
@@ -59,6 +62,18 @@ pub fn install_log_handle(handle: LogFilterReloadHandle) {
 /// Returns `true` if at least one global log handle is available.
 pub fn log_handle_available() -> bool {
     LOG_HANDLE.lock().expect("log handle poisoned").is_available()
+}
+
+/// Records the tracing directives in effect at startup.
+///
+/// The first call wins so the baseline cannot be replaced by a runtime override.
+pub fn set_startup_log_directives(directives: String) {
+    let _ = STARTUP_LOG_DIRECTIVES.set(directives);
+}
+
+/// Returns the tracing directives in effect when the node started.
+pub fn startup_log_directives() -> Option<&'static str> {
+    STARTUP_LOG_DIRECTIVES.get().map(String::as_str)
 }
 
 /// Sets the global log verbosity level.

--- a/crates/tracing/src/log_handle.rs
+++ b/crates/tracing/src/log_handle.rs
@@ -7,14 +7,25 @@
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{reload, EnvFilter, Registry};
 
-/// Tracing directives in effect when the node started.
-static STARTUP_LOG_DIRECTIVES: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-
 /// Type alias for a single layer's reload handle.
 pub type LogFilterReloadHandle = reload::Handle<EnvFilter, Registry>;
 
+/// Reloadable tracing output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogFilterTarget {
+    /// Standard output logs.
+    Stdout,
+    /// File logs.
+    File,
+    /// OTLP traces.
+    OtlpTraces,
+    /// OTLP logs.
+    OtlpLogs,
+}
+
 #[derive(Debug)]
 struct ReloadableFilter {
+    target: LogFilterTarget,
     handle: LogFilterReloadHandle,
     startup_filter: EnvFilter,
 }
@@ -32,13 +43,29 @@ impl LogFilterHandle {
     }
 
     /// Adds a reload handle for a layer.
-    fn push(&mut self, handle: LogFilterReloadHandle, startup_filter: EnvFilter) {
-        self.filters.push(ReloadableFilter { handle, startup_filter });
+    fn push(
+        &mut self,
+        target: LogFilterTarget,
+        handle: LogFilterReloadHandle,
+        startup_filter: EnvFilter,
+    ) {
+        self.filters.push(ReloadableFilter { target, handle, startup_filter });
     }
 
     /// Returns `true` if at least one handle is registered.
     const fn is_available(&self) -> bool {
         !self.filters.is_empty()
+    }
+
+    /// Returns the unique targets with registered reload handles.
+    fn available_targets(&self) -> Vec<LogFilterTarget> {
+        let mut targets = Vec::new();
+        for filter in &self.filters {
+            if !targets.contains(&filter.target) {
+                targets.push(filter.target);
+            }
+        }
+        targets
     }
 
     /// Reloads every registered layer with a fresh filter built by `make_filter`.
@@ -53,9 +80,33 @@ impl LogFilterHandle {
         Ok(())
     }
 
+    /// Reloads layers matching one of the requested targets.
+    fn reload_targets(
+        &self,
+        targets: &[LogFilterTarget],
+        make_filter: impl Fn() -> Result<EnvFilter, String>,
+    ) -> Result<(), String> {
+        for reloadable in self.filters.iter().filter(|filter| targets.contains(&filter.target)) {
+            let filter = make_filter()?;
+            reloadable.handle.reload(filter).map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+
     /// Restores every registered layer to its own startup directives.
     fn reset_all(&self) -> Result<(), String> {
         for reloadable in &self.filters {
+            reloadable
+                .handle
+                .reload(reloadable.startup_filter.clone())
+                .map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+
+    /// Restores matching layers to their own startup directives.
+    fn reset_targets(&self, targets: &[LogFilterTarget]) -> Result<(), String> {
+        for reloadable in self.filters.iter().filter(|filter| targets.contains(&filter.target)) {
             reloadable
                 .handle
                 .reload(reloadable.startup_filter.clone())
@@ -73,7 +124,8 @@ static LOG_HANDLE: std::sync::Mutex<LogFilterHandle> =
 ///
 /// Can be called multiple times — each handle is appended.
 pub fn install_log_handle(handle: LogFilterReloadHandle) {
-    install_log_handle_with_baseline(
+    install_log_handle_with_target(
+        LogFilterTarget::Stdout,
         handle,
         EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).parse_lossy(""),
     );
@@ -81,7 +133,16 @@ pub fn install_log_handle(handle: LogFilterReloadHandle) {
 
 /// Registers a reload handle and the filter that should be restored on reset.
 pub fn install_log_handle_with_baseline(handle: LogFilterReloadHandle, startup_filter: EnvFilter) {
-    LOG_HANDLE.lock().expect("log handle poisoned").push(handle, startup_filter);
+    install_log_handle_with_target(LogFilterTarget::Stdout, handle, startup_filter);
+}
+
+/// Registers a targeted reload handle and the filter that should be restored on reset.
+pub fn install_log_handle_with_target(
+    target: LogFilterTarget,
+    handle: LogFilterReloadHandle,
+    startup_filter: EnvFilter,
+) {
+    LOG_HANDLE.lock().expect("log handle poisoned").push(target, handle, startup_filter);
 }
 
 /// Returns `true` if at least one global log handle is available.
@@ -89,16 +150,9 @@ pub fn log_handle_available() -> bool {
     LOG_HANDLE.lock().expect("log handle poisoned").is_available()
 }
 
-/// Records the tracing directives in effect at startup.
-///
-/// The first call wins so the baseline cannot be replaced by a runtime override.
-pub fn set_startup_log_directives(directives: String) {
-    let _ = STARTUP_LOG_DIRECTIVES.set(directives);
-}
-
-/// Returns the tracing directives in effect when the node started.
-pub fn startup_log_directives() -> Option<&'static str> {
-    STARTUP_LOG_DIRECTIVES.get().map(String::as_str)
+/// Returns the tracing targets with registered reload handles.
+pub fn available_log_filter_targets() -> Vec<LogFilterTarget> {
+    LOG_HANDLE.lock().expect("log handle poisoned").available_targets()
 }
 
 /// Restores every reloadable layer to the tracing directives it started with.
@@ -108,6 +162,15 @@ pub fn reset_log_filters() -> Result<(), String> {
         return Err("Log filter reload not available".to_string());
     }
     guard.reset_all()
+}
+
+/// Restores the requested reloadable layers to their startup filters.
+pub fn reset_log_filters_for_targets(targets: &[LogFilterTarget]) -> Result<(), String> {
+    let guard = LOG_HANDLE.lock().expect("log handle poisoned");
+    if !guard.is_available() {
+        return Err("Log filter reload not available".to_string());
+    }
+    guard.reset_targets(targets)
 }
 
 /// Sets the global log verbosity level.
@@ -177,12 +240,28 @@ pub fn set_log_vmodule(pattern: &str) -> Result<(), String> {
     }
 }
 
+/// Sets module-specific log levels for the requested reloadable layers.
+pub fn set_log_vmodule_for_targets(
+    pattern: &str,
+    targets: &[LogFilterTarget],
+) -> Result<(), String> {
+    let guard = LOG_HANDLE.lock().expect("log handle poisoned");
+    if !guard.is_available() {
+        return Err("Log filter reload not available".to_string());
+    }
+
+    EnvFilter::try_new(pattern).map_err(|e| format!("Invalid filter pattern: {e}"))?;
+    guard.reload_targets(targets, || {
+        EnvFilter::try_new(pattern).map_err(|e| format!("Invalid filter pattern: {e}"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn reset_restores_each_layers_startup_directives() {
+    fn scoped_reload_and_reset_only_affect_targeted_layers() {
         let (_stdout_layer, stdout_handle): (_, LogFilterReloadHandle) =
             reload::Layer::new(EnvFilter::try_new("info,reth=debug").unwrap());
         let (_otlp_layer, otlp_handle): (_, LogFilterReloadHandle) =
@@ -191,10 +270,20 @@ mod tests {
         let otlp_baseline = otlp_handle.with_current(Clone::clone).unwrap();
 
         let mut filters = LogFilterHandle::new();
-        filters.push(stdout_handle.clone(), stdout_baseline.clone());
-        filters.push(otlp_handle.clone(), otlp_baseline.clone());
-        filters.reload_all(|| EnvFilter::try_new("trace").map_err(|err| err.to_string())).unwrap();
-        filters.reset_all().unwrap();
+        filters.push(LogFilterTarget::Stdout, stdout_handle.clone(), stdout_baseline.clone());
+        filters.push(LogFilterTarget::OtlpTraces, otlp_handle.clone(), otlp_baseline.clone());
+        filters
+            .reload_targets(&[LogFilterTarget::Stdout], || {
+                EnvFilter::try_new("trace").map_err(|err| err.to_string())
+            })
+            .unwrap();
+        assert_eq!(stdout_handle.with_current(ToString::to_string).unwrap(), "trace");
+        assert_eq!(
+            otlp_handle.with_current(ToString::to_string).unwrap(),
+            otlp_baseline.to_string()
+        );
+
+        filters.reset_targets(&[LogFilterTarget::Stdout]).unwrap();
 
         assert_eq!(
             stdout_handle.with_current(ToString::to_string).unwrap(),


### PR DESCRIPTION
Adds `admin_tracingDirectives` for scoped `RUST_LOG`-style overrides across `stdout`, `file`, `otlpTraces`, and `otlpLogs`; omitting `targets` selects every configured output. `ttlSecs` may be omitted to keep an override active, set positive for automatic restoration, or set to `0` to reset immediately; each target maintains independent generation/revert state and restores its own startup filter. Inspired by worldcoin/world-chain#800.

Validation: `cargo +nightly fmt --all --check`, `cargo metadata --no-deps --format-version 1`, and `git diff --check`; compilation was blocked by invalid sandbox Git credentials while fetching the public pinned `sigp/discv5` dependency.

Prompted by: @shekhirin