### PR TITLE
ci(bench): RPC replay mode

### DIFF
--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -1660,6 +1660,7 @@ def generate_comparison_table(
     warmup_blocks: str | None = None,
     wait_time: str | None = None,
     bal_mode: str | None = None,
+    mode: str = "engine",
     run_pairs: int | None = None,
 ) -> str:
     """Generate a markdown comparison table between baseline and feature."""
@@ -1715,7 +1716,7 @@ def generate_comparison_table(
         f"| Persist Wait | {fmt_ms(run1['mean_persist_ms'])} | {fmt_ms(run2['mean_persist_ms'])} | {change_str(persist_pct, persist_ci_pct, persist_floor, lower_is_better=True, informational=persist_informational)} |",
         "",
     ]
-    meta_parts = [f"{n} {'big blocks' if big_blocks else 'blocks'}"]
+    meta_parts = [f"{n} {'big blocks' if big_blocks else 'blocks'}", f"mode: {mode}"]
     if warmup_blocks:
         meta_parts.append(f"{warmup_blocks} warmup")
     if run_pairs:
@@ -1970,6 +1971,7 @@ def main():
     parser.add_argument("--warmup-blocks", default=None, help="Number of warmup blocks")
     parser.add_argument("--wait-time", default=None, help="Wait time interval used between blocks")
     parser.add_argument("--bal-mode", default=None, help="BAL mode (true, feature, baseline)")
+    parser.add_argument("--mode", choices=("engine", "rpc"), default="engine", help="Benchmark execution mode")
     parser.add_argument("--benchmark-id", default=os.environ.get("BENCH_ID"), help="Benchmark ID used for OTLP labels")
     parser.add_argument("--grafana-url", default=None, help="Grafana dashboard URL for this benchmark run")
     parser.add_argument("--logs-url", default=None, help="Grafana Explore URL for benchmark logs")
@@ -2034,6 +2036,7 @@ def main():
         warmup_blocks=args.warmup_blocks,
         wait_time=args.wait_time,
         bal_mode=bal_mode,
