### PR TITLE
refactor(builder): lease resources

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3305,13 +3305,7 @@ where
         //    payloadAttributes is not null and the forkchoice state has been updated successfully.
         //    The build process is specified in the Payload building section.
 
-        let cache = if self.config.share_execution_cache_with_payload_builder() {
-            self.payload_validator.cache_for(state.head_block_hash)
-        } else {
-            None
-        };
-
-        let state_root_handle = self.payload_validator.payload_state_root_handle_for(
+        let resources = self.payload_validator.payload_builder_resources(
             state.head_block_hash,
             head,
             attributes.timestamp(),
@@ -3323,8 +3317,7 @@ where
         let pending_payload_id = self.payload_builder.send_new_payload(BuildNewPayload {
             parent_hash: state.head_block_hash,
             attributes,
-            cache,
-            state_root_handle,
+            resources,
         });
 
         // Client software MUST respond to this method call in the following way:

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -136,7 +136,8 @@ use reth_evm::{
     block::BlockExecutor, execute::ExecutableTxFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
     OnStateHook, SpecFor,
 };
-use reth_execution_cache::{CacheFillMode, CacheStats, SavedCache};
+use reth_execution_cache::{CacheFillMode, CacheStats};
+use reth_payload_builder::PayloadBuilderResources;
 use reth_payload_primitives::{
     BuiltPayload, BuiltPayloadExecutedBlock, InvalidPayloadAttributesError, NewPayloadError,
     PayloadTypes,
@@ -1429,6 +1430,57 @@ where
             .with_state_trie_overlay_manager(state.tree_state.state_trie_overlays.clone())
     }
 
+    /// Prepares the optional payload-builder state-root handle through the installed
+    /// [`StateRootStrategy`].
+    fn payload_state_root_handle_for(
+        &self,
+        parent_hash: B256,
+        parent_header: &N::BlockHeader,
+        timestamp: u64,
+        state: &mut EngineApiTreeState<N>,
+    ) -> Option<PayloadStateRootHandle> {
+        let provider_builder = match self.state_provider_builder(parent_hash, state) {
+            Ok(Some(provider_builder)) => provider_builder,
+            Ok(None) => return None,
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::payload_validator",
+                    %err,
+                    %parent_hash,
+                    "failed to prepare payload-builder state-root provider"
+                );
+                return None
+            }
+        };
+        let overlay_factory = OverlayStateProviderFactory::new(
+            self.provider.clone(),
+            Self::overlay_builder_for_parent(parent_hash, state, self.changeset_cache.clone()),
+        );
+
+        match self.state_root_strategy.prepare_payload_builder(PayloadStateRootJobContext::new(
+            &self.runtime,
+            &self.state_trie_overlays,
+            parent_hash,
+            parent_header,
+            timestamp,
+            state,
+            provider_builder,
+            overlay_factory,
+            &self.config,
+        )) {
+            Ok(handle) => handle,
+            Err(err) => {
+                warn!(
+                    target: "engine::tree::payload_validator",
+                    %err,
+                    %parent_hash,
+                    "failed to prepare payload-builder state-root job"
+                );
+                None
+            }
+        }
+    }
+
     /// Spawns a background task to compute and sort trie data for the executed block.
     ///
     /// This function creates a [`LazyTrieData`] handle and spawns a blocking task that:
@@ -1687,24 +1739,16 @@ pub trait EngineValidator<
         block: BuiltPayloadExecutedBlock<N>,
     ) -> ProviderResult<ExecutedBlock<N>>;
 
-    /// Returns [`SavedCache`] for the given block hash.
-    fn cache_for(&self, _block_hash: B256) -> Option<SavedCache>;
-
-    /// Prepares the optional payload-builder state-root handle through the installed
-    /// [`StateRootStrategy`].
+    /// Prepares the resources loaned to a payload builder job.
     ///
-    /// Returns `None` when the strategy declines, in which case the payload builder computes
-    /// the state root itself.
-    ///
-    /// `timestamp` is the timestamp of the payload being built, taken from the payload
-    /// attributes.
-    fn payload_state_root_handle_for(
+    /// `timestamp` is taken from the payload attributes.
+    fn payload_builder_resources(
         &self,
         parent_hash: B256,
         parent_header: &N::BlockHeader,
         timestamp: u64,
         state: &mut EngineApiTreeState<N>,
-    ) -> Option<PayloadStateRootHandle>;
+    ) -> PayloadBuilderResources;
 }
 
 impl<N, Types, P, Evm, V> EngineValidator<Types> for BasicEngineValidator<P, Evm, V>
