### PR TITLE
fix(engine): cancel stale persistence saves

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -7,13 +7,15 @@ use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     providers::ProviderNodeTypes, BalProvider, BlockExecutionWriter, BlockHashReader,
-    ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksMode,
+    BlockNumReader, ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory,
+    SaveBlocksMode, StaticFileProviderFactory, StaticFileWriter,
 };
 use reth_prune::{PrunerError, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};
 use reth_tasks::spawn_os_thread;
 use std::{
     sync::{
+        atomic::{AtomicBool, Ordering},
         mpsc::{Receiver, SendError, Sender},
         Arc,
     },
@@ -30,6 +32,24 @@ pub struct PersistenceResult {
     pub last_block: Option<BlockNumHash>,
     /// The commit duration, only available for save-blocks operations.
     pub commit_duration: Option<Duration>,
+    /// Whether the save was cancelled and its staged writes were rolled back.
+    pub cancelled: bool,
+}
+
+/// Best-effort cancellation signal for an in-flight persistence operation.
+#[derive(Clone, Debug, Default)]
+pub struct PersistenceCanceller(Arc<AtomicBool>);
+
+impl PersistenceCanceller {
+    /// Cancels the associated persistence operation.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns whether the associated persistence operation was cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
 }
 
 /// Writes parts of reth's in memory tree state to the database and static files.
@@ -100,10 +120,14 @@ where
                     // send new sync metrics based on removed blocks
                     let _ =
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
-                    let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
+                    let _ = sender.send(PersistenceResult {
+                        last_block,
+                        commit_duration: None,
+                        cancelled: false,
+                    });
                 }
