### PR TITLE
perf(storage): stream merged state and trie updates

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -845,9 +845,15 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     /// - If already computed: returns cached result immediately
     /// - If not computed: first caller waits for the publishing task, others wait for that result
     #[inline]
-    #[tracing::instrument(level = "debug", target = "engine::tree", name = "trie_data", skip_all)]
     pub fn trie_data(&self) -> ComputedTrieData {
-        self.trie_data.get().clone()
+        self.trie_data_ref().clone()
+    }
+
+    /// Returns a reference to the trie data, waiting for the background task if needed.
+    #[inline]
+    #[tracing::instrument(level = "debug", target = "engine::tree", name = "trie_data", skip_all)]
+    pub fn trie_data_ref(&self) -> &ComputedTrieData {
+        self.trie_data.get()
     }
 
     /// Returns a clone of the deferred trie data handle.

--- a/crates/chain-state/src/state_trie_overlay.rs
+++ b/crates/chain-state/src/state_trie_overlay.rs
@@ -546,25 +546,25 @@ fn merge_blocks<N: NodePrimitives>(blocks: Vec<ExecutedBlock<N>>) -> TrieInputSo
     #[cfg(feature = "rayon")]
     let (nodes, state) = rayon::join(
         || {
-            TrieUpdatesSorted::merge_batch(
-                trie_data.iter().map(|data| Arc::clone(&data.sorted.trie_updates)),
-            )
+            Arc::new(TrieUpdatesSorted::from(TrieUpdatesSorted::merge_batch(
+                trie_data.iter().map(|data| data.sorted.trie_updates.as_lazy()),
+            )))
         },
         || {
-            HashedPostStateSorted::merge_batch(
-                trie_data.iter().map(|data| Arc::clone(&data.sorted.hashed_state)),
-            )
+            Arc::new(HashedPostStateSorted::from(HashedPostStateSorted::merge_batch(
+                trie_data.iter().map(|data| data.sorted.hashed_state.as_lazy()),
+            )))
         },
     );
 
     #[cfg(not(feature = "rayon"))]
     let (nodes, state) = (
-        TrieUpdatesSorted::merge_batch(
-            trie_data.iter().map(|data| Arc::clone(&data.sorted.trie_updates)),
-        ),
-        HashedPostStateSorted::merge_batch(
-            trie_data.iter().map(|data| Arc::clone(&data.sorted.hashed_state)),
-        ),
+        Arc::new(TrieUpdatesSorted::from(TrieUpdatesSorted::merge_batch(
+            trie_data.iter().map(|data| data.sorted.trie_updates.as_lazy()),
+        ))),
+        Arc::new(HashedPostStateSorted::from(HashedPostStateSorted::merge_batch(
+            trie_data.iter().map(|data| data.sorted.hashed_state.as_lazy()),
+        ))),
     );
 
     TrieInputSorted::new(nodes, state, Default::default())

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -498,7 +498,7 @@ where
 
         if provider.cached_storage_settings().use_hashed_state() {
             let hashed_state = state.hash_state_slow::<KeccakKeyHasher>();
-            provider.write_hashed_state(&hashed_state.into_sorted())?;
+            provider.write_hashed_state(hashed_state.into_sorted().as_lazy())?;
         }
 
         let db_write_duration = time.elapsed();

--- a/crates/stages/stages/tests/pipeline.rs
+++ b/crates/stages/stages/tests/pipeline.rs
@@ -384,7 +384,7 @@ async fn run_pipeline_forward_and_unwind(
         // Write the plain state to database so subsequent blocks build on it
         let plain_state = output.state.to_plain_state(OriginalValuesKnown::Yes);
         provider.write_state_changes(plain_state)?;
-        provider.write_hashed_state(&hashed_state.into_sorted())?;
+        provider.write_hashed_state(hashed_state.into_sorted().as_lazy())?;
         provider.commit()?;
 
         parent_hash = block.hash();

--- a/crates/stages/stages/tests/preimage.rs
+++ b/crates/stages/stages/tests/preimage.rs
@@ -991,7 +991,7 @@ fn execute_and_commit_block(
 
     let plain_state = output.state.to_plain_state(OriginalValuesKnown::Yes);
     provider.write_state_changes(plain_state)?;
-    provider.write_hashed_state(&hashed_state.into_sorted())?;
+    provider.write_hashed_state(hashed_state.into_sorted().as_lazy())?;
     provider.commit()?;
 
     Ok(block)

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -66,10 +66,7 @@ use reth_storage_api::{
 };
 use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
 use reth_trie::{
-    updates::{
-        LazyStorageTrieUpdatesSorted, LazyTrieUpdatesSorted, StorageTrieUpdatesSorted,
-        TrieUpdatesSorted,
-    },
+    updates::{LazyStorageTrieUpdatesSorted, LazyTrieUpdatesSorted, TrieUpdatesSorted},
     BranchNodeCompact, ComputedTrieData, HashedPostStateSorted, LazyHashedPostStateSorted, Nibbles,
 };
 use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor, TrieTableAdapter};
@@ -728,38 +725,24 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // This reduces cursor open/close overhead from N calls to 1.
             if save_mode.with_state() {
                 let start = Instant::now();
-                if blocks.len() == 1 {
-                    let trie_data = blocks[0].trie_data_ref();
-                    if !trie_data.sorted.hashed_state.is_empty() {
-                        self.write_hashed_state(&trie_data.sorted.hashed_state)?;
-                    }
-                } else {
-                    // Blocks are oldest-to-newest; lazy merges expect newest-to-oldest.
-                    let merged_hashed_state = HashedPostStateSorted::merge_batch_lazy(
-                        blocks
-                            .iter()
-                            .rev()
-                            .map(|block| block.trie_data_ref().sorted.hashed_state.as_ref()),
-                    );
-                    self.write_hashed_state_lazy(merged_hashed_state)?;
-                }
+                // Blocks are oldest-to-newest; merges expect newest-to-oldest.
+                let merged_hashed_state = HashedPostStateSorted::merge_batch(
+                    blocks
+                        .iter()
+                        .rev()
+                        .map(|block| block.trie_data_ref().sorted.hashed_state.as_lazy()),
+                );
+                self.write_hashed_state(merged_hashed_state)?;
                 timings.write_hashed_state += start.elapsed();
 
                 let start = Instant::now();
-                if blocks.len() == 1 {
-                    let trie_data = blocks[0].trie_data_ref();
-                    if !trie_data.sorted.trie_updates.is_empty() {
-                        self.write_trie_updates_sorted(&trie_data.sorted.trie_updates)?;
-                    }
-                } else {
-                    let merged_trie = TrieUpdatesSorted::merge_batch_lazy(
-                        blocks
-                            .iter()
-                            .rev()
-                            .map(|block| block.trie_data_ref().sorted.trie_updates.as_ref()),
-                    );
-                    self.write_trie_updates_lazy(merged_trie)?;
-                }
+                let merged_trie = TrieUpdatesSorted::merge_batch(
+                    blocks
+                        .iter()
+                        .rev()
+                        .map(|block| block.trie_data_ref().sorted.trie_updates.as_lazy()),
+                );
+                self.write_trie_updates_sorted(merged_trie)?;
                 timings.write_trie_updates += start.elapsed();
             }
 
@@ -897,7 +880,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             })?;
 
         let trie_revert = self.changeset_cache.get_or_compute_range(self, from..=db_tip_block)?;
-        self.write_trie_updates_sorted(&trie_revert)?;
+        self.write_trie_updates_sorted(trie_revert.as_lazy())?;
 
         Ok(())
     }
@@ -2716,47 +2699,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
     }
 
     #[instrument(level = "debug", target = "providers::db", skip_all)]
-    fn write_hashed_state(&self, hashed_state: &HashedPostStateSorted) -> ProviderResult<()> {
-        // Write hashed account updates.
-        let mut hashed_accounts_cursor = self.tx_ref().cursor_write::<tables::HashedAccounts>()?;
-        for (hashed_address, account) in hashed_state.accounts() {
-            if let Some(account) = account {
-                hashed_accounts_cursor.upsert(*hashed_address, account)?;
-            } else if hashed_accounts_cursor.seek_exact(*hashed_address)?.is_some() {
-                hashed_accounts_cursor.delete_current()?;
-            }
-        }
-
-        // Write hashed storage changes.
-        let sorted_storages = hashed_state.account_storages().iter().sorted_by_key(|(key, _)| *key);
-        let mut hashed_storage_cursor =
-            self.tx_ref().cursor_dup_write::<tables::HashedStorages>()?;
-        for (hashed_address, storage) in sorted_storages {
-            if storage.is_wiped() && hashed_storage_cursor.seek_exact(*hashed_address)?.is_some() {
-                hashed_storage_cursor.delete_current_duplicates()?;
-            }
-
-            for (hashed_slot, value) in storage.storage_slots_ref() {
-                let entry = StorageEntry { key: *hashed_slot, value: *value };
-
-                if let Some(db_entry) =
-                    hashed_storage_cursor.seek_by_key_subkey(*hashed_address, entry.key)? &&
-                    db_entry.key == entry.key
-                {
-                    hashed_storage_cursor.delete_current()?;
-                }
-
-                if !entry.value.is_zero() {
-                    hashed_storage_cursor.upsert(*hashed_address, &entry)?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    #[instrument(level = "debug", target = "providers::db", skip_all)]
-    fn write_hashed_state_lazy(
+    fn write_hashed_state(
         &self,
         hashed_state: LazyHashedPostStateSorted<'_>,
     ) -> ProviderResult<()> {
@@ -3152,55 +3095,6 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     fn write_account_trie_updates<A: TrieTableAdapter>(
         tx: &TX,
-        trie_updates: &TrieUpdatesSorted,
-        num_entries: &mut usize,
-    ) -> ProviderResult<()>
-    where
-        TX: DbTxMut,
-    {
-        let mut account_trie_cursor = tx.cursor_write::<A::AccountTrieTable>()?;
-        // Process sorted account nodes
-        for (key, updated_node) in trie_updates.account_nodes_ref() {
-            let nibbles = A::AccountKey::from(*key);
-            match updated_node {
-                Some(node) => {
-                    if !key.is_empty() {
-                        *num_entries += 1;
-                        account_trie_cursor.upsert(nibbles, node)?;
-                    }
-                }
-                None => {
-                    *num_entries += 1;
-                    if account_trie_cursor.seek_exact(nibbles)?.is_some() {
-                        account_trie_cursor.delete_current()?;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn write_storage_tries<A: TrieTableAdapter>(
-        tx: &TX,
-        storage_tries: Vec<(&B256, &StorageTrieUpdatesSorted)>,
-        num_entries: &mut usize,
-    ) -> ProviderResult<()>
-    where
-        TX: DbTxMut,
-    {
-        let mut cursor = tx.cursor_dup_write::<A::StorageTrieTable>()?;
-        for (hashed_address, storage_trie_updates) in storage_tries {
-            let mut db_storage_trie_cursor: DatabaseStorageTrieCursor<_, A> =
-                DatabaseStorageTrieCursor::new(cursor, *hashed_address);
-            *num_entries +=
-                db_storage_trie_cursor.write_storage_trie_updates_sorted(storage_trie_updates)?;
-            cursor = db_storage_trie_cursor.cursor;
-        }
-        Ok(())
-    }
-
-    fn write_account_trie_updates_lazy<A: TrieTableAdapter>(
-        tx: &TX,
         account_nodes: impl Iterator<Item = (Nibbles, Option<BranchNodeCompact>)>,
         num_entries: &mut usize,
     ) -> ProviderResult<()>
@@ -3228,7 +3122,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         Ok(())
     }
 
-    fn write_storage_tries_lazy<'a, A: TrieTableAdapter>(
+    fn write_storage_tries<'a, A: TrieTableAdapter>(
         tx: &TX,
         storage_tries: impl Iterator<Item = (B256, LazyStorageTrieUpdatesSorted<'a>)>,
         num_entries: &mut usize,
@@ -3241,7 +3135,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
             let mut db_storage_trie_cursor: DatabaseStorageTrieCursor<_, A> =
                 DatabaseStorageTrieCursor::new(cursor, hashed_address);
             *num_entries +=
-                db_storage_trie_cursor.write_storage_trie_updates_lazy(storage_trie_updates)?;
+                db_storage_trie_cursor.write_storage_trie_updates_sorted(storage_trie_updates)?;
             cursor = db_storage_trie_cursor.cursor;
         }
         Ok(())
@@ -3253,26 +3147,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
     ///
     /// Returns the number of entries modified.
     #[instrument(level = "debug", target = "providers::db", skip_all)]
-    fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize> {
-        if trie_updates.is_empty() {
-            return Ok(0)
-        }
-
-        // Track the number of inserted entries.
-        let mut num_entries = 0;
-
-        reth_trie_db::with_adapter!(self, |A| {
-            Self::write_account_trie_updates::<A>(self.tx_ref(), trie_updates, &mut num_entries)?;
-        });
-
-        num_entries +=
-            self.write_storage_trie_updates_sorted(trie_updates.storage_tries_ref().iter())?;
-
-        Ok(num_entries)
-    }
-
-    #[instrument(level = "debug", target = "providers::db", skip_all)]
-    fn write_trie_updates_lazy(
+    fn write_trie_updates_sorted(
         &self,
         trie_updates: LazyTrieUpdatesSorted<'_>,
     ) -> ProviderResult<usize> {
@@ -3280,12 +3155,8 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
         let mut num_entries = 0;
 
         reth_trie_db::with_adapter!(self, |A| {
-            Self::write_account_trie_updates_lazy::<A>(
-                self.tx_ref(),
-                account_nodes,
-                &mut num_entries,
-            )?;
-            Self::write_storage_tries_lazy::<A>(self.tx_ref(), storage_tries, &mut num_entries)?;
+            Self::write_account_trie_updates::<A>(self.tx_ref(), account_nodes, &mut num_entries)?;
+            Self::write_storage_tries::<A>(self.tx_ref(), storage_tries, &mut num_entries)?;
         });
 
         Ok(num_entries)
@@ -3300,11 +3171,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> StorageTrieWriter for DatabaseP
     /// Returns the number of entries modified.
     fn write_storage_trie_updates_sorted<'a>(
         &self,
-        storage_tries: impl Iterator<Item = (&'a B256, &'a StorageTrieUpdatesSorted)>,
+        storage_tries: impl Iterator<Item = (B256, LazyStorageTrieUpdatesSorted<'a>)>,
     ) -> ProviderResult<usize> {
         let mut num_entries = 0;
-        let mut storage_tries = storage_tries.collect::<Vec<_>>();
-        storage_tries.sort_unstable_by(|a, b| a.0.cmp(b.0));
         reth_trie_db::with_adapter!(self, |A| {
             Self::write_storage_tries::<A>(self.tx_ref(), storage_tries, &mut num_entries)?;
         });
@@ -3871,7 +3740,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
         durations_recorder.record_relative(metrics::Action::InsertState);
 
         // insert hashes and intermediate merkle nodes
-        self.write_hashed_state(&hashed_state)?;
+        self.write_hashed_state(hashed_state.as_lazy())?;
         durations_recorder.record_relative(metrics::Action::InsertHashes);
 
         // Use pre-computed transitions for history indices since static file
@@ -4382,7 +4251,8 @@ mod tests {
         assert!(provider.receipts_by_block(1.into()).unwrap().is_none());
     }
 
-    fn run_write_hashed_state(lazy: bool) {
+    #[test]
+    fn test_write_hashed_state_sorted() {
         use reth_trie::HashedStorageSorted;
 
         let factory = create_test_provider_factory();
@@ -4440,12 +4310,8 @@ mod tests {
             ]),
         );
 
-        if lazy {
-            let hashed_state = HashedPostStateSorted::merge_batch_lazy([&hashed_state]);
-            provider_rw.write_hashed_state_lazy(hashed_state).unwrap();
-        } else {
-            provider_rw.write_hashed_state(&hashed_state).unwrap();
-        }
+        let hashed_state = HashedPostStateSorted::merge_batch([hashed_state.as_lazy()]);
+        provider_rw.write_hashed_state(hashed_state).unwrap();
 
         let mut accounts = provider_rw.tx_ref().cursor_read::<tables::HashedAccounts>().unwrap();
         assert_eq!(accounts.seek_exact(updated_account).unwrap().unwrap().1.nonce, 7);
@@ -4472,16 +4338,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_hashed_state_sorted() {
-        run_write_hashed_state(false);
-    }
-
-    #[test]
-    fn test_write_hashed_state_lazy() {
-        run_write_hashed_state(true);
-    }
-
-    fn run_write_trie_updates(lazy: bool) {
+    fn test_write_trie_updates_sorted() {
         use reth_trie::{
             updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
             BranchNodeCompact, StorageTrieEntry,
@@ -4636,13 +4493,8 @@ mod tests {
         storage_tries.insert(storage_address2, storage_trie2);
 
         let trie_updates = TrieUpdatesSorted::new(account_nodes, storage_tries);
-
-        let num_entries = if lazy {
-            let trie_updates = TrieUpdatesSorted::merge_batch_lazy([&trie_updates]);
-            provider_rw.write_trie_updates_lazy(trie_updates).unwrap()
-        } else {
-            provider_rw.write_trie_updates_sorted(&trie_updates).unwrap()
-        };
+        let trie_updates = TrieUpdatesSorted::merge_batch([trie_updates.as_lazy()]);
+        let num_entries = provider_rw.write_trie_updates_sorted(trie_updates).unwrap();
 
         // We should have 2 account insertions + 1 account deletion + 1 storage insertion + 1
         // storage deletion = 5
@@ -4702,16 +4554,6 @@ mod tests {
         assert_eq!(storage_entries2.len(), 0, "Storage address2 should be empty after wipe");
 
         provider_rw.commit().unwrap();
-    }
-
-    #[test]
-    fn test_write_trie_updates_sorted() {
-        run_write_trie_updates(false);
-    }
-
-    #[test]
-    fn test_write_trie_updates_lazy() {
-        run_write_trie_updates(true);
     }
 
     #[test]
@@ -5010,7 +4852,7 @@ mod tests {
 
         let hashed_state =
             execution_outcome.hash_state_slow::<reth_trie::KeccakKeyHasher>().into_sorted();
-        provider_rw.write_hashed_state(&hashed_state).unwrap();
+        provider_rw.write_hashed_state(hashed_state.as_lazy()).unwrap();
 
         let account = provider_rw
             .tx
@@ -5217,7 +5059,7 @@ mod tests {
 
         let hashed_state =
             HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle.state()).into_sorted();
-        provider_rw.write_hashed_state(&hashed_state).unwrap();
+        provider_rw.write_hashed_state(hashed_state.as_lazy()).unwrap();
 
         let plain_storage_entries = provider_rw
             .tx
@@ -5622,7 +5464,7 @@ mod tests {
 
         let hashed_state =
             HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle.state()).into_sorted();
-        provider_rw.write_hashed_state(&hashed_state).unwrap();
+        provider_rw.write_hashed_state(hashed_state.as_lazy()).unwrap();
 
         let hashed_account = provider_rw
             .tx

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -66,8 +66,11 @@ use reth_storage_api::{
 };
 use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
 use reth_trie::{
-    updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
-    ComputedTrieData, HashedPostStateSorted,
+    updates::{
+        LazyStorageTrieUpdatesSorted, LazyTrieUpdatesSorted, StorageTrieUpdatesSorted,
+        TrieUpdatesSorted,
+    },
+    BranchNodeCompact, ComputedTrieData, HashedPostStateSorted, LazyHashedPostStateSorted, Nibbles,
 };
 use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor, TrieTableAdapter};
 use revm::database::states::{
@@ -724,21 +727,38 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // Write all hashed state and trie updates in single batches.
             // This reduces cursor open/close overhead from N calls to 1.
             if save_mode.with_state() {
-                // Blocks are oldest-to-newest, merge_batch expects newest-to-oldest.
                 let start = Instant::now();
-                let merged_hashed_state = HashedPostStateSorted::merge_batch(
-                    blocks.iter().rev().map(|b| b.trie_data().sorted.hashed_state),
-                );
-                if !merged_hashed_state.is_empty() {
-                    self.write_hashed_state(&merged_hashed_state)?;
+                if blocks.len() == 1 {
+                    let trie_data = blocks[0].trie_data_ref();
+                    if !trie_data.sorted.hashed_state.is_empty() {
+                        self.write_hashed_state(&trie_data.sorted.hashed_state)?;
+                    }
+                } else {
+                    // Blocks are oldest-to-newest; lazy merges expect newest-to-oldest.
+                    let merged_hashed_state = HashedPostStateSorted::merge_batch_lazy(
+                        blocks
+                            .iter()
+                            .rev()
+                            .map(|block| block.trie_data_ref().sorted.hashed_state.as_ref()),
+                    );
+                    self.write_hashed_state_lazy(merged_hashed_state)?;
                 }
                 timings.write_hashed_state += start.elapsed();
 
                 let start = Instant::now();
-                let merged_trie =
-                    TrieUpdatesSorted::merge_batch(blocks.iter().rev().map(|b| b.trie_updates()));
-                if !merged_trie.is_empty() {
-                    self.write_trie_updates_sorted(&merged_trie)?;
+                if blocks.len() == 1 {
+                    let trie_data = blocks[0].trie_data_ref();
+                    if !trie_data.sorted.trie_updates.is_empty() {
+                        self.write_trie_updates_sorted(&trie_data.sorted.trie_updates)?;
+                    }
+                } else {
+                    let merged_trie = TrieUpdatesSorted::merge_batch_lazy(
+                        blocks
+                            .iter()
+                            .rev()
+                            .map(|block| block.trie_data_ref().sorted.trie_updates.as_ref()),
+                    );
+                    self.write_trie_updates_lazy(merged_trie)?;
                 }
                 timings.write_trie_updates += start.elapsed();
             }
@@ -2735,6 +2755,48 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         Ok(())
     }
 
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn write_hashed_state_lazy(
+        &self,
+        hashed_state: LazyHashedPostStateSorted<'_>,
+    ) -> ProviderResult<()> {
+        let (accounts, storages) = hashed_state.into_parts();
+
+        let mut hashed_accounts_cursor = self.tx_ref().cursor_write::<tables::HashedAccounts>()?;
+        for (hashed_address, account) in accounts {
+            if let Some(account) = account {
+                hashed_accounts_cursor.upsert(hashed_address, &account)?;
+            } else if hashed_accounts_cursor.seek_exact(hashed_address)?.is_some() {
+                hashed_accounts_cursor.delete_current()?;
+            }
+        }
+
+        let mut hashed_storage_cursor =
+            self.tx_ref().cursor_dup_write::<tables::HashedStorages>()?;
+        for (hashed_address, storage) in storages {
+            let (wiped, storage_slots) = storage.into_parts();
+            if wiped && hashed_storage_cursor.seek_exact(hashed_address)?.is_some() {
+                hashed_storage_cursor.delete_current_duplicates()?;
+            }
+
+            for (hashed_slot, value) in storage_slots {
+                let entry = StorageEntry { key: hashed_slot, value };
+                if let Some(db_entry) =
+                    hashed_storage_cursor.seek_by_key_subkey(hashed_address, entry.key)? &&
+                    db_entry.key == entry.key
+                {
+                    hashed_storage_cursor.delete_current()?;
+                }
+
+                if !entry.value.is_zero() {
+                    hashed_storage_cursor.upsert(hashed_address, &entry)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Remove the last N blocks of state.
     ///
     /// The latest state will be unwound
@@ -3136,6 +3198,54 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         }
         Ok(())
     }
+
+    fn write_account_trie_updates_lazy<A: TrieTableAdapter>(
+        tx: &TX,
+        account_nodes: impl Iterator<Item = (Nibbles, Option<BranchNodeCompact>)>,
+        num_entries: &mut usize,
+    ) -> ProviderResult<()>
+    where
+        TX: DbTxMut,
+    {
+        let mut account_trie_cursor = tx.cursor_write::<A::AccountTrieTable>()?;
+        for (key, updated_node) in account_nodes {
+            let nibbles = A::AccountKey::from(key);
+            match updated_node {
+                Some(node) => {
+                    if !key.is_empty() {
+                        *num_entries += 1;
+                        account_trie_cursor.upsert(nibbles, &node)?;
+                    }
+                }
+                None => {
+                    *num_entries += 1;
+                    if account_trie_cursor.seek_exact(nibbles)?.is_some() {
+                        account_trie_cursor.delete_current()?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn write_storage_tries_lazy<'a, A: TrieTableAdapter>(
+        tx: &TX,
+        storage_tries: impl Iterator<Item = (B256, LazyStorageTrieUpdatesSorted<'a>)>,
+        num_entries: &mut usize,
+    ) -> ProviderResult<()>
+    where
+        TX: DbTxMut,
+    {
+        let mut cursor = tx.cursor_dup_write::<A::StorageTrieTable>()?;
+        for (hashed_address, storage_trie_updates) in storage_tries {
+            let mut db_storage_trie_cursor: DatabaseStorageTrieCursor<_, A> =
+                DatabaseStorageTrieCursor::new(cursor, hashed_address);
+            *num_entries +=
+                db_storage_trie_cursor.write_storage_trie_updates_lazy(storage_trie_updates)?;
+            cursor = db_storage_trie_cursor.cursor;
+        }
+        Ok(())
+    }
 }
 
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider<TX, N> {
@@ -3157,6 +3267,26 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
 
         num_entries +=
             self.write_storage_trie_updates_sorted(trie_updates.storage_tries_ref().iter())?;
+
+        Ok(num_entries)
+    }
+
+    #[instrument(level = "debug", target = "providers::db", skip_all)]
+    fn write_trie_updates_lazy(
+        &self,
+        trie_updates: LazyTrieUpdatesSorted<'_>,
+    ) -> ProviderResult<usize> {
+        let (account_nodes, storage_tries) = trie_updates.into_parts();
+        let mut num_entries = 0;
+
+        reth_trie_db::with_adapter!(self, |A| {
+            Self::write_account_trie_updates_lazy::<A>(
+                self.tx_ref(),
+                account_nodes,
+                &mut num_entries,
+            )?;
+            Self::write_storage_tries_lazy::<A>(self.tx_ref(), storage_tries, &mut num_entries)?;
+        });
 
         Ok(num_entries)
     }
@@ -4252,8 +4382,106 @@ mod tests {
         assert!(provider.receipts_by_block(1.into()).unwrap().is_none());
     }
 
+    fn run_write_hashed_state(lazy: bool) {
+        use reth_trie::HashedStorageSorted;
+
+        let factory = create_test_provider_factory();
+        let provider_rw = factory.provider_rw().unwrap();
+        let updated_account = B256::with_last_byte(0x10);
+        let deleted_account = B256::with_last_byte(0x11);
+        let wiped_storage = B256::with_last_byte(0x12);
+        let updated_storage = B256::with_last_byte(0x13);
+        let old_slot = B256::with_last_byte(0x20);
+        let deleted_slot = B256::with_last_byte(0x21);
+        let updated_slot = B256::with_last_byte(0x22);
+
+        {
+            let mut accounts =
+                provider_rw.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
+            accounts.upsert(updated_account, &Account::default()).unwrap();
+            accounts.upsert(deleted_account, &Account::default()).unwrap();
+
+            let mut storages =
+                provider_rw.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+            storages
+                .upsert(wiped_storage, &StorageEntry { key: old_slot, value: U256::from(1) })
+                .unwrap();
+            storages
+                .upsert(updated_storage, &StorageEntry { key: deleted_slot, value: U256::from(2) })
+                .unwrap();
+            storages
+                .upsert(updated_storage, &StorageEntry { key: updated_slot, value: U256::from(3) })
+                .unwrap();
+        }
+
+        let hashed_state = HashedPostStateSorted::new(
+            vec![
+                (updated_account, Some(Account { nonce: 7, ..Default::default() })),
+                (deleted_account, None),
+            ],
+            B256Map::from_iter([
+                (
+                    wiped_storage,
+                    HashedStorageSorted {
+                        storage_slots: vec![(updated_slot, U256::from(4))],
+                        wiped: true,
+                    },
+                ),
+                (
+                    updated_storage,
+                    HashedStorageSorted {
+                        storage_slots: vec![
+                            (deleted_slot, U256::ZERO),
+                            (updated_slot, U256::from(5)),
+                        ],
+                        wiped: false,
+                    },
+                ),
+            ]),
+        );
+
+        if lazy {
+            let hashed_state = HashedPostStateSorted::merge_batch_lazy([&hashed_state]);
+            provider_rw.write_hashed_state_lazy(hashed_state).unwrap();
+        } else {
+            provider_rw.write_hashed_state(&hashed_state).unwrap();
+        }
+
+        let mut accounts = provider_rw.tx_ref().cursor_read::<tables::HashedAccounts>().unwrap();
+        assert_eq!(accounts.seek_exact(updated_account).unwrap().unwrap().1.nonce, 7);
+        assert!(accounts.seek_exact(deleted_account).unwrap().is_none());
+
+        let mut storages =
+            provider_rw.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap();
+        assert!(storages
+            .seek_by_key_subkey(wiped_storage, old_slot)
+            .unwrap()
+            .is_none_or(|entry| entry.key != old_slot));
+        assert_eq!(
+            storages.seek_by_key_subkey(wiped_storage, updated_slot).unwrap().unwrap().value,
+            U256::from(4)
+        );
+        assert!(storages
+            .seek_by_key_subkey(updated_storage, deleted_slot)
+            .unwrap()
+            .is_none_or(|entry| entry.key != deleted_slot));
+        assert_eq!(
+            storages.seek_by_key_subkey(updated_storage, updated_slot).unwrap().unwrap().value,
+            U256::from(5)
+        );
+    }
+
     #[test]
-    fn test_write_trie_updates_sorted() {
+    fn test_write_hashed_state_sorted() {
+        run_write_hashed_state(false);
+    }
+
+    #[test]
+    fn test_write_hashed_state_lazy() {
+        run_write_hashed_state(true);
+    }
+
+    fn run_write_trie_updates(lazy: bool) {
         use reth_trie::{
             updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
             BranchNodeCompact, StorageTrieEntry,
@@ -4409,8 +4637,12 @@ mod tests {
 
         let trie_updates = TrieUpdatesSorted::new(account_nodes, storage_tries);
 
-        // Write the sorted trie updates
-        let num_entries = provider_rw.write_trie_updates_sorted(&trie_updates).unwrap();
+        let num_entries = if lazy {
+            let trie_updates = TrieUpdatesSorted::merge_batch_lazy([&trie_updates]);
+            provider_rw.write_trie_updates_lazy(trie_updates).unwrap()
+        } else {
+            provider_rw.write_trie_updates_sorted(&trie_updates).unwrap()
+        };
 
         // We should have 2 account insertions + 1 account deletion + 1 storage insertion + 1
         // storage deletion = 5
@@ -4470,6 +4702,16 @@ mod tests {
         assert_eq!(storage_entries2.len(), 0, "Storage address2 should be empty after wipe");
 
         provider_rw.commit().unwrap();
+    }
+
+    #[test]
+    fn test_write_trie_updates_sorted() {
+        run_write_trie_updates(false);
+    }
+
+    #[test]
+    fn test_write_trie_updates_lazy() {
+        run_write_trie_updates(true);
     }
 
     #[test]

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -70,7 +70,10 @@ mod tests {
         hashed_state.storages.insert(destroyed_address_hashed, HashedStorage::new(true));
 
         let provider_rw = provider_factory.provider_rw().unwrap();
-        assert!(matches!(provider_rw.write_hashed_state(&hashed_state.into_sorted()), Ok(())));
+        assert!(matches!(
+            provider_rw.write_hashed_state(hashed_state.into_sorted().as_lazy()),
+            Ok(())
+        ));
         provider_rw.commit().unwrap();
 
         let provider = provider_factory.provider().unwrap();
@@ -1134,7 +1137,7 @@ mod tests {
         );
         let mut state = HashedPostState::default();
         state.storages.insert(hashed_address, init_storage.clone());
-        provider_rw.write_hashed_state(&state.clone().into_sorted()).unwrap();
+        provider_rw.write_hashed_state(state.clone().into_sorted().as_lazy()).unwrap();
 
         // calculate database storage root and write intermediate storage nodes.
         let StorageRootProgress::Complete(storage_root, _, storage_updates) =
@@ -1147,10 +1150,11 @@ mod tests {
         };
         assert_eq!(storage_root, storage_root_prehashed(init_storage.storage));
         assert!(!storage_updates.is_empty());
+        let storage_updates = storage_updates.into_sorted();
         provider_rw
             .write_storage_trie_updates_sorted(core::iter::once((
-                &hashed_address,
-                &storage_updates.into_sorted(),
+                hashed_address,
+                storage_updates.as_lazy(),
             )))
             .unwrap();
 
@@ -1166,7 +1170,7 @@ mod tests {
         );
         let mut state = HashedPostState::default();
         state.storages.insert(hashed_address, updated_storage.clone());
-        provider_rw.write_hashed_state(&state.clone().into_sorted()).unwrap();
+        provider_rw.write_hashed_state(state.clone().into_sorted().as_lazy()).unwrap();
 
         // re-calculate database storage root
         type TestStorageRoot<'a, TX, A> = StorageRoot<

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -3,7 +3,7 @@ use alloy_consensus::transaction::Either;
 use alloy_primitives::BlockNumber;
 use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
 use reth_storage_errors::provider::ProviderResult;
-use reth_trie_common::HashedPostStateSorted;
+use reth_trie_common::{HashedPostStateSorted, LazyHashedPostStateSorted};
 use revm::database::{
     states::{PlainStateReverts, StateChangeset},
     BundleState, OriginalValuesKnown,
@@ -114,6 +114,14 @@ pub trait StateWriter {
 
     /// Writes the hashed state changes to the database
     fn write_hashed_state(&self, hashed_state: &HashedPostStateSorted) -> ProviderResult<()>;
+
+    /// Writes lazily merged hashed state changes to the database.
+    fn write_hashed_state_lazy(
+        &self,
+        hashed_state: LazyHashedPostStateSorted<'_>,
+    ) -> ProviderResult<()> {
+        self.write_hashed_state(&hashed_state.into())
+    }
 
     /// Remove the block range of state above the given block. The state of the passed block is not
     /// removed.

--- a/crates/storage/storage-api/src/state_writer.rs
+++ b/crates/storage/storage-api/src/state_writer.rs
@@ -3,7 +3,7 @@ use alloy_consensus::transaction::Either;
 use alloy_primitives::BlockNumber;
 use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
 use reth_storage_errors::provider::ProviderResult;
-use reth_trie_common::{HashedPostStateSorted, LazyHashedPostStateSorted};
+use reth_trie_common::LazyHashedPostStateSorted;
 use revm::database::{
     states::{PlainStateReverts, StateChangeset},
     BundleState, OriginalValuesKnown,
@@ -112,16 +112,9 @@ pub trait StateWriter {
     /// Write state changes to the database.
     fn write_state_changes(&self, changes: StateChangeset) -> ProviderResult<()>;
 
-    /// Writes the hashed state changes to the database
-    fn write_hashed_state(&self, hashed_state: &HashedPostStateSorted) -> ProviderResult<()>;
-
-    /// Writes lazily merged hashed state changes to the database.
-    fn write_hashed_state_lazy(
-        &self,
-        hashed_state: LazyHashedPostStateSorted<'_>,
-    ) -> ProviderResult<()> {
-        self.write_hashed_state(&hashed_state.into())
-    }
+    /// Writes sorted hashed state changes to the database.
+    fn write_hashed_state(&self, hashed_state: LazyHashedPostStateSorted<'_>)
+        -> ProviderResult<()>;
 
     /// Remove the block range of state above the given block. The state of the passed block is not
     /// removed.

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_primitives_traits::Account;
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::{
-    updates::{LazyTrieUpdatesSorted, StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
+    updates::{LazyStorageTrieUpdatesSorted, LazyTrieUpdatesSorted, TrieUpdates},
     AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProof,
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
@@ -178,23 +178,17 @@ pub trait TrieWriter: Send {
     ///
     /// Returns the number of entries modified.
     fn write_trie_updates(&self, trie_updates: TrieUpdates) -> ProviderResult<usize> {
-        self.write_trie_updates_sorted(&trie_updates.into_sorted())
+        let trie_updates = trie_updates.into_sorted();
+        self.write_trie_updates_sorted(trie_updates.as_lazy())
     }
 
     /// Writes trie updates to the database with already sorted updates.
     ///
     /// Returns the number of entries modified.
-    fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize>;
-
-    /// Writes lazily merged trie updates to the database.
-    ///
-    /// Returns the number of entries modified.
-    fn write_trie_updates_lazy(
+    fn write_trie_updates_sorted(
         &self,
         trie_updates: LazyTrieUpdatesSorted<'_>,
-    ) -> ProviderResult<usize> {
-        self.write_trie_updates_sorted(&trie_updates.into())
-    }
+    ) -> ProviderResult<usize>;
 }
 
 /// Storage Trie Writer
@@ -207,6 +201,6 @@ pub trait StorageTrieWriter: Send {
     /// Returns the number of entries modified.
     fn write_storage_trie_updates_sorted<'a>(
         &self,
-        storage_tries: impl Iterator<Item = (&'a B256, &'a StorageTrieUpdatesSorted)>,
+        storage_tries: impl Iterator<Item = (B256, LazyStorageTrieUpdatesSorted<'a>)>,
     ) -> ProviderResult<usize>;
 }

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_primitives_traits::Account;
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::{
-    updates::{StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
+    updates::{LazyTrieUpdatesSorted, StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
     AccountProof, ExecutionWitnessMode, HashedPostState, HashedStorage, MultiProof,
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
@@ -185,6 +185,16 @@ pub trait TrieWriter: Send {
     ///
     /// Returns the number of entries modified.
     fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize>;
+
+    /// Writes lazily merged trie updates to the database.
+    ///
+    /// Returns the number of entries modified.
+    fn write_trie_updates_lazy(
+        &self,
+        trie_updates: LazyTrieUpdatesSorted<'_>,
+    ) -> ProviderResult<usize> {
+        self.write_trie_updates_sorted(&trie_updates.into())
+    }
 }
 
 /// Storage Trie Writer

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -1,4 +1,4 @@
-use core::ops::Not;
+use core::{fmt, ops::Not};
 
 use crate::{
     added_removed_keys::MultiAddedRemovedKeys,
@@ -6,7 +6,7 @@ use crate::{
     utils::{extend_sorted_vec, kway_merge_sorted},
     KeyHasher, MultiProofTargets, Nibbles,
 };
-use alloc::{borrow::Cow, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap, vec::Vec};
 use alloy_primitives::{
     keccak256,
     map::{hash_map, B256Map, HashMap, HashSet},
@@ -650,19 +650,68 @@ impl HashedPostStateSorted {
         }
 
         // Large k: k-way merge.
-        let accounts = kway_merge_sorted(items.iter().map(|i| i.as_ref().accounts.as_slice()));
+        Self::merge_batch_lazy(items.iter().map(|item| item.as_ref())).into()
+    }
 
+    /// Lazily batch-merge sorted hashed post states supplied **newest to oldest**.
+    ///
+    /// The returned iterators yield entries in ascending key order and clone them only as they are
+    /// consumed. For duplicate keys, the value from the newest input is retained.
+    pub fn merge_batch_lazy<'a>(
+        items: impl IntoIterator<Item = &'a Self>,
+    ) -> LazyHashedPostStateSorted<'a> {
+        LazyHashedPostStateSorted::merge_batch(items)
+    }
+
+    /// Clears all accounts and storage data.
+    pub fn clear(&mut self) {
+        self.accounts.clear();
+        self.storages.clear();
+    }
+}
+
+impl AsRef<Self> for HashedPostStateSorted {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+/// Lazily merged sorted hashed post state optimized for streaming updates to storage.
+pub struct LazyHashedPostStateSorted<'a> {
+    accounts: LazyHashedAccountIter<'a>,
+    storages: LazyHashedStorageIter<'a>,
+}
+
+/// Boxed iterator over lazily merged hashed account updates.
+pub type LazyHashedAccountIter<'a> = Box<dyn Iterator<Item = (B256, Option<Account>)> + Send + 'a>;
+
+/// Boxed iterator over lazily merged hashed storage updates.
+pub type LazyHashedStorageIter<'a> =
+    Box<dyn Iterator<Item = (B256, LazyHashedStorageSorted<'a>)> + Send + 'a>;
+
+/// Boxed iterator over lazily merged hashed storage slot updates.
+pub type LazyHashedStorageSlotIter<'a> = Box<dyn Iterator<Item = (B256, U256)> + Send + 'a>;
+
+impl fmt::Debug for LazyHashedPostStateSorted<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyHashedPostStateSorted").finish_non_exhaustive()
+    }
+}
+
+impl<'a> LazyHashedPostStateSorted<'a> {
+    fn merge_batch(items: impl IntoIterator<Item = &'a HashedPostStateSorted>) -> Self {
         struct StorageAcc<'a> {
             wiped: bool,
             sealed: bool,
             slices: Vec<&'a [(B256, U256)]>,
         }
 
-        let mut acc: B256Map<StorageAcc<'_>> = B256Map::default();
-
+        let mut account_slices = Vec::new();
+        let mut acc = BTreeMap::<B256, StorageAcc<'a>>::new();
         for item in items {
-            for (addr, storage) in &item.as_ref().storages {
-                let entry = acc.entry(*addr).or_insert_with(|| StorageAcc {
+            account_slices.push(item.accounts.as_slice());
+            for (address, storage) in &item.storages {
+                let entry = acc.entry(*address).or_insert_with(|| StorageAcc {
                     wiped: false,
                     sealed: false,
                     slices: Vec::new(),
@@ -680,27 +729,23 @@ impl HashedPostStateSorted {
             }
         }
 
-        let storages = acc
-            .into_iter()
-            .map(|(addr, entry)| {
-                let storage_slots = kway_merge_sorted(entry.slices);
-                (addr, HashedStorageSorted { wiped: entry.wiped, storage_slots })
-            })
-            .collect();
+        let accounts = Box::new(kway_merge_sorted(account_slices));
+        let storages = Box::new(acc.into_iter().map(|(address, entry)| {
+            (
+                address,
+                LazyHashedStorageSorted {
+                    storage_slots: Box::new(kway_merge_sorted(entry.slices)),
+                    wiped: entry.wiped,
+                },
+            )
+        }));
 
         Self { accounts, storages }
     }
 
-    /// Clears all accounts and storage data.
-    pub fn clear(&mut self) {
-        self.accounts.clear();
-        self.storages.clear();
-    }
-}
-
-impl AsRef<Self> for HashedPostStateSorted {
-    fn as_ref(&self) -> &Self {
-        self
+    /// Consumes the state and returns its account and storage update iterators.
+    pub fn into_parts(self) -> (LazyHashedAccountIter<'a>, LazyHashedStorageIter<'a>) {
+        (self.accounts, self.storages)
     }
 }
 
@@ -762,9 +807,48 @@ impl HashedStorageSorted {
 
         let wipe_idx = updates.iter().position(|u| u.wiped);
         let relevant = wipe_idx.map_or(&updates[..], |idx| &updates[..=idx]);
-        let storage_slots = kway_merge_sorted(relevant.iter().map(|u| u.storage_slots.as_slice()));
+        let storage_slots =
+            kway_merge_sorted(relevant.iter().map(|u| u.storage_slots.as_slice())).collect();
 
         Self { wiped: wipe_idx.is_some(), storage_slots }
+    }
+}
+
+/// Lazily merged sorted hashed storage updates.
+pub struct LazyHashedStorageSorted<'a> {
+    storage_slots: LazyHashedStorageSlotIter<'a>,
+    wiped: bool,
+}
+
+impl fmt::Debug for LazyHashedStorageSorted<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyHashedStorageSorted")
+            .field("wiped", &self.wiped)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> LazyHashedStorageSorted<'a> {
+    /// Consumes the storage updates and returns the wipe flag and slot update iterator.
+    pub fn into_parts(self) -> (bool, LazyHashedStorageSlotIter<'a>) {
+        (self.wiped, self.storage_slots)
+    }
+}
+
+impl From<LazyHashedStorageSorted<'_>> for HashedStorageSorted {
+    fn from(lazy: LazyHashedStorageSorted<'_>) -> Self {
+        let (wiped, storage_slots) = lazy.into_parts();
+        Self { storage_slots: storage_slots.collect(), wiped }
+    }
+}
+
+impl From<LazyHashedPostStateSorted<'_>> for HashedPostStateSorted {
+    fn from(lazy: LazyHashedPostStateSorted<'_>) -> Self {
+        let (accounts, storages) = lazy.into_parts();
+        Self {
+            accounts: accounts.collect(),
+            storages: storages.map(|(address, storage)| (address, storage.into())).collect(),
+        }
     }
 }
 
@@ -1432,6 +1516,82 @@ mod tests {
         assert_eq!(state1.accounts[4].1, None);
         assert_eq!(state1.accounts[5].0, B256::from([6; 32]));
         assert_eq!(state1.accounts[5].1, None);
+    }
+
+    #[test]
+    fn test_hashed_post_state_sorted_lazy_merge() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LazyHashedPostStateSorted<'static>>();
+
+        let account0 = B256::with_last_byte(0x10);
+        let account1 = B256::with_last_byte(0x11);
+        let account2 = B256::with_last_byte(0x12);
+        let storage_address = B256::with_last_byte(0x20);
+        let empty_wiped_address = B256::with_last_byte(0x21);
+        let slot0 = B256::with_last_byte(0x30);
+        let slot1 = B256::with_last_byte(0x31);
+        let slot2 = B256::with_last_byte(0x32);
+
+        let newest = HashedPostStateSorted::new(
+            vec![(account2, None)],
+            B256Map::from_iter([(
+                storage_address,
+                HashedStorageSorted { storage_slots: vec![(slot2, U256::from(2))], wiped: false },
+            )]),
+        );
+        let middle = HashedPostStateSorted::new(
+            vec![(account1, Some(Account { nonce: 1, ..Default::default() }))],
+            B256Map::from_iter([
+                (
+                    storage_address,
+                    HashedStorageSorted {
+                        storage_slots: vec![(slot1, U256::from(1)), (slot2, U256::from(20))],
+                        wiped: true,
+                    },
+                ),
+                (empty_wiped_address, HashedStorageSorted { storage_slots: vec![], wiped: true }),
+            ]),
+        );
+        let oldest = HashedPostStateSorted::new(
+            vec![
+                (account0, Some(Account::default())),
+                (account2, Some(Account { nonce: 2, ..Default::default() })),
+            ],
+            B256Map::from_iter([
+                (
+                    storage_address,
+                    HashedStorageSorted {
+                        storage_slots: vec![(slot0, U256::from(10)), (slot1, U256::from(10))],
+                        wiped: false,
+                    },
+                ),
+                (
+                    empty_wiped_address,
+                    HashedStorageSorted {
+                        storage_slots: vec![(slot0, U256::from(10))],
+                        wiped: false,
+                    },
+                ),
+            ]),
+        );
+
+        let merged: HashedPostStateSorted =
+            HashedPostStateSorted::merge_batch_lazy([&newest, &middle, &oldest]).into();
+
+        assert_eq!(
+            merged.accounts,
+            vec![
+                (account0, Some(Account::default())),
+                (account1, Some(Account { nonce: 1, ..Default::default() })),
+                (account2, None),
+            ]
+        );
+        let storage = &merged.storages[&storage_address];
+        assert!(storage.wiped);
+        assert_eq!(storage.storage_slots, vec![(slot1, U256::from(1)), (slot2, U256::from(2))]);
+        let empty_wiped = &merged.storages[&empty_wiped_address];
+        assert!(empty_wiped.wiped);
+        assert!(empty_wiped.storage_slots.is_empty());
     }
 
     #[test]

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -3,10 +3,10 @@ use core::{fmt, ops::Not};
 use crate::{
     added_removed_keys::MultiAddedRemovedKeys,
     prefix_set::{PrefixSetMut, TriePrefixSetsMut},
-    utils::{extend_sorted_vec, kway_merge_sorted},
+    utils::{extend_sorted_vec, kway_merge_sorted, kway_merge_sorted_groups},
     KeyHasher, MultiProofTargets, Nibbles,
 };
-use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 use alloy_primitives::{
     keccak256,
     map::{hash_map, B256Map, HashMap, HashSet},
@@ -609,58 +609,46 @@ impl HashedPostStateSorted {
         }
     }
 
-    /// Batch-merge sorted hashed post states. Iterator yields **newest to oldest**.
-    ///
-    /// For small batches, uses `extend_ref_and_sort` loop.
-    /// For large batches, uses k-way merge for O(n log k) complexity.
-    pub fn merge_batch<T: AsRef<Self> + From<Self>>(iter: impl IntoIterator<Item = T>) -> T {
-        let items: alloc::vec::Vec<_> = iter.into_iter().collect();
-        match items.len() {
-            0 => Self::default().into(),
-            1 => items.into_iter().next().expect("len == 1"),
-            _ => Self::merge_slice(&items).into(),
+    /// Returns a borrowed lazy view of this sorted state.
+    pub fn as_lazy(&self) -> LazyHashedPostStateSorted<'_> {
+        LazyHashedPostStateSorted {
+            accounts: Box::new(self.accounts.iter().copied()),
+            storages: Box::new(
+                self.storages
+                    .iter()
+                    .sorted_by_key(|(address, _)| *address)
+                    .map(|(address, storage)| (*address, storage.as_lazy())),
+            ),
         }
     }
 
-    /// Batch-merge sorted hashed post states from a slice. Slice is **newest to oldest**.
+    /// Lazily batch-merges sorted hashed post states supplied **newest to oldest**.
     ///
-    /// This variant takes a slice reference directly, avoiding iterator collection overhead.
-    /// For small batches, uses `extend_ref_and_sort` loop.
-    /// For large batches, uses k-way merge for O(n log k) complexity.
-    pub fn merge_slice<T: AsRef<Self>>(items: &[T]) -> Self {
-        const THRESHOLD: usize = 30;
-
-        let k = items.len();
-
-        if k == 0 {
-            return Self::default();
-        }
-        if k == 1 {
-            return items[0].as_ref().clone();
-        }
-
-        if k < THRESHOLD {
-            // Small k: extend loop, oldest-to-newest so newer overrides older.
-            let mut iter = items.iter().rev();
-            let mut acc = iter.next().expect("k > 0").as_ref().clone();
-            for next in iter {
-                acc.extend_ref_and_sort(next.as_ref());
-            }
-            return acc;
-        }
-
-        // Large k: k-way merge.
-        Self::merge_batch_lazy(items.iter().map(|item| item.as_ref())).into()
-    }
-
-    /// Lazily batch-merge sorted hashed post states supplied **newest to oldest**.
-    ///
-    /// The returned iterators yield entries in ascending key order and clone them only as they are
-    /// consumed. For duplicate keys, the value from the newest input is retained.
-    pub fn merge_batch_lazy<'a>(
-        items: impl IntoIterator<Item = &'a Self>,
+    /// The returned iterators yield entries in ascending key order. For duplicate keys, the value
+    /// from the newest input is retained.
+    pub fn merge_batch<'a>(
+        states: impl IntoIterator<Item = LazyHashedPostStateSorted<'a>>,
     ) -> LazyHashedPostStateSorted<'a> {
-        LazyHashedPostStateSorted::merge_batch(items)
+        let mut states = states.into_iter();
+        let Some(first) = states.next() else { return LazyHashedPostStateSorted::default() };
+        let Some(second) = states.next() else { return first };
+
+        let mut account_iters = Vec::new();
+        let mut storage_iters = Vec::new();
+        for state in core::iter::once(first).chain(core::iter::once(second)).chain(states) {
+            let (accounts, storages) = state.into_parts();
+            account_iters.push(accounts);
+            storage_iters.push(storages);
+        }
+
+        LazyHashedPostStateSorted {
+            accounts: kway_merge_sorted(account_iters),
+            storages: Box::new(
+                kway_merge_sorted_groups(storage_iters).map(|(address, storages)| {
+                    (address, HashedStorageSorted::merge_batch(storages))
+                }),
+            ),
+        }
     }
 
     /// Clears all accounts and storage data.
@@ -676,20 +664,20 @@ impl AsRef<Self> for HashedPostStateSorted {
     }
 }
 
-/// Lazily merged sorted hashed post state optimized for streaming updates to storage.
+/// Lazy sorted hashed post state optimized for streaming updates to storage.
 pub struct LazyHashedPostStateSorted<'a> {
     accounts: LazyHashedAccountIter<'a>,
     storages: LazyHashedStorageIter<'a>,
 }
 
-/// Boxed iterator over lazily merged hashed account updates.
+/// Boxed iterator over lazy hashed account updates.
 pub type LazyHashedAccountIter<'a> = Box<dyn Iterator<Item = (B256, Option<Account>)> + Send + 'a>;
 
-/// Boxed iterator over lazily merged hashed storage updates.
+/// Boxed iterator over lazy hashed storage updates.
 pub type LazyHashedStorageIter<'a> =
     Box<dyn Iterator<Item = (B256, LazyHashedStorageSorted<'a>)> + Send + 'a>;
 
-/// Boxed iterator over lazily merged hashed storage slot updates.
+/// Boxed iterator over lazy hashed storage slot updates.
 pub type LazyHashedStorageSlotIter<'a> = Box<dyn Iterator<Item = (B256, U256)> + Send + 'a>;
 
 impl fmt::Debug for LazyHashedPostStateSorted<'_> {
@@ -698,51 +686,13 @@ impl fmt::Debug for LazyHashedPostStateSorted<'_> {
     }
 }
 
-impl<'a> LazyHashedPostStateSorted<'a> {
-    fn merge_batch(items: impl IntoIterator<Item = &'a HashedPostStateSorted>) -> Self {
-        struct StorageAcc<'a> {
-            wiped: bool,
-            sealed: bool,
-            slices: Vec<&'a [(B256, U256)]>,
-        }
-
-        let mut account_slices = Vec::new();
-        let mut acc = BTreeMap::<B256, StorageAcc<'a>>::new();
-        for item in items {
-            account_slices.push(item.accounts.as_slice());
-            for (address, storage) in &item.storages {
-                let entry = acc.entry(*address).or_insert_with(|| StorageAcc {
-                    wiped: false,
-                    sealed: false,
-                    slices: Vec::new(),
-                });
-
-                if entry.sealed {
-                    continue;
-                }
-
-                entry.slices.push(storage.storage_slots.as_slice());
-                if storage.wiped {
-                    entry.wiped = true;
-                    entry.sealed = true;
-                }
-            }
-        }
-
-        let accounts = Box::new(kway_merge_sorted(account_slices));
-        let storages = Box::new(acc.into_iter().map(|(address, entry)| {
-            (
-                address,
-                LazyHashedStorageSorted {
-                    storage_slots: Box::new(kway_merge_sorted(entry.slices)),
-                    wiped: entry.wiped,
-                },
-            )
-        }));
-
-        Self { accounts, storages }
+impl Default for LazyHashedPostStateSorted<'_> {
+    fn default() -> Self {
+        Self { accounts: Box::new(core::iter::empty()), storages: Box::new(core::iter::empty()) }
     }
+}
 
+impl<'a> LazyHashedPostStateSorted<'a> {
     /// Consumes the state and returns its account and storage update iterators.
     pub fn into_parts(self) -> (LazyHashedAccountIter<'a>, LazyHashedStorageIter<'a>) {
         (self.accounts, self.storages)
@@ -797,24 +747,44 @@ impl HashedStorageSorted {
         extend_sorted_vec(&mut self.storage_slots, &other.storage_slots);
     }
 
-    /// Batch-merge sorted hashed storage. Iterator yields **newest to oldest**.
-    /// If any update is wiped, prior data is discarded.
-    pub fn merge_batch<'a>(updates: impl IntoIterator<Item = &'a Self>) -> Self {
-        let updates: Vec<_> = updates.into_iter().collect();
-        if updates.is_empty() {
-            return Self::default();
+    /// Returns a borrowed lazy view of these sorted storage updates.
+    pub fn as_lazy(&self) -> LazyHashedStorageSorted<'_> {
+        LazyHashedStorageSorted {
+            storage_slots: Box::new(self.storage_slots.iter().copied()),
+            wiped: self.wiped,
+        }
+    }
+
+    /// Lazily batch-merges sorted hashed storage supplied **newest to oldest**.
+    ///
+    /// If any update is wiped, older data is discarded.
+    pub fn merge_batch<'a>(
+        updates: impl IntoIterator<Item = LazyHashedStorageSorted<'a>>,
+    ) -> LazyHashedStorageSorted<'a> {
+        let mut relevant = Vec::new();
+        for update in updates {
+            let wiped = update.wiped;
+            relevant.push(update);
+            if wiped {
+                break
+            }
         }
 
-        let wipe_idx = updates.iter().position(|u| u.wiped);
-        let relevant = wipe_idx.map_or(&updates[..], |idx| &updates[..=idx]);
-        let storage_slots =
-            kway_merge_sorted(relevant.iter().map(|u| u.storage_slots.as_slice())).collect();
+        let mut relevant = relevant.into_iter();
+        let Some(first) = relevant.next() else { return LazyHashedStorageSorted::default() };
+        let Some(second) = relevant.next() else { return first };
+        let wiped =
+            first.wiped || second.wiped || relevant.as_slice().iter().any(|item| item.wiped);
+        let storage_slots = core::iter::once(first)
+            .chain(core::iter::once(second))
+            .chain(relevant)
+            .map(|storage| storage.storage_slots);
 
-        Self { wiped: wipe_idx.is_some(), storage_slots }
+        LazyHashedStorageSorted { storage_slots: kway_merge_sorted(storage_slots), wiped }
     }
 }
 
-/// Lazily merged sorted hashed storage updates.
+/// Lazy sorted hashed storage updates.
 pub struct LazyHashedStorageSorted<'a> {
     storage_slots: LazyHashedStorageSlotIter<'a>,
     wiped: bool,
@@ -825,6 +795,12 @@ impl fmt::Debug for LazyHashedStorageSorted<'_> {
         f.debug_struct("LazyHashedStorageSorted")
             .field("wiped", &self.wiped)
             .finish_non_exhaustive()
+    }
+}
+
+impl Default for LazyHashedStorageSorted<'_> {
+    fn default() -> Self {
+        Self { storage_slots: Box::new(core::iter::empty()), wiped: false }
     }
 }
 
@@ -1519,7 +1495,31 @@ mod tests {
     }
 
     #[test]
-    fn test_hashed_post_state_sorted_lazy_merge() {
+    fn test_hashed_post_state_sorted_as_lazy() {
+        let low = B256::with_last_byte(0x01);
+        let high = B256::with_last_byte(0xff);
+        let state = HashedPostStateSorted::new(
+            vec![(low, Some(Account::default()))],
+            B256Map::from_iter([
+                (high, HashedStorageSorted::default()),
+                (low, HashedStorageSorted::default()),
+            ]),
+        );
+
+        let roundtrip: HashedPostStateSorted =
+            HashedPostStateSorted::merge_batch([state.as_lazy()]).into();
+        assert_eq!(roundtrip, state);
+
+        let (_, storages) = state.as_lazy().into_parts();
+        assert_eq!(storages.map(|(address, _)| address).collect::<Vec<_>>(), vec![low, high]);
+
+        let empty: HashedPostStateSorted =
+            HashedPostStateSorted::merge_batch(core::iter::empty()).into();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_hashed_post_state_sorted_merge_batch() {
         fn assert_send<T: Send>() {}
         assert_send::<LazyHashedPostStateSorted<'static>>();
 
@@ -1575,8 +1575,10 @@ mod tests {
             ]),
         );
 
+        let newest_and_middle =
+            HashedPostStateSorted::merge_batch([newest.as_lazy(), middle.as_lazy()]);
         let merged: HashedPostStateSorted =
-            HashedPostStateSorted::merge_batch_lazy([&newest, &middle, &oldest]).into();
+            HashedPostStateSorted::merge_batch([newest_and_middle, oldest.as_lazy()]).into();
 
         assert_eq!(
             merged.accounts,

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -3,6 +3,7 @@ use crate::{
     BranchNodeCompact, HashBuilder, Nibbles,
 };
 use alloc::{
+    boxed::Box,
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},
     vec::Vec,
 };
@@ -668,20 +669,60 @@ impl TrieUpdatesSorted {
         }
 
         // Large k: k-way merge.
-        let account_nodes =
-            kway_merge_sorted(items.iter().map(|i| i.as_ref().account_nodes.as_slice()));
+        Self::merge_batch_lazy(items.iter().map(|item| item.as_ref())).into()
+    }
 
+    /// Lazily batch-merge sorted trie updates supplied **newest to oldest**.
+    ///
+    /// The returned iterators yield entries in ascending key order and clone them only as they are
+    /// consumed. For duplicate keys, the value from the newest input is retained.
+    pub fn merge_batch_lazy<'a>(
+        items: impl IntoIterator<Item = &'a Self>,
+    ) -> LazyTrieUpdatesSorted<'a> {
+        LazyTrieUpdatesSorted::merge_batch(items)
+    }
+}
+
+impl AsRef<Self> for TrieUpdatesSorted {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+/// Lazily merged sorted trie updates optimized for streaming updates to storage.
+pub struct LazyTrieUpdatesSorted<'a> {
+    account_nodes: LazyTrieNodeIter<'a>,
+    storage_tries: LazyStorageTrieIter<'a>,
+}
+
+/// Boxed iterator over lazily merged trie node updates.
+pub type LazyTrieNodeIter<'a> =
+    Box<dyn Iterator<Item = (Nibbles, Option<BranchNodeCompact>)> + Send + 'a>;
+
+/// Boxed iterator over lazily merged storage trie updates.
+pub type LazyStorageTrieIter<'a> =
+    Box<dyn Iterator<Item = (B256, LazyStorageTrieUpdatesSorted<'a>)> + Send + 'a>;
+
+impl core::fmt::Debug for LazyTrieUpdatesSorted<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LazyTrieUpdatesSorted").finish_non_exhaustive()
+    }
+}
+
+impl<'a> LazyTrieUpdatesSorted<'a> {
+    fn merge_batch(items: impl IntoIterator<Item = &'a TrieUpdatesSorted>) -> Self {
         struct StorageAcc<'a> {
             is_deleted: bool,
             sealed: bool,
             slices: Vec<&'a [(Nibbles, Option<BranchNodeCompact>)]>,
         }
 
-        let mut acc: B256Map<StorageAcc<'_>> = B256Map::default();
-
+        let mut account_slices = Vec::new();
+        let mut acc = BTreeMap::<B256, StorageAcc<'a>>::new();
         for item in items {
-            for (addr, storage) in &item.as_ref().storage_tries {
-                let entry = acc.entry(*addr).or_insert_with(|| StorageAcc {
+            account_slices.push(item.account_nodes.as_slice());
+            for (address, storage) in &item.storage_tries {
+                let entry = acc.entry(*address).or_insert_with(|| StorageAcc {
                     is_deleted: false,
                     sealed: false,
                     slices: Vec::new(),
@@ -692,7 +733,6 @@ impl TrieUpdatesSorted {
                 }
 
                 entry.slices.push(storage.storage_nodes.as_slice());
-
                 if storage.is_deleted {
                     entry.is_deleted = true;
                     entry.sealed = true;
@@ -700,21 +740,23 @@ impl TrieUpdatesSorted {
             }
         }
 
-        let storage_tries = acc
-            .into_iter()
-            .map(|(addr, entry)| {
-                let storage_nodes = kway_merge_sorted(entry.slices);
-                (addr, StorageTrieUpdatesSorted { is_deleted: entry.is_deleted, storage_nodes })
-            })
-            .collect();
+        let account_nodes = Box::new(kway_merge_sorted(account_slices));
+        let storage_tries = Box::new(acc.into_iter().map(|(address, entry)| {
+            (
+                address,
+                LazyStorageTrieUpdatesSorted {
+                    is_deleted: entry.is_deleted,
+                    storage_nodes: Box::new(kway_merge_sorted(entry.slices)),
+                },
+            )
+        }));
 
         Self { account_nodes, storage_tries }
     }
-}
 
-impl AsRef<Self> for TrieUpdatesSorted {
-    fn as_ref(&self) -> &Self {
-        self
+    /// Consumes the updates and returns the account and storage trie update iterators.
+    pub fn into_parts(self) -> (LazyTrieNodeIter<'a>, LazyStorageTrieIter<'a>) {
+        (self.account_nodes, self.storage_tries)
     }
 }
 
@@ -813,9 +855,50 @@ impl StorageTrieUpdatesSorted {
         // Discard updates older than the first deletion since the trie was wiped at that point.
         let del_idx = updates.iter().position(|u| u.is_deleted);
         let relevant = del_idx.map_or(&updates[..], |idx| &updates[..=idx]);
-        let storage_nodes = kway_merge_sorted(relevant.iter().map(|u| u.storage_nodes.as_slice()));
+        let storage_nodes =
+            kway_merge_sorted(relevant.iter().map(|u| u.storage_nodes.as_slice())).collect();
 
         Self { is_deleted: del_idx.is_some(), storage_nodes }
+    }
+}
+
+/// Lazily merged sorted storage trie updates.
+pub struct LazyStorageTrieUpdatesSorted<'a> {
+    is_deleted: bool,
+    storage_nodes: LazyTrieNodeIter<'a>,
+}
+
+impl core::fmt::Debug for LazyStorageTrieUpdatesSorted<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LazyStorageTrieUpdatesSorted")
+            .field("is_deleted", &self.is_deleted)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> LazyStorageTrieUpdatesSorted<'a> {
+    /// Consumes the updates and returns the deletion flag and storage node update iterator.
+    pub fn into_parts(self) -> (bool, LazyTrieNodeIter<'a>) {
+        (self.is_deleted, self.storage_nodes)
+    }
+}
+
+impl From<LazyStorageTrieUpdatesSorted<'_>> for StorageTrieUpdatesSorted {
+    fn from(lazy: LazyStorageTrieUpdatesSorted<'_>) -> Self {
+        let (is_deleted, storage_nodes) = lazy.into_parts();
+        Self { is_deleted, storage_nodes: storage_nodes.collect() }
+    }
+}
+
+impl From<LazyTrieUpdatesSorted<'_>> for TrieUpdatesSorted {
+    fn from(lazy: LazyTrieUpdatesSorted<'_>) -> Self {
+        let (account_nodes, storage_tries) = lazy.into_parts();
+        Self {
+            account_nodes: account_nodes.collect(),
+            storage_tries: storage_tries
+                .map(|(address, storage)| (address, storage.into()))
+                .collect(),
+        }
     }
 }
 
@@ -920,6 +1003,94 @@ mod tests {
         // Check that storage trie for hashed_address1 was extended
         let merged_storage = &updates1.storage_tries[&hashed_address1];
         assert_eq!(merged_storage.storage_nodes.len(), 2);
+    }
+
+    #[test]
+    fn test_trie_updates_sorted_lazy_merge() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LazyTrieUpdatesSorted<'static>>();
+
+        let account0 = Nibbles::from_nibbles([0x00]);
+        let account1 = Nibbles::from_nibbles([0x01]);
+        let account2 = Nibbles::from_nibbles([0x02]);
+        let storage_address = B256::with_last_byte(0x10);
+        let empty_deleted_address = B256::with_last_byte(0x11);
+        let node0 = Nibbles::from_nibbles([0x03]);
+        let node1 = Nibbles::from_nibbles([0x04]);
+        let node2 = Nibbles::from_nibbles([0x05]);
+
+        let newest = TrieUpdatesSorted::new(
+            vec![(account2, None)],
+            B256Map::from_iter([(
+                storage_address,
+                StorageTrieUpdatesSorted { is_deleted: false, storage_nodes: vec![(node2, None)] },
+            )]),
+        );
+        let middle = TrieUpdatesSorted::new(
+            vec![(account1, Some(BranchNodeCompact::default()))],
+            B256Map::from_iter([
+                (
+                    storage_address,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: true,
+                        storage_nodes: vec![
+                            (node1, Some(BranchNodeCompact::default())),
+                            (node2, Some(BranchNodeCompact::default())),
+                        ],
+                    },
+                ),
+                (
+                    empty_deleted_address,
+                    StorageTrieUpdatesSorted { is_deleted: true, storage_nodes: vec![] },
+                ),
+            ]),
+        );
+        let oldest = TrieUpdatesSorted::new(
+            vec![
+                (account0, Some(BranchNodeCompact::default())),
+                (account2, Some(BranchNodeCompact::default())),
+            ],
+            B256Map::from_iter([
+                (
+                    storage_address,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: false,
+                        storage_nodes: vec![
+                            (node0, Some(BranchNodeCompact::default())),
+                            (node1, None),
+                        ],
+                    },
+                ),
+                (
+                    empty_deleted_address,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: false,
+                        storage_nodes: vec![(node0, Some(BranchNodeCompact::default()))],
+                    },
+                ),
+            ]),
+        );
+
+        let merged: TrieUpdatesSorted =
+            TrieUpdatesSorted::merge_batch_lazy([&newest, &middle, &oldest]).into();
+
+        assert_eq!(
+            merged.account_nodes,
+            vec![
+                (account0, Some(BranchNodeCompact::default())),
+                (account1, Some(BranchNodeCompact::default())),
+                (account2, None),
+            ]
+        );
+        let storage = &merged.storage_tries[&storage_address];
+        assert!(storage.is_deleted);
+        assert_eq!(
+            storage.storage_nodes,
+            vec![(node1, Some(BranchNodeCompact::default())), (node2, None)]
+        );
+        let empty_deleted = &merged.storage_tries[&empty_deleted_address];
+        assert!(empty_deleted.is_deleted);
+        assert!(empty_deleted.storage_nodes.is_empty());
     }
 
     #[test]

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -1,5 +1,5 @@
 use crate::{
-    utils::{extend_sorted_vec, kway_merge_sorted},
+    utils::{extend_sorted_vec, kway_merge_sorted, kway_merge_sorted_groups},
     BranchNodeCompact, HashBuilder, Nibbles,
 };
 use alloc::{
@@ -11,6 +11,7 @@ use alloy_primitives::{
     map::{B256Map, B256Set, HashMap, HashSet},
     FixedBytes, B256,
 };
+use itertools::Itertools;
 
 /// The aggregation of trie updates.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
@@ -628,58 +629,44 @@ impl TrieUpdatesSorted {
         self.storage_tries.clear();
     }
 
-    /// Batch-merge sorted trie updates. Iterator yields **newest to oldest**.
-    ///
-    /// For small batches, uses `extend_ref_and_sort` loop.
-    /// For large batches, uses k-way merge for O(n log k) complexity.
-    pub fn merge_batch<T: AsRef<Self> + From<Self>>(iter: impl IntoIterator<Item = T>) -> T {
-        let items: alloc::vec::Vec<_> = iter.into_iter().collect();
-        match items.len() {
-            0 => Self::default().into(),
-            1 => items.into_iter().next().expect("len == 1"),
-            _ => Self::merge_slice(&items).into(),
+    /// Returns a borrowed lazy view of these sorted trie updates.
+    pub fn as_lazy(&self) -> LazyTrieUpdatesSorted<'_> {
+        LazyTrieUpdatesSorted {
+            account_nodes: Box::new(self.account_nodes.iter().cloned()),
+            storage_tries: Box::new(
+                self.storage_tries
+                    .iter()
+                    .sorted_by_key(|(address, _)| *address)
+                    .map(|(address, storage)| (*address, storage.as_lazy())),
+            ),
         }
     }
 
-    /// Batch-merge sorted trie updates from a slice. Slice is **newest to oldest**.
+    /// Lazily batch-merges sorted trie updates supplied **newest to oldest**.
     ///
-    /// This variant takes a slice reference directly, avoiding iterator collection overhead.
-    /// For small batches, uses `extend_ref_and_sort` loop.
-    /// For large batches, uses k-way merge for O(n log k) complexity.
-    pub fn merge_slice<T: AsRef<Self>>(items: &[T]) -> Self {
-        const THRESHOLD: usize = 30;
-
-        let k = items.len();
-
-        if k == 0 {
-            return Self::default();
-        }
-        if k == 1 {
-            return items[0].as_ref().clone();
-        }
-
-        if k < THRESHOLD {
-            // Small k: extend loop, oldest-to-newest so newer overrides older.
-            let mut iter = items.iter().rev();
-            let mut acc = iter.next().expect("k > 0").as_ref().clone();
-            for next in iter {
-                acc.extend_ref_and_sort(next.as_ref());
-            }
-            return acc;
-        }
-
-        // Large k: k-way merge.
-        Self::merge_batch_lazy(items.iter().map(|item| item.as_ref())).into()
-    }
-
-    /// Lazily batch-merge sorted trie updates supplied **newest to oldest**.
-    ///
-    /// The returned iterators yield entries in ascending key order and clone them only as they are
-    /// consumed. For duplicate keys, the value from the newest input is retained.
-    pub fn merge_batch_lazy<'a>(
-        items: impl IntoIterator<Item = &'a Self>,
+    /// The returned iterators yield entries in ascending key order. For duplicate keys, the value
+    /// from the newest input is retained.
+    pub fn merge_batch<'a>(
+        updates: impl IntoIterator<Item = LazyTrieUpdatesSorted<'a>>,
     ) -> LazyTrieUpdatesSorted<'a> {
-        LazyTrieUpdatesSorted::merge_batch(items)
+        let mut updates = updates.into_iter();
+        let Some(first) = updates.next() else { return LazyTrieUpdatesSorted::default() };
+        let Some(second) = updates.next() else { return first };
+
+        let mut account_iters = Vec::new();
+        let mut storage_iters = Vec::new();
+        for updates in core::iter::once(first).chain(core::iter::once(second)).chain(updates) {
+            let (account_nodes, storage_tries) = updates.into_parts();
+            account_iters.push(account_nodes);
+            storage_iters.push(storage_tries);
+        }
+
+        LazyTrieUpdatesSorted {
+            account_nodes: kway_merge_sorted(account_iters),
+            storage_tries: Box::new(kway_merge_sorted_groups(storage_iters).map(
+                |(address, updates)| (address, StorageTrieUpdatesSorted::merge_batch(updates)),
+            )),
+        }
     }
 }
 
@@ -689,17 +676,17 @@ impl AsRef<Self> for TrieUpdatesSorted {
     }
 }
 
-/// Lazily merged sorted trie updates optimized for streaming updates to storage.
+/// Lazy sorted trie updates optimized for streaming updates to storage.
 pub struct LazyTrieUpdatesSorted<'a> {
     account_nodes: LazyTrieNodeIter<'a>,
     storage_tries: LazyStorageTrieIter<'a>,
 }
 
-/// Boxed iterator over lazily merged trie node updates.
+/// Boxed iterator over lazy trie node updates.
 pub type LazyTrieNodeIter<'a> =
     Box<dyn Iterator<Item = (Nibbles, Option<BranchNodeCompact>)> + Send + 'a>;
 
-/// Boxed iterator over lazily merged storage trie updates.
+/// Boxed iterator over lazy storage trie updates.
 pub type LazyStorageTrieIter<'a> =
     Box<dyn Iterator<Item = (B256, LazyStorageTrieUpdatesSorted<'a>)> + Send + 'a>;
 
@@ -709,51 +696,16 @@ impl core::fmt::Debug for LazyTrieUpdatesSorted<'_> {
     }
 }
 
-impl<'a> LazyTrieUpdatesSorted<'a> {
-    fn merge_batch(items: impl IntoIterator<Item = &'a TrieUpdatesSorted>) -> Self {
-        struct StorageAcc<'a> {
-            is_deleted: bool,
-            sealed: bool,
-            slices: Vec<&'a [(Nibbles, Option<BranchNodeCompact>)]>,
+impl Default for LazyTrieUpdatesSorted<'_> {
+    fn default() -> Self {
+        Self {
+            account_nodes: Box::new(core::iter::empty()),
+            storage_tries: Box::new(core::iter::empty()),
         }
-
-        let mut account_slices = Vec::new();
-        let mut acc = BTreeMap::<B256, StorageAcc<'a>>::new();
-        for item in items {
-            account_slices.push(item.account_nodes.as_slice());
-            for (address, storage) in &item.storage_tries {
-                let entry = acc.entry(*address).or_insert_with(|| StorageAcc {
-                    is_deleted: false,
-                    sealed: false,
-                    slices: Vec::new(),
-                });
-
-                if entry.sealed {
-                    continue;
-                }
-
-                entry.slices.push(storage.storage_nodes.as_slice());
-                if storage.is_deleted {
-                    entry.is_deleted = true;
-                    entry.sealed = true;
-                }
-            }
-        }
-
-        let account_nodes = Box::new(kway_merge_sorted(account_slices));
-        let storage_tries = Box::new(acc.into_iter().map(|(address, entry)| {
-            (
-                address,
-                LazyStorageTrieUpdatesSorted {
-                    is_deleted: entry.is_deleted,
-                    storage_nodes: Box::new(kway_merge_sorted(entry.slices)),
-                },
-            )
-        }));
-
-        Self { account_nodes, storage_tries }
     }
+}
 
+impl<'a> LazyTrieUpdatesSorted<'a> {
     /// Consumes the updates and returns the account and storage trie update iterators.
     pub fn into_parts(self) -> (LazyTrieNodeIter<'a>, LazyStorageTrieIter<'a>) {
         (self.account_nodes, self.storage_tries)
@@ -844,25 +796,45 @@ impl StorageTrieUpdatesSorted {
         self.is_deleted = self.is_deleted || other.is_deleted;
     }
 
-    /// Batch-merge sorted storage trie updates. Iterator yields **newest to oldest**.
+    /// Returns a borrowed lazy view of these sorted storage trie updates.
+    pub fn as_lazy(&self) -> LazyStorageTrieUpdatesSorted<'_> {
+        LazyStorageTrieUpdatesSorted {
+            is_deleted: self.is_deleted,
+            storage_nodes: Box::new(self.storage_nodes.iter().cloned()),
+        }
+    }
+
+    /// Lazily batch-merges sorted storage trie updates supplied **newest to oldest**.
+    ///
     /// If any update is deleted, older data is discarded.
-    pub fn merge_batch<'a>(updates: impl IntoIterator<Item = &'a Self>) -> Self {
-        let updates: Vec<_> = updates.into_iter().collect();
-        if updates.is_empty() {
-            return Self::default();
+    pub fn merge_batch<'a>(
+        updates: impl IntoIterator<Item = LazyStorageTrieUpdatesSorted<'a>>,
+    ) -> LazyStorageTrieUpdatesSorted<'a> {
+        let mut relevant = Vec::new();
+        for update in updates {
+            let is_deleted = update.is_deleted;
+            relevant.push(update);
+            if is_deleted {
+                break
+            }
         }
 
-        // Discard updates older than the first deletion since the trie was wiped at that point.
-        let del_idx = updates.iter().position(|u| u.is_deleted);
-        let relevant = del_idx.map_or(&updates[..], |idx| &updates[..=idx]);
-        let storage_nodes =
-            kway_merge_sorted(relevant.iter().map(|u| u.storage_nodes.as_slice())).collect();
+        let mut relevant = relevant.into_iter();
+        let Some(first) = relevant.next() else { return LazyStorageTrieUpdatesSorted::default() };
+        let Some(second) = relevant.next() else { return first };
+        let is_deleted = first.is_deleted ||
+            second.is_deleted ||
+            relevant.as_slice().iter().any(|item| item.is_deleted);
+        let storage_nodes = core::iter::once(first)
+            .chain(core::iter::once(second))
+            .chain(relevant)
+            .map(|storage| storage.storage_nodes);
 
-        Self { is_deleted: del_idx.is_some(), storage_nodes }
+        LazyStorageTrieUpdatesSorted { is_deleted, storage_nodes: kway_merge_sorted(storage_nodes) }
     }
 }
 
-/// Lazily merged sorted storage trie updates.
+/// Lazy sorted storage trie updates.
 pub struct LazyStorageTrieUpdatesSorted<'a> {
     is_deleted: bool,
     storage_nodes: LazyTrieNodeIter<'a>,
@@ -873,6 +845,12 @@ impl core::fmt::Debug for LazyStorageTrieUpdatesSorted<'_> {
         f.debug_struct("LazyStorageTrieUpdatesSorted")
             .field("is_deleted", &self.is_deleted)
             .finish_non_exhaustive()
+    }
+}
+
+impl Default for LazyStorageTrieUpdatesSorted<'_> {
+    fn default() -> Self {
+        Self { is_deleted: false, storage_nodes: Box::new(core::iter::empty()) }
     }
 }
 
@@ -1006,7 +984,30 @@ mod tests {
     }
 
     #[test]
-    fn test_trie_updates_sorted_lazy_merge() {
+    fn test_trie_updates_sorted_as_lazy() {
+        let low = B256::with_last_byte(0x01);
+        let high = B256::with_last_byte(0xff);
+        let updates = TrieUpdatesSorted::new(
+            vec![(Nibbles::from_nibbles([0x01]), None)],
+            B256Map::from_iter([
+                (high, StorageTrieUpdatesSorted::default()),
+                (low, StorageTrieUpdatesSorted::default()),
+            ]),
+        );
+
+        let roundtrip: TrieUpdatesSorted =
+            TrieUpdatesSorted::merge_batch([updates.as_lazy()]).into();
+        assert_eq!(roundtrip, updates);
+
+        let (_, storage_tries) = updates.as_lazy().into_parts();
+        assert_eq!(storage_tries.map(|(address, _)| address).collect::<Vec<_>>(), vec![low, high]);
+
+        let empty: TrieUpdatesSorted = TrieUpdatesSorted::merge_batch(core::iter::empty()).into();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_trie_updates_sorted_merge_batch() {
         fn assert_send<T: Send>() {}
         assert_send::<LazyTrieUpdatesSorted<'static>>();
 
@@ -1071,8 +1072,10 @@ mod tests {
             ]),
         );
 
+        let newest_and_middle =
+            TrieUpdatesSorted::merge_batch([newest.as_lazy(), middle.as_lazy()]);
         let merged: TrieUpdatesSorted =
-            TrieUpdatesSorted::merge_batch_lazy([&newest, &middle, &oldest]).into();
+            TrieUpdatesSorted::merge_batch([newest_and_middle, oldest.as_lazy()]).into();
 
         assert_eq!(
             merged.account_nodes,

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -2,16 +2,17 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use itertools::Itertools;
 
-/// Merge sorted slices into a sorted `Vec`. First occurrence wins for duplicate keys.
+/// Merge sorted slices. First occurrence wins for duplicate keys.
 ///
 /// Callers pass slices in priority order (index 0 = highest priority), so the first
-/// slice's value for a key takes precedence over later slices.
-pub(crate) fn kway_merge_sorted<'a, K, V>(
-    slices: impl IntoIterator<Item = &'a [(K, V)]>,
-) -> Vec<(K, V)>
+/// slice's value for a key takes precedence over later slices. Keys and values are cloned as the
+/// returned iterator is consumed.
+pub(crate) fn kway_merge_sorted<'a, K, V, I>(slices: I) -> impl Iterator<Item = (K, V)> + 'a
 where
     K: Ord + Clone + 'a,
     V: Clone + 'a,
+    I: IntoIterator<Item = &'a [(K, V)]> + 'a,
+    I::IntoIter: 'a,
 {
     slices
         .into_iter()
@@ -23,7 +24,6 @@ where
         .dedup_by(|(_, k1, _), (_, k2, _)| *k1 == *k2)
         // Clone only surviving elements after dedup
         .map(|(_, k, v)| (k.clone(), v.clone()))
-        .collect()
 }
 
 /// Extend a sorted vector with another sorted vector using 2 pointer merge.
@@ -81,6 +81,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::rc::Rc;
+    use core::cell::Cell;
+
+    #[derive(Debug)]
+    struct CloneCounter {
+        value: u8,
+        count: Rc<Cell<usize>>,
+    }
+
+    impl Clone for CloneCounter {
+        fn clone(&self) -> Self {
+            self.count.set(self.count.get() + 1);
+            Self { value: self.value, count: Rc::clone(&self.count) }
+        }
+    }
 
     #[test]
     fn test_extend_sorted_vec() {
@@ -145,7 +160,8 @@ mod tests {
         let slice2 = vec![(2, "b2"), (3, "c2")];
         let slice3 = vec![(1, "a3"), (4, "d3")];
 
-        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()]);
+        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()])
+            .collect::<Vec<_>>();
         // First occurrence wins: key 1 -> a1 (slice1), key 3 -> c1 (slice1)
         assert_eq!(result, vec![(1, "a1"), (2, "b2"), (3, "c1"), (4, "d3")]);
     }
@@ -156,7 +172,8 @@ mod tests {
         let slice2 = vec![(1, "a")];
         let slice3: Vec<(i32, &str)> = vec![];
 
-        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()]);
+        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()])
+            .collect::<Vec<_>>();
         assert_eq!(result, vec![(1, "a")]);
     }
 
@@ -166,7 +183,8 @@ mod tests {
         let slice2 = vec![(5, "middle")];
         let slice3 = vec![(5, "last")];
 
-        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()]);
+        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()])
+            .collect::<Vec<_>>();
         // First occurrence wins (slice1 has highest priority)
         assert_eq!(result, vec![(5, "first")]);
     }
@@ -174,13 +192,28 @@ mod tests {
     #[test]
     fn test_kway_merge_sorted_single_slice() {
         let slice = vec![(1, "a"), (2, "b"), (3, "c")];
-        let result = kway_merge_sorted([slice.as_slice()]);
+        let result = kway_merge_sorted([slice.as_slice()]).collect::<Vec<_>>();
         assert_eq!(result, vec![(1, "a"), (2, "b"), (3, "c")]);
     }
 
     #[test]
     fn test_kway_merge_sorted_no_slices() {
-        let result: Vec<(i32, &str)> = kway_merge_sorted(Vec::<&[(i32, &str)]>::new());
+        let result: Vec<(i32, &str)> = kway_merge_sorted(Vec::<&[(i32, &str)]>::new()).collect();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_kway_merge_sorted_clones_lazily() {
+        let clone_count = Rc::new(Cell::new(0));
+        let slice = vec![
+            (1, CloneCounter { value: 1, count: Rc::clone(&clone_count) }),
+            (2, CloneCounter { value: 2, count: Rc::clone(&clone_count) }),
+            (3, CloneCounter { value: 3, count: Rc::clone(&clone_count) }),
+        ];
+
+        let mut result = kway_merge_sorted([slice.as_slice()]);
+        assert_eq!(clone_count.get(), 0);
+        assert_eq!(result.next().unwrap().1.value, 1);
+        assert_eq!(clone_count.get(), 1);
     }
 }

--- a/crates/trie/common/src/utils.rs
+++ b/crates/trie/common/src/utils.rs
@@ -1,29 +1,60 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::cmp::Ordering;
 use itertools::Itertools;
 
-/// Merge sorted slices. First occurrence wins for duplicate keys.
+type BoxedIterator<'a, T> = Box<dyn Iterator<Item = T> + Send + 'a>;
+
+/// Merge sorted iterators. First occurrence wins for duplicate keys.
 ///
-/// Callers pass slices in priority order (index 0 = highest priority), so the first
-/// slice's value for a key takes precedence over later slices. Keys and values are cloned as the
-/// returned iterator is consumed.
-pub(crate) fn kway_merge_sorted<'a, K, V, I>(slices: I) -> impl Iterator<Item = (K, V)> + 'a
+/// Callers pass iterators in priority order (index 0 = highest priority), so the first iterator's
+/// value for a key takes precedence over later iterators.
+pub(crate) fn kway_merge_sorted<'a, K, V, I>(iterators: I) -> BoxedIterator<'a, (K, V)>
 where
-    K: Ord + Clone + 'a,
-    V: Clone + 'a,
-    I: IntoIterator<Item = &'a [(K, V)]> + 'a,
-    I::IntoIter: 'a,
+    K: Ord + Send + 'a,
+    V: Send + 'a,
+    I: IntoIterator<Item = BoxedIterator<'a, (K, V)>>,
+    I::IntoIter: Send + 'a,
 {
-    slices
+    let mut iterators = iterators.into_iter();
+    let Some(first) = iterators.next() else { return Box::new(core::iter::empty()) };
+    let Some(second) = iterators.next() else { return first };
+
+    Box::new(
+        core::iter::once(first)
+            .chain(core::iter::once(second))
+            .chain(iterators)
+            .enumerate()
+            .map(|(priority, entries)| entries.map(move |(key, value)| (priority, key, value)))
+            .kmerge_by(|(i1, k1, _), (i2, k2, _)| (k1, i1) < (k2, i2))
+            .dedup_by(|(_, k1, _), (_, k2, _)| k1 == k2)
+            .map(|(_, key, value)| (key, value)),
+    )
+}
+
+/// Merge sorted iterators and group values with the same key in priority order.
+pub(crate) fn kway_merge_sorted_groups<'a, K, V, I>(iterators: I) -> BoxedIterator<'a, (K, Vec<V>)>
+where
+    K: Ord + Send + 'a,
+    V: Send + 'a,
+    I: IntoIterator<Item = BoxedIterator<'a, (K, V)>>,
+    I::IntoIter: Send + 'a,
+{
+    let merged = iterators
         .into_iter()
-        .filter(|s| !s.is_empty())
         .enumerate()
-        // Merge by reference: (priority, &K, &V) - avoids cloning all elements upfront
-        .map(|(i, s)| s.iter().map(move |(k, v)| (i, k, v)))
-        .kmerge_by(|(i1, k1, _), (i2, k2, _)| (k1, i1) < (k2, i2))
-        .dedup_by(|(_, k1, _), (_, k2, _)| *k1 == *k2)
-        // Clone only surviving elements after dedup
-        .map(|(_, k, v)| (k.clone(), v.clone()))
+        .map(|(priority, entries)| entries.map(move |(key, value)| (priority, key, value)))
+        .kmerge_by(|(i1, k1, _), (i2, k2, _)| (k1, i1) < (k2, i2));
+    let mut merged = merged.peekable();
+
+    Box::new(core::iter::from_fn(move || {
+        let (_, key, value) = merged.next()?;
+        let mut values = Vec::new();
+        values.push(value);
+        while merged.peek().is_some_and(|(_, next_key, _)| next_key == &key) {
+            values.push(merged.next().expect("peeked value exists").2);
+        }
+        Some((key, values))
+    }))
 }
 
 /// Extend a sorted vector with another sorted vector using 2 pointer merge.
@@ -81,20 +112,24 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::rc::Rc;
-    use core::cell::Cell;
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
     struct CloneCounter {
         value: u8,
-        count: Rc<Cell<usize>>,
+        count: Arc<AtomicUsize>,
     }
 
     impl Clone for CloneCounter {
         fn clone(&self) -> Self {
-            self.count.set(self.count.get() + 1);
-            Self { value: self.value, count: Rc::clone(&self.count) }
+            self.count.fetch_add(1, Ordering::Relaxed);
+            Self { value: self.value, count: Arc::clone(&self.count) }
         }
+    }
+
+    fn boxed<'a, T: Send + 'a>(iter: impl Iterator<Item = T> + Send + 'a) -> BoxedIterator<'a, T> {
+        Box::new(iter)
     }
 
     #[test]
@@ -156,64 +191,77 @@ mod tests {
 
     #[test]
     fn test_kway_merge_sorted_basic() {
-        let slice1 = vec![(1, "a1"), (3, "c1")];
-        let slice2 = vec![(2, "b2"), (3, "c2")];
-        let slice3 = vec![(1, "a3"), (4, "d3")];
+        let slice1 = [(1, "a1"), (3, "c1")];
+        let slice2 = [(2, "b2"), (3, "c2")];
+        let slice3 = [(1, "a3"), (4, "d3")];
 
-        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()])
-            .collect::<Vec<_>>();
+        let result = kway_merge_sorted([
+            boxed(slice1.iter().copied()),
+            boxed(slice2.iter().copied()),
+            boxed(slice3.iter().copied()),
+        ])
+        .collect::<Vec<_>>();
         // First occurrence wins: key 1 -> a1 (slice1), key 3 -> c1 (slice1)
         assert_eq!(result, vec![(1, "a1"), (2, "b2"), (3, "c1"), (4, "d3")]);
     }
 
     #[test]
     fn test_kway_merge_sorted_empty_slices() {
-        let slice1: Vec<(i32, &str)> = vec![];
-        let slice2 = vec![(1, "a")];
-        let slice3: Vec<(i32, &str)> = vec![];
+        let slice1: [(i32, &str); 0] = [];
+        let slice2 = [(1, "a")];
+        let slice3: [(i32, &str); 0] = [];
 
-        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()])
-            .collect::<Vec<_>>();
+        let result = kway_merge_sorted([
+            boxed(slice1.iter().copied()),
+            boxed(slice2.iter().copied()),
+            boxed(slice3.iter().copied()),
+        ])
+        .collect::<Vec<_>>();
         assert_eq!(result, vec![(1, "a")]);
     }
 
     #[test]
     fn test_kway_merge_sorted_all_same_key() {
-        let slice1 = vec![(5, "first")];
-        let slice2 = vec![(5, "middle")];
-        let slice3 = vec![(5, "last")];
+        let slice1 = [(5, "first")];
+        let slice2 = [(5, "middle")];
+        let slice3 = [(5, "last")];
 
-        let result = kway_merge_sorted([slice1.as_slice(), slice2.as_slice(), slice3.as_slice()])
-            .collect::<Vec<_>>();
+        let result = kway_merge_sorted([
+            boxed(slice1.iter().copied()),
+            boxed(slice2.iter().copied()),
+            boxed(slice3.iter().copied()),
+        ])
+        .collect::<Vec<_>>();
         // First occurrence wins (slice1 has highest priority)
         assert_eq!(result, vec![(5, "first")]);
     }
 
     #[test]
     fn test_kway_merge_sorted_single_slice() {
-        let slice = vec![(1, "a"), (2, "b"), (3, "c")];
-        let result = kway_merge_sorted([slice.as_slice()]).collect::<Vec<_>>();
+        let slice = [(1, "a"), (2, "b"), (3, "c")];
+        let result = kway_merge_sorted([boxed(slice.iter().copied())]).collect::<Vec<_>>();
         assert_eq!(result, vec![(1, "a"), (2, "b"), (3, "c")]);
     }
 
     #[test]
     fn test_kway_merge_sorted_no_slices() {
-        let result: Vec<(i32, &str)> = kway_merge_sorted(Vec::<&[(i32, &str)]>::new()).collect();
+        let result: Vec<(i32, &str)> =
+            kway_merge_sorted(Vec::<BoxedIterator<'_, (i32, &str)>>::new()).collect();
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_kway_merge_sorted_clones_lazily() {
-        let clone_count = Rc::new(Cell::new(0));
-        let slice = vec![
-            (1, CloneCounter { value: 1, count: Rc::clone(&clone_count) }),
-            (2, CloneCounter { value: 2, count: Rc::clone(&clone_count) }),
-            (3, CloneCounter { value: 3, count: Rc::clone(&clone_count) }),
+        let clone_count = Arc::new(AtomicUsize::new(0));
+        let slice = [
+            (1, CloneCounter { value: 1, count: Arc::clone(&clone_count) }),
+            (2, CloneCounter { value: 2, count: Arc::clone(&clone_count) }),
+            (3, CloneCounter { value: 3, count: Arc::clone(&clone_count) }),
         ];
 
-        let mut result = kway_merge_sorted([slice.as_slice()]);
-        assert_eq!(clone_count.get(), 0);
+        let mut result = kway_merge_sorted([boxed(slice.iter().cloned())]);
+        assert_eq!(clone_count.load(Ordering::Relaxed), 0);
         assert_eq!(result.next().unwrap().1.value, 1);
-        assert_eq!(clone_count.get(), 1);
+        assert_eq!(clone_count.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -520,9 +520,12 @@ impl ChangesetCache {
         }
 
         if all_cached {
-            // `merge_slice` gives precedence to earlier items, so pass reverts oldest-to-newest.
+            // `merge_batch` gives precedence to earlier items, so pass reverts oldest-to-newest.
             cached_reverts.reverse();
-            let accumulated_reverts = Arc::new(TrieUpdatesSorted::merge_slice(&cached_reverts));
+            let accumulated_reverts =
+                Arc::new(TrieUpdatesSorted::from(TrieUpdatesSorted::merge_batch(
+                    cached_reverts.iter().map(|updates| updates.as_lazy()),
+                )));
             let elapsed = timer.elapsed();
 
             let num_account_nodes = accumulated_reverts.account_nodes_ref().len();

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -8,7 +8,7 @@ use reth_db_api::{
 };
 use reth_trie::{
     trie_cursor::{TrieCursor, TrieCursorFactory, TrieStorageCursor},
-    updates::StorageTrieUpdatesSorted,
+    updates::{LazyStorageTrieUpdatesSorted, StorageTrieUpdatesSorted},
     BranchNodeCompact, Nibbles, PackedStorageTrieEntry, PackedStoredNibbles,
     PackedStoredNibblesSubKey, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
 };
@@ -305,6 +305,37 @@ where
             if let Some(node) = maybe_updated {
                 self.cursor
                     .upsert(self.hashed_address, &A::StorageValue::new(nibbles, node.clone()))?;
+            }
+        }
+
+        Ok(num_entries)
+    }
+
+    /// Writes lazily merged storage updates that are already sorted.
+    pub fn write_storage_trie_updates_lazy(
+        &mut self,
+        updates: LazyStorageTrieUpdatesSorted<'_>,
+    ) -> Result<usize, DatabaseError> {
+        let (is_deleted, storage_nodes) = updates.into_parts();
+        if is_deleted && self.cursor.seek_exact(self.hashed_address)?.is_some() {
+            self.cursor.delete_current_duplicates()?;
+        }
+
+        let mut num_entries = 0;
+        for (nibbles, maybe_updated) in storage_nodes.filter(|(nibbles, _)| !nibbles.is_empty()) {
+            num_entries += 1;
+            let nibbles = A::StorageSubKey::from(nibbles);
+            if self
+                .cursor
+                .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
+                .as_ref()
+                .is_some_and(|entry| *entry.nibbles() == nibbles)
+            {
+                self.cursor.delete_current()?;
+            }
+
+            if let Some(node) = maybe_updated {
+                self.cursor.upsert(self.hashed_address, &A::StorageValue::new(nibbles, node))?;
             }
         }
 

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -8,7 +8,7 @@ use reth_db_api::{
 };
 use reth_trie::{
     trie_cursor::{TrieCursor, TrieCursorFactory, TrieStorageCursor},
-    updates::{LazyStorageTrieUpdatesSorted, StorageTrieUpdatesSorted},
+    updates::LazyStorageTrieUpdatesSorted,
     BranchNodeCompact, Nibbles, PackedStorageTrieEntry, PackedStoredNibbles,
     PackedStoredNibblesSubKey, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
 };
@@ -276,43 +276,8 @@ where
         + DbDupCursorRO<A::StorageTrieTable>
         + DbDupCursorRW<A::StorageTrieTable>,
 {
-    /// Writes storage updates that are already sorted
+    /// Writes storage updates that are already sorted.
     pub fn write_storage_trie_updates_sorted(
-        &mut self,
-        updates: &StorageTrieUpdatesSorted,
-    ) -> Result<usize, DatabaseError> {
-        // The storage trie for this account has to be deleted.
-        if updates.is_deleted() && self.cursor.seek_exact(self.hashed_address)?.is_some() {
-            self.cursor.delete_current_duplicates()?;
-        }
-
-        let mut num_entries = 0;
-        for (nibbles, maybe_updated) in updates.storage_nodes.iter().filter(|(n, _)| !n.is_empty())
-        {
-            num_entries += 1;
-            let nibbles = A::StorageSubKey::from(*nibbles);
-            // Delete the old entry if it exists.
-            if self
-                .cursor
-                .seek_by_key_subkey(self.hashed_address, nibbles.clone())?
-                .as_ref()
-                .is_some_and(|e| *e.nibbles() == nibbles)
-            {
-                self.cursor.delete_current()?;
-            }
-
-            // There is an updated version of this node, insert new entry.
-            if let Some(node) = maybe_updated {
-                self.cursor
-                    .upsert(self.hashed_address, &A::StorageValue::new(nibbles, node.clone()))?;
-            }
-        }
-
-        Ok(num_entries)
-    }
-
-    /// Writes lazily merged storage updates that are already sorted.
-    pub fn write_storage_trie_updates_lazy(
         &mut self,
         updates: LazyStorageTrieUpdatesSorted<'_>,
     ) -> Result<usize, DatabaseError> {

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -93,9 +93,10 @@ fn incremental_vs_full_root(inputs: &[&str], modified: &str) {
         let modified_root = loader.root().unwrap();
 
         // Update the intermediate roots table so that we can run the incremental verification
+        let trie_updates = trie_updates.into_sorted();
         tx.write_storage_trie_updates_sorted(core::iter::once((
-            &hashed_address,
-            &trie_updates.into_sorted(),
+            hashed_address,
+            trie_updates.as_lazy(),
         )))
         .unwrap();
 

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -283,7 +283,7 @@ fn run_case(case: &BlockchainTest) -> Result<(), Error> {
             .map_err(|err| Error::block_failed(block_number, err))?;
 
         provider
-            .write_hashed_state(&hashed_state.into_sorted())
+            .write_hashed_state(hashed_state.into_sorted().as_lazy())
             .map_err(|err| Error::block_failed(block_number, err))?;
         provider
             .update_history_indices(block.number..=block.number)


### PR DESCRIPTION
Adds borrowed lazy views for sorted hashed state and trie updates, with merge_batch consuming and returning lazy containers. Provider writers consume those lazy containers directly, so save_blocks uses one uniform merge path and streams k-way output into database cursors without materializing flattened vectors. The boxed streams use dyn Iterator (which itself implements IntoIterator) because a bare dyn IntoIterator cannot be consumed as a trait object.