@@ -1784,57 +1828,21 @@ where
         ))
     }
 
-    fn cache_for(&self, block_hash: B256) -> Option<SavedCache> {
-        Some(self.payload_processor.cache_for(block_hash))
-    }
-
-    fn payload_state_root_handle_for(
+    fn payload_builder_resources(
         &self,
         parent_hash: B256,
         parent_header: &N::BlockHeader,
         timestamp: u64,
         state: &mut EngineApiTreeState<N>,
-    ) -> Option<PayloadStateRootHandle> {
-        let provider_builder = match self.state_provider_builder(parent_hash, state) {
-            Ok(Some(provider_builder)) => provider_builder,
-            Ok(None) => return None,
-            Err(err) => {
-                warn!(
-                    target: "engine::tree::payload_validator",
-                    %err,
-                    %parent_hash,
-                    "failed to prepare payload-builder state-root provider"
-                );
-                return None
-            }
-        };
-        let overlay_factory = OverlayStateProviderFactory::new(
-            self.provider.clone(),
-            Self::overlay_builder_for_parent(parent_hash, state, self.changeset_cache.clone()),
-        );
+    ) -> PayloadBuilderResources {
+        let execution_cache = self
+            .config
+            .share_execution_cache_with_payload_builder()
+            .then(|| self.payload_processor.cache_for(parent_hash));
+        let state_root_handle =
+            self.payload_state_root_handle_for(parent_hash, parent_header, timestamp, state);
 
-        match self.state_root_strategy.prepare_payload_builder(PayloadStateRootJobContext::new(
-            &self.runtime,
-            &self.state_trie_overlays,
-            parent_hash,
-            parent_header,
-            timestamp,
-            state,
-            provider_builder,
-            overlay_factory,
-            &self.config,
-        )) {
-            Ok(handle) => handle,
-            Err(err) => {
-                warn!(
-                    target: "engine::tree::payload_validator",
-                    %err,
-                    %parent_hash,
-                    "failed to prepare payload-builder state-root job"
-                );
-                None
-            }
-        }
+        PayloadBuilderResources::new(execution_cache, state_root_handle)
     }
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -694,7 +694,7 @@ fn process_payload_attributes_shares_sparse_trie_during_validation_fallback() {
     let PayloadServiceCommand::BuildNewPayload(input, _, _) = command else {
         panic!("expected build new payload command")
     };
-    assert!(input.state_root_handle.is_some());
+    assert!(input.resources.state_root_handle().is_some());
 }
 
 #[tokio::test]

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -164,7 +164,8 @@ where
         input: BuildNewPayload<Builder::Attributes>,
         id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
-        let parent_header = if input.parent_hash.is_zero() {
+        let BuildNewPayload { attributes, parent_hash, mut resources } = input;
+        let parent_header = if parent_hash.is_zero() {
             // Use latest header for genesis block case
             self.client
                 .latest_header()
@@ -173,16 +174,16 @@ where
         } else {
             // Fetch specific header by hash
             self.client
-                .sealed_header_by_hash(input.parent_hash)
+                .sealed_header_by_hash(parent_hash)
                 .map_err(PayloadBuilderError::from)?
-                .ok_or_else(|| PayloadBuilderError::MissingParentHeader(input.parent_hash))?
+                .ok_or_else(|| PayloadBuilderError::MissingParentHeader(parent_hash))?
         };
 
         let parent_hash = parent_header.hash();
         let cached_reads = self.maybe_pre_cached(parent_hash);
         let parent_block_info = self.maybe_parent_block_info(parent_hash);
 
-        let config = PayloadConfig::new(Arc::new(parent_header), input.attributes, id)
+        let config = PayloadConfig::new(Arc::new(parent_header), attributes, id)
             .with_parent_block_info(parent_block_info);
 
         let until = self.job_deadline(config.attributes.timestamp());
@@ -197,8 +198,8 @@ where
             best_payload: PayloadState::Missing,
             pending_block: None,
             cached_reads,
-            execution_cache: input.cache,
-            state_root_handle: input.state_root_handle,
+            execution_cache: resources.take_execution_cache(),
+            state_root_handle: resources.take_state_root_handle(),
             payload_task_guard: self.payload_task_guard.clone(),
             metrics: Default::default(),
             builder: self.builder.clone(),

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -126,8 +126,8 @@ pub use alloy_rpc_types::engine::PayloadId;
 pub use reth_payload_builder_primitives::PayloadBuilderError;
 pub use reth_payload_primitives::PayloadKind;
 pub use service::{
-    BuildNewPayload, PayloadBuilderHandle, PayloadBuilderService, PayloadServiceCommand,
-    PayloadStore,
+    BuildNewPayload, PayloadBuilderHandle, PayloadBuilderLease, PayloadBuilderResources,
+    PayloadBuilderService, PayloadServiceCommand, PayloadStore,
 };
 pub use traits::{KeepPayloadJobAlive, PayloadJob, PayloadJobGenerator};
 

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -32,7 +32,6 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, debug_span, info, trace, warn, Span};
 
 type PayloadFuture<P> = Pin<Box<dyn Future<Output = Result<P, PayloadBuilderError>> + Send>>;
-type PayloadJobEntry<Job> = (Job, PayloadId, Span);
 type ResolvePayloadResult<P, Job> = (Option<PayloadFuture<P>>, Option<PayloadJobEntry<Job>>);
 
 /// A communication channel to the [`PayloadBuilderService`] that can retrieve payloads.
@@ -223,7 +222,7 @@ where
     /// All active payload jobs, each accompanied by its id and the caller's tracing span
     /// propagated across the channel so that poll and resolve work appears as children of the
     /// original Engine API request.
-    payload_jobs: Vec<(Gen::Job, PayloadId, Span)>,
+    payload_jobs: Vec<PayloadJobEntry<Gen::Job>>,
     /// Copy of the sender half, so new [`PayloadBuilderHandle`] can be created on demand.
     service_tx: mpsc::UnboundedSender<PayloadServiceCommand<T>>,
     /// Receiver half of the command channel.
@@ -293,7 +292,7 @@ where
 
     /// Returns true if the given payload is currently being built.
     fn contains_payload(&self, id: PayloadId) -> bool {
-        self.payload_jobs.iter().any(|(_, job_id, _)| *job_id == id)
+        self.payload_jobs.iter().any(|entry| entry.id == id)
     }
 
     /// Returns the best payload for the given identifier that has been built so far.
@@ -301,8 +300,8 @@ where
         let res = self
             .payload_jobs
             .iter()
-            .find(|(_, job_id, _)| *job_id == id)
-            .map(|(j, _, _)| j.best_payload().map(|p| p.into()));
+            .find(|entry| entry.id == id)
+            .map(|entry| entry.job.best_payload().map(|payload| payload.into()));
         if let Some(Ok(ref best)) = res {
             self.metrics.set_best_revenue(best.block().number(), f64::from(best.fees()));
         }
@@ -329,14 +328,18 @@ where
             return (Some(Box::pin(core::future::ready(Ok(payload.clone())))), None);
         }
 
-        let Some(job) = self.payload_jobs.iter().position(|(_, job_id, _)| *job_id == id) else {
+        let Some(job) = self.payload_jobs.iter().position(|entry| entry.id == id) else {
             return (None, None)
         };
-        let (fut, keep_alive) = self.payload_jobs[job].0.resolve_kind(kind);
-        let payload_timestamp = self.payload_jobs[job].0.payload_timestamp();
+        let (fut, keep_alive) = self.payload_jobs[job].job.resolve_kind(kind);
+        let payload_timestamp = self.payload_jobs[job].job.payload_timestamp();
 
-        let resolved_job =
+        let mut resolved_job =
             (keep_alive == KeepPayloadJobAlive::No).then(|| self.payload_jobs.swap_remove(job));
+        let leases = resolved_job
+            .as_mut()
+            .map(|entry| std::mem::take(&mut entry.leases))
+            .unwrap_or_default();
 
         // Since the fees will not be known until the payload future is resolved / awaited, we wrap
         // the future in a new future that will update the metrics.
@@ -345,6 +348,7 @@ where
         let cached_payload_tx = self.cached_payload_tx.clone();
 
         let fut = async move {
+            let _leases = leases;
             let res = fut.await;
             resolved_metrics.resolve_duration_seconds.record(start.elapsed());
             if let Ok(payload) = &res {
@@ -376,8 +380,8 @@ where
         let timestamp = self
             .payload_jobs
             .iter()
-            .find(|(_, job_id, _)| *job_id == id)
-            .map(|(j, _, _)| j.payload_timestamp());
+            .find(|entry| entry.id == id)
+            .map(|entry| entry.job.payload_timestamp());
 
         if timestamp.is_none() {
             trace!(target: "payload_builder", %id, "no matching payload job found to get timestamp for");
@@ -411,10 +415,11 @@ where
             // requests
             // we don't care about the order of the jobs, so we can just swap_remove them
             for idx in (0..this.payload_jobs.len()).rev() {
-                let (mut job, id, job_span) = this.payload_jobs.swap_remove(idx);
+                let PayloadJobEntry { mut job, id, span, leases } =
+                    this.payload_jobs.swap_remove(idx);
 
                 let poll_result = {
-                    let _entered = job_span.enter();
+                    let _entered = span.enter();
                     job.poll_unpin(cx)
                 };
 
@@ -429,7 +434,7 @@ where
                         this.metrics.set_active_jobs(this.payload_jobs.len());
                     }
                     Poll::Pending => {
-                        this.payload_jobs.push((job, id, job_span));
+                        this.payload_jobs.push(PayloadJobEntry { job, id, span, leases });
                     }
                 }
             }
@@ -440,7 +445,7 @@ where
             // drain all requests
             while let Poll::Ready(Some(cmd)) = this.command_rx.poll_next_unpin(cx) {
                 match cmd {
-                    PayloadServiceCommand::BuildNewPayload(input, job_span, tx) => {
+                    PayloadServiceCommand::BuildNewPayload(mut input, job_span, tx) => {
                         let id = input.payload_id();
                         let mut res = Ok(id);
                         let parent = input.parent_hash;
@@ -450,6 +455,7 @@ where
                         } else {
                             let start = Instant::now();
                             let attributes = input.attributes.clone();
+                            let leases = input.resources.take_leases();
                             let job_result = {
                                 let _entered = job_span.enter();
                                 this.generator.new_payload_job(*input, id)
@@ -461,7 +467,12 @@ where
                                     info!(target: "payload_builder", %id, %parent, "New payload job created");
                                     this.metrics.inc_initiated_jobs();
                                     new_job = true;
-                                    this.payload_jobs.push((job, id, job_span));
+                                    this.payload_jobs.push(PayloadJobEntry {
+                                        job,
+                                        id,
+                                        span: job_span,
+                                        leases,
+                                    });
                                     this.payload_events.send(Events::Attributes(attributes)).ok();
 
                                     // Clear stale cached payload for this id so
@@ -499,8 +510,8 @@ where
                         let (payload_fut, resolved_job) = this.resolve(id, strategy);
                         let _ = tx.send(payload_fut);
 
-                        if let Some((_job, id, _job_span)) = resolved_job {
-                            debug!(target: "payload_builder", %id, "terminated resolved job");
+                        if let Some(entry) = resolved_job {
+                            debug!(target: "payload_builder", id = %entry.id, "terminated resolved job");
                         }
                     }
                     PayloadServiceCommand::Subscribe(tx) => {
@@ -550,17 +561,141 @@ pub struct BuildNewPayload<T> {
     pub attributes: T,
     /// The parent hash of the new payload
     pub parent_hash: B256,
-    /// Optional execution cache to use for the payload.
-    ///
-    /// Only provided if `--engine.share-execution-cache-with-payload-builder` is enabled.
-    pub cache: Option<SavedCache>,
-    /// Optional handle to a background state-root task.
-    pub state_root_handle: Option<PayloadStateRootHandle>,
+    /// Resources loaned to the payload builder for this job.
+    pub resources: PayloadBuilderResources,
 }
 
 impl<T: PayloadAttributes> BuildNewPayload<T> {
     /// Returns the payload id for the new payload.
     pub fn payload_id(&self) -> PayloadId {
         self.attributes.payload_id(&self.parent_hash)
+    }
+}
+
+/// Resources loaned to a payload builder job by the engine.
+#[derive(Debug, Default)]
+pub struct PayloadBuilderResources {
+    /// Optional execution cache to use for the payload.
+    ///
+    /// Only provided if `--engine.share-execution-cache-with-payload-builder` is enabled.
+    execution_cache: Option<SavedCache>,
+    /// Optional handle to a background state-root task.
+    state_root_handle: Option<PayloadStateRootHandle>,
+    /// Lifecycle leases retained by the service while the payload job is active.
+    leases: Vec<PayloadBuilderLease>,
+}
+
+impl PayloadBuilderResources {
+    /// Creates a new payload builder resource bundle.
+    pub const fn new(
+        execution_cache: Option<SavedCache>,
+        state_root_handle: Option<PayloadStateRootHandle>,
+    ) -> Self {
+        Self { execution_cache, state_root_handle, leases: Vec::new() }
+    }
+
+    /// Adds a lease that remains active for the lifetime of the payload job.
+    pub fn with_lease(mut self, lease: PayloadBuilderLease) -> Self {
+        self.leases.push(lease);
+        self
+    }
+
+    /// Returns the loaned execution cache, if any.
+    pub const fn execution_cache(&self) -> Option<&SavedCache> {
+        self.execution_cache.as_ref()
+    }
+
+    /// Takes the loaned execution cache, if any.
+    pub const fn take_execution_cache(&mut self) -> Option<SavedCache> {
+        self.execution_cache.take()
+    }
+
+    /// Returns the loaned state-root task handle, if any.
+    pub const fn state_root_handle(&self) -> Option<&PayloadStateRootHandle> {
+        self.state_root_handle.as_ref()
+    }
+
+    /// Takes the loaned state-root task handle, if any.
+    pub const fn take_state_root_handle(&mut self) -> Option<PayloadStateRootHandle> {
+        self.state_root_handle.take()
+    }
+
+    /// Takes the lifecycle leases that the service must retain for this job.
+    fn take_leases(&mut self) -> Vec<PayloadBuilderLease> {
+        std::mem::take(&mut self.leases)
+    }
+}
+
+/// Keeps a loaned resource active for the lifetime of a payload job.
+pub struct PayloadBuilderLease {
+    _lease: Box<dyn Send>,
+}
+
+impl PayloadBuilderLease {
+    /// Wraps a lease that releases its resource when dropped.
+    pub fn new(lease: impl Send + 'static) -> Self {
+        Self { _lease: Box::new(lease) }
+    }
+}
+
+impl std::fmt::Debug for PayloadBuilderLease {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PayloadBuilderLease").finish_non_exhaustive()
+    }
+}
+
+/// An active payload job and its service metadata.
+#[derive(Debug)]
+struct PayloadJobEntry<Job> {
+    job: Job,
+    id: PayloadId,
+    span: Span,
+    leases: Vec<PayloadBuilderLease>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::test_payload_service;
+    use alloy_primitives::Address;
+    use reth_ethereum_engine_primitives::{EthEngineTypes, EthPayloadAttributes};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropProbe(Arc<AtomicBool>);
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+
+    #[test]
+    fn payload_builder_lease_is_held_until_resolve_finishes() {
+        tokio::runtime::Builder::new_current_thread().build().unwrap().block_on(async {
+            let (service, handle) = test_payload_service::<EthEngineTypes>();
+            let service = tokio::spawn(service);
+            let dropped = Arc::new(AtomicBool::new(false));
+            let lease = PayloadBuilderLease::new(DropProbe(Arc::clone(&dropped)));
+            let input = BuildNewPayload {
+                attributes: EthPayloadAttributes {
+                    timestamp: 1,
+                    prev_randao: B256::ZERO,
+                    suggested_fee_recipient: Address::ZERO,
+                    withdrawals: None,
+                    parent_beacon_block_root: None,
+                    slot_number: None,
+                    target_gas_limit: None,
+                },
+                parent_hash: B256::ZERO,
+                resources: PayloadBuilderResources::default().with_lease(lease),
+            };
+
+            let id = handle.send_new_payload(input).await.unwrap().unwrap();
+            assert!(!dropped.load(Ordering::Acquire));
+
+            handle.resolve_kind(id, PayloadKind::Earliest).await.unwrap().unwrap();
+            assert!(dropped.load(Ordering::Acquire));
+            service.abort();
+        });
     }
 }


### PR DESCRIPTION
There is already a pattern: the payload builder can loan some resources from the engine for the duration of building. The examples include the execution cache and the state root handle.

In this changeset we introduce a payload builder resources struct which is intended to collect those resources. On top of that it introduces the concept of leases: those are mostly intended to be used as opaque RAII guards that track the payload builder lifecycle. In a follow up this mechanism is going to be used for txpool prewarming inhibition for the duration of the payload building.