+        mode=args.mode,
         run_pairs=args.run_pairs,
     )
     print(
@@ -2085,6 +2088,7 @@ def main():
         "run_pairs": args.run_pairs,
         "wait_time": args.wait_time,
         "bal_mode": bal_mode,
+        "mode": args.mode,
         "baseline": {
             "name": baseline_name,
             "ref": baseline_ref,

--- a/.github/scripts/bench-reth-summary.py
+++ b/.github/scripts/bench-reth-summary.py
@@ -1659,6 +1659,7 @@ def generate_comparison_table(
     big_blocks: bool = False,
     warmup_blocks: str | None = None,
     wait_time: str | None = None,
+    block_time: str | None = None,
     bal_mode: str | None = None,
     mode: str = "engine",
     run_pairs: int | None = None,
@@ -1723,6 +1724,8 @@ def generate_comparison_table(
         meta_parts.append(f"{run_pairs} run pairs")
     if wait_time:
         meta_parts.append(f"wait time: {wait_time}")
+    if block_time:
+        meta_parts.append(f"block time: {block_time}")
     display_mode = display_bal_mode(bal_mode)
     if big_blocks and display_mode:
         meta_parts.append(f"BAL: {display_mode}")
@@ -1970,6 +1973,7 @@ def main():
     parser.add_argument("--big-blocks", action="store_true", default=False, help="Big blocks mode")
     parser.add_argument("--warmup-blocks", default=None, help="Number of warmup blocks")
     parser.add_argument("--wait-time", default=None, help="Wait time interval used between blocks")
+    parser.add_argument("--block-time", default=None, help="RPC mode local block interval")
     parser.add_argument("--bal-mode", default=None, help="BAL mode (true, feature, baseline)")
     parser.add_argument("--mode", choices=("engine", "rpc"), default="engine", help="Benchmark execution mode")
     parser.add_argument("--benchmark-id", default=os.environ.get("BENCH_ID"), help="Benchmark ID used for OTLP labels")
@@ -2035,6 +2039,7 @@ def main():
         big_blocks=args.big_blocks,
         warmup_blocks=args.warmup_blocks,
         wait_time=args.wait_time,
+        block_time=args.block_time,
         bal_mode=bal_mode,
         mode=args.mode,
         run_pairs=args.run_pairs,
@@ -2087,6 +2092,7 @@ def main():
         "warmup_blocks": args.warmup_blocks,
         "run_pairs": args.run_pairs,
         "wait_time": args.wait_time,
+        "block_time": args.block_time,
         "bal_mode": bal_mode,
         "mode": args.mode,
         "baseline": {

--- a/.github/scripts/bench-txgen-extract.sh
+++ b/.github/scripts/bench-txgen-extract.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Pre-extracts txgen payloads (normal or big blocks) so they can be reused
+# Pre-extracts txgen payloads or transactions so they can be reused
 # across multiple benchmark runs instead of re-fetching from the remote RPC
 # every time.
 #
 # Starts a throwaway reth node to discover the snapshot's chain tip, extracts
-# payloads from BENCH_RPC_URL, then stops the node and recovers the snapshot.
+# data from BENCH_RPC_URL, then stops the node and recovers the snapshot.
 #
 # Usage: bench-txgen-extract.sh <binary> <output-dir>
 #
@@ -13,15 +13,17 @@
 #   <output-dir>/all-blocks.ndjson   (or all-big-blocks.ndjson)
 #   <output-dir>/warmup-blocks.ndjson
 #   <output-dir>/benchmark-blocks.ndjson
+# In RPC mode, the corresponding names end in `-transactions.ndjson`.
 #
 # Required env: SCHELK_MOUNT, BENCH_RPC_URL, BENCH_BLOCKS, BENCH_WARMUP_BLOCKS
-# Optional env: BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS, BENCH_BAL
+# Optional env: BENCH_EXECUTION_MODE, BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS, BENCH_BAL
 set -euxo pipefail
 
 BINARY="$1"
 OUTPUT_DIR="$2"
 
 BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
+EXECUTION_MODE="${BENCH_EXECUTION_MODE:-engine}"
 BAL_MODE="${BENCH_BAL:-false}"
 INCLUDE_BAL=false
 if [ "$BAL_MODE" != "false" ] && [ -n "$BAL_MODE" ]; then
@@ -123,19 +125,44 @@ fi
 ALL_BLOCKS="$OUTPUT_DIR/all-blocks.ndjson"
 WARMUP_FILE="$OUTPUT_DIR/warmup-blocks.ndjson"
 BENCHMARK_FILE="$OUTPUT_DIR/benchmark-blocks.ndjson"
-
-if [ "$BIG_BLOCKS" = "true" ]; then
-  ALL_BLOCKS="$OUTPUT_DIR/all-big-blocks.ndjson"
-  WARMUP_FILE="$OUTPUT_DIR/warmup-big-blocks.ndjson"
-  BENCHMARK_FILE="$OUTPUT_DIR/measured-big-blocks.ndjson"
-fi
-
 EXTRACT_FROM=$(( HEAD_DEC + 1 ))
 TXGEN_EXTRACT_ARGS=()
 if [ "$INCLUDE_BAL" = "true" ]; then
   TXGEN_EXTRACT_ARGS+=(--bal)
 fi
-if [ "$BIG_BLOCKS" = "true" ]; then
+
+if [ "$EXECUTION_MODE" = "rpc" ]; then
+  ALL_BLOCKS="$OUTPUT_DIR/all-transactions.ndjson"
+  WARMUP_FILE="$OUTPUT_DIR/warmup-transactions.ndjson"
+  BENCHMARK_FILE="$OUTPUT_DIR/benchmark-transactions.ndjson"
+  if [ "$BIG_BLOCKS" = "true" ] || [ "$INCLUDE_BAL" = "true" ]; then
+    echo "::error::RPC mode does not support big blocks or BAL"
+    exit 1
+  fi
+
+  EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
+  echo "Extracting transactions from blocks ${EXTRACT_FROM}..${EXTRACT_TO} for RPC benchmark (${WARMUP} warmup blocks, ${BLOCKS} measured blocks)"
+  if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
+    "$TXGEN_ETHEREUM" extract \
+      --rpc "$BENCH_RPC_URL" \
+      --from "$EXTRACT_FROM" \
+      --to "$(( HEAD_DEC + WARMUP ))" \
+      --format transactions \
+      -o "$WARMUP_FILE"
+  else
+    : > "$WARMUP_FILE"
+  fi
+  "$TXGEN_ETHEREUM" extract \
+    --rpc "$BENCH_RPC_URL" \
+    --from "$(( HEAD_DEC + WARMUP + 1 ))" \
+    --to "$EXTRACT_TO" \
+    --format transactions \
+    -o "$BENCHMARK_FILE"
+  cat "$WARMUP_FILE" "$BENCHMARK_FILE" > "$ALL_BLOCKS"
+elif [ "$BIG_BLOCKS" = "true" ]; then
+  ALL_BLOCKS="$OUTPUT_DIR/all-big-blocks.ndjson"
+  WARMUP_FILE="$OUTPUT_DIR/warmup-big-blocks.ndjson"
+  BENCHMARK_FILE="$OUTPUT_DIR/measured-big-blocks.ndjson"
   echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured, bal=${INCLUDE_BAL})"
   "$TXGEN_ETHEREUM" extract-big-blocks \
     --rpc "$BENCH_RPC_URL" \
@@ -155,13 +182,16 @@ else
     -o "$ALL_BLOCKS"
 fi
 
-# Split into warmup and measured files
-if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
-  head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_FILE"
-else
-  : > "$WARMUP_FILE"
+# Block output has one line per source block. Transaction output is extracted
+# separately above because it has one line per transaction.
+if [ "$EXECUTION_MODE" = "engine" ]; then
+  if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
+    head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_FILE"
+  else
+    : > "$WARMUP_FILE"
+  fi
+  awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_FILE"
 fi
-awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_FILE"
 
 if [ "$INCLUDE_BAL" = "true" ] && [ "$BAL_MODE" != "true" ]; then
   echo "Writing no-BAL payload variants for selective BAL mode (${BAL_MODE})"
@@ -170,4 +200,4 @@ if [ "$INCLUDE_BAL" = "true" ] && [ "$BAL_MODE" != "true" ]; then
   done
 fi
 
-echo "Extraction complete: $(wc -l < "$ALL_BLOCKS") payloads in ${OUTPUT_DIR}"
+echo "Extraction complete: $(wc -l < "$ALL_BLOCKS") ${EXECUTION_MODE} records in ${OUTPUT_DIR}"

--- a/.github/scripts/bench-txgen-report-to-reth-csv.py
+++ b/.github/scripts/bench-txgen-report-to-reth-csv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Convert txgen `bench send-blocks` JSON into legacy benchmark CSVs.
+"""Convert txgen `bench send-blocks` or `bench send` JSON into legacy benchmark CSVs.
 
 The benchmark rendering pipeline still consumes `combined_latency.csv` and
 `total_gas.csv`. This adapter lets the txgen runner reuse the existing
@@ -18,12 +18,17 @@ def opt_int(value, default=None):
     return int(value)
 
 
-def block_latency_us(block: dict) -> tuple[int, int, int]:
+def block_latency_us(block: dict, fallback_block_time_ms: int = 0) -> tuple[int, int, int]:
     # txgen currently records server newPayload latency in microseconds but
     # client-side forkchoiceUpdated latency in milliseconds.
     new_payload_us = opt_int(block.get("new_payload_server_latency_us"))
     if new_payload_us is None:
-        new_payload_us = opt_int(block.get("new_payload_ms"), 0) * 1000
+        new_payload_ms = opt_int(block.get("new_payload_ms"))
+        if new_payload_ms is None:
+            # `bench send` has no Engine API timings. Use locally mined block
+            # time so the existing gas/latency summaries remain meaningful.
+            new_payload_ms = opt_int(block.get("block_time_ms"), fallback_block_time_ms)
+        new_payload_us = new_payload_ms * 1000
     fcu_us = opt_int(block.get("forkchoice_updated_ms"), 0) * 1000
     return new_payload_us, fcu_us, new_payload_us + fcu_us
 
@@ -45,6 +50,11 @@ def main() -> None:
     if not blocks:
         raise SystemExit(f"txgen report {report_path} does not contain any blocks")
 
+    fallback_block_time_ms = next(
+        (int(block["block_time_ms"]) for block in blocks if block.get("block_time_ms") is not None),
+        0,
+    )
+
     combined_path = output_dir / "combined_latency.csv"
     with combined_path.open("w", newline="") as f:
         writer = csv.DictWriter(
@@ -64,7 +74,7 @@ def main() -> None:
         )
         writer.writeheader()
         for block in blocks:
-            new_payload_us, fcu_us, total_us = block_latency_us(block)
+            new_payload_us, fcu_us, total_us = block_latency_us(block, fallback_block_time_ms)
             writer.writerow(
                 {
                     "block_number": block["number"],
@@ -89,7 +99,7 @@ def main() -> None:
         )
         writer.writeheader()
         for block in blocks:
-            _, _, total_us = block_latency_us(block)
+            _, _, total_us = block_latency_us(block, fallback_block_time_ms)
             elapsed_us += total_us
             writer.writerow(
                 {

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -9,7 +9,7 @@
 # Required env: SCHELK_MOUNT, BENCH_RPC_URL, BENCH_BLOCKS, BENCH_WARMUP_BLOCKS
 # Optional env: BENCH_EXECUTION_MODE, BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS,
 #               BENCH_REORG, BENCH_BAL,
-#               BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
+#               BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BLOCK_TIME, BENCH_BASELINE_ARGS,
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
 #               BENCH_TRACING_CHROME, BENCH_TRACY,
@@ -266,7 +266,7 @@ if [ "$EXECUTION_MODE" = "rpc" ]; then
     echo "::error::RPC mode does not support big blocks, reorg, or BAL"
     exit 1
   fi
-  RETH_ARGS+=(--dev --dev.block-time "${BENCH_WAIT_TIME:-1s}")
+  RETH_ARGS+=(--dev --dev.block-time "${BENCH_BLOCK_TIME:-1s}")
 fi
 
 SYNC_STATE_IDLE=false

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -266,7 +266,7 @@ if [ "$EXECUTION_MODE" = "rpc" ]; then
     echo "::error::RPC mode does not support big blocks, reorg, or BAL"
     exit 1
   fi
-  RETH_ARGS+=(--dev --dev.block-time "${BENCH_BLOCK_TIME:-1s}")
+  RETH_ARGS+=(--chain mainnet --dev --dev.block-time "${BENCH_BLOCK_TIME:-1s}")
 fi
 
 SYNC_STATE_IDLE=false

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 #
-# Runs a single txgen-backed Engine API benchmark cycle:
-# mount snapshot → start node → extract source blocks → warmup → send-blocks →
+# Runs a single txgen-backed benchmark cycle:
+# mount snapshot → start node → extract source blocks → warmup → replay →
 # convert txgen JSON report into legacy benchmark CSVs.
 #
 # Usage: bench-txgen-run.sh <label> <binary> <output-dir>
 #
 # Required env: SCHELK_MOUNT, BENCH_RPC_URL, BENCH_BLOCKS, BENCH_WARMUP_BLOCKS
-# Optional env: BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS, BENCH_REORG, BENCH_BAL,
+# Optional env: BENCH_EXECUTION_MODE, BENCH_BIG_BLOCKS, BENCH_BIG_BLOCKS_TARGET_GAS,
+#               BENCH_REORG, BENCH_BAL,
 #               BENCH_WORK_DIR, BENCH_WAIT_TIME, BENCH_BASELINE_ARGS,
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
@@ -45,6 +46,7 @@ fi
 
 DATADIR_NAME="datadir"
 BIG_BLOCKS="${BENCH_BIG_BLOCKS:-false}"
+EXECUTION_MODE="${BENCH_EXECUTION_MODE:-engine}"
 if [ "$BIG_BLOCKS" = "true" ]; then
   DATADIR_NAME="datadir-big-blocks"
 fi
@@ -250,7 +252,7 @@ RETH_ARGS=(
   --engine.accept-execution-requests-hash
   --http
   # txgen reorg mode builds synthetic side-fork blocks via testing_buildBlockV1.
-  --http.api eth,net,web3,debug,reth,testing
+  --http.api eth,net,web3,debug,reth,testing,txpool
   --http.port 8545
   --ws
   --ws.api all
@@ -258,6 +260,14 @@ RETH_ARGS=(
   --disable-discovery
   --no-persist-peers
 )
+
+if [ "$EXECUTION_MODE" = "rpc" ]; then
+  if [ "$BIG_BLOCKS" = "true" ] || [ -n "${BENCH_REORG:-}" ] || [ "$USE_BAL" = "true" ]; then
+    echo "::error::RPC mode does not support big blocks, reorg, or BAL"
+    exit 1
+  fi
+  RETH_ARGS+=(--dev --dev.block-time "${BENCH_WAIT_TIME:-1s}")
+fi
 
 SYNC_STATE_IDLE=false
 if "$BINARY" node --help 2>/dev/null | grep -qF -- '--debug.startup-sync-state-idle'; then
@@ -397,7 +407,7 @@ fi
 TXGEN_BENCH="$(which bench)"
 BENCH_NICE="sudo nice -n -20 sudo -u $(id -un)"
 TXGEN_SEND_ARGS=()
-if [ -n "${BENCH_WAIT_TIME:-}" ]; then
+if [ "$EXECUTION_MODE" = "engine" ] && [ -n "${BENCH_WAIT_TIME:-}" ]; then
   TXGEN_SEND_ARGS+=(--wait-time "$BENCH_WAIT_TIME")
 fi
 if [ -n "${BENCH_REORG:-}" ]; then
@@ -421,6 +431,9 @@ if [ -n "${TXGEN_PAYLOADS_DIR:-}" ] && [ -d "$TXGEN_PAYLOADS_DIR" ]; then
   if [ "$BIG_BLOCKS" = "true" ]; then
     WARMUP_BLOCKS="$TXGEN_PAYLOADS_DIR/warmup-big-blocks.ndjson"
     BENCHMARK_BLOCKS="$TXGEN_PAYLOADS_DIR/measured-big-blocks.ndjson"
+  elif [ "$EXECUTION_MODE" = "rpc" ]; then
+    WARMUP_BLOCKS="$TXGEN_PAYLOADS_DIR/warmup-transactions.ndjson"
+    BENCHMARK_BLOCKS="$TXGEN_PAYLOADS_DIR/benchmark-transactions.ndjson"
   else
     WARMUP_BLOCKS="$TXGEN_PAYLOADS_DIR/warmup-blocks.ndjson"
     BENCHMARK_BLOCKS="$TXGEN_PAYLOADS_DIR/benchmark-blocks.ndjson"
@@ -449,7 +462,11 @@ else
   ALL_BLOCKS="$TXGEN_DIR/all-blocks.ndjson"
   WARMUP_BLOCKS="$TXGEN_DIR/warmup-blocks.ndjson"
   BENCHMARK_BLOCKS="$TXGEN_DIR/benchmark-blocks.ndjson"
-  if [ "$BIG_BLOCKS" = "true" ]; then
+  if [ "$EXECUTION_MODE" = "rpc" ]; then
+    ALL_BLOCKS="$TXGEN_DIR/all-transactions.ndjson"
+    WARMUP_BLOCKS="$TXGEN_DIR/warmup-transactions.ndjson"
+    BENCHMARK_BLOCKS="$TXGEN_DIR/benchmark-transactions.ndjson"
+  elif [ "$BIG_BLOCKS" = "true" ]; then
     ALL_BLOCKS="$TXGEN_DIR/all-big-blocks.ndjson"
     WARMUP_BLOCKS="$TXGEN_DIR/warmup-big-blocks.ndjson"
     BENCHMARK_BLOCKS="$TXGEN_DIR/measured-big-blocks.ndjson"
@@ -460,7 +477,26 @@ else
   if [ "$USE_BAL" = "true" ]; then
     TXGEN_EXTRACT_ARGS+=(--bal)
   fi
-  if [ "$BIG_BLOCKS" = "true" ]; then
+  if [ "$EXECUTION_MODE" = "rpc" ]; then
+    EXTRACT_TO=$(( HEAD_DEC + TOTAL ))
+    if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
+      "$TXGEN_ETHEREUM" extract \
+        --rpc "$BENCH_RPC_URL" \
+        --from "$EXTRACT_FROM" \
+        --to "$(( HEAD_DEC + WARMUP ))" \
+        --format transactions \
+        -o "$WARMUP_BLOCKS"
+    else
+      : > "$WARMUP_BLOCKS"
+    fi
+    "$TXGEN_ETHEREUM" extract \
+      --rpc "$BENCH_RPC_URL" \
+      --from "$(( HEAD_DEC + WARMUP + 1 ))" \
+      --to "$EXTRACT_TO" \
+      --format transactions \
+      -o "$BENCHMARK_BLOCKS"
+    cat "$WARMUP_BLOCKS" "$BENCHMARK_BLOCKS" > "$ALL_BLOCKS"
+  elif [ "$BIG_BLOCKS" = "true" ]; then
     echo "Extracting ${TOTAL} big blocks from ${EXTRACT_FROM} for txgen benchmark (${WARMUP} warmup, ${BLOCKS} measured, bal=${USE_BAL})"
     "$TXGEN_ETHEREUM" extract-big-blocks \
       --rpc "$BENCH_RPC_URL" \
@@ -480,23 +516,33 @@ else
       -o "$ALL_BLOCKS"
   fi
 
-  if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
-    head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_BLOCKS"
-  else
-    : > "$WARMUP_BLOCKS"
+  if [ "$EXECUTION_MODE" = "engine" ]; then
+    if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
+      head -n "$WARMUP" "$ALL_BLOCKS" > "$WARMUP_BLOCKS"
+    else
+      : > "$WARMUP_BLOCKS"
+    fi
+    awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_BLOCKS"
   fi
-  awk -v warmup="$WARMUP" 'NR > warmup { print }' "$ALL_BLOCKS" > "$BENCHMARK_BLOCKS"
 fi
 
 if [ "$WARMUP" -gt 0 ] 2>/dev/null; then
-  echo "Running txgen warmup (${WARMUP} blocks)..."
-  $BENCH_NICE "$TXGEN_BENCH" send-blocks \
-    --engine http://127.0.0.1:8551 \
-    --jwt-secret "$DATADIR/jwt.hex" \
-    --input "$WARMUP_BLOCKS" \
-    "${TXGEN_SEND_ARGS[@]}" \
-    --wait-for-persistence never \
-    --report json:"$TXGEN_DIR/warmup-report.json" 2>&1 | sed -u "s/^/[bench] /"
+  echo "Running txgen warmup (${WARMUP} source blocks, mode=${EXECUTION_MODE})..."
+  if [ "$EXECUTION_MODE" = "rpc" ]; then
+    $BENCH_NICE "$TXGEN_BENCH" send \
+      --rpc-url http://127.0.0.1:8545 \
+      --input "$WARMUP_BLOCKS" \
+      --drain-timeout 300 \
+      --report json:"$TXGEN_DIR/warmup-report.json" 2>&1 | sed -u "s/^/[bench] /"
+  else
+    $BENCH_NICE "$TXGEN_BENCH" send-blocks \
+      --engine http://127.0.0.1:8551 \
+      --jwt-secret "$DATADIR/jwt.hex" \
+      --input "$WARMUP_BLOCKS" \
+      "${TXGEN_SEND_ARGS[@]}" \
+      --wait-for-persistence never \
+      --report json:"$TXGEN_DIR/warmup-report.json" 2>&1 | sed -u "s/^/[bench] /"
+  fi
 else
   echo "Skipping warmup (0 blocks)..."
 fi
@@ -567,14 +613,19 @@ if [ "$JIT_ENABLED" = "true" ]; then
   call_reth_jit pause
 fi
 
-echo "Running txgen measured benchmark (${BLOCKS} blocks)..."
-$BENCH_NICE "$TXGEN_BENCH" send-blocks \
-  --engine http://127.0.0.1:8551 \
-  --jwt-secret "$DATADIR/jwt.hex" \
+echo "Running txgen measured benchmark (${BLOCKS} source blocks, mode=${EXECUTION_MODE})..."
+TXGEN_REPLAY_ARGS=()
+BENCH_SCENARIO="replay"
+if [ "$EXECUTION_MODE" = "rpc" ]; then
+  TXGEN_REPLAY_ARGS=(send --rpc-url http://127.0.0.1:8545 --drain-timeout 300)
+  BENCH_SCENARIO="rpc-replay"
+else
+  TXGEN_REPLAY_ARGS=(send-blocks --engine http://127.0.0.1:8551 --jwt-secret "$DATADIR/jwt.hex" --wait-for-persistence never)
+fi
+$BENCH_NICE "$TXGEN_BENCH" "${TXGEN_REPLAY_ARGS[@]}" \
   --input "$BENCHMARK_BLOCKS" \
   "${TXGEN_SEND_ARGS[@]}" \
   "${METRICS_ARGS[@]}" \
-  --wait-for-persistence never \
   --report json:"$OUTPUT_DIR/report.json" \
   "${CLICKHOUSE_REPORT[@]}" \
   "${PROMETHEUS_REPORT[@]}" \
@@ -582,7 +633,7 @@ $BENCH_NICE "$TXGEN_BENCH" send-blocks \
   -m "git-ref=$GIT_REF" \
   -m "job=github-reth-bench" \
   -m "platform=ethereum" \
-  -m "scenario=replay" \
+  -m "scenario=$BENCH_SCENARIO" \
   -m "bal-mode=${BENCH_BAL:-false}" \
   -m "bal-enabled=$USE_BAL" \
   "${PROMETHEUS_METADATA[@]}" 2>&1 | sed -u "s/^/[bench] /"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,8 @@
 # Runs benchmarks.
 #
-# The bench job replays real blocks via the Engine API against a reth node
-# backed by a local snapshot managed with schelk.
+# The bench job replays real blocks either via the Engine API or by submitting
+# their transactions to a locally mined txpool against a reth node backed by a
+# local snapshot managed with schelk.
 #
 # It runs the baseline binary and the feature (candidate) binary on the
 # same block range (snapshot recovered between runs) to compare performance.
@@ -16,6 +17,14 @@ on:
         required: false
         default: ""
         type: string
+      mode:
+        description: "Benchmark mode: Engine API blocks or RPC transactions"
+        required: false
+        default: "engine"
+        type: choice
+        options:
+          - engine
+          - rpc
       big_blocks:
         description: "Use big blocks mode: false, true, or target gas like 100M/2G"
         required: false
@@ -158,6 +167,7 @@ jobs:
       run-order: ${{ steps.args.outputs.run-order }}
       otlp: ${{ steps.args.outputs.otlp }}
       node-bin: ${{ steps.args.outputs.node-bin }}
+      mode: ${{ steps.args.outputs.mode }}
       comment-id: ${{ steps.ack.outputs.comment-id }}
       pr-head-sha: ${{ steps.args.outputs.pr-head-sha }}
       pr-head-ref: ${{ steps.args.outputs.pr-head-ref }}
@@ -256,7 +266,8 @@ jobs:
           script: |
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
             const validSlackModes = new Set(['always', 'on-win', 'on-error', 'never']);
-            const usage = '`@decofe bench [blocks=N] [big-blocks[=true|false|100M|2G]] [reorg[=N]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [tracing-chrome] [skip-state-root] [slack=always|on-win|on-error|never] [cores=N] [run-pairs=N] [otlp=true|false] [metrics[=true|false]] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
+            const validModes = new Set(['engine', 'rpc']);
+            const usage = '`@decofe bench [mode=engine|rpc] [blocks=N] [big-blocks[=true|false|100M|2G]] [reorg[=N]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [tracing-chrome] [skip-state-root] [slack=always|on-win|on-error|never] [cores=N] [run-pairs=N] [otlp=true|false] [metrics[=true|false]] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
             let pr, actor, blocks, warmup, baseline, feature, samply, tracingChrome, cores, bigBlocks, bal;
             let bigBlocksTargetGas = '';
             let reorg = '';
@@ -291,6 +302,7 @@ jobs:
             if (context.eventName === 'workflow_dispatch') {
               actor = '${{ github.actor }}';
               blocks = '${{ github.event.inputs.blocks }}' || '';
+              var mode = '${{ github.event.inputs.mode }}' || 'engine';
               explicitBlocks = blocks !== '';
               warmup = '${{ github.event.inputs.warmup }}' || '';
               explicitWarmup = warmup !== '';
@@ -343,10 +355,10 @@ jobs:
               const intArgs = new Set(['warmup', 'cores', 'blocks', 'run-pairs']);
               const refArgs = new Set(['baseline', 'feature']);
               const boolArgs = new Set(['samply', 'tracing-chrome', 'otlp', 'metrics', 'skip-state-root']);
-              const enumArgs = new Map([['bal', validBalModes], ['slack', validSlackModes]]);
+              const enumArgs = new Map([['bal', validBalModes], ['slack', validSlackModes], ['mode', validModes]]);
               const durationArgs = new Set(['wait-time']);
               const stringArgs = new Set(['baseline-args', 'feature-args']);
-              const defaults = { blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', 'tracing-chrome': 'false', slack: 'always', 'big-blocks': 'false', reorg: '', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'true', metrics: 'false', 'skip-state-root': 'false', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
+              const defaults = { mode: 'engine', blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', 'tracing-chrome': 'false', slack: 'always', 'big-blocks': 'false', reorg: '', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'true', metrics: 'false', 'skip-state-root': 'false', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -405,7 +417,7 @@ jobs:
                   if (enumArgs.get(key).has(value)) {
                     defaults[key] = value;
                   } else {
-                    invalid.push(`\`${key}=${value}\` (must be true, false, feature, or baseline)`);
+                    invalid.push(`\`${key}=${value}\` (must be one of: ${[...enumArgs.get(key)].join(', ')})`);
                   }
                 } else if (intArgs.has(key)) {
                   if (!/^\d+$/.test(value)) {
@@ -443,6 +455,7 @@ jobs:
                 return;
               }
               blocks = defaults.blocks;
+              var mode = defaults.mode;
               warmup = defaults.warmup;
               baseline = defaults.baseline;
               feature = defaults.feature;
@@ -497,6 +510,14 @@ jobs:
               core.setFailed(`Invalid bal mode: ${bal}`);
               return;
             }
+            if (!validModes.has(mode)) {
+              core.setFailed(`Invalid benchmark mode: ${mode}`);
+              return;
+            }
+            if (mode === 'rpc' && (isBigBlocks || reorg || bal !== 'false')) {
+              core.setFailed('RPC mode does not support big-blocks, reorg, or BAL');
+              return;
+            }
 
             const releaseRef = (ref) => /^v\d+\.\d+\.\d+/.test(ref || '');
             if (releaseRef(baseline) || releaseRef(feature) || '${{ github.ref_type }}' === 'tag') {
@@ -546,6 +567,7 @@ jobs:
             core.setOutput('otlp', otlp);
             core.setOutput('metrics', metrics);
             core.setOutput('node-bin', nodeBin);
+            core.setOutput('mode', mode);
 
       - name: Acknowledge request
         id: ack
@@ -607,6 +629,7 @@ jobs:
             const tracingChrome = '${{ steps.args.outputs.tracing-chrome }}' === 'true';
             const slack = '${{ steps.args.outputs.slack }}' || 'always';
             const bigBlocks = '${{ steps.args.outputs.big-blocks }}' === 'true';
+            const mode = '${{ steps.args.outputs.mode }}' || 'engine';
             const reorg = '${{ steps.args.outputs.reorg }}';
             const bal = '${{ steps.args.outputs.bal }}' || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
@@ -614,6 +637,7 @@ jobs:
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const reorgNote = reorg ? `, reorg: \`${reorg}\`` : '';
             const balNote = bal !== 'false' ? `, BAL: \`${bal}\`` : '';
+            const modeNote = mode !== 'engine' ? `, mode: \`${mode}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
             const coresNote = cores && cores !== '0' ? `, cores: \`${cores}\`` : '';
             const runPairs = '${{ steps.args.outputs.run-pairs }}' || '6';
@@ -628,7 +652,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -656,6 +680,7 @@ jobs:
             const tracingChrome = '${{ steps.args.outputs.tracing-chrome }}' === 'true';
             const slack = '${{ steps.args.outputs.slack }}' || 'always';
             const bigBlocks = '${{ steps.args.outputs.big-blocks }}' === 'true';
+            const mode = '${{ steps.args.outputs.mode }}' || 'engine';
             const reorg = '${{ steps.args.outputs.reorg }}';
             const bal = '${{ steps.args.outputs.bal }}' || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
@@ -663,6 +688,7 @@ jobs:
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const reorgNote = reorg ? `, reorg: \`${reorg}\`` : '';
             const balNote = bal !== 'false' ? `, BAL: \`${bal}\`` : '';
+            const modeNote = mode !== 'engine' ? `, mode: \`${mode}\`` : '';
             const cores = '${{ steps.args.outputs.cores }}';
             const coresNote = cores && cores !== '0' ? `, cores: \`${cores}\`` : '';
             const runPairs = '${{ steps.args.outputs.run-pairs }}' || '6';
@@ -677,7 +703,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
@@ -764,6 +790,7 @@ jobs:
       BENCH_COMMENT_ID: ${{ needs.bench-ack.outputs.comment-id }}
       BENCH_SLACK: ${{ needs.bench-ack.outputs.slack }}
       BENCH_NODE_BIN: ${{ needs.bench-ack.outputs.node-bin }}
+      BENCH_EXECUTION_MODE: ${{ needs.bench-ack.outputs.mode }}
       BENCH_SNAPSHOT_MANIFEST_URL: ${{ secrets.BENCH_SNAPSHOT_MANIFEST_URL }}
       BENCH_METRICS_ADDR: "127.0.0.1:9001"
       BENCH_TARGET_METRICS_CONFIG: .github/config/bench-metrics-targets.json
@@ -827,6 +854,7 @@ jobs:
             const tracingChrome = process.env.BENCH_TRACING_CHROME === 'true';
             const slack = process.env.BENCH_SLACK || 'always';
             const bigBlocks = process.env.BENCH_BIG_BLOCKS === 'true';
+            const mode = process.env.BENCH_EXECUTION_MODE || 'engine';
             const reorg = process.env.BENCH_REORG || '';
             const bal = process.env.BENCH_BAL || 'false';
             const samplyNote = samply ? ', samply: `enabled`' : '';
@@ -834,6 +862,7 @@ jobs:
             const slackNote = slack !== 'always' ? `, slack: \`${slack}\`` : '';
             const reorgNote = reorg ? `, reorg: \`${reorg}\`` : '';
             const balNote = bal !== 'false' ? `, BAL: \`${bal}\`` : '';
+            const modeNote = mode !== 'engine' ? `, mode: \`${mode}\`` : '';
             const cores = process.env.BENCH_CORES || '0';
             const coresNote = cores && cores !== '0' ? `, cores: \`${cores}\`` : '';
             const runPairs = process.env.BENCH_RUN_PAIRS || '6';
@@ -848,7 +877,7 @@ jobs:
             const featureArgsVal = process.env.BENCH_FEATURE_ARGS || '';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -1165,6 +1194,7 @@ jobs:
           }
 
           derek_cmd=(derek bench)
+          [ "$BENCH_EXECUTION_MODE" != "engine" ] && derek_cmd+=(mode="$BENCH_EXECUTION_MODE")
           [ "$BENCH_BIG_BLOCKS" = "true" ] && derek_cmd+=(big-blocks="${BENCH_BIG_BLOCKS_TARGET_GAS:-true}")
           [ -n "$BENCH_REORG" ] && derek_cmd+=(reorg="$BENCH_REORG")
           derek_cmd+=(
@@ -1202,7 +1232,7 @@ jobs:
           echo '{}' > "$LABELS_FILE"
           echo "BENCH_LABELS_FILE=${LABELS_FILE}" >> "$GITHUB_ENV"
 
-      # Extract txgen payloads once so they are reused across all benchmark
+      # Extract txgen payloads or transactions once so they are reused across all benchmark
       # runs instead of re-fetching from the remote RPC for every run.
       - name: Extract txgen payloads
         run: |
@@ -1491,6 +1521,7 @@ jobs:
           SUMMARY_ARGS="$SUMMARY_ARGS --baseline-csv ${BASELINE_CSVS[*]}"
           SUMMARY_ARGS="$SUMMARY_ARGS --feature-csv ${FEATURE_CSVS[*]}"
           SUMMARY_ARGS="$SUMMARY_ARGS --run-pairs ${BENCH_RUN_PAIRS:-6}"
+          SUMMARY_ARGS="$SUMMARY_ARGS --mode ${BENCH_EXECUTION_MODE:-engine}"
           if [ "$BEHIND_BASELINE" -gt 0 ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --behind-baseline $BEHIND_BASELINE"
           fi
@@ -1667,7 +1698,7 @@ jobs:
             try {
               comment = fs.readFileSync(process.env.BENCH_WORK_DIR + '/comment.md', 'utf8');
             } catch (e) {
-              comment = '⚠️ Engine benchmark completed but failed to generate comparison.';
+              comment = '⚠️ Benchmark completed but failed to generate comparison.';
             }
 
             const sha = '${{ steps.push-charts.outputs.sha }}';

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: ""
         type: string
+      block_time:
+        description: "RPC mode local block interval (default: 1s)"
+        required: false
+        default: ""
+        type: string
       baseline_args:
         description: "Extra CLI args for the baseline reth node"
         required: false
@@ -161,6 +166,7 @@ jobs:
       reorg: ${{ steps.args.outputs.reorg }}
       bal: ${{ steps.args.outputs.bal }}
       wait-time: ${{ steps.args.outputs.wait-time }}
+      block-time: ${{ steps.args.outputs.block-time }}
       baseline-args: ${{ steps.args.outputs.baseline-args }}
       feature-args: ${{ steps.args.outputs.feature-args }}
       run-pairs: ${{ steps.args.outputs.run-pairs }}
@@ -267,7 +273,7 @@ jobs:
             const validBalModes = new Set(['false', 'true', 'feature', 'baseline']);
             const validSlackModes = new Set(['always', 'on-win', 'on-error', 'never']);
             const validModes = new Set(['engine', 'rpc']);
-            const usage = '`@decofe bench [mode=engine|rpc] [blocks=N] [big-blocks[=true|false|100M|2G]] [reorg[=N]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [tracing-chrome] [skip-state-root] [slack=always|on-win|on-error|never] [cores=N] [run-pairs=N] [otlp=true|false] [metrics[=true|false]] [wait-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
+            const usage = '`@decofe bench [mode=engine|rpc] [blocks=N] [big-blocks[=true|false|100M|2G]] [reorg[=N]] [bal=true|false|feature|baseline] [warmup=N] [baseline=REF] [feature=REF] [samply] [tracing-chrome] [skip-state-root] [slack=always|on-win|on-error|never] [cores=N] [run-pairs=N] [otlp=true|false] [metrics[=true|false]] [wait-time=DURATION] [block-time=DURATION] [baseline-args="..."] [feature-args="..."]`';
             let pr, actor, blocks, warmup, baseline, feature, samply, tracingChrome, cores, bigBlocks, bal;
             let bigBlocksTargetGas = '';
             let reorg = '';
@@ -330,6 +336,7 @@ jobs:
               var otlp = '${{ github.event.inputs.otlp }}' === 'false' ? 'false' : 'true';
               var metrics = '${{ github.event.inputs.metrics }}' === 'true' ? 'true' : 'false';
               var waitTime = '${{ github.event.inputs.wait_time }}' || '';
+              var blockTime = '${{ github.event.inputs.block_time }}' || '';
               var baselineNodeArgs = '${{ github.event.inputs.baseline_args }}' || '';
               var featureNodeArgs = '${{ github.event.inputs.feature_args }}' || '';
               var skipStateRoot = 'false';
@@ -356,9 +363,9 @@ jobs:
               const refArgs = new Set(['baseline', 'feature']);
               const boolArgs = new Set(['samply', 'tracing-chrome', 'otlp', 'metrics', 'skip-state-root']);
               const enumArgs = new Map([['bal', validBalModes], ['slack', validSlackModes], ['mode', validModes]]);
-              const durationArgs = new Set(['wait-time']);
+              const durationArgs = new Set(['wait-time', 'block-time']);
               const stringArgs = new Set(['baseline-args', 'feature-args']);
-              const defaults = { mode: 'engine', blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', 'tracing-chrome': 'false', slack: 'always', 'big-blocks': 'false', reorg: '', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'true', metrics: 'false', 'skip-state-root': 'false', 'wait-time': '', 'baseline-args': '', 'feature-args': '' };
+              const defaults = { mode: 'engine', blocks: '', warmup: '', baseline: '', feature: '', samply: 'false', 'tracing-chrome': 'false', slack: 'always', 'big-blocks': 'false', reorg: '', bal: 'false', cores: '0', 'run-pairs': '', otlp: 'true', metrics: 'false', 'skip-state-root': 'false', 'wait-time': '', 'block-time': '', 'baseline-args': '', 'feature-args': '' };
               const unknown = [];
               const invalid = [];
               const args = body.replace(/^(?:@decofe|derek) bench\s*/, '');
@@ -472,6 +479,7 @@ jobs:
               var otlp = defaults.otlp;
               var metrics = defaults.metrics;
               var waitTime = defaults['wait-time'];
+              var blockTime = defaults['block-time'];
               var baselineNodeArgs = defaults['baseline-args'];
               var featureNodeArgs = defaults['feature-args'];
               var skipStateRoot = defaults['skip-state-root'];
@@ -518,6 +526,17 @@ jobs:
               core.setFailed('RPC mode does not support big-blocks, reorg, or BAL');
               return;
             }
+            if (mode === 'engine' && blockTime) {
+              core.setFailed('block-time is only supported in RPC mode');
+              return;
+            }
+            if (mode === 'rpc' && waitTime) {
+              core.setFailed('wait-time is only supported in Engine mode');
+              return;
+            }
+            if (mode === 'rpc' && !blockTime) {
+              blockTime = '1s';
+            }
 
             const releaseRef = (ref) => /^v\d+\.\d+\.\d+/.test(ref || '');
             if (releaseRef(baseline) || releaseRef(feature) || '${{ github.ref_type }}' === 'tag') {
@@ -560,6 +579,7 @@ jobs:
             core.setOutput('reorg', reorg);
             core.setOutput('bal', bal);
             core.setOutput('wait-time', waitTime);
+            core.setOutput('block-time', blockTime);
             core.setOutput('baseline-args', baselineNodeArgs);
             core.setOutput('feature-args', featureNodeArgs);
             core.setOutput('run-pairs', runPairs);
@@ -647,12 +667,14 @@ jobs:
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
             const waitTimeVal = '${{ steps.args.outputs.wait-time }}';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
+            const blockTimeVal = '${{ steps.args.outputs.block-time }}';
+            const blockTimeNote = blockTimeVal ? `, block-time: \`${blockTimeVal}\`` : '';
             const baselineArgsVal = '${{ steps.args.outputs.baseline-args }}';
             const baselineArgsNote = baselineArgsVal ? `, baseline-args: \`${baselineArgsVal}\`` : '';
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -698,12 +720,14 @@ jobs:
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
             const waitTimeVal = '${{ steps.args.outputs.wait-time }}';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
+            const blockTimeVal = '${{ steps.args.outputs.block-time }}';
+            const blockTimeNote = blockTimeVal ? `, block-time: \`${blockTimeVal}\`` : '';
             const baselineArgsVal = '${{ steps.args.outputs.baseline-args }}';
             const baselineArgsNote = baselineArgsVal ? `, baseline-args: \`${baselineArgsVal}\`` : '';
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
@@ -781,6 +805,7 @@ jobs:
       BENCH_REORG: ${{ needs.bench-ack.outputs.reorg }}
       BENCH_BAL: ${{ needs.bench-ack.outputs.bal }}
       BENCH_WAIT_TIME: ${{ needs.bench-ack.outputs.wait-time }}
+      BENCH_BLOCK_TIME: ${{ needs.bench-ack.outputs.block-time }}
       BENCH_BASELINE_ARGS: ${{ needs.bench-ack.outputs.baseline-args }}
       BENCH_FEATURE_ARGS: ${{ needs.bench-ack.outputs.feature-args }}
       BENCH_RUN_PAIRS: ${{ needs.bench-ack.outputs.run-pairs }}
@@ -872,12 +897,14 @@ jobs:
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
             const waitTimeVal = process.env.BENCH_WAIT_TIME || '';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
+            const blockTimeVal = process.env.BENCH_BLOCK_TIME || '';
+            const blockTimeNote = blockTimeVal ? `, block-time: \`${blockTimeVal}\`` : '';
             const baselineArgsVal = process.env.BENCH_BASELINE_ARGS || '';
             const baselineArgsNote = baselineArgsVal ? `, baseline-args: \`${baselineArgsVal}\`` : '';
             const featureArgsVal = process.env.BENCH_FEATURE_ARGS || '';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${baselineArgsNote}${featureArgsNote}`);
+            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`);
 
             const { buildBody } = require('./.github/scripts/bench-update-status.js');
             await github.rest.issues.updateComment({
@@ -1212,6 +1239,7 @@ jobs:
           [ "$BENCH_SAMPLY" = "true" ] && derek_cmd+=(samply)
           [ "$BENCH_TRACING_CHROME" = "true" ] && derek_cmd+=(tracing-chrome)
           [ -n "$BENCH_WAIT_TIME" ] && derek_cmd+=(wait-time="$BENCH_WAIT_TIME")
+          [ -n "$BENCH_BLOCK_TIME" ] && derek_cmd+=(block-time="$BENCH_BLOCK_TIME")
           [ -n "$BENCH_BASELINE_ARGS" ] && derek_cmd+=(baseline-args="$BENCH_BASELINE_ARGS")
           [ -n "$BENCH_FEATURE_ARGS" ] && derek_cmd+=(feature-args="$BENCH_FEATURE_ARGS")
           DEREK_BENCH_COMMAND=""
@@ -1533,6 +1561,9 @@ jobs:
           fi
           if [ -n "${BENCH_WAIT_TIME:-}" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --wait-time $BENCH_WAIT_TIME"
+          fi
+          if [ -n "${BENCH_BLOCK_TIME:-}" ]; then
+            SUMMARY_ARGS="$SUMMARY_ARGS --block-time $BENCH_BLOCK_TIME"
           fi
           if [ -n "${BENCH_BAL:-}" ] && [ "${BENCH_BAL}" != "false" ]; then
             SUMMARY_ARGS="$SUMMARY_ARGS --bal-mode $BENCH_BAL"


### PR DESCRIPTION
## Summary
- Add a `mode=rpc` benchmark path that replays transaction streams against a locally mined txpool alongside the existing Engine API flow.
- Thread the new mode through txgen extraction, replay, and summary rendering so benchmark artifacts and metadata stay consistent.
- Update workflow validation and status messaging to reject unsupported RPC combinations such as big blocks, reorgs, and BAL.

## Testing
- Not run (not requested)