### PR TITLE
chore: re-enable nightly Docker cron

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,7 @@
 #
 # Triggers:
 #   - Push tag v*: builds release (RC or latest)
+#   - Schedule: builds nightly + profiling
 #   - Manual: builds git-sha or nightly
 
 name: docker
@@ -10,6 +11,8 @@ on:
   push:
     tags:
       - v*
+  schedule:
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       build_type:


### PR DESCRIPTION
Re-enables the daily 01:00 UTC Docker workflow schedule disabled in #26400. Manual and release Docker triggers remain unchanged.

Prompted by: @mattsse