### PR TITLE
fix(net): return None instead of panicking when the transactions handle is unavailable

### DIFF
--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -155,11 +155,11 @@ impl<N: NetworkPrimitives> NetworkHandle<N> {
 
     /// Send message to get the [`TransactionsHandle`].
     ///
-    /// Returns `None` if no transaction task is installed.
+    /// Returns `None` if no transaction task is installed or if the network manager is unavailable.
     pub async fn transactions_handle(&self) -> Option<TransactionsHandle<N>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.manager().send(NetworkHandleMessage::GetTransactionsHandle(tx));
-        rx.await.unwrap()
+        rx.await.ok().flatten()
     }
 
     /// Send message to gracefully shutdown node.


### PR DESCRIPTION
fix(net): return None instead of panicking when the transactions handle is unavailable

NetworkHandle::transactions_handle unwraps the response channel, but the
manager forwards the request to the transactions manager over the
memory-bounded channel and discards the try_send result, so on
TrySendError::Full or Closed the response sender is dropped and the unwrap
panics. The method already documents None as the unavailable signal and the
manager already answers None when no transactions task is installed, so map
the dropped channel to None as well.
