### PR TITLE
fix(trie): retain leaves with their branch

### DIFF
--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -78,6 +78,12 @@ impl ArenaCursor {
         (len >= 2).then(|| &self.stack[len - 2])
     }
 
+    /// Returns the entry two below the top of the stack, or `None`.
+    pub(super) fn grandparent(&self) -> Option<&ArenaCursorStackEntry> {
+        let len = self.stack.len();
+        (len >= 3).then(|| &self.stack[len - 3])
+    }
+
     /// Returns the depth of the head node (0 for the root).
     ///
     /// # Panics

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -219,12 +219,13 @@ impl ArenaSparseSubtrie {
         );
     }
 
-    /// Prunes revealed subtrees that are not ancestors of any retained leaf, compacting the arena
+    /// Prunes revealed branches that are not ancestors of any retained leaf, compacting the arena
     /// in lexicographic order.
     ///
     /// `retained_leaves` must yield leaves in sorted order and be scoped to this subtrie's key
     /// range. Builds a fresh arena by copying retained nodes from the root, blinding non-retained
-    /// children at the boundary unless their parent branch is retained.
+    /// branch children at the boundary. Leaves remain revealed as long as their parent branch
+    /// does.
     ///
     /// Expects that all nodes have computed hashes (i.e. `prune` is called after hashing).
     fn prune<'a>(&mut self, retained_leaves: impl IntoIterator<Item = &'a Nibbles>) -> usize {
@@ -281,8 +282,9 @@ impl ArenaSparseSubtrie {
 
             let child_is_retained =
                 retained_leaves.peek().is_some_and(|retained| retained.starts_with(&child_path));
-            if child_is_retained || frame.branch_is_retained {
-                // Retained or protected by a retained parent branch.
+            let child_is_leaf = matches!(self.arena[old_child_idx], ArenaSparseNode::Leaf { .. });
+            if child_is_retained || frame.branch_is_retained || child_is_leaf {
+                // A leaf stays revealed for as long as its parent branch does.
                 let child_node = self.arena.remove(old_child_idx).expect("child exists");
                 let new_child_idx = new_arena.insert(child_node);
                 if let Some(frame) = prepare_retained_node(
@@ -666,10 +668,10 @@ impl Default for ArenaParallelismThresholds {
 ///
 /// ## Pruning
 ///
-/// [`SparseTrie::prune`] removes revealed nodes that are not ancestors of any retained leaf.
-/// Pruned nodes are replaced with `ArenaSparseNodeBranchChild::Blinded` entries using their
-/// cached RLP. Subtries are pruned in parallel when their leaf count exceeds
-/// [`ArenaParallelismThresholds::min_leaves_for_prune`].
+/// [`SparseTrie::prune`] removes revealed branches that are not ancestors of any retained leaf.
+/// Leaves stay revealed until their parent branch is pruned. Pruned nodes are replaced with
+/// `ArenaSparseNodeBranchChild::Blinded` entries using their cached RLP. Subtries are pruned in
+/// parallel when their leaf count exceeds [`ArenaParallelismThresholds::min_leaves_for_prune`].
 #[derive(Debug, Clone)]
 pub struct ArenaParallelSparseTrie {
     /// The arena allocating nodes in the upper trie.
@@ -2841,15 +2843,28 @@ impl SparseTrie for ArenaParallelSparseTrie {
             let head = cursor.head().expect("cursor is non-empty");
             let head_idx = head.index;
             let head_path = head.path;
-            let protected_by_retained_parent = if cursor.depth() == 0 {
-                false
-            } else {
+            let protected_by_retained_parent = || {
+                if cursor.depth() == 0 {
+                    return false
+                }
+
                 let parent_path = cursor.parent().expect("cursor must have a parent").path;
                 !prefix_range(retained_leaves, 0, &parent_path).is_empty()
             };
+            let leaf_parent_will_be_pruned = || {
+                if cursor.depth() <= 1 {
+                    return false
+                }
+
+                let parent_path = cursor.parent().expect("cursor must have a parent").path;
+                let grandparent_path =
+                    cursor.grandparent().expect("cursor must have a grandparent").path;
+                prefix_range(retained_leaves, 0, &parent_path).is_empty() &&
+                    prefix_range(retained_leaves, 0, &grandparent_path).is_empty()
+            };
 
             match &self.upper_arena[head_idx] {
-                ArenaSparseNode::Branch(_) | ArenaSparseNode::Leaf { .. } => {
+                ArenaSparseNode::Branch(_) => {
                     // Don't prune the root.
                     if cursor.depth() == 0 {
                         continue;
@@ -2860,7 +2875,20 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         continue;
                     }
 
-                    if protected_by_retained_parent {
+                    if protected_by_retained_parent() {
+                        continue;
+                    }
+
+                    Self::remove_pruned_node(
+                        &mut self.upper_arena,
+                        &cursor,
+                        head_idx,
+                        head_path.last(),
+                    );
+                    pruned += 1;
+                }
+                ArenaSparseNode::Leaf { .. } => {
+                    if !leaf_parent_will_be_pruned() {
                         continue;
                     }
 
@@ -2877,7 +2905,14 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     retained_idx = subtrie_range.end;
 
                     if subtrie_range.is_empty() {
-                        if protected_by_retained_parent {
+                        let ArenaSparseNode::Subtrie(subtrie) = &self.upper_arena[head_idx] else {
+                            unreachable!()
+                        };
+                        let root_is_leaf =
+                            matches!(subtrie.arena[subtrie.root], ArenaSparseNode::Leaf { .. });
+                        if protected_by_retained_parent() ||
+                            (root_is_leaf && !leaf_parent_will_be_pruned())
+                        {
                             let ArenaSparseNode::Subtrie(subtrie) = &mut self.upper_arena[head_idx]
                             else {
                                 unreachable!()

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -214,11 +214,12 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// and auxiliary data structures.
     fn memory_size(&self) -> usize;
 
-    /// Prunes all subtrees that do not contain retained leaves.
+    /// Prunes revealed branches according to the retained leaf paths.
     ///
     /// Each retained leaf is a full key path (usually 64 nibbles for hashed keys).
-    /// Any revealed subtree that is not a prefix of at least one retained key is collapsed into
-    /// hash stubs when hashes are available.
+    /// Revealed branches that are not a prefix of at least one retained key are collapsed into
+    /// hash stubs when hashes are available. A leaf remains revealed while its parent branch does
+    /// and is only pruned together with that branch.
     ///
     /// # Preconditions
     ///

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -64,18 +64,27 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
 /// Multiple rounds of (update → root → `take_updates`), followed by a prune, simulating block
 /// processing.
 pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(new_trie: fn() -> T) {
-    // Build a trie with 10 primary leaves, each with a sibling under the same root child.
+    // Build a trie with 10 primary leaves, each below a branch that can be pruned independently
+    // of the root's immediate children.
     let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
     let mut keys = Vec::new();
     for i in 0u8..10 {
         let mut key = B256::ZERO;
-        key.0[0] = i << 4; // nibble prefixes: 0x0, 0x1, 0x2, ... 0x9
+        key.0[0] = i << 4;
         storage.insert(key, U256::from(i as u64 + 1));
         keys.push(key);
 
-        let mut sibling = B256::ZERO;
-        sibling.0[0] = (i << 4) | 1;
+        let mut sibling = key;
+        sibling.0[1] = 0x10;
         storage.insert(sibling, U256::from(i as u64 + 100));
+
+        let mut other_branch = key;
+        other_branch.0[0] |= 1;
+        storage.insert(other_branch, U256::from(i as u64 + 200));
+
+        let mut other_sibling = other_branch;
+        other_sibling.0[1] = 0x10;
+        storage.insert(other_sibling, U256::from(i as u64 + 300));
     }
 
     let mut harness = SuiteTestHarness::new(storage.clone());
@@ -120,6 +129,10 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     if pre_prune_size > 0 {
         assert!(post_prune_size < pre_prune_size, "prune should reduce node count");
     }
+    assert!(
+        trie.get_leaf_value(&Nibbles::unpack(keys[4])).is_none(),
+        "cold leaf should be pruned with its parent branch"
+    );
 
     // Root should still be correct after prune.
     let root_after_prune = trie.root();

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -282,8 +282,9 @@ sparse_trie_tests! {
 
     // prune
     test_prune_retains_specified_leaves,
-    test_prune_keeps_upper_children_of_retained_branch,
-    test_prune_keeps_lower_children_of_retained_branch,
+    test_prune_keeps_upper_leaves_with_root_branch,
+    test_prune_keeps_subtrie_root_leaves_with_their_branch,
+    test_prune_keeps_lower_leaves_with_their_branch,
     test_prune_protects_children_by_parent_base_path,
     test_prune_reduces_node_count,
     test_prune_empty_retained_set,

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -15,23 +15,15 @@ fn key_with_prefix(prefix: &[u8]) -> B256 {
     key
 }
 
-fn changed_update(value: u64) -> LeafUpdate {
-    LeafUpdate::Changed(encode_fixed_size(&U256::from(value)).to_vec())
-}
-
-fn assert_update_requests_min_len<T: SparseTrie>(trie: &mut T, key: B256, min_len: u8, value: u64) {
-    let mut leaf_updates = B256Map::from_iter([(key, changed_update(value))]);
-    let mut targets = Vec::new();
-    trie.update_leaves(&mut leaf_updates, |key, min_len| {
-        targets.push((key, min_len));
-    })
-    .expect("update_leaves should succeed");
-
-    assert_eq!(targets, vec![(key, min_len)]);
-    assert!(
-        leaf_updates.contains_key(&key),
-        "update should remain pending until proof is revealed"
-    );
+fn branched_keys() -> Vec<B256> {
+    (0u8..16)
+        .flat_map(|root_child| {
+            (0u8..2).flat_map(move |branch_child| {
+                (0u8..2)
+                    .map(move |leaf_child| key_with_prefix(&[root_child, branch_child, leaf_child]))
+            })
+        })
+        .collect()
 }
 
 fn rlp_node(node: TrieNodeV2) -> RlpNode {
@@ -80,7 +72,26 @@ pub(super) fn test_prune_retains_specified_leaves<T: SparseTrie>(new_trie: fn() 
     assert!(val_b.is_some(), "retained leaf B should be accessible after prune");
 }
 
-pub(super) fn test_prune_keeps_upper_children_of_retained_branch<T: SparseTrie>(
+pub(super) fn test_prune_keeps_upper_leaves_with_root_branch<T: SparseTrie>(new_trie: fn() -> T) {
+    let key_a = key_with_prefix(&[0x0]);
+    let key_b = key_with_prefix(&[0x1]);
+    let storage = BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2))]);
+
+    let harness = SuiteTestHarness::new(storage);
+    let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
+    let root_before = trie.root();
+
+    let pruned = trie.prune(&[]);
+
+    assert_eq!(trie.root(), root_before, "root must not change after prune");
+    assert_eq!(pruned, 0, "leaves should remain revealed with the root branch");
+    assert!(
+        trie.get_leaf_value(&Nibbles::unpack(key_b)).is_some(),
+        "leaf should remain accessible after prune"
+    );
+}
+
+pub(super) fn test_prune_keeps_subtrie_root_leaves_with_their_branch<T: SparseTrie>(
     new_trie: fn() -> T,
 ) {
     let retained_key = key_with_prefix(&[0x0]);
@@ -100,13 +111,14 @@ pub(super) fn test_prune_keeps_upper_children_of_retained_branch<T: SparseTrie>(
     let pruned = trie.prune(&retained);
 
     assert_eq!(trie.root(), root_before, "root must not change after prune");
-    assert_eq!(pruned, 2, "protected branch children should be blinded, not removed");
-    assert_update_requests_min_len(&mut trie, protected_key_a, 2, 20);
+    assert_eq!(pruned, 0, "leaves should remain revealed with their parent branch");
+    assert!(
+        trie.get_leaf_value(&Nibbles::unpack(protected_key_a)).is_some(),
+        "leaf should remain accessible after prune"
+    );
 }
 
-pub(super) fn test_prune_keeps_lower_children_of_retained_branch<T: SparseTrie>(
-    new_trie: fn() -> T,
-) {
+pub(super) fn test_prune_keeps_lower_leaves_with_their_branch<T: SparseTrie>(new_trie: fn() -> T) {
     let retained_key = key_with_prefix(&[0x0, 0x0, 0x0]);
     let protected_key_a = key_with_prefix(&[0x0, 0x0, 0x1, 0x2]);
     let protected_key_b = key_with_prefix(&[0x0, 0x0, 0x1, 0x3]);
@@ -124,8 +136,11 @@ pub(super) fn test_prune_keeps_lower_children_of_retained_branch<T: SparseTrie>(
     let pruned = trie.prune(&retained);
 
     assert_eq!(trie.root(), root_before, "root must not change after prune");
-    assert_eq!(pruned, 2, "protected lower branch children should be blinded, not removed");
-    assert_update_requests_min_len(&mut trie, protected_key_a, 4, 20);
+    assert_eq!(pruned, 0, "leaves should remain revealed with their parent branch");
+    assert!(
+        trie.get_leaf_value(&Nibbles::unpack(protected_key_a)).is_some(),
+        "leaf should remain accessible after prune"
+    );
 }
 
 pub(super) fn test_prune_protects_children_by_parent_base_path<T: SparseTrie>(new_trie: fn() -> T) {
@@ -179,21 +194,11 @@ pub(super) fn test_prune_protects_children_by_parent_base_path<T: SparseTrie>(ne
 
 /// Pruning should reduce the node count.
 ///
-/// Build a trie with several root children that each contain grandchildren, fully reveal
+/// Build a trie with several root children that each contain lower branches, fully reveal
 /// and compute root. Then prune retaining only 1 leaf. `size_hint()` must
 /// decrease and `prune` must return > 0.
 pub(super) fn test_prune_reduces_node_count<T: SparseTrie>(new_trie: fn() -> T) {
-    // Create 16 pairs with different first nibbles. Pruning keeps direct
-    // children of the retained root branch, so each child needs grandchildren that can be pruned.
-    let keys: Vec<B256> = (0u8..16)
-        .flat_map(|i| {
-            [0u8, 1].map(move |child| {
-                let mut k = B256::ZERO;
-                k.0[0] = (i << 4) | child;
-                k
-            })
-        })
-        .collect();
+    let keys = branched_keys();
 
     let storage: BTreeMap<B256, U256> =
         keys.iter().enumerate().map(|(i, k)| (*k, U256::from(i + 1))).collect();
@@ -222,13 +227,7 @@ pub(super) fn test_prune_reduces_node_count<T: SparseTrie>(new_trie: fn() -> T) 
 /// Pruning with an empty retained set should convert all subtrees to
 /// hash stubs (maximum pruning). Root hash must be unchanged.
 pub(super) fn test_prune_empty_retained_set<T: SparseTrie>(new_trie: fn() -> T) {
-    let keys: Vec<B256> = (0u8..16)
-        .map(|i| {
-            let mut k = B256::ZERO;
-            k.0[0] = (i + 1) << 4;
-            k
-        })
-        .collect();
+    let keys = branched_keys();
 
     let storage: BTreeMap<B256, U256> =
         keys.iter().enumerate().map(|(i, k)| (*k, U256::from(i + 1))).collect();


### PR DESCRIPTION
Keeps sparse trie leaves revealed whenever their parent branch remains revealed, including leaves stored as subtrie roots. Leaves are still removed when the parent branch is pruned, avoiding unnecessary proof requests for preserved branches.