### PR TITLE
fix(engine): avoid rewinding preserved sparse trie anchors

### DIFF
--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -775,9 +775,21 @@ fn published_sparse_trie_anchor_hash<N: NodePrimitives>(
         return sparse_trie_anchor_hash
     }
 
-    pending_sparse_trie_prune_blocks
-        .and_then(|blocks| blocks.last().map(|block| block.recovered_block().parent_hash()))
-        .unwrap_or(sparse_trie_anchor_hash)
+    let Some(prune_blocks) = pending_sparse_trie_prune_blocks else {
+        return sparse_trie_anchor_hash
+    };
+    let Some(oldest_prune_block) = prune_blocks.last() else { return sparse_trie_anchor_hash };
+
+    // Prune blocks contain the complete in-memory parent chain from newest to oldest, with the
+    // oldest block's parent being the persisted tip. A fresh trie can be anchored to an in-memory
+    // block ahead of that tip. If that anchor is still in the prune range, publishing the
+    // persisted tip as the new anchor would expand the trie's claimed coverage backwards even
+    // though pruning cannot reveal those paths.
+    if prune_blocks.iter().any(|block| block.recovered_block().hash() == sparse_trie_anchor_hash) {
+        return sparse_trie_anchor_hash
+    }
+
+    oldest_prune_block.recovered_block().parent_hash()
 }
 
 impl<N, P, Evm> StateRootStrategy<N, P, Evm> for DefaultStateRootStrategy
@@ -1358,19 +1370,37 @@ mod tests {
     }
 
     #[test]
-    fn published_sparse_trie_anchor_uses_prune_anchor_for_reused_trie() {
-        let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..3).collect();
-        let reused_anchor_hash = B256::with_last_byte(0xaa);
+    fn published_sparse_trie_anchor_advances_to_prune_anchor() {
+        let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..5).collect();
+        let reused_anchor_hash = blocks[0].recovered_block().hash();
+        let expected_prune_anchor = blocks[1].recovered_block().hash();
+        let prune_blocks: Vec<_> = blocks.into_iter().skip(2).rev().collect();
 
         assert_eq!(
-            published_sparse_trie_anchor_hash(reused_anchor_hash, true, Some(&blocks)),
-            blocks.last().unwrap().recovered_block().parent_hash()
+            published_sparse_trie_anchor_hash(reused_anchor_hash, true, Some(&prune_blocks)),
+            expected_prune_anchor
+        );
+    }
+
+    #[test]
+    fn published_sparse_trie_anchor_does_not_move_backwards_when_anchor_is_in_prune_range() {
+        let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..5).collect();
+        let reused_anchor_hash = blocks[2].recovered_block().hash();
+        let mut prune_blocks = blocks;
+        prune_blocks.reverse();
+        let prune_anchor = prune_blocks.last().unwrap().recovered_block().parent_hash();
+
+        assert_ne!(reused_anchor_hash, prune_anchor);
+        assert_eq!(
+            published_sparse_trie_anchor_hash(reused_anchor_hash, true, Some(&prune_blocks)),
+            reused_anchor_hash
         );
     }
 
     #[test]
     fn published_sparse_trie_anchor_keeps_parent_for_fresh_trie() {
-        let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..3).collect();
+        let mut blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..3).collect();
+        blocks.reverse();
         let parent_hash = B256::with_last_byte(0xaa);
 
         assert_eq!(


### PR DESCRIPTION
## Summary

- keep a reused sparse trie's published coverage anchor from moving backwards during pruning
- advance the anchor once persistence has caught up to or passed the existing anchor
- cover both directions with prune snapshots in their production newest-to-oldest order

## Problem

A fresh sparse trie can be anchored to an in-memory parent that is ahead of the persisted database tip. The trie is built using the full state overlay, but it only reveals the paths needed by the blocks it processes; pruning can remove revealed nodes, but it cannot reveal the remaining paths between the older database tip and that anchor.

When that trie was reused during a later prune, we unconditionally republished it with the parent of the oldest in-memory block as its anchor. If persistence had not yet reached the existing anchor, this moved the advertised anchor backwards to the database tip. The next state-root job could then conclude that the reused trie covered the database-tip-to-parent range and skip an overlay the trie still needed.

This keeps the existing anchor while it is present in the complete in-memory prune chain. Once it is no longer in that chain, persistence has caught up to or passed it and the anchor can safely advance to the persisted tip.

### Example scenario

In the replay that exposed this, the state-root job for block `25,460,716` created a fresh trie anchored at its parent, block `25,460,715`, while the database tip was block `25,460,705`. The trie was then reused through block `25,460,726`, when the database tip had only advanced to block `25,460,712`.

The prune path republished the trie anchor as block `25,460,712`, moving it backwards from block `25,460,715`. Validation of block `25,460,727` therefore skipped the overlay between the database tip and the trie's real coverage boundary and produced an incorrect sparse-trie root before falling back to serial computation. With this change, block `25,460,715` remains the anchor until persistence reaches it.

## Tests

- `cargo test --profile profiling -p reth-engine-tree published_sparse_trie_anchor --lib`
- `cargo +nightly fmt --all -- --check`
