### PR TITLE
fix(engine): pass post-execution hook state_updates by value

### DIFF
--- a/crates/engine/primitives/src/lib.rs
+++ b/crates/engine/primitives/src/lib.rs
@@ -214,12 +214,15 @@ pub trait PayloadValidator<Types: PayloadTypes>: Send + Sync + Unpin + 'static {
 
     /// Verifies payload post-execution w.r.t. hashed state updates.
     ///
+    /// `state_updates` lazily yields the block's hashed post-state; call it only if the
+    /// implementation needs the executed state changes (the L1 default does not).
+    ///
     /// `parent_state` lazily builds the overlay-aware provider for the block's parent that the
     /// engine used for execution — resolving even a not-yet-canonical in-memory parent. It is only
     /// built if the implementation needs it (the L1 default does not).
     fn validate_block_post_execution_with_hashed_state<'a>(
         &self,
-        _state_updates: &dyn FnOnce() -> &'a HashedPostState,
+        _state_updates: impl FnOnce() -> &'a HashedPostState,
         _block: &RecoveredBlock<Self::Block>,
         _parent_state: impl FnOnce() -> ProviderResult<StateProviderBox>,
     ) -> Result<(), InsertBlockErrorKind>

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -787,7 +787,7 @@ where
         )
         .in_scope(|| {
             self.validator.validate_block_post_execution_with_hashed_state(
-                &|| hashed_state.get(),
+                || hashed_state.get(),
                 &block,
                 || provider_builder.build(),
             )
@@ -823,7 +823,7 @@ where
             )
             .in_scope(|| {
                 self.validator.validate_block_post_execution_with_hashed_state(
-                    &|| hashed_state.get(),
+                    || hashed_state.get(),
                     &block,
                     || provider_builder.build(),
                 )


### PR DESCRIPTION
## Description

`PayloadValidator::validate_block_post_execution_with_hashed_state` takes `state_updates` as
`&dyn FnOnce() -> &HashedPostState`. That type **can't be called** — invoking a `FnOnce` moves
`self`, which isn't possible through a shared reference — so an implementation that needs the
block's executed state changes has no way to obtain them.

This went unnoticed because the only in-tree implementer is the L1 default, which ignores the
argument. But L2 validators need it: the OP Stack post-execution check (the consumer #26330 added
`parent_state` for) reads the `L2ToL1MessagePasser` storage delta from `state_updates` to recompute
the `withdrawals_root` storage root, and can't with the current type.

## Change

Take `state_updates` as `impl FnOnce() -> &HashedPostState` instead:

- callable by value (`let hashed = state_updates();`),
- statically dispatched (no trait object),
- symmetric with the existing `parent_state: impl FnOnce()` argument.

The method already carries `where Self: Sized` (from `parent_state`), so this costs nothing in
object-safety. The two engine-tree call sites drop the `&` (`&|| hashed_state.get()` →
`|| hashed_state.get()`).

## Testing

- `cargo test -p reth-engine-primitives -p reth-engine-tree` passes locally: 134 `reth-engine-tree`
  unit tests + 14 `e2e-testsuite` integration tests, 0 failures (`reth-engine-primitives` and
  doctests included).
- `reth-engine-primitives` also builds with `--no-default-features` (`no_std`).