-                PersistenceAction::SaveBlocks(blocks, sender) => {
-                    let result = self.on_save_blocks(blocks)?;
+                PersistenceAction::SaveBlocks(blocks, canceller, sender) => {
+                    let result = self.on_save_blocks(blocks, canceller)?;
                     let result_number = result.last_block.map(|b| b.number);
 
                     let _ = sender.send(result);
@@ -149,6 +173,7 @@ where
     fn on_save_blocks(
         &mut self,
         blocks: Vec<ExecutedBlock<N::Primitives>>,
+        canceller: PersistenceCanceller,
     ) -> Result<PersistenceResult, PersistenceError> {
         let first_block = blocks.first().map(|b| b.recovered_block.num_hash());
         let last_block = blocks.last().map(|b| b.recovered_block.num_hash());
@@ -163,7 +188,33 @@ where
 
         if let Some(last) = last_block {
             let provider_rw = self.provider.database_provider_rw()?;
+            let previous_tip = provider_rw.last_block_number()?;
             provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
+
+            if canceller.is_cancelled() {
+                self.pending_finalized_block = pending_finalized;
+                self.pending_safe_block = pending_safe;
+
+                // Replace the append-side RocksDB batches with those produced by unwind.
+                provider_rw.discard_pending_rocksdb_batches();
+                // Unwind reads changesets from static files. Finalizing makes the staged rows
+                // visible; the subsequently queued prunes make commit use unwind ordering.
+                provider_rw.static_file_provider().finalize()?;
+                provider_rw.remove_block_and_execution_above(previous_tip)?;
+                provider_rw.commit()?;
+
+                let elapsed = start_time.elapsed();
+                self.metrics.save_blocks_batch_size.record(block_count as f64);
+                self.metrics.save_blocks_duration_seconds.record(elapsed);
+
+                debug!(target: "engine::persistence", first=?first_block, last=?last_block, ?previous_tip, "Rolled back cancelled block save");
+
+                return Ok(PersistenceResult {
+                    last_block: None,
+                    commit_duration: Some(elapsed),
+                    cancelled: true,
+                });
+            }
 
             if let Some(finalized) = pending_finalized {
                 provider_rw.save_finalized_block_number(finalized.min(last.number))?;
@@ -189,7 +240,7 @@ where
         self.metrics.save_blocks_batch_size.record(block_count as f64);
         self.metrics.save_blocks_duration_seconds.record(elapsed);
 
-        Ok(PersistenceResult { last_block, commit_duration: Some(elapsed) })
+        Ok(PersistenceResult { last_block, commit_duration: Some(elapsed), cancelled: false })
     }
 
     fn maybe_run_pruner(&mut self, block_number: u64) -> Result<(), PersistenceError> {
@@ -237,7 +288,7 @@ pub enum PersistenceAction<N: NodePrimitives = EthPrimitives> {
     ///
     /// First, header, transaction, and receipt-related data should be written to static files.
     /// Then the execution history-related data will be written to the database.
-    SaveBlocks(Vec<ExecutedBlock<N>>, CrossbeamSender<PersistenceResult>),
+    SaveBlocks(Vec<ExecutedBlock<N>>, PersistenceCanceller, CrossbeamSender<PersistenceResult>),
 
     /// Removes block data above the given block number from the database.
     ///
@@ -322,9 +373,10 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
     pub fn save_blocks(
         &self,
         blocks: Vec<ExecutedBlock<T>>,
+        canceller: PersistenceCanceller,
         tx: CrossbeamSender<PersistenceResult>,
     ) -> Result<(), SendError<PersistenceAction<T>>> {
-        self.send_action(PersistenceAction::SaveBlocks(blocks, tx))
+        self.send_action(PersistenceAction::SaveBlocks(blocks, canceller, tx))
     }
 
     /// Queues the finalized block number to be persisted on disk.
@@ -395,8 +447,8 @@ mod tests {
         providers::{ProviderFactoryBuilder, ReadOnlyConfig},
         test_utils::{create_test_provider_factory, MockNodeTypes},
         AccountReader, BalConfig, BalNotificationStream, BalStore, BalStoreHandle,
-        ChainSpecProvider, HeaderProvider, InMemoryBalStore, ProviderError, ProviderResult, RawBal,
-        StorageSettingsCache, TryIntoHistoricalStateProvider,
+        ChainSpecProvider, ChainStateBlockReader, HeaderProvider, InMemoryBalStore, ProviderError,
+        ProviderResult, RawBal, StorageSettingsCache, TryIntoHistoricalStateProvider,
     };
     use reth_prune::Pruner;
     use reth_prune_types::PruneMode;
@@ -495,7 +547,7 @@ mod tests {
         let blocks = vec![];
         let (tx, rx) = crossbeam_channel::bounded(1);
 
-        handle.save_blocks(blocks, tx).unwrap();
+        handle.save_blocks(blocks, PersistenceCanceller::default(), tx).unwrap();
 
         let result = rx.recv().unwrap();
         assert!(result.last_block.is_none());
@@ -514,7 +566,7 @@ mod tests {
         let blocks = vec![executed];
         let (tx, rx) = crossbeam_channel::bounded(1);
 
-        handle.save_blocks(blocks, tx).unwrap();
+        handle.save_blocks(blocks, PersistenceCanceller::default(), tx).unwrap();
 
         let result = rx.recv_timeout(std::time::Duration::from_secs(10)).expect("test timed out");
 
@@ -531,7 +583,7 @@ mod tests {
         let last_hash = blocks.last().unwrap().recovered_block().hash();
         let (tx, rx) = crossbeam_channel::bounded(1);
 
-        handle.save_blocks(blocks, tx).unwrap();
+        handle.save_blocks(blocks, PersistenceCanceller::default(), tx).unwrap();
         let result = rx.recv().unwrap();
         assert_eq!(last_hash, result.last_block.unwrap().hash);
     }
@@ -548,11 +600,68 @@ mod tests {
             let last_hash = blocks.last().unwrap().recovered_block().hash();
             let (tx, rx) = crossbeam_channel::bounded(1);
 
-            handle.save_blocks(blocks, tx).unwrap();
+            handle.save_blocks(blocks, PersistenceCanceller::default(), tx).unwrap();
 
             let result = rx.recv().unwrap();
             assert_eq!(last_hash, result.last_block.unwrap().hash);
         }
+    }
+
+    #[test]
+    fn test_cancelled_save_blocks_rolls_back() {
+        reth_tracing::init_test_tracing();
+
+        let provider = create_test_provider_factory();
+        let (_finished_exex_height_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+        let pruner =
+            Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
+        let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
+        let handle = PersistenceHandle::<EthPrimitives>::spawn_service(
+            provider.clone(),
+            pruner,
+            sync_metrics_tx,
+        );
+
+        let mut test_block_builder = TestBlockBuilder::eth();
+        let mut blocks = test_block_builder.get_executed_blocks(0..2);
+        let first = blocks.next().unwrap();
+        let second = blocks.next().unwrap();
+
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        handle.save_blocks(vec![first], PersistenceCanceller::default(), tx).unwrap();
+        let result = rx.recv().unwrap();
+        assert!(!result.cancelled);
+        assert_eq!(result.last_block.unwrap().number, 0);
+
+        handle.save_finalized_block_number(1).unwrap();
+        handle.save_safe_block_number(1).unwrap();
+
+        let canceller = PersistenceCanceller::default();
+        canceller.cancel();
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        handle.save_blocks(vec![second.clone()], canceller, tx).unwrap();
+
+        let result = rx.recv().unwrap();
+        assert!(result.cancelled);
+        assert!(result.last_block.is_none());
+
+        let provider_ro = provider.provider().unwrap();
+        assert_eq!(provider_ro.last_block_number().unwrap(), 0);
+        assert_eq!(provider_ro.block_hash(1).unwrap(), None);
+        assert_eq!(provider_ro.last_finalized_block_number().unwrap(), None);
+        assert_eq!(provider_ro.last_safe_block_number().unwrap(), None);
+        drop(provider_ro);
+
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        handle.save_blocks(vec![second], PersistenceCanceller::default(), tx).unwrap();
+        let result = rx.recv().unwrap();
+        assert!(!result.cancelled);
+        assert_eq!(result.last_block.unwrap().number, 1);
+
+        let provider_ro = provider.provider().unwrap();
+        assert_eq!(provider_ro.last_finalized_block_number().unwrap(), Some(1));
+        assert_eq!(provider_ro.last_safe_block_number().unwrap(), Some(1));
     }
 
     /// Verifies that committing `save_blocks` history before running the pruner

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -7,8 +7,8 @@ use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     providers::ProviderNodeTypes, BalProvider, BlockExecutionWriter, BlockHashReader,
-    BlockNumReader, ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory,
-    SaveBlocksMode, StaticFileProviderFactory, StaticFileWriter,
+    ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksMode,
+    StaticFileProviderFactory,
 };
 use reth_prune::{PrunerError, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};
@@ -179,35 +179,54 @@ where
         let last_block = blocks.last().map(|b| b.recovered_block.num_hash());
         let block_count = blocks.len();
 
-        let pending_finalized = self.pending_finalized_block.take();
-        let pending_safe = self.pending_safe_block.take();
-
         debug!(target: "engine::persistence", ?block_count, first=?first_block, last=?last_block, "Saving range of blocks");
 
         let start_time = Instant::now();
 
         if let Some(last) = last_block {
             let provider_rw = self.provider.database_provider_rw()?;
-            let previous_tip = provider_rw.last_block_number()?;
-            provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
+            let static_file_provider = provider_rw.static_file_provider();
+            let static_file_savepoint = static_file_provider.savepoint()?;
+            let pending_finalized = self.pending_finalized_block.take();
+            let pending_safe = self.pending_safe_block.take();
+
+            let save_result = (|| -> Result<(), ProviderError> {
+                provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
+
+                if let Some(finalized) = pending_finalized {
+                    provider_rw.save_finalized_block_number(finalized.min(last.number))?;
+                }
+                if let Some(safe) = pending_safe {
+                    provider_rw.save_safe_block_number(safe.min(last.number))?;
+                }
+
+                Ok(())
+            })();
+
+            if let Err(save_error) = save_result {
+                self.pending_finalized_block = pending_finalized;
+                self.pending_safe_block = pending_safe;
+                provider_rw.abort();
+
+                if let Err(rollback_error) = static_file_provider.rollback(static_file_savepoint) {
+                    error!(target: "engine::persistence", ?save_error, ?rollback_error, "Failed to roll back static files after block save error");
+                    return Err(rollback_error.into())
+                }
+
+                return Err(save_error.into())
+            }
 
             if canceller.is_cancelled() {
                 self.pending_finalized_block = pending_finalized;
                 self.pending_safe_block = pending_safe;
-
-                // Replace the append-side RocksDB batches with those produced by unwind.
-                provider_rw.discard_pending_rocksdb_batches();
-                // Unwind reads changesets from static files. Finalizing makes the staged rows
-                // visible; the subsequently queued prunes make commit use unwind ordering.
-                provider_rw.static_file_provider().finalize()?;
-                provider_rw.remove_block_and_execution_above(previous_tip)?;
-                provider_rw.commit()?;
+                provider_rw.abort();
+                static_file_provider.rollback(static_file_savepoint)?;
 
                 let elapsed = start_time.elapsed();
                 self.metrics.save_blocks_batch_size.record(block_count as f64);
                 self.metrics.save_blocks_duration_seconds.record(elapsed);
 
-                debug!(target: "engine::persistence", first=?first_block, last=?last_block, ?previous_tip, "Rolled back cancelled block save");
+                debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Rolled back cancelled block save");
 
                 return Ok(PersistenceResult {
                     last_block: None,
@@ -216,20 +235,23 @@ where
                 });
             }
 
-            if let Some(finalized) = pending_finalized {
-                provider_rw.save_finalized_block_number(finalized.min(last.number))?;
-                if finalized > last.number {
-                    self.pending_finalized_block = Some(finalized);
-                }
-            }
-            if let Some(safe) = pending_safe {
-                provider_rw.save_safe_block_number(safe.min(last.number))?;
-                if safe > last.number {
-                    self.pending_safe_block = Some(safe);
-                }
-            }
+            if let Err(commit_error) = provider_rw.commit() {
+                self.pending_finalized_block = pending_finalized;
+                self.pending_safe_block = pending_safe;
 
-            provider_rw.commit()?;
+                if let Err(rollback_error) = static_file_provider.rollback(static_file_savepoint) {
+                    error!(target: "engine::persistence", ?commit_error, ?rollback_error, "Failed to roll back static files after block commit error");
+                    return Err(rollback_error.into())
+                }
+
+                return Err(commit_error.into())
+            }
+            if pending_finalized.is_some_and(|finalized| finalized > last.number) {
+                self.pending_finalized_block = pending_finalized;
+            }
+            if pending_safe.is_some_and(|safe| safe > last.number) {
+                self.pending_safe_block = pending_safe;
+            }
             let _ = self.provider.bal_store().flush().inspect_err(|err| {
                 warn!(target: "engine::persistence", last=?last_block, ?err, "Failed to flush BAL store");
             });
@@ -442,13 +464,15 @@ mod tests {
     use alloy_eips::NumHash;
     use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256, U256};
     use reth_chain_state::test_utils::TestBlockBuilder;
+    use reth_db::Database;
     use reth_exex_types::FinishedExExHeight;
     use reth_provider::{
         providers::{ProviderFactoryBuilder, ReadOnlyConfig},
         test_utils::{create_test_provider_factory, MockNodeTypes},
-        AccountReader, BalConfig, BalNotificationStream, BalStore, BalStoreHandle,
+        AccountReader, BalConfig, BalNotificationStream, BalStore, BalStoreHandle, BlockNumReader,
         ChainSpecProvider, ChainStateBlockReader, HeaderProvider, InMemoryBalStore, ProviderError,
-        ProviderResult, RawBal, StorageSettingsCache, TryIntoHistoricalStateProvider,
+        ProviderResult, RawBal, RocksDBProviderFactory, StorageSettingsCache,
+        TryIntoHistoricalStateProvider,
     };
     use reth_prune::Pruner;
     use reth_prune_types::PruneMode;
@@ -637,6 +661,10 @@ mod tests {
         handle.save_finalized_block_number(1).unwrap();
         handle.save_safe_block_number(1).unwrap();
 
+        let expected_mdbx_txid = provider.db_ref().last_txnid();
+        let rocksdb = provider.rocksdb_provider();
+        let expected_rocksdb_sequence = rocksdb.latest_sequence_number();
+
         let canceller = PersistenceCanceller::default();
         canceller.cancel();
         let (tx, rx) = crossbeam_channel::bounded(1);
@@ -645,6 +673,8 @@ mod tests {
         let result = rx.recv().unwrap();
         assert!(result.cancelled);
         assert!(result.last_block.is_none());
+        assert_eq!(provider.db_ref().last_txnid(), expected_mdbx_txid);
+        assert_eq!(rocksdb.latest_sequence_number(), expected_rocksdb_sequence);
 
         let provider_ro = provider.provider().unwrap();
         assert_eq!(provider_ro.last_block_number().unwrap(), 0);
@@ -664,6 +694,58 @@ mod tests {
         assert_eq!(provider_ro.last_safe_block_number().unwrap(), Some(1));
     }
 
+    #[test]
+    fn test_save_blocks_error_rolls_back_static_files() {
+        reth_tracing::init_test_tracing();
+
+        let provider = create_test_provider_factory();
+        provider.set_storage_settings_cache(reth_provider::StorageSettings::v2());
+        let (_finished_exex_height_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+        let pruner =
+            Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
+        let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
+        let (_tx, rx) = std::sync::mpsc::channel::<PersistenceAction<EthPrimitives>>();
+        let mut service = PersistenceService::new(provider.clone(), rx, pruner, sync_metrics_tx);
+
+        let mut block_builder = TestBlockBuilder::eth().with_state();
+        let mut blocks = block_builder.get_executed_blocks(0..4);
+        let genesis = blocks.next().unwrap();
+        let block_1 = blocks.next().unwrap();
+        let block_2 = blocks.next().unwrap();
+        let block_3 = blocks.next().unwrap();
+
+        service.on_save_blocks(vec![genesis], PersistenceCanceller::default()).unwrap();
+        service.pending_finalized_block = Some(3);
+        service.pending_safe_block = Some(3);
+
+        let expected_mdbx_txid = provider.db_ref().last_txnid();
+        let rocksdb = provider.rocksdb_provider();
+        let expected_rocksdb_sequence = rocksdb.latest_sequence_number();
+
+        // The gap makes each static writer append block 1 before rejecting block 3.
+        assert!(
+            service
+                .on_save_blocks(
+                    vec![block_1.clone(), block_3.clone()],
+                    PersistenceCanceller::default(),
+                )
+                .is_err()
+        );
+
+        assert_eq!(provider.db_ref().last_txnid(), expected_mdbx_txid);
+        assert_eq!(rocksdb.latest_sequence_number(), expected_rocksdb_sequence);
+        assert_eq!(service.pending_finalized_block, Some(3));
+        assert_eq!(service.pending_safe_block, Some(3));
+        assert_eq!(provider.provider().unwrap().last_block_number().unwrap(), 0);
+
+        let result = service
+            .on_save_blocks(vec![block_1, block_2, block_3], PersistenceCanceller::default())
+            .unwrap();
+        assert_eq!(result.last_block.unwrap().number, 3);
+        assert!(!result.cancelled);
+    }
+
     /// Verifies that committing `save_blocks` history before running the pruner
     /// prevents the pruner from overwriting new entries.
     ///
@@ -674,7 +756,6 @@ mod tests {
     #[test]
     fn test_save_blocks_then_prune_preserves_new_history() {
         use reth_db::{models::ShardedKey, tables, BlockNumberList};
-        use reth_provider::RocksDBProviderFactory;
 
         reth_tracing::init_test_tracing();
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     backfill::{BackfillAction, BackfillSyncState},
     chain::FromOrchestrator,
     engine::{DownloadRequest, EngineApiEvent, EngineApiKind, EngineApiRequest, FromEngine},
-    persistence::PersistenceHandle,
+    persistence::{PersistenceCanceller, PersistenceHandle},
     tree::{error::InsertPayloadError, payload_validator::TreeCtx},
 };
 use alloy_consensus::BlockHeader;
@@ -477,6 +477,7 @@ where
         let persistence_state = PersistenceState {
             last_persisted_block: BlockNumHash::new(best_block_number, header.hash()),
             rx: None,
+            save_canceller: None,
         };
 
         let (tx, outgoing) = unbounded_channel();
@@ -1004,6 +1005,10 @@ where
         let new_head_number = canonical_header.number();
         let new_head_hash = canonical_header.hash();
 
+        if new_head_number < current_head_number {
+            self.persistence_state.cancel_save_if_intersects(new_head_number.saturating_add(1));
+        }
+
         // Update tree state with the new canonical head
         self.state.tree_state.set_canonical_head(canonical_header.num_hash());
 
@@ -1421,9 +1426,10 @@ where
 
         debug!(target: "engine::tree", count=blocks_to_persist.len(), blocks = ?blocks_to_persist.iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(), "Persisting blocks");
         let (tx, rx) = crossbeam_channel::bounded(1);
-        let _ = self.persistence.save_blocks(blocks_to_persist, tx);
+        let canceller = PersistenceCanceller::default();
+        let _ = self.persistence.save_blocks(blocks_to_persist, canceller.clone(), tx);
 
-        self.persistence_state.start_save(highest_num_hash, rx);
+        self.persistence_state.start_save(highest_num_hash, canceller, rx);
     }
 
     /// Triggers new persistence actions if no persistence task is currently in progress.
@@ -1511,6 +1517,12 @@ where
         start_time: Instant,
     ) -> Result<(), AdvancePersistenceError> {
         self.metrics.engine.persistence_duration.record(start_time.elapsed());
+
+        if result.cancelled {
+            debug!(target: "engine::tree", elapsed=?start_time.elapsed(), "Persistence task cancelled");
+            self.persistence_state.finish_cancelled();
+            return Ok(())
+        }
 
         let commit_duration = result.commit_duration;
         let Some(BlockNumHash {
@@ -2697,6 +2709,13 @@ where
     fn on_canonical_chain_update(&mut self, chain_update: NewCanonicalChain<N>) {
         trace!(target: "engine::tree", new_blocks = %chain_update.new_block_count(), reorged_blocks =  %chain_update.reorged_block_count(), "applying new chain update");
         let start = Instant::now();
+
+        if let NewCanonicalChain::Reorg { old, .. } = &chain_update &&
+            let Some(first_reorged) = old.first()
+        {
+            self.persistence_state
+                .cancel_save_if_intersects(first_reorged.recovered_block().number());
+        }
 
         // update the tracked canonical head
         self.state.tree_state.set_canonical_head(chain_update.tip().num_hash());

--- a/crates/engine/tree/src/tree/persistence_state.rs
+++ b/crates/engine/tree/src/tree/persistence_state.rs
@@ -20,7 +20,7 @@
 //! The [`PersistenceState`] tracks ongoing persistence operations and coordinates
 //! between the main execution thread and background persistence workers.
 
-use crate::persistence::PersistenceResult;
+use crate::persistence::{PersistenceCanceller, PersistenceResult};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use crossbeam_channel::Receiver as CrossbeamReceiver;
@@ -38,6 +38,8 @@ pub struct PersistenceState {
     /// sent when done. A None value means there's no persistence task in progress.
     pub(crate) rx:
         Option<(CrossbeamReceiver<PersistenceResult>, Instant, CurrentPersistenceAction)>,
+    /// Cancels the currently running block save, if any.
+    pub(crate) save_canceller: Option<PersistenceCanceller>,
 }
 
 impl PersistenceState {
@@ -53,6 +55,7 @@ impl PersistenceState {
         new_tip_num: u64,
         rx: CrossbeamReceiver<PersistenceResult>,
     ) {
+        self.save_canceller = None;
         self.rx =
             Some((rx, Instant::now(), CurrentPersistenceAction::RemovingBlocks { new_tip_num }));
     }
@@ -61,9 +64,21 @@ impl PersistenceState {
     pub(crate) fn start_save(
         &mut self,
         highest: BlockNumHash,
+        canceller: PersistenceCanceller,
         rx: CrossbeamReceiver<PersistenceResult>,
     ) {
+        self.save_canceller = Some(canceller);
         self.rx = Some((rx, Instant::now(), CurrentPersistenceAction::SavingBlocks { highest }));
+    }
+
+    /// Cancels the current block save if it includes a block at or above `first_invalidated`.
+    pub(crate) fn cancel_save_if_intersects(&self, first_invalidated: u64) {
+        if let Some((_, _, CurrentPersistenceAction::SavingBlocks { highest })) = &self.rx &&
+            first_invalidated <= highest.number &&
+            let Some(canceller) = &self.save_canceller
+        {
+            canceller.cancel();
+        }
     }
 
     /// Returns the current persistence action. If there is no persistence task in progress, then
@@ -71,6 +86,12 @@ impl PersistenceState {
     #[cfg(test)]
     pub(crate) fn current_action(&self) -> Option<&CurrentPersistenceAction> {
         self.rx.as_ref().map(|rx| &rx.2)
+    }
+
+    /// Clears the currently running persistence operation without advancing the persisted tip.
+    pub(crate) fn finish_cancelled(&mut self) {
+        self.rx = None;
+        self.save_canceller = None;
     }
 
     /// Sets state for a finished persistence task.
@@ -81,6 +102,7 @@ impl PersistenceState {
     ) {
         trace!(target: "engine::tree", block= %last_persisted_block_number, hash=%last_persisted_block_hash, "updating persistence state");
         self.rx = None;
+        self.save_canceller = None;
         self.last_persisted_block =
             BlockNumHash::new(last_persisted_block_number, last_persisted_block_hash);
     }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    persistence::PersistenceAction,
+    persistence::{PersistenceAction, PersistenceCanceller},
     tree::{
         payload_validator::{BasicEngineValidator, TreeCtx, ValidationOutcome},
         persistence_state::CurrentPersistenceAction,
@@ -246,7 +246,11 @@ impl TestHarness {
             engine_api_tree_state,
             canonical_in_memory_state,
             persistence_handle,
-            PersistenceState { last_persisted_block: BlockNumHash::default(), rx: None },
+            PersistenceState {
+                last_persisted_block: BlockNumHash::default(),
+                rx: None,
+                save_canceller: None,
+            },
             payload_builder,
             tree_config,
             EngineApiKind::Ethereum,
@@ -454,7 +458,11 @@ impl ValidatorTestHarness {
         match action {
             CurrentPersistenceAction::SavingBlocks { highest } => {
                 let (_tx, rx) = crossbeam_channel::bounded(1);
-                self.harness.tree.persistence_state.start_save(highest, rx);
+                self.harness.tree.persistence_state.start_save(
+                    highest,
+                    PersistenceCanceller::default(),
+                    rx,
+                );
             }
             CurrentPersistenceAction::RemovingBlocks { new_tip_num } => {
                 let (_tx, rx) = crossbeam_channel::bounded(1);
@@ -585,7 +593,7 @@ async fn test_tree_persist_blocks() {
 
     let received_action =
         test_harness.action_rx.recv().expect("Failed to receive save blocks action");
-    if let PersistenceAction::SaveBlocks(saved_blocks, _) = received_action {
+    if let PersistenceAction::SaveBlocks(saved_blocks, _, _) = received_action {
         // only blocks.len() - tree_config.memory_block_buffer_target() will be
         // persisted
         let expected_persist_len = blocks.len() - tree_config.memory_block_buffer_target() as usize;
@@ -873,7 +881,11 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
 
     let (persist_tx, persist_rx) = crossbeam_channel::bounded(1);
     let persisted = blocks.last().unwrap().recovered_block().num_hash();
-    test_harness.tree.persistence_state.start_save(persisted, persist_rx);
+    test_harness.tree.persistence_state.start_save(
+        persisted,
+        PersistenceCanceller::default(),
+        persist_rx,
+    );
     assert!(test_harness.tree.should_backpressure());
 
     let (tx, mut rx) = oneshot::channel();
@@ -901,6 +913,7 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
             .send(PersistenceResult {
                 last_block: Some(persisted),
                 commit_duration: Some(Duration::ZERO),
+                cancelled: false,
             })
             .unwrap();
     });
@@ -988,7 +1001,7 @@ async fn test_tree_state_on_new_head_reorg() {
 
     // get rid of the prev action
     let received_action = test_harness.action_rx.recv().unwrap();
-    let PersistenceAction::SaveBlocks(saved_blocks, sender) = received_action else {
+    let PersistenceAction::SaveBlocks(saved_blocks, _, sender) = received_action else {
         panic!("received wrong action");
     };
     assert_eq!(saved_blocks, vec![blocks[0].clone(), blocks[1].clone()]);
@@ -998,6 +1011,7 @@ async fn test_tree_state_on_new_head_reorg() {
         .send(PersistenceResult {
             last_block: Some(blocks[1].recovered_block().num_hash()),
             commit_duration: Some(Duration::ZERO),
+            cancelled: false,
         })
         .unwrap();
 
@@ -1051,6 +1065,80 @@ async fn test_tree_state_on_new_head_reorg() {
             highest: fork_block_4.recovered_block().num_hash()
         })
     );
+}
+
+#[test]
+fn canonical_reorg_cancels_only_intersecting_persistence() {
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec);
+    let mut test_block_builder = TestBlockBuilder::eth();
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..6).collect();
+
+    for block in &blocks {
+        test_harness.tree.state.tree_state.insert_executed(block.clone());
+    }
+    test_harness.tree.state.tree_state.set_canonical_head(blocks[2].recovered_block().num_hash());
+
+    let fork_block_3 =
+        test_block_builder.get_executed_block_with_number(3, blocks[1].recovered_block().hash());
+    let fork_block_4 =
+        test_block_builder.get_executed_block_with_number(4, fork_block_3.recovered_block().hash());
+    let fork_block_5 =
+        test_block_builder.get_executed_block_with_number(5, fork_block_4.recovered_block().hash());
+    for block in [&fork_block_3, &fork_block_4, &fork_block_5] {
+        test_harness.tree.state.tree_state.insert_executed(block.clone());
+    }
+
+    let chain_update = test_harness
+        .tree
+        .on_new_head(fork_block_5.recovered_block().hash())
+        .unwrap()
+        .expect("fork should connect to canonical chain");
+    let (persist_tx, persist_rx) = crossbeam_channel::bounded(1);
+    let canceller = PersistenceCanceller::default();
+    test_harness.tree.persistence_state.start_save(
+        blocks[2].recovered_block().num_hash(),
+        canceller.clone(),
+        persist_rx,
+    );
+
+    test_harness.tree.persistence_state.cancel_save_if_intersects(4);
+    assert!(!canceller.is_cancelled());
+
+    test_harness.tree.on_canonical_chain_update(chain_update);
+
+    assert!(canceller.is_cancelled());
+    drop(persist_tx);
+}
+
+#[test]
+fn cancelled_persistence_does_not_advance_persisted_tip() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    let previous_tip = BlockNumHash::new(1, B256::random());
+    let attempted_tip = BlockNumHash::new(2, B256::random());
+    test_harness.tree.persistence_state.last_persisted_block = previous_tip;
+
+    let (_persist_tx, persist_rx) = crossbeam_channel::bounded(1);
+    test_harness.tree.persistence_state.start_save(
+        attempted_tip,
+        PersistenceCanceller::default(),
+        persist_rx,
+    );
+
+    test_harness
+        .tree
+        .on_persistence_complete(
+            PersistenceResult {
+                last_block: Some(attempted_tip),
+                commit_duration: Some(Duration::ZERO),
+                cancelled: true,
+            },
+            Instant::now(),
+        )
+        .unwrap();
+
+    assert_eq!(test_harness.tree.persistence_state.last_persisted_block, previous_tip);
+    assert!(!test_harness.tree.persistence_state.in_progress());
 }
 
 #[test]
@@ -1313,6 +1401,13 @@ async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
 
     // Now perform FCU to a canonical ancestor (block 2)
     let ancestor_block = blocks[1].recovered_block().clone(); // Block 2 (0-indexed as blocks[1])
+    let (_persist_tx, persist_rx) = crossbeam_channel::bounded(1);
+    let canceller = PersistenceCanceller::default();
+    test_harness.tree.persistence_state.start_save(
+        blocks[2].recovered_block().num_hash(),
+        canceller.clone(),
+        persist_rx,
+    );
 
     // Send FCU to the canonical ancestor
     let (tx, rx) = oneshot::channel();
@@ -1335,6 +1430,7 @@ async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
     // Verify FCU succeeds
     let response = rx.await.unwrap().unwrap().await.unwrap();
     assert!(response.payload_status.is_valid());
+    assert!(canceller.is_cancelled());
 
     // The critical test: verify that Latest block has been updated to the canonical ancestor
     // Check tree state
@@ -2269,7 +2365,7 @@ mod forkchoice_updated_tests {
                 break;
             }
 
-            if let Ok(PersistenceAction::SaveBlocks(saved_blocks, sender)) =
+            if let Ok(PersistenceAction::SaveBlocks(saved_blocks, _, sender)) =
                 action_rx.recv_timeout(std::time::Duration::from_millis(100))
             {
                 if let Some(last) = saved_blocks.last() {
@@ -2279,6 +2375,7 @@ mod forkchoice_updated_tests {
                     .send(PersistenceResult {
                         last_block: saved_blocks.last().map(|b| b.recovered_block().num_hash()),
                         commit_duration: Some(Duration::ZERO),
+                        cancelled: false,
                     })
                     .unwrap();
             }

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -46,7 +46,7 @@ mod cursor;
 pub use cursor::NippyJarCursor;
 
 mod writer;
-pub use writer::NippyJarWriter;
+pub use writer::{NippyJarWriter, NippyJarWriterSavepoint};
 
 mod consistency;
 pub use consistency::NippyJarChecker;
@@ -813,6 +813,69 @@ mod tests {
 
         // Simulate an unexpected shutdown during commit, and see that it unwinds successfully
         test_append_consistency_partial_commit(file_path.path(), &col1, &col2);
+    }
+
+    #[test]
+    fn test_writer_rollback_discards_partial_row() {
+        let (col1, col2) = test_data(None);
+        let file_path = tempfile::NamedTempFile::new().unwrap();
+        let nippy = NippyJar::new_without_header(2, file_path.path());
+        nippy.freeze_config().unwrap();
+
+        let mut writer = NippyJarWriter::new(nippy).unwrap();
+        writer.append_column(Some(Ok(&col1[0]))).unwrap();
+        writer.append_column(Some(Ok(&col2[0]))).unwrap();
+        writer.commit().unwrap();
+
+        let savepoint = writer.savepoint().unwrap();
+        let expected_data_len = File::open(writer.data_path()).unwrap().metadata().unwrap().len();
+        let expected_offsets_len =
+            File::open(writer.offsets_path()).unwrap().metadata().unwrap().len();
+
+        writer.append_column(Some(Ok(&col1[1]))).unwrap();
+        writer.append_column(Some(Ok(&col2[1]))).unwrap();
+        writer.append_column(Some(Ok(&col1[2]))).unwrap();
+        writer.rollback(&savepoint).unwrap();
+        writer.commit().unwrap();
+        drop(writer);
+
+        let nippy = NippyJar::load_without_header(file_path.path()).unwrap();
+        assert_eq!(nippy.rows(), 1);
+        assert_eq!(
+            File::open(nippy.data_path()).unwrap().metadata().unwrap().len(),
+            expected_data_len
+        );
+        assert_eq!(
+            File::open(nippy.offsets_path()).unwrap().metadata().unwrap().len(),
+            expected_offsets_len
+        );
+        let mut cursor = NippyJarCursor::new(&nippy).unwrap();
+        let row = cursor.next_row().unwrap().unwrap();
+        assert_eq!(row, vec![col1[0].as_slice(), col2[0].as_slice()]);
+        assert!(cursor.next_row().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_writer_rejects_foreign_rollback_savepoint() {
+        let (col1, col2) = test_data(None);
+        let first_path = tempfile::NamedTempFile::new().unwrap();
+        let first = NippyJar::new_without_header(2, first_path.path());
+        first.freeze_config().unwrap();
+        let mut first_writer = NippyJarWriter::new(first).unwrap();
+        first_writer.append_column(Some(Ok(&col1[0]))).unwrap();
+        first_writer.append_column(Some(Ok(&col2[0]))).unwrap();
+        first_writer.commit().unwrap();
+        let savepoint = first_writer.savepoint().unwrap();
+
+        let second_path = tempfile::NamedTempFile::new().unwrap();
+        let second = NippyJar::new_without_header(2, second_path.path());
+        second.freeze_config().unwrap();
+        let mut second_writer = NippyJarWriter::new(second).unwrap();
+        second_writer.append_column(Some(Ok(&col1[0]))).unwrap();
+        second_writer.append_column(Some(Ok(&col2[0]))).unwrap();
+        second_writer.commit().unwrap();
+
+        assert!(second_writer.rollback(&savepoint).is_err());
     }
 
     #[test]

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::{
     fs::{File, OpenOptions},
     io::{BufWriter, Read, Seek, SeekFrom, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 /// Size of one offset in bytes.
@@ -45,7 +45,77 @@ pub struct NippyJarWriter<H: NippyJarHeader = ()> {
     dirty: bool,
 }
 
+/// Exact append position of a [`NippyJarWriter`].
+///
+/// This is an opaque token used to discard all rows and even a partially written row appended
+/// after it was captured.
+#[derive(Debug, Clone)]
+pub struct NippyJarWriterSavepoint {
+    data_path: PathBuf,
+    rows: usize,
+    max_row_size: usize,
+    data_file_len: u64,
+    offsets_file_len: u64,
+}
+
 impl<H: NippyJarHeader> NippyJarWriter<H> {
+    /// Captures the current append position without committing the jar configuration.
+    ///
+    /// Buffered complete rows and offsets are flushed to the operating system so their exact file
+    /// boundaries can be restored later. A partial row cannot be used as a savepoint.
+    pub fn savepoint(&mut self) -> Result<NippyJarWriterSavepoint, NippyJarError> {
+        if self.column != 0 {
+            return Err(NippyJarError::Custom(
+                "cannot create a NippyJar savepoint in the middle of a row".to_string(),
+            ))
+        }
+
+        self.data_file.flush()?;
+        self.commit_offsets_inner()?;
+        self.offsets_file.flush()?;
+
+        Ok(NippyJarWriterSavepoint {
+            data_path: self.jar.data_path().to_path_buf(),
+            rows: self.jar.rows,
+            max_row_size: self.jar.max_row_size,
+            data_file_len: self.data_file.get_ref().metadata()?.len(),
+            offsets_file_len: self.offsets_file.get_ref().metadata()?.len(),
+        })
+    }
+
+    /// Discards everything appended after `savepoint`, including a partially written row.
+    pub fn rollback(&mut self, savepoint: &NippyJarWriterSavepoint) -> Result<(), NippyJarError> {
+        if self.jar.data_path() != savepoint.data_path {
+            return Err(NippyJarError::Custom(
+                "NippyJar rollback savepoint belongs to another writer".to_string(),
+            ))
+        }
+        if self.jar.rows < savepoint.rows {
+            return Err(NippyJarError::Custom(
+                "NippyJar has fewer rows than its rollback savepoint".to_string(),
+            ))
+        }
+
+        // Flush buffered data before truncating it. Pending offsets are deliberately discarded:
+        // they describe rows written after the savepoint and may include a partial row.
+        self.data_file.flush()?;
+        self.offsets.clear();
+        self.offsets_file.flush()?;
+
+        self.data_file.get_mut().set_len(savepoint.data_file_len)?;
+        self.data_file.seek(SeekFrom::End(0))?;
+        self.offsets_file.get_mut().set_len(savepoint.offsets_file_len)?;
+        self.offsets_file.seek(SeekFrom::End(0))?;
+
+        self.jar.rows = savepoint.rows;
+        self.jar.max_row_size = savepoint.max_row_size;
+        self.tmp_buf.clear();
+        self.uncompressed_row_size = 0;
+        self.column = 0;
+        self.dirty = true;
+        Ok(())
+    }
+
     /// Creates a [`NippyJarWriter`] from [`NippyJar`].
     ///
     /// It will **always** attempt to heal any inconsistent state when called.

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -25,7 +25,7 @@ pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
     HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
     PruneShardOutcome, PrunedIndices, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
-    StaticFileWriteCtx, StaticFileWriter,
+    StaticFileProviderSavepoint, StaticFileWriteCtx, StaticFileWriter,
 };
 
 pub mod changeset_walker;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -508,6 +508,14 @@ impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
+    /// Discards all pending `RocksDB` batches without committing them.
+    ///
+    /// This restores the pending batch state of a fresh provider and is intended for aborting
+    /// writes before preparing replacement batches, such as when unwinding a staged block save.
+    pub fn discard_pending_rocksdb_batches(&self) {
+        self.pending_rocksdb_batches.lock().clear();
+    }
+
     /// Executes a closure with a `RocksDB` batch, automatically registering it for commit.
     ///
     /// This helper encapsulates all the cfg-gated `RocksDB` batch handling.
@@ -5019,6 +5027,151 @@ mod tests {
     enum StorageMode {
         V1,
         V2,
+    }
+
+    fn executed_block_with_state(
+        number: BlockNumber,
+        parent_hash: B256,
+        state: BundleState,
+    ) -> ExecutedBlock {
+        let hashed_state =
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(state.state()).into_sorted();
+        let block = SealedBlock::<reth_ethereum_primitives::Block>::seal_parts(
+            Header { number, parent_hash, ..Default::default() },
+            Default::default(),
+        );
+
+        ExecutedBlock::new(
+            Arc::new(block.try_recover().unwrap()),
+            Arc::new(BlockExecutionOutput {
+                result: BlockExecutionResult {
+                    receipts: Vec::new(),
+                    requests: Default::default(),
+                    gas_used: 0,
+                    blob_gas_used: 0,
+                },
+                state,
+            }),
+            ComputedTrieData {
+                sorted: SortedTrieData::new(Arc::new(hashed_state), Default::default()),
+            },
+        )
+    }
+
+    fn run_cancelled_save_rollback(mode: StorageMode) {
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(match mode {
+            StorageMode::V1 => StorageSettings::v1(),
+            StorageMode::V2 => StorageSettings::v2(),
+        });
+
+        let address = Address::with_last_byte(1);
+        let slot = U256::from(1);
+        let retained_account =
+            AccountInfo { nonce: 1, balance: U256::from(10), ..Default::default() };
+        let retained_storage = U256::from(10);
+
+        let genesis = executed_block_with_state(0, B256::ZERO, BundleState::default());
+        let retained_state = BundleState::builder(1..=1)
+            .state_present_account_info(address, retained_account.clone())
+            .revert_account_info(1, address, Some(None))
+            .state_storage(address, HashMap::from_iter([(slot, (U256::ZERO, retained_storage))]))
+            .revert_storage(1, address, vec![(slot, U256::ZERO)])
+            .build();
+        let retained_block =
+            executed_block_with_state(1, genesis.recovered_block().hash(), retained_state);
+        let retained_hash = retained_block.recovered_block().hash();
+
+        let staged_state = BundleState::builder(2..=2)
+            .state_present_account_info(
+                address,
+                AccountInfo { nonce: 2, balance: U256::from(20), ..Default::default() },
+            )
+            .revert_account_info(2, address, Some(Some(retained_account)))
+            .state_storage(
+                address,
+                HashMap::from_iter([(slot, (retained_storage, U256::from(20)))]),
+            )
+            .revert_storage(2, address, vec![(slot, retained_storage)])
+            .build();
+        let staged_block = executed_block_with_state(2, retained_hash, staged_state);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.save_blocks(vec![genesis, retained_block], SaveBlocksMode::Full).unwrap();
+        provider_rw.commit().unwrap();
+
+        let expected_hashed_accounts =
+            factory.provider().unwrap().table::<tables::HashedAccounts>().unwrap();
+        let expected_hashed_storages =
+            factory.provider().unwrap().table::<tables::HashedStorages>().unwrap();
+        assert!(!expected_hashed_accounts.is_empty());
+        assert!(!expected_hashed_storages.is_empty());
+        let rocksdb = factory.rocksdb_provider();
+        let expected_account_history = rocksdb
+            .iter::<tables::AccountsHistory>()
+            .unwrap()
+            .collect::<ProviderResult<Vec<_>>>()
+            .unwrap();
+        let expected_storage_history = rocksdb
+            .iter::<tables::StoragesHistory>()
+            .unwrap()
+            .collect::<ProviderResult<Vec<_>>>()
+            .unwrap();
+        if mode == StorageMode::V2 {
+            assert!(!expected_account_history.is_empty());
+            assert!(!expected_storage_history.is_empty());
+        }
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.save_blocks(vec![staged_block], SaveBlocksMode::Full).unwrap();
+
+        // Make staged static-file rows visible to the existing unwind implementation, then
+        // replace the append-side RocksDB batches with the batches produced by unwind.
+        provider_rw.static_file_provider().finalize().unwrap();
+        provider_rw.discard_pending_rocksdb_batches();
+        provider_rw.remove_block_and_execution_above(1).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        assert_eq!(provider.best_block_number().unwrap(), 1);
+        assert_eq!(provider.block_hash(1).unwrap(), Some(retained_hash));
+        assert_eq!(provider.block_hash(2).unwrap(), None);
+        assert_eq!(provider.table::<tables::HashedAccounts>().unwrap(), expected_hashed_accounts);
+        assert_eq!(provider.table::<tables::HashedStorages>().unwrap(), expected_hashed_storages);
+        assert_eq!(
+            provider
+                .static_file_provider()
+                .get_highest_static_file_block(StaticFileSegment::Headers),
+            Some(1)
+        );
+
+        let rocksdb = factory.rocksdb_provider();
+        assert_eq!(
+            rocksdb
+                .iter::<tables::AccountsHistory>()
+                .unwrap()
+                .collect::<ProviderResult<Vec<_>>>()
+                .unwrap(),
+            expected_account_history
+        );
+        assert_eq!(
+            rocksdb
+                .iter::<tables::StoragesHistory>()
+                .unwrap()
+                .collect::<ProviderResult<Vec<_>>>()
+                .unwrap(),
+            expected_storage_history
+        );
+    }
+
+    #[test]
+    fn cancelled_save_rolls_back_with_same_provider_v1() {
+        run_cancelled_save_rollback(StorageMode::V1);
+    }
+
+    #[test]
+    fn cancelled_save_rolls_back_with_same_provider_v2() {
+        run_cancelled_save_rollback(StorageMode::V2);
     }
 
     fn run_save_blocks_and_verify(mode: StorageMode) {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -142,6 +142,13 @@ impl<DB: Database, N: NodeTypes + 'static> DatabaseProviderRW<DB, N> {
         self.0.commit()
     }
 
+    /// Aborts the database transaction and discards all deferred writes.
+    ///
+    /// Static file writers are shared by the provider factory and must be rolled back separately.
+    pub fn abort(self) {
+        self.0.abort()
+    }
+
     /// Consume `DbTx` or `DbTxMut`.
     pub fn into_tx(self) -> <DB as Database>::TXMut {
         self.0.into_tx()
@@ -260,6 +267,13 @@ impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Aborts the database transaction and discards all deferred writes.
+    ///
+    /// Static file writers are shared by the provider factory and must be rolled back separately.
+    pub fn abort(self) {
+        self.tx.abort()
+    }
+
     /// Commits unwind writes in MDBX -> `RocksDB` -> static-file order.
     ///
     /// This keeps MDBX as the first durable step so an interrupted unwind can be recovered by
@@ -508,14 +522,6 @@ impl<TX, N: NodeTypes> AsRef<Self> for DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
-    /// Discards all pending `RocksDB` batches without committing them.
-    ///
-    /// This restores the pending batch state of a fresh provider and is intended for aborting
-    /// writes before preparing replacement batches, such as when unwinding a staged block save.
-    pub fn discard_pending_rocksdb_batches(&self) {
-        self.pending_rocksdb_batches.lock().clear();
-    }
-
     /// Executes a closure with a `RocksDB` batch, automatically registering it for commit.
     ///
     /// This helper encapsulates all the cfg-gated `RocksDB` batch handling.
@@ -5121,18 +5127,19 @@ mod tests {
             assert!(!expected_account_history.is_empty());
             assert!(!expected_storage_history.is_empty());
         }
+        let expected_mdbx_txid = factory.db_ref().last_txnid();
+        let expected_rocksdb_sequence = rocksdb.latest_sequence_number();
 
         let provider_rw = factory.provider_rw().unwrap();
+        let static_file_provider = provider_rw.static_file_provider();
+        let static_file_savepoint = static_file_provider.savepoint().unwrap();
         provider_rw.save_blocks(vec![staged_block], SaveBlocksMode::Full).unwrap();
-
-        // Make staged static-file rows visible to the existing unwind implementation, then
-        // replace the append-side RocksDB batches with the batches produced by unwind.
-        provider_rw.static_file_provider().finalize().unwrap();
-        provider_rw.discard_pending_rocksdb_batches();
-        provider_rw.remove_block_and_execution_above(1).unwrap();
-        provider_rw.commit().unwrap();
+        provider_rw.abort();
+        static_file_provider.rollback(static_file_savepoint).unwrap();
 
         let provider = factory.provider().unwrap();
+        assert_eq!(factory.db_ref().last_txnid(), expected_mdbx_txid);
+        assert_eq!(rocksdb.latest_sequence_number(), expected_rocksdb_sequence);
         assert_eq!(provider.best_block_number().unwrap(), 1);
         assert_eq!(provider.block_hash(1).unwrap(), Some(retained_hash));
         assert_eq!(provider.block_hash(2).unwrap(), None);

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -10,7 +10,8 @@ pub use database::*;
 mod static_file;
 pub use static_file::{
     StaticFileAccess, StaticFileJarProvider, StaticFileProvider, StaticFileProviderBuilder,
-    StaticFileProviderRW, StaticFileProviderRWRefMut, StaticFileWriteCtx, StaticFileWriter,
+    StaticFileProviderRW, StaticFileProviderRWRefMut, StaticFileProviderSavepoint,
+    StaticFileWriteCtx, StaticFileWriter,
 };
 
 mod state;

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -750,6 +750,15 @@ impl RocksDBProvider {
         matches!(self.0.as_ref(), RocksDBProviderInner::Secondary { .. })
     }
 
+    /// Returns the sequence number of the most recent committed write.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn latest_sequence_number(&self) -> u64 {
+        match self.0.as_ref() {
+            RocksDBProviderInner::ReadWrite { db, .. } => db.latest_sequence_number(),
+            RocksDBProviderInner::Secondary { db, .. } => db.latest_sequence_number(),
+        }
+    }
+
     /// Tries to catch up with the primary instance by reading new WAL and MANIFEST entries.
     ///
     /// This is a no-op for read-write and read-only providers.

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1,6 +1,7 @@
 use super::{
-    metrics::StaticFileProviderMetrics, writer::StaticFileWriters, LoadedJar,
-    StaticFileJarProvider, StaticFileProviderRW, StaticFileProviderRWRefMut,
+    metrics::StaticFileProviderMetrics,
+    writer::{StaticFileWriterSavepoint, StaticFileWriters},
+    LoadedJar, StaticFileJarProvider, StaticFileProviderRW, StaticFileProviderRWRefMut,
 };
 use crate::{
     changeset_walker::{StaticFileAccountChangesetWalker, StaticFileStorageChangesetWalker},
@@ -121,6 +122,22 @@ impl<N> Clone for StaticFileProvider<N> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
+}
+
+/// Captures the exact static file state before a group of append operations.
+///
+/// This token is intentionally opaque. It can only be consumed by
+/// [`StaticFileProvider::rollback`] on the provider that created it.
+#[derive(Debug)]
+pub struct StaticFileProviderSavepoint {
+    directory: PathBuf,
+    segments: StaticFileMap<StaticFileSegmentSavepoint>,
+}
+
+#[derive(Debug)]
+enum StaticFileSegmentSavepoint {
+    Absent,
+    Present(StaticFileWriterSavepoint),
 }
 
 /// Builder for [`StaticFileProvider`] that allows configuration before initialization.
@@ -257,6 +274,82 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     /// Creates a new [`StaticFileProvider`] with read-write access.
     pub fn read_write(path: impl AsRef<Path>) -> ProviderResult<Self> {
         Self::new(path, StaticFileAccess::RW)
+    }
+
+    /// Captures the current state of every static file segment.
+    ///
+    /// Cached writers are captured directly at their latest commit boundary. Segments without a
+    /// cached writer are opened directly from the provider's per-segment tip index.
+    pub fn savepoint(&self) -> ProviderResult<StaticFileProviderSavepoint> {
+        let mut segments = StaticFileMap::default();
+
+        for segment in StaticFileSegment::iter() {
+            let savepoint = if let Some(savepoint) = self.writers.savepoint(segment)? {
+                StaticFileSegmentSavepoint::Present(savepoint)
+            } else if let Some(block) = self.get_highest_static_file_block(segment) {
+                // Opening by the indexed tip is O(1) and also caches the writer for the upcoming
+                // append, avoiding a static-directory scan on every persistence job.
+                let mut writer = self.get_writer(block, segment)?;
+                StaticFileSegmentSavepoint::Present(writer.savepoint()?)
+            } else {
+                StaticFileSegmentSavepoint::Absent
+            };
+            segments.insert(segment, savepoint);
+        }
+
+        Ok(StaticFileProviderSavepoint { directory: self.path.clone(), segments })
+    }
+
+    /// Restores static files to a previously captured savepoint without reading or unwinding
+    /// database state.
+    ///
+    /// Appended rows are truncated directly, jars created after the savepoint are deleted, and
+    /// changeset sidecars, configurations, indexes, and read caches are restored. The savepoint is
+    /// consumed so it cannot accidentally be reused after subsequent writes.
+    pub fn rollback(&self, mut savepoint: StaticFileProviderSavepoint) -> ProviderResult<()> {
+        if self.access.is_read_only() {
+            return Err(ProviderError::ReadOnlyStaticFileAccess)
+        }
+        if self.path != savepoint.directory {
+            return Err(ProviderError::other(StaticFileWriterError::new(
+                "static file savepoint belongs to another provider",
+            )))
+        }
+
+        for segment in StaticFileSegment::iter() {
+            match savepoint
+                .segments
+                .remove(segment)
+                .expect("savepoint contains every static file segment")
+            {
+                StaticFileSegmentSavepoint::Present(segment_savepoint) => {
+                    if !self.writers.rollback(segment, &segment_savepoint)? {
+                        return Err(ProviderError::other(StaticFileWriterError::new(
+                            "static file writer was removed after its savepoint was captured",
+                        )))
+                    }
+                }
+                StaticFileSegmentSavepoint::Absent => {
+                    let Some(writer) = self.writers.take(segment) else {
+                        // No writer means this segment was not touched after the savepoint.
+                        continue
+                    };
+                    let opened_paths = writer.opened_paths().to_vec();
+                    drop(writer);
+
+                    self.map.retain(|(_, cached_segment), _| *cached_segment != segment);
+                    for path in opened_paths {
+                        NippyJar::<SegmentHeader>::load(&path)
+                            .map_err(ProviderError::other)?
+                            .delete()
+                            .map_err(ProviderError::other)?;
+                    }
+                    self.indexes.write().remove(segment);
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -1,7 +1,7 @@
 mod manager;
 pub use manager::{
-    StaticFileAccess, StaticFileProvider, StaticFileProviderBuilder, StaticFileWriteCtx,
-    StaticFileWriter,
+    StaticFileAccess, StaticFileProvider, StaticFileProviderBuilder, StaticFileProviderSavepoint,
+    StaticFileWriteCtx, StaticFileWriter,
 };
 
 mod jar;

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -8,7 +8,7 @@ use parking_lot::{lock_api::RwLockWriteGuard, RawRwLock, RwLock};
 use reth_codecs::Compact;
 use reth_db::models::{AccountBeforeTx, StorageBeforeTx};
 use reth_db_api::models::CompactU256;
-use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter};
+use reth_nippy_jar::{NippyJar, NippyJarError, NippyJarWriter, NippyJarWriterSavepoint};
 use reth_node_types::NodePrimitives;
 use reth_primitives_traits::FastInstant as Instant;
 use reth_static_file_types::{
@@ -94,6 +94,59 @@ impl<N> Default for StaticFileWriters<N> {
 }
 
 impl<N: NodePrimitives> StaticFileWriters<N> {
+    /// Captures the current state of a cached segment writer without creating one.
+    pub(crate) fn savepoint(
+        &self,
+        segment: StaticFileSegment,
+    ) -> ProviderResult<Option<StaticFileWriterSavepoint>> {
+        let mut writer = match segment {
+            StaticFileSegment::Headers => self.headers.write(),
+            StaticFileSegment::Transactions => self.transactions.write(),
+            StaticFileSegment::Receipts => self.receipts.write(),
+            StaticFileSegment::TransactionSenders => self.transaction_senders.write(),
+            StaticFileSegment::AccountChangeSets => self.account_change_sets.write(),
+            StaticFileSegment::StorageChangeSets => self.storage_change_sets.write(),
+        };
+
+        writer.as_mut().map(StaticFileProviderRW::savepoint).transpose()
+    }
+
+    /// Restores a cached segment writer to a previously captured state.
+    ///
+    /// Returns `false` if the segment has no cached writer and therefore has not been modified
+    /// through this provider since the savepoint was captured.
+    pub(crate) fn rollback(
+        &self,
+        segment: StaticFileSegment,
+        savepoint: &StaticFileWriterSavepoint,
+    ) -> ProviderResult<bool> {
+        let mut writer = match segment {
+            StaticFileSegment::Headers => self.headers.write(),
+            StaticFileSegment::Transactions => self.transactions.write(),
+            StaticFileSegment::Receipts => self.receipts.write(),
+            StaticFileSegment::TransactionSenders => self.transaction_senders.write(),
+            StaticFileSegment::AccountChangeSets => self.account_change_sets.write(),
+            StaticFileSegment::StorageChangeSets => self.storage_change_sets.write(),
+        };
+
+        let Some(writer) = writer.as_mut() else { return Ok(false) };
+        writer.rollback(savepoint)?;
+        Ok(true)
+    }
+
+    /// Removes and returns the cached writer for a segment.
+    pub(crate) fn take(&self, segment: StaticFileSegment) -> Option<StaticFileProviderRW<N>> {
+        let mut writer = match segment {
+            StaticFileSegment::Headers => self.headers.write(),
+            StaticFileSegment::Transactions => self.transactions.write(),
+            StaticFileSegment::Receipts => self.receipts.write(),
+            StaticFileSegment::TransactionSenders => self.transaction_senders.write(),
+            StaticFileSegment::AccountChangeSets => self.account_change_sets.write(),
+            StaticFileSegment::StorageChangeSets => self.storage_change_sets.write(),
+        };
+        writer.take()
+    }
+
     pub(crate) fn get_or_create(
         &self,
         segment: StaticFileSegment,
@@ -241,6 +294,8 @@ pub struct StaticFileProviderRW<N> {
     writer: NippyJarWriter<SegmentHeader>,
     /// Path to opened file.
     data_path: PathBuf,
+    /// Jars opened while this writer advanced. Used to remove an entirely new segment on rollback.
+    opened_paths: Vec<PathBuf>,
     /// Reusable buffer for encoding appended data.
     buf: Vec<u8>,
     /// Metrics.
@@ -255,7 +310,82 @@ pub struct StaticFileProviderRW<N> {
     current_changeset_offset: Option<ChangesetOffset>,
 }
 
+/// Exact state of a single static file writer before an append operation.
+#[derive(Debug, Clone)]
+pub(crate) struct StaticFileWriterSavepoint {
+    data_path: PathBuf,
+    header: SegmentHeader,
+    writer: NippyJarWriterSavepoint,
+}
+
 impl<N: NodePrimitives> StaticFileProviderRW<N> {
+    /// Captures enough writer state to restore this segment without consulting database state.
+    pub(crate) fn savepoint(&mut self) -> ProviderResult<StaticFileWriterSavepoint> {
+        if self.writer.is_dirty() ||
+            self.prune_on_commit.is_some() ||
+            self.synced ||
+            self.current_changeset_offset.is_some()
+        {
+            return Err(ProviderError::other(StaticFileWriterError::new(
+                "cannot create a static file savepoint with uncommitted writer state",
+            )))
+        }
+
+        Ok(StaticFileWriterSavepoint {
+            data_path: self.data_path.clone(),
+            header: self.writer.user_header().clone(),
+            writer: self.writer.savepoint().map_err(ProviderError::other)?,
+        })
+    }
+
+    /// Restores this writer to an exact previously captured state.
+    ///
+    /// Jars created after the savepoint are deleted. The original jar is truncated to its old
+    /// physical row count, including for changeset segments where the row count cannot be derived
+    /// from the segment header, and its changeset sidecar and configuration are restored.
+    fn rollback(&mut self, savepoint: &StaticFileWriterSavepoint) -> ProviderResult<()> {
+        let segment = self.writer.user_header().segment();
+        if segment != savepoint.header.segment() {
+            return Err(ProviderError::other(StaticFileWriterError::new(
+                "cannot roll back a static file writer using a savepoint for another segment",
+            )))
+        }
+
+        self.prune_on_commit = None;
+        self.current_changeset_offset = None;
+
+        while self.data_path != savepoint.data_path {
+            if self.writer.user_header().expected_block_start() <=
+                savepoint.header.expected_block_start()
+            {
+                return Err(ProviderError::other(StaticFileWriterError::new(
+                    "static file writer is not descended from its rollback savepoint",
+                )))
+            }
+            self.delete_current_and_open_previous()?;
+        }
+
+        if segment.is_change_based() {
+            let changeset_offsets = self.changeset_offsets.as_mut().ok_or_else(|| {
+                ProviderError::other(StaticFileWriterError::new(
+                    "changeset static file writer is missing its offset sidecar",
+                ))
+            })?;
+            changeset_offsets
+                .truncate(savepoint.header.changeset_offsets_len())
+                .map_err(ProviderError::other)?;
+        }
+
+        *self.writer.user_header_mut() = savepoint.header.clone();
+        self.writer.rollback(&savepoint.writer).map_err(ProviderError::other)?;
+
+        // Persist the restored header and exact row count, including for empty blocks.
+        self.writer.commit().map_err(ProviderError::other)?;
+        self.synced = false;
+        self.update_index()?;
+        Ok(())
+    }
+
     /// Creates a new [`StaticFileProviderRW`] for a [`StaticFileSegment`].
     ///
     /// Before use, transaction based segments should ensure the block end range is the expected
@@ -271,6 +401,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         // Create writer WITHOUT sidecar first - we'll add it after healing
         let mut writer = Self {
             writer,
+            opened_paths: vec![data_path.clone()],
             data_path,
             buf: Vec::with_capacity(100),
             reader,
@@ -790,6 +921,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                     Self::open(segment, last_block + 1, self.reader.clone(), self.metrics.clone())?;
                 self.writer = writer;
                 self.data_path = data_path.clone();
+                self.opened_paths.push(data_path.clone());
 
                 // Update changeset offsets writer for the new file (starts empty)
                 if segment.is_change_based() {
@@ -1704,6 +1836,11 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     /// Helper function to access a mutable reference to [`SegmentHeader`].
     pub const fn user_header_mut(&mut self) -> &mut SegmentHeader {
         self.writer.user_header_mut()
+    }
+
+    /// Returns every jar opened while this writer advanced.
+    pub(crate) fn opened_paths(&self) -> &[PathBuf] {
+        &self.opened_paths
     }
 
     /// Helper function to override block range for testing.

--- a/crates/storage/provider/src/providers/static_file/writer_tests.rs
+++ b/crates/storage/provider/src/providers/static_file/writer_tests.rs
@@ -883,4 +883,80 @@ mod tests {
 
         drop(writer);
     }
+
+    #[test]
+    fn test_rollback_removes_new_segment_across_jars() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 3);
+        let savepoint = provider.savepoint().unwrap();
+
+        {
+            let mut writer = provider.get_writer(0, StaticFileSegment::AccountChangeSets).unwrap();
+            for block in 0..8 {
+                writer.append_account_changeset(generate_test_changeset(block, 2), block).unwrap();
+            }
+            writer.sync_all().unwrap();
+        }
+
+        provider.rollback(savepoint).unwrap();
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets),
+            None
+        );
+        let has_account_changeset_file = std::fs::read_dir(provider.directory())
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().contains("account-change-sets"));
+        assert!(!has_account_changeset_file);
+    }
+
+    #[test]
+    fn test_rollback_restores_changesets_across_jars() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 3);
+
+        {
+            let mut writer = provider.get_writer(0, StaticFileSegment::AccountChangeSets).unwrap();
+            for block in 0..2 {
+                writer.append_account_changeset(generate_test_changeset(block, 2), block).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        let sidecar_path = get_sidecar_path(&provider, 0);
+        let savepoint = provider.savepoint().unwrap();
+        {
+            let mut writer = provider.latest_writer(StaticFileSegment::AccountChangeSets).unwrap();
+            for block in 2..9 {
+                writer.append_account_changeset(generate_test_changeset(block, 3), block).unwrap();
+            }
+            writer.sync_all().unwrap();
+        }
+
+        provider.rollback(savepoint).unwrap();
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::AccountChangeSets),
+            Some(1)
+        );
+        assert_eq!(get_nippy_row_count(&provider, 0), 4);
+        assert_eq!(get_header_block_count(&provider, 0), 2);
+        assert_eq!(get_sidecar_block_count(&sidecar_path), 2);
+        assert!(!get_sidecar_path(&provider, 3).exists());
+        assert!(!get_sidecar_path(&provider, 6).exists());
+    }
+
+    #[test]
+    fn test_savepoint_rejects_uncommitted_writer_state() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 3);
+
+        {
+            let mut writer = provider.get_writer(0, StaticFileSegment::AccountChangeSets).unwrap();
+            writer.append_account_changeset(generate_test_changeset(0, 2), 0).unwrap();
+        }
+
+        assert!(provider.savepoint().is_err());
+    }
 }


### PR DESCRIPTION
Adds a best-effort per-save cancellation signal retained by the engine tree and trips it when a canonical reorg intersects an in-flight persistence range. Cancellation aborts MDBX, drops deferred RocksDB batches, and restores static files directly from a pre-save checkpoint without a database unwind; pre-commit save failures use the same cleanup path.