### PR TITLE
chore(trie): remove V2 from multiproof span names

### DIFF
--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -58,7 +58,7 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{debug, debug_span, error, instrument, trace};
+use tracing::{debug, debug_span, error, instrument, trace, trace_span};
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::{
@@ -432,9 +432,9 @@ where
     {
         let StorageProofInput { hashed_address, mut targets } = input;
 
-        let span = debug_span!(
+        let span = trace_span!(
             target: "trie::proof_task",
-            "V2 Storage proof calculation",
+            "Storage proof calculation",
             n = %targets.len(),
         );
         let _span_guard = span.enter();
@@ -969,9 +969,9 @@ where
     {
         let MultiProofTargetsV2 { mut account_targets, storage_targets } = targets;
 
-        let span = debug_span!(
+        let span = trace_span!(
             target: "trie::proof_task",
-            "Account V2 multiproof calculation",
+            "Account multiproof calculation",
             account_targets = account_targets.len(),
             storage_targets = storage_targets.values().map(|t| t.len()).sum::<usize>(),
         );

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -58,7 +58,7 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{debug, debug_span, error, instrument, trace, trace_span};
+use tracing::{debug, debug_span, error, instrument, trace};
 
 #[cfg(feature = "metrics")]
 use crate::proof_task_metrics::{
@@ -432,7 +432,7 @@ where
     {
         let StorageProofInput { hashed_address, mut targets } = input;
 
-        let span = trace_span!(
+        let span = debug_span!(
             target: "trie::proof_task",
             "Storage proof calculation",
             n = %targets.len(),
@@ -969,7 +969,7 @@ where
     {
         let MultiProofTargetsV2 { mut account_targets, storage_targets } = targets;
 
-        let span = trace_span!(
+        let span = debug_span!(
             target: "trie::proof_task",
             "Account multiproof calculation",
             account_targets = account_targets.len(),


### PR DESCRIPTION
## Summary
- rename `V2 Storage proof calculation` to `Storage proof calculation`
- rename `Account V2 multiproof calculation` to `Account multiproof calculation`
- keep both spans at debug level

## Testing
- `cargo +nightly fmt --all -- --check`

Prompted by: @shekhirin