### PR TITLE
chore: bump version to 2.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7568,7 +7568,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7644,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bb"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7744,7 +7744,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7756,7 +7756,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7846,7 +7846,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7855,7 +7855,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7909,7 +7909,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7927,7 +7927,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7940,7 +7940,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7954,7 +7954,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7978,7 +7978,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8073,7 +8073,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8089,7 +8089,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8115,7 +8115,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8140,7 +8140,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8168,7 +8168,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8206,7 +8206,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8288,7 +8288,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8310,7 +8310,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8405,7 +8405,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8434,7 +8434,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8477,7 +8477,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8515,7 +8515,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8553,7 +8553,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8580,7 +8580,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8620,7 +8620,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8643,7 +8643,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8659,7 +8659,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8675,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8688,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8717,7 +8717,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8773,7 +8773,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8798,7 +8798,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8816,7 +8816,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8894,7 +8894,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -8925,7 +8925,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8942,7 +8942,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8951,7 +8951,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8982,7 +8982,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bytes",
  "futures",
@@ -9004,7 +9004,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -9021,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -9029,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "futures",
  "metrics",
@@ -9041,7 +9041,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9049,7 +9049,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9063,7 +9063,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9150,7 +9150,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9174,7 +9174,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9204,7 +9204,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9316,7 +9316,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9372,7 +9372,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9441,7 +9441,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9464,7 +9464,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,7 +9487,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9527,7 +9527,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9550,7 +9550,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9561,7 +9561,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9585,7 +9585,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9636,7 +9636,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9689,7 +9689,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9720,7 +9720,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9740,7 +9740,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9756,7 +9756,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9836,7 +9836,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9866,7 +9866,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9924,7 +9924,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9944,7 +9944,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9964,7 +9964,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10000,7 +10000,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10046,7 +10046,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10098,7 +10098,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10115,7 +10115,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10145,7 +10145,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10207,7 +10207,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10241,7 +10241,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10257,7 +10257,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10280,7 +10280,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10298,7 +10298,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10325,7 +10325,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10341,7 +10341,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10370,7 +10370,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10390,7 +10390,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10406,7 +10406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10415,7 +10415,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10434,7 +10434,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10452,7 +10452,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10503,7 +10503,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10534,7 +10534,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10566,7 +10566,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10596,7 +10596,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10624,7 +10624,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.4.0"
+version = "2.4.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     { text: 'Rustdocs', link: '/docs' },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v2.4.0',
+      text: 'v2.4.1',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Bumps the workspace package version and docs version selector to v2.4.1, and refreshes workspace package versions in Cargo.lock.

Validation:
- `cargo metadata --locked --format-version=1 --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Prompted by: @emmajam