### PR TITLE
feat(bench): RPC replay mode with constant dev base fee

### DIFF
--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -267,6 +267,18 @@ if [ "$EXECUTION_MODE" = "rpc" ]; then
     exit 1
   fi
   RETH_ARGS+=(--chain mainnet --dev --dev.block-time "${BENCH_BLOCK_TIME:-1s}")
+  # Replayed transactions are already signed, so their fee caps cannot be adjusted.
+  # Without this, sustained full blocks compound the base fee by 12.5% per block until
+  # it exceeds those caps and inclusion stalls on fee dynamics instead of node throughput.
+  # Pinning to 1 wei (rather than freezing at the tip value) keeps replayed transactions
+  # includable (the txpool still enforces its 7 wei minimum protocol fee cap at the door,
+  # which no mainnet transaction is below). The probe matches the `[=` suffix because older
+  # binaries support the flag only as a bare boolean and reject an attached value.
+  if "$BINARY" node --help 2>/dev/null | grep -qF -- '--dev.constant-base-fee[='; then
+    RETH_ARGS+=(--dev.constant-base-fee=1)
+  else
+    echo "::warning::${LABEL} binary does not support --dev.constant-base-fee; base fee will drift during RPC replay"
+  fi
 fi
 
 if [ -n "${BENCH_REORG:-}" ]; then

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{ChainSpec, DepositContract};
+use crate::{BaseFeeParamsKind, ChainSpec, DepositContract};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_chains::Chain;
 use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
@@ -83,6 +83,20 @@ impl<H: BlockHeader> EthChainSpec for ChainSpec<H> {
 
     fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams {
         self.base_fee_params_at_timestamp(timestamp)
+    }
+
+    fn next_block_base_fee(&self, parent: &Self::Header, target_timestamp: u64) -> Option<u64> {
+        // Only applies to post-London parents, mirroring the default implementation.
+        let parent_base_fee = parent.base_fee_per_gas()?;
+        if let BaseFeeParamsKind::TestingOverride { base_fee, .. } = self.base_fee_params {
+            return Some(base_fee);
+        }
+        Some(calc_next_block_base_fee(
+            parent.gas_used(),
+            parent.gas_limit(),
+            parent_base_fee,
+            self.base_fee_params_at_timestamp(target_timestamp),
+        ))
     }
 
     fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<BlobParams> {

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -372,6 +372,21 @@ pub enum BaseFeeParamsKind {
     /// Variable [`BaseFeeParams`]; used for chains that have dynamic EIP-1559 parameters like
     /// Optimism
     Variable(ForkBaseFeeParams),
+    /// Overrides the computed next-block base fee with a constant value, disabling EIP-1559 fee
+    /// dynamics entirely.
+    ///
+    /// Only intended for dev and testing chains (e.g. `--dev.constant-base-fee`), where already
+    /// signed transactions with fixed fee caps are replayed and must stay includable. The
+    /// override only takes effect through [`ChainSpec`]'s `next_block_base_fee`; `params` is
+    /// what [`ChainSpec::base_fee_params_at_timestamp`] returns to consumers that read the
+    /// adjustment params directly (use a zero max change denominator there so such consumers
+    /// keep the base fee frozen rather than drifting).
+    TestingOverride {
+        /// The base fee every new block is pinned to.
+        base_fee: u64,
+        /// Params reported to consumers that read the adjustment params directly.
+        params: BaseFeeParams,
+    },
 }
 
 impl Default for BaseFeeParamsKind {
@@ -538,6 +553,9 @@ impl<H: BlockHeader> ChainSpec<H> {
     pub fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams {
         match self.base_fee_params {
             BaseFeeParamsKind::Constant(bf_params) => bf_params,
+            // The base fee is pinned, so the adjustment params only reach consumers that read
+            // them directly (e.g. the gas target in gas limit validation).
+            BaseFeeParamsKind::TestingOverride { params, .. } => params,
             BaseFeeParamsKind::Variable(ForkBaseFeeParams(ref bf_params)) => {
                 // Walk through the base fee params configuration in reverse order, and return the
                 // first one that corresponds to a hardfork that is active at the

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use clap::Subcommand;
 use eyre::{eyre, Result};
-use reth_chainspec::{ChainSpec, EthChainSpec, Hardforks};
+use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec, EthChainSpec, Hardforks};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     common::{CliComponentsBuilder, CliNodeTypes, HeaderMut},
@@ -14,6 +14,7 @@ use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_node_api::NodePrimitives;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
+use reth_node_core::args::DevArgs;
 use reth_node_ethereum::{consensus::EthBeaconConsensus, EthereumNode};
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_rpc_server_types::RpcModuleValidator;
@@ -65,10 +66,14 @@ where
     ///
     /// This accepts a closure that is used to launch the node via the
     /// [`NodeCommand`](reth_cli_commands::node::NodeCommand).
-    pub fn run(self, launcher: impl Launcher<C, Ext>) -> Result<()>
+    pub fn run(mut self, launcher: impl Launcher<C, Ext>) -> Result<()>
     where
         C: ChainSpecParser<ChainSpec = ChainSpec>,
     {
+        if let Commands::Node(command) = &mut self.cli.command {
+            apply_dev_chain_spec_overrides(&mut command.dev, &mut command.chain);
+        }
+
         let jit_args = match &self.cli.command {
             Commands::ReExecute(cmd) => cmd.jit.clone(),
             _ => Default::default(),
@@ -227,6 +232,44 @@ pub trait ExtendedCommand {
     fn execute(self, runner: CliRunner) -> Result<()>;
 }
 
+/// Applies dev-mode overrides to the chain spec before the node is built.
+///
+/// With a bare `--dev.constant-base-fee`, base fee adjustment is disabled by setting the
+/// EIP-1559 max change denominator to zero: `alloy_eips::eip1559::calc_next_block_base_fee`
+/// then returns the parent's base fee unchanged. With an explicit value
+/// (`--dev.constant-base-fee=<WEI>`), the base fee of every mined block is pinned to that
+/// value via [`BaseFeeParamsKind::TestingOverride`]. The payload builder, consensus
+/// validation and the transaction pool all derive the next base fee from the chain spec, so
+/// locally mined blocks stay self-consistent either way.
+///
+/// The flag is taken out of `dev` once applied: entry points that never call this (e.g. the
+/// `run_with_components` family) leave it set, which the dev-mode launcher detects to warn
+/// that the flag was ignored.
+fn apply_dev_chain_spec_overrides(dev: &mut DevArgs, chain: &mut Arc<ChainSpec>) {
+    if !dev.dev {
+        return;
+    }
+    // The chain's own elasticity is preserved in both arms: it still feeds consumers that
+    // read the adjustment params directly, such as gas limit validation at the London
+    // transition block.
+    let elasticity = chain.base_fee_params_at_timestamp(u64::MAX).elasticity_multiplier;
+    match dev.constant_base_fee.take() {
+        // freeze at the parent (i.e. chain tip) value
+        Some(None) => {
+            Arc::make_mut(chain).base_fee_params =
+                BaseFeeParamsKind::Constant(BaseFeeParams::new(0, elasticity));
+        }
+        // pin to an explicit value
+        Some(Some(base_fee)) => {
+            Arc::make_mut(chain).base_fee_params = BaseFeeParamsKind::TestingOverride {
+                base_fee,
+                params: BaseFeeParams::new(0, elasticity),
+            };
+        }
+        None => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,6 +300,72 @@ mod tests {
             app.set_runner(runner);
             assert!(app.runner.is_some());
         }
+    }
+
+    #[test]
+    fn dev_constant_base_fee_freezes_base_fee() {
+        let cli = Cli::<EthereumChainSpecParser, NoArgs>::try_parse_from([
+            "reth",
+            "node",
+            "--chain",
+            "dev",
+            "--dev",
+            "--dev.constant-base-fee",
+        ])
+        .unwrap();
+        let Commands::Node(mut command) = cli.command else { panic!("expected node command") };
+
+        let parent = command.chain.genesis_header().clone();
+        let parent_base_fee = parent.base_fee_per_gas.unwrap();
+
+        // sanity: with default params the base fee of an empty parent block decreases
+        let next = command.chain.next_block_base_fee(&parent, parent.timestamp + 1).unwrap();
+        assert!(next < parent_base_fee);
+
+        apply_dev_chain_spec_overrides(&mut command.dev, &mut command.chain);
+        let next = command.chain.next_block_base_fee(&parent, parent.timestamp + 1).unwrap();
+        assert_eq!(next, parent_base_fee);
+        // consumed once applied so unapplied uses can be detected
+        assert!(command.dev.constant_base_fee.is_none());
+    }
+
+    #[test]
+    fn dev_constant_base_fee_pins_base_fee() {
+        let cli = Cli::<EthereumChainSpecParser, NoArgs>::try_parse_from([
+            "reth",
+            "node",
+            "--chain",
+            "dev",
+            "--dev",
+            "--dev.constant-base-fee=7",
+        ])
+        .unwrap();
+        let Commands::Node(mut command) = cli.command else { panic!("expected node command") };
+
+        let parent = command.chain.genesis_header().clone();
+        assert_ne!(parent.base_fee_per_gas, Some(7));
+
+        let elasticity_before =
+            command.chain.base_fee_params_at_timestamp(u64::MAX).elasticity_multiplier;
+        apply_dev_chain_spec_overrides(&mut command.dev, &mut command.chain);
+        let next = command.chain.next_block_base_fee(&parent, parent.timestamp + 1).unwrap();
+        assert_eq!(next, 7);
+        // the chain's elasticity survives the override, and the reported params freeze the
+        // base fee for consumers that bypass `ChainSpec::next_block_base_fee`
+        let params = command.chain.base_fee_params_at_timestamp(u64::MAX);
+        assert_eq!(params.elasticity_multiplier, elasticity_before);
+        assert_eq!(params.max_change_denominator, 0);
+    }
+
+    #[test]
+    fn dev_overrides_noop_without_flag() {
+        let cli = Cli::<EthereumChainSpecParser, NoArgs>::try_parse_from(["reth", "node", "--dev"])
+            .unwrap();
+        let Commands::Node(mut command) = cli.command else { panic!("expected node command") };
+
+        let params_before = command.chain.base_fee_params_at_timestamp(u64::MAX);
+        apply_dev_chain_spec_overrides(&mut command.dev, &mut command.chain);
+        assert_eq!(command.chain.base_fee_params_at_timestamp(u64::MAX), params_before);
     }
 
     #[test]

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -18,7 +18,7 @@ use std::{
     pin::Pin,
     sync::Arc,
 };
-use tracing::info;
+use tracing::{info, warn};
 
 /// Helper adapter type for accessing [`PayloadTypes::ExecutionData`] on [`NodeTypes`].
 pub(crate) type PayloadDataTy<N> = <<N as NodeTypes>::Payload as PayloadTypes>::ExecutionData;
@@ -302,6 +302,16 @@ where
 
         if config.dev.dev {
             info!(target: "reth::cli", "Using local payload attributes builder for dev mode");
+
+            // The flag is applied (and taken) by the ethereum CLI before launch; if it is
+            // still set here, this launch path does not support it.
+            if config.dev.constant_base_fee.is_some() {
+                warn!(
+                    target: "reth::cli",
+                    "--dev.constant-base-fee was not applied; it is only supported by the \
+                     standard ethereum CLI entry point and the base fee will adjust normally"
+                );
+            }
 
             let blockchain_db = handle.node.provider.clone();
             let chain_spec = config.chain.clone();

--- a/crates/node/core/src/args/dev.rs
+++ b/crates/node/core/src/args/dev.rs
@@ -58,6 +58,25 @@ pub struct DevArgs {
     )]
     pub payload_wait_time: Option<Duration>,
 
+    /// Keep the EIP-1559 base fee constant for locally mined blocks.
+    ///
+    /// Without a value, disables base fee adjustment so every mined block inherits the
+    /// parent's base fee. With a value (`--dev.constant-base-fee=<WEI>`), pins the base fee
+    /// of every mined block to that value instead.
+    ///
+    /// Useful when replaying already-signed transactions whose fee caps cannot be adjusted,
+    /// where sustained full blocks would otherwise drive the base fee above those caps.
+    #[arg(
+        long = "dev.constant-base-fee",
+        help_heading = "Dev testnet",
+        value_name = "WEI",
+        num_args = 0..=1,
+        require_equals = true,
+        requires = "dev",
+        verbatim_doc_comment
+    )]
+    pub constant_base_fee: Option<Option<u64>>,
+
     /// Derive dev accounts from a fixed mnemonic instead of random ones.
     #[arg(
         long = "dev.mnemonic",
@@ -77,6 +96,7 @@ impl Default for DevArgs {
             block_max_transactions: None,
             block_time: None,
             payload_wait_time: None,
+            constant_base_fee: None,
             dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
         }
     }
@@ -104,6 +124,7 @@ mod tests {
                 block_max_transactions: None,
                 block_time: None,
                 payload_wait_time: None,
+                constant_base_fee: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -116,6 +137,7 @@ mod tests {
                 block_max_transactions: None,
                 block_time: None,
                 payload_wait_time: None,
+                constant_base_fee: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -128,6 +150,7 @@ mod tests {
                 block_max_transactions: None,
                 block_time: None,
                 payload_wait_time: None,
+                constant_base_fee: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -146,6 +169,7 @@ mod tests {
                 block_max_transactions: Some(2),
                 block_time: None,
                 payload_wait_time: None,
+                constant_base_fee: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
@@ -159,9 +183,28 @@ mod tests {
                 block_max_transactions: None,
                 block_time: Some(std::time::Duration::from_secs(1)),
                 payload_wait_time: None,
+                constant_base_fee: None,
                 dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
             }
         );
+    }
+
+    #[test]
+    fn test_parse_dev_args_constant_base_fee() {
+        // bare flag freezes the base fee at the parent value
+        let args =
+            CommandParser::<DevArgs>::parse_from(["reth", "--dev", "--dev.constant-base-fee"]).args;
+        assert_eq!(args.constant_base_fee, Some(None));
+
+        // explicit value pins the base fee
+        let args =
+            CommandParser::<DevArgs>::parse_from(["reth", "--dev", "--dev.constant-base-fee=1"])
+                .args;
+        assert_eq!(args.constant_base_fee, Some(Some(1)));
+
+        // requires --dev
+        let args = CommandParser::<DevArgs>::try_parse_from(["reth", "--dev.constant-base-fee"]);
+        assert!(args.is_err());
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -891,6 +891,16 @@ Dev testnet:
           Parses strings using [`humantime::parse_duration`]
           --dev.payload-wait-time 450ms
 
+      --dev.constant-base-fee[=<WEI>]
+          Keep the EIP-1559 base fee constant for locally mined blocks.
+
+          Without a value, disables base fee adjustment so every mined block inherits the
+          parent's base fee. With a value (`--dev.constant-base-fee=<WEI>`), pins the base fee
+          of every mined block to that value instead.
+
+          Useful when replaying already-signed transactions whose fee caps cannot be adjusted,
+          where sustained full blocks would otherwise drive the base fee above those caps.
+
       --dev.mnemonic <MNEMONIC>
           Derive dev accounts from a fixed mnemonic instead of random ones.
 


### PR DESCRIPTION
Builds on the RPC replay mode from #26418 and adds `--dev.constant-base-fee[=<WEI>]`, wired into the RPC bench path.

In RPC replay mode the dev miner packs blocks full, compounding the EIP-1559 base fee by 12.5% per block (0.12 → 0.70 Gwei within ~14 blocks in [this run](https://github.com/paradigmxyz/reth/actions/runs/29589761700)) until it exceeds the replayed transactions' fee caps — inclusion then stalls on fee dynamics instead of measuring node throughput. The transactions are already signed, so their fee caps cannot be adjusted.

Bare `--dev.constant-base-fee` disables base fee adjustment (max change denominator of zero, which `calc_next_block_base_fee` treats as "no adjustment"), freezing the base fee at the tip value. In a [validation run](https://github.com/paradigmxyz/reth/actions/runs/29601530733) this eliminated the fee climb (every measured block full, wall clock −56%), but ~27% of accepted transactions had fee caps below the frozen tip value and parked forever. `--dev.constant-base-fee=<WEI>` therefore pins the base fee to an explicit value via a new `BaseFeeParamsKind::TestingOverride` chain spec variant; the bench pins to 1 wei so every replayed transaction stays includable. The payload builder, consensus validation and txpool all derive the next base fee from the chain spec, so mined blocks stay self-consistent in both modes.

Verified on a dev node: bare flag holds the base fee at the tip value across empty blocks (vs the expected 12.5%/block decay without); `=7` pins every block to exactly 7 wei from block 1. The override is applied in the ethereum CLI; op-reth parses the flag but does not honor it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
