### PR TITLE
fix(discv4): use provided rng in test utils instead of thread_rng

### DIFF
--- a/crates/net/discv4/src/test_utils.rs
+++ b/crates/net/discv4/src/test_utils.rs
@@ -267,8 +267,9 @@ pub fn rng_endpoint(rng: &mut impl Rng) -> NodeEndpoint {
 /// Generates a random [`NodeRecord`] using the provided random number generator.
 pub fn rng_record(rng: &mut impl RngCore) -> NodeRecord {
     let NodeEndpoint { address, udp_port, tcp_port } = rng_endpoint(rng);
-    // TODO(rand)
-    NodeRecord { address, tcp_port, udp_port, id: B512::random() }
+    let mut id = B512::ZERO;
+    rng.fill_bytes(&mut id[..]);
+    NodeRecord { address, tcp_port, udp_port, id }
 }
 
 /// Generates a random IPv6 [`NodeRecord`] using the provided random number generator.
@@ -276,8 +277,9 @@ pub fn rng_ipv6_record(rng: &mut impl RngCore) -> NodeRecord {
     let mut ip = [0u8; 16];
     rng.fill_bytes(&mut ip);
     let address = IpAddr::V6(ip.into());
-    // TODO(rand)
-    NodeRecord { address, tcp_port: rng.r#gen(), udp_port: rng.r#gen(), id: B512::random() }
+    let mut id = B512::ZERO;
+    rng.fill_bytes(&mut id[..]);
+    NodeRecord { address, tcp_port: rng.r#gen(), udp_port: rng.r#gen(), id }
 }
 
 /// Generates a random IPv4 [`NodeRecord`] using the provided random number generator.
@@ -285,8 +287,9 @@ pub fn rng_ipv4_record(rng: &mut impl RngCore) -> NodeRecord {
     let mut ip = [0u8; 4];
     rng.fill_bytes(&mut ip);
     let address = IpAddr::V4(ip.into());
-    // TODO(rand)
-    NodeRecord { address, tcp_port: rng.r#gen(), udp_port: rng.r#gen(), id: B512::random() }
+    let mut id = B512::ZERO;
+    rng.fill_bytes(&mut id[..]);
+    NodeRecord { address, tcp_port: rng.r#gen(), udp_port: rng.r#gen(), id }
 }
 
 /// Generates a random [`Message`] using the provided random number generator.
@@ -298,13 +301,16 @@ pub fn rng_message(rng: &mut impl RngCore) -> Message {
             expire: rng.r#gen(),
             enr_sq: None,
         }),
-        2 => Message::Pong(Pong {
-            to: rng_endpoint(rng),
-            echo: B256::random(),
-            expire: rng.r#gen(),
-            enr_sq: None,
-        }),
-        3 => Message::FindNode(FindNode { id: B512::random(), expire: rng.r#gen() }),
+        2 => {
+            let mut echo = B256::ZERO;
+            rng.fill_bytes(&mut echo[..]);
+            Message::Pong(Pong { to: rng_endpoint(rng), echo, expire: rng.r#gen(), enr_sq: None })
+        }
+        3 => {
+            let mut id = B512::ZERO;
+            rng.fill_bytes(&mut id[..]);
+            Message::FindNode(FindNode { id, expire: rng.r#gen() })
+        }
         4 => {
             let num: usize = rng.gen_range(1..=SAFE_MAX_DATAGRAM_NEIGHBOUR_RECORDS);
             Message::Neighbours(Neighbours {

--- a/crates/net/discv4/src/test_utils.rs
+++ b/crates/net/discv4/src/test_utils.rs
@@ -1,7 +1,5 @@
 //! Mock discovery support
 
-// TODO(rand): update ::random calls after rand_09 migration
-
 use crate::{
     proto::{FindNode, Message, Neighbours, NodeEndpoint, Packet, Ping, Pong},
     receive_loop, send_loop, Discv4, Discv4Config, Discv4Service, EgressSender, IngressEvent,


### PR DESCRIPTION
Functions like `rng_record`, `rng_ipv6_record`, `rng_ipv4_record`, and `rng_message` accept an `rng` parameter but were calling `B512::random()` and `B256::random()`, which internally use `thread_rng()`. Replace these calls with `rng.fill_bytes()` so the provided rng is actually used.