### PR TITLE
feat(builder): pause jit while building payloads

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -137,7 +137,7 @@ use reth_evm::{
     OnStateHook, SpecFor,
 };
 use reth_execution_cache::{CacheFillMode, CacheStats};
-use reth_payload_builder::PayloadBuilderResources;
+use reth_payload_builder::{PayloadBuilderLease, PayloadBuilderResources};
 use reth_payload_primitives::{
     BuiltPayload, BuiltPayloadExecutedBlock, InvalidPayloadAttributesError, NewPayloadError,
     PayloadTypes,
@@ -1845,6 +1845,7 @@ where
             self.payload_state_root_handle_for(parent_hash, parent_header, timestamp, state);
 
         PayloadBuilderResources::new(execution_cache, state_root_handle)
+            .with_lease(PayloadBuilderLease::new(JitPauseGuard::new(&self.evm_config)))
     }
 }
 


### PR DESCRIPTION
Pause background JIT helper execution for the lifetime of payload builder jobs by attaching a `JitPauseGuard` to the newly introduced resource leases. The guard resumes JIT work when the payload job releases its leases.

Prompted by: @pepyakin