### PR TITLE
feat(engine): configure dev finality depth

### DIFF
--- a/crates/engine/local/src/lib.rs
+++ b/crates/engine/local/src/lib.rs
@@ -11,5 +11,5 @@
 pub mod miner;
 pub mod payload;
 
-pub use miner::{LocalMiner, MiningMode};
+pub use miner::{LocalMiner, MiningMode, DEFAULT_FINALITY_DEPTH};
 pub use payload::LocalPayloadAttributesBuilder;

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -14,6 +14,7 @@ use std::{
     collections::VecDeque,
     fmt,
     future::Future,
+    num::NonZeroUsize,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -21,6 +22,12 @@ use std::{
 use tokio::time::Interval;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
+
+/// Default number of confirmations required before a block is finalized in dev mode.
+pub const DEFAULT_FINALITY_DEPTH: NonZeroUsize = NonZeroUsize::new(64).unwrap();
+
+/// Default number of confirmations required before a block is considered safe in dev mode.
+const DEFAULT_SAFE_DEPTH: usize = 32;
 
 /// A mining mode for the local dev engine.
 pub enum MiningMode<Pool: TransactionPool + Unpin> {
@@ -141,6 +148,8 @@ pub struct LocalMiner<T: PayloadTypes, B, Pool: TransactionPool + Unpin> {
     last_header: SealedHeaderFor<<T::BuiltPayload as BuiltPayload>::Primitives>,
     /// Stores latest mined blocks.
     last_block_hashes: VecDeque<B256>,
+    /// Number of confirmations required before a block is finalized.
+    finality_depth: NonZeroUsize,
     /// Optional sleep duration between initiating payload building and resolving.
     ///
     /// When set, the miner sleeps after `fork_choice_updated` before calling
@@ -174,9 +183,16 @@ where
             mode,
             payload_builder,
             last_block_hashes: VecDeque::from([last_header.hash()]),
+            finality_depth: DEFAULT_FINALITY_DEPTH,
             last_header,
             payload_wait_time: None,
         }
+    }
+
+    /// Sets the number of confirmations required before a block is finalized.
+    pub const fn with_finality_depth(mut self, finality_depth: NonZeroUsize) -> Self {
+        self.finality_depth = finality_depth;
+        self
     }
 
     /// Sets the payload wait time, if any.
@@ -208,16 +224,12 @@ where
 
     /// Returns current forkchoice state.
     fn forkchoice_state(&self) -> ForkchoiceState {
+        let finality_depth = self.finality_depth.get();
+        let safe_depth = finality_depth.min(DEFAULT_SAFE_DEPTH);
         ForkchoiceState {
-            head_block_hash: *self.last_block_hashes.back().expect("at least 1 block exists"),
-            safe_block_hash: *self
-                .last_block_hashes
-                .get(self.last_block_hashes.len().saturating_sub(32))
-                .expect("at least 1 block exists"),
-            finalized_block_hash: *self
-                .last_block_hashes
-                .get(self.last_block_hashes.len().saturating_sub(64))
-                .expect("at least 1 block exists"),
+            head_block_hash: block_hash_at_depth(&self.last_block_hashes, 1),
+            safe_block_hash: block_hash_at_depth(&self.last_block_hashes, safe_depth),
+            finalized_block_hash: block_hash_at_depth(&self.last_block_hashes, finality_depth),
         }
     }
 
@@ -269,11 +281,30 @@ where
 
         self.last_block_hashes.push_back(header.hash());
         self.last_header = header;
-        // ensure we keep at most 64 blocks
-        if self.last_block_hashes.len() > 64 {
+        // Ensure we retain only the hashes needed to calculate the finalized block.
+        if self.last_block_hashes.len() > self.finality_depth.get() {
             self.last_block_hashes.pop_front();
         }
 
         Ok(())
+    }
+}
+
+fn block_hash_at_depth(block_hashes: &VecDeque<B256>, depth: usize) -> B256 {
+    *block_hashes.get(block_hashes.len().saturating_sub(depth)).expect("at least 1 block exists")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_hash_at_configured_depth() {
+        let block_hashes = (0..64).map(B256::with_last_byte).collect();
+
+        assert_eq!(block_hash_at_depth(&block_hashes, 1), B256::with_last_byte(63));
+        assert_eq!(block_hash_at_depth(&block_hashes, 32), B256::with_last_byte(32));
+        assert_eq!(block_hash_at_depth(&block_hashes, 64), B256::with_last_byte(0));
+        assert_eq!(block_hash_at_depth(&block_hashes, 128), B256::with_last_byte(0));
     }
 }

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -7,19 +7,23 @@ use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeBuilder, NodeConfig, N
 use reth_node_core::args::DevArgs;
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_primitives_traits::transaction::TxHashRef;
-use reth_provider::{providers::BlockchainProvider, CanonStateSubscriptions};
+use reth_provider::{
+    providers::BlockchainProvider, BlockIdReader, BlockNumReader, CanonStateSubscriptions,
+};
 use reth_rpc_eth_api::{helpers::EthTransactions, EthApiServer};
 use reth_tasks::Runtime;
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 #[tokio::test]
 async fn can_run_dev_node() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     let runtime = Runtime::test();
 
-    let node_config = NodeConfig::test()
-        .with_chain(custom_chain())
-        .with_dev(DevArgs { dev: true, ..Default::default() });
+    let node_config = NodeConfig::test().with_chain(custom_chain()).with_dev(DevArgs {
+        dev: true,
+        finality_depth: NonZeroUsize::new(1).unwrap(),
+        ..Default::default()
+    });
     let NodeHandle { node, .. } = NodeBuilder::new(node_config.clone())
         .testing_node(runtime.clone())
         .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
@@ -29,6 +33,10 @@ async fn can_run_dev_node() -> eyre::Result<()> {
         .await?;
 
     assert_chain_advances(&node).await;
+
+    let chain_info = node.provider.chain_info()?;
+    assert_eq!(node.provider.safe_block_num_hash()?, Some(chain_info.into()));
+    assert_eq!(node.provider.finalized_block_num_hash()?, Some(chain_info.into()));
 
     Ok(())
 }

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -323,6 +323,7 @@ where
 
             let dev_mining_mode =
                 mining_mode.unwrap_or_else(|| handle.node.config.dev_mining_mode(pool));
+            let finality_depth = config.dev.finality_depth;
             let payload_wait_time = config.dev.payload_wait_time;
             if let (Some(wait_time), Some(block_time)) = (payload_wait_time, config.dev.block_time)
             {
@@ -339,6 +340,7 @@ where
                     dev_mining_mode,
                     payload_builder_handle,
                 )
+                .with_finality_depth(finality_depth)
                 .with_payload_wait_time_opt(payload_wait_time)
                 .run()
                 .await

--- a/crates/node/core/src/args/dev.rs
+++ b/crates/node/core/src/args/dev.rs
@@ -1,9 +1,10 @@
 //! clap [Args](clap::Args) for Dev testnet configuration
 
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use clap::Args;
 use humantime::parse_duration;
+use reth_engine_local::DEFAULT_FINALITY_DEPTH;
 
 const DEFAULT_MNEMONIC: &str = "test test test test test test test test test test test junk";
 
@@ -42,6 +43,17 @@ pub struct DevArgs {
     )]
     pub block_time: Option<Duration>,
 
+    /// Number of confirmations required before a block is finalized.
+    ///
+    /// A depth of `1` finalizes the canonical head immediately.
+    #[arg(
+        long = "dev.finality-depth",
+        help_heading = "Dev testnet",
+        default_value_t = DEFAULT_FINALITY_DEPTH,
+        verbatim_doc_comment
+    )]
+    pub finality_depth: NonZeroUsize,
+
     /// Time to wait after initiating payload building before resolving.
     ///
     /// Introduces a sleep between `fork_choice_updated` and `resolve_kind` in the
@@ -76,6 +88,7 @@ impl Default for DevArgs {
             dev: false,
             block_max_transactions: None,
             block_time: None,
+            finality_depth: DEFAULT_FINALITY_DEPTH,
             payload_wait_time: None,
             dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
         }
@@ -103,6 +116,7 @@ mod tests {
                 dev: false,
                 block_max_transactions: None,
                 block_time: None,
+                finality_depth: DEFAULT_FINALITY_DEPTH,
                 payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
@@ -115,6 +129,7 @@ mod tests {
                 dev: true,
                 block_max_transactions: None,
                 block_time: None,
+                finality_depth: DEFAULT_FINALITY_DEPTH,
                 payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
@@ -127,6 +142,7 @@ mod tests {
                 dev: true,
                 block_max_transactions: None,
                 block_time: None,
+                finality_depth: DEFAULT_FINALITY_DEPTH,
                 payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
@@ -145,6 +161,7 @@ mod tests {
                 dev: true,
                 block_max_transactions: Some(2),
                 block_time: None,
+                finality_depth: DEFAULT_FINALITY_DEPTH,
                 payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
@@ -158,10 +175,27 @@ mod tests {
                 dev: true,
                 block_max_transactions: None,
                 block_time: Some(std::time::Duration::from_secs(1)),
+                finality_depth: DEFAULT_FINALITY_DEPTH,
                 payload_wait_time: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
+
+        let args =
+            CommandParser::<DevArgs>::parse_from(["reth", "--dev", "--dev.finality-depth", "1"])
+                .args;
+        assert_eq!(args.finality_depth, NonZeroUsize::new(1).unwrap());
+    }
+
+    #[test]
+    fn test_rejects_zero_finality_depth() {
+        assert!(CommandParser::<DevArgs>::try_parse_from([
+            "reth",
+            "--dev",
+            "--dev.finality-depth",
+            "0",
+        ])
+        .is_err());
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -881,6 +881,13 @@ Dev testnet:
           Parses strings using [`humantime::parse_duration`]
           --dev.block-time 12s
 
+      --dev.finality-depth <FINALITY_DEPTH>
+          Number of confirmations required before a block is finalized.
+
+          A depth of `1` finalizes the canonical head immediately.
+
+          [default: 64]
+
       --dev.payload-wait-time <PAYLOAD_WAIT_TIME>
           Time to wait after initiating payload building before resolving.
 


### PR DESCRIPTION
Adds `--dev.finality-depth` to configure how many confirmations the local miner requires before marking a block safe and finalized. The default of 64 preserves existing behavior, while a depth of 1 makes the canonical head immediately safe and finalized for dev-chain consumers that follow the finalized tag.

Validated with focused engine and node-core tests, the Ethereum dev-node e2e test, generated CLI docs, nightly rustfmt, and focused all-feature clippy.
