### PR TITLE
ci: refresh Hive no-simulator-build patch

### DIFF
--- a/.github/scripts/hive/no_sim_build.diff
+++ b/.github/scripts/hive/no_sim_build.diff
@@ -35,6 +35,7 @@ index 1c9714df..2aa493ca 100644
 -	return tag, err
 +	return tag, nil
  }
+ 
  // BuildImage creates a container by archiving the given file system,
 diff --git a/internal/libdocker/proxy.go b/internal/libdocker/proxy.go
 index 386b4224..7545fda0 100644

--- a/.github/scripts/hive/no_sim_build.diff
+++ b/.github/scripts/hive/no_sim_build.diff
@@ -1,5 +1,5 @@
 diff --git a/internal/libdocker/builder.go b/internal/libdocker/builder.go
-index e4bf99b6..2023f7e2 100644
+index 1c9714df..2aa493ca 100644
 --- a/internal/libdocker/builder.go
 +++ b/internal/libdocker/builder.go
 @@ -8,7 +8,6 @@ import (
@@ -8,9 +8,9 @@ index e4bf99b6..2023f7e2 100644
  	"log/slog"
 -	"os"
  	"path/filepath"
+ 	"regexp"
  	"slices"
- 	"strings"
-@@ -49,25 +48,8 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
+@@ -50,25 +49,8 @@ func (b *Builder) BuildClientImage(ctx context.Context, client libhive.ClientDes
  
  // BuildSimulatorImage builds a docker image of a simulator.
  func (b *Builder) BuildSimulatorImage(ctx context.Context, name string, buildArgs map[string]string) (string, error) {
@@ -35,18 +35,19 @@ index e4bf99b6..2023f7e2 100644
 -	return tag, err
 +	return tag, nil
  }
- 
  // BuildImage creates a container by archiving the given file system,
 diff --git a/internal/libdocker/proxy.go b/internal/libdocker/proxy.go
-index d3a14ae6..8779671e 100644
+index 386b4224..7545fda0 100644
 --- a/internal/libdocker/proxy.go
 +++ b/internal/libdocker/proxy.go
-@@ -16,7 +16,7 @@ const hiveproxyTag = "hive/hiveproxy"
+@@ -16,10 +16,6 @@ const hiveproxyTag = "hive/hiveproxy"
  
  // Build builds the hiveproxy image.
  func (cb *ContainerBackend) Build(ctx context.Context, b libhive.Builder) error {
--	return b.BuildImage(ctx, hiveproxyTag, hiveproxy.Source)
-+	return nil
+-	err := b.BuildImage(ctx, hiveproxyTag, hiveproxy.Source)
+-	if err != nil && !imageAlreadyExists(err) {
+-		return err
+-	}
+ 	return nil
  }
  
- // ServeAPI starts the API server.


### PR DESCRIPTION
## Summary

Updates the Hive `no_sim_build.diff` patch to support Hive commit `f385e22d`.

## Problem

Hive changed its Docker builder and hiveproxy build logic to handle concurrent image creation. The existing patch targeted the old source layout, causing `git apply` to fail during `build_simulators.sh`.

## Changes

- Updated the `builder.go` patch context for the new `regexp` import.
- Updated the `proxy.go` patch for the new `AlreadyExists` handling.
- Preserved disabling redundant simulator and hiveproxy image rebuilds after images are cached.

## Testing

Verified that the patch applies cleanly to Hive `f385e22d` using `git apply --check`.