### PR TITLE
feat(stages): add partial persistence finish checkpoint

### DIFF
--- a/bin/reth-bb/Cargo.toml
+++ b/bin/reth-bb/Cargo.toml
@@ -122,6 +122,8 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
+partial-persistence = ["reth-node-core/partial-persistence"]
+
 [[bin]]
 name = "reth-bb"
 path = "src/main.rs"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -199,6 +199,7 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
+partial-persistence = ["reth-node-core/partial-persistence"]
 trie-debug = ["reth-node-builder/trie-debug", "reth-node-core/trie-debug"]
 
 [[bin]]

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -90,6 +90,8 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
+partial-persistence = ["reth-stages-types/partial-persistence"]
+
 # Debug recording for sparse trie mutations
 trie-debug = ["reth-engine-primitives/trie-debug"]
 

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -35,6 +35,7 @@ modular-bitfield.workspace = true
 
 [features]
 default = ["std"]
+partial-persistence = []
 std = [
     "alloy-primitives/std",
     "bytes?/std",

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -431,13 +431,39 @@ impl StageCheckpoint {
                 progress: entities,
                 ..
             }) => Some(entities),
-            StageUnitCheckpoint::MerkleChangeSets(_) => None,
+            StageUnitCheckpoint::MerkleChangeSets(_) | StageUnitCheckpoint::Finish(_) => None,
         }
     }
 }
 
 #[cfg(any(test, feature = "reth-codec"))]
 reth_codecs::impl_compression_for_compact!(StageCheckpoint);
+
+/// Saves the progress of the Finish stage.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FinishCheckpoint {
+    /// The highest block with a partially persisted state and trie.
+    #[cfg(feature = "partial-persistence")]
+    pub partial_state_trie: Option<BlockNumber>,
+}
+
+impl FinishCheckpoint {
+    /// Returns the highest block with a partially persisted state and trie, if enabled.
+    pub const fn partial_state_trie(&self) -> Option<BlockNumber> {
+        #[cfg(feature = "partial-persistence")]
+        {
+            self.partial_state_trie
+        }
+        #[cfg(not(feature = "partial-persistence"))]
+        {
+            None
+        }
+    }
+}
 
 // TODO(alexey): add a merkle checkpoint. Currently it's hard because [`MerkleCheckpoint`]
 //  is not a Copy type.
@@ -465,6 +491,8 @@ pub enum StageUnitCheckpoint {
     /// Note: This variant is only kept for backward compatibility with the Compact codec.
     /// The `MerkleChangeSets` stage has been removed.
     MerkleChangeSets(MerkleChangeSetsCheckpoint),
+    /// Saves the progress of the Finish stage.
+    Finish(FinishCheckpoint),
 }
 
 impl StageUnitCheckpoint {
@@ -573,6 +601,15 @@ stage_unit_checkpoints!(
         index_history_stage_checkpoint,
         /// Sets the stage checkpoint to index history.
         with_index_history_stage_checkpoint
+    ),
+    (
+        6,
+        Finish,
+        FinishCheckpoint,
+        /// Returns the finish stage checkpoint, if any.
+        finish_stage_checkpoint,
+        /// Sets the stage checkpoint to finish.
+        with_finish_stage_checkpoint
     )
 );
 
@@ -663,5 +700,24 @@ mod tests {
         let encoded = checkpoint.to_compact(&mut buf);
         let (decoded, _) = MerkleCheckpoint::from_compact(&buf, encoded);
         assert_eq!(decoded, checkpoint);
+    }
+
+    #[test]
+    fn finish_checkpoint_roundtrip() {
+        let finish_checkpoint = FinishCheckpoint {
+            #[cfg(feature = "partial-persistence")]
+            partial_state_trie: Some(21),
+        };
+        let checkpoint = StageCheckpoint::new(42).with_finish_stage_checkpoint(finish_checkpoint);
+
+        let mut buf = Vec::new();
+        let encoded = checkpoint.to_compact(&mut buf);
+        let (decoded, _) = StageCheckpoint::from_compact(&buf, encoded);
+
+        assert_eq!(decoded, checkpoint);
+        assert_eq!(
+            decoded.finish_stage_checkpoint().unwrap().partial_state_trie(),
+            cfg!(feature = "partial-persistence").then_some(21)
+        );
     }
 }

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -442,12 +442,17 @@ reth_codecs::impl_compression_for_compact!(StageCheckpoint);
 /// Saves the progress of the Finish stage.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
-#[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
-#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "partial-persistence"),
+    derive(reth_codecs::Compact)
+)]
+#[cfg_attr(
+    all(any(test, feature = "reth-codec"), feature = "partial-persistence"),
+    reth_codecs::add_arbitrary_tests(compact)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FinishCheckpoint {
     /// The highest block with a partially persisted state and trie.
-    #[cfg(feature = "partial-persistence")]
     pub partial_state_trie: Option<BlockNumber>,
 }
 
@@ -462,6 +467,20 @@ impl FinishCheckpoint {
         {
             None
         }
+    }
+}
+
+#[cfg(all(any(test, feature = "reth-codec"), not(feature = "partial-persistence")))]
+impl reth_codecs::Compact for FinishCheckpoint {
+    fn to_compact<B>(&self, _buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        panic!("serializing FinishCheckpoint requires the `partial-persistence` feature")
+    }
+
+    fn from_compact(_buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        panic!("deserializing FinishCheckpoint requires the `partial-persistence` feature")
     }
 }
 
@@ -492,6 +511,10 @@ pub enum StageUnitCheckpoint {
     /// The `MerkleChangeSets` stage has been removed.
     MerkleChangeSets(MerkleChangeSetsCheckpoint),
     /// Saves the progress of the Finish stage.
+    #[cfg_attr(
+        all(any(test, feature = "test-utils"), not(feature = "partial-persistence")),
+        arbitrary(skip)
+    )]
     Finish(FinishCheckpoint),
 }
 
@@ -702,12 +725,10 @@ mod tests {
         assert_eq!(decoded, checkpoint);
     }
 
+    #[cfg(feature = "partial-persistence")]
     #[test]
     fn finish_checkpoint_roundtrip() {
-        let finish_checkpoint = FinishCheckpoint {
-            #[cfg(feature = "partial-persistence")]
-            partial_state_trie: Some(21),
-        };
+        let finish_checkpoint = FinishCheckpoint { partial_state_trie: Some(21) };
         let checkpoint = StageCheckpoint::new(42).with_finish_stage_checkpoint(finish_checkpoint);
 
         let mut buf = Vec::new();
@@ -715,9 +736,28 @@ mod tests {
         let (decoded, _) = StageCheckpoint::from_compact(&buf, encoded);
 
         assert_eq!(decoded, checkpoint);
-        assert_eq!(
-            decoded.finish_stage_checkpoint().unwrap().partial_state_trie(),
-            cfg!(feature = "partial-persistence").then_some(21)
-        );
+        assert_eq!(decoded.finish_stage_checkpoint().unwrap().partial_state_trie(), Some(21));
+    }
+
+    #[cfg(not(feature = "partial-persistence"))]
+    #[test]
+    #[should_panic(
+        expected = "serializing FinishCheckpoint requires the `partial-persistence` feature"
+    )]
+    fn finish_checkpoint_serialization_requires_partial_persistence() {
+        let finish_checkpoint = FinishCheckpoint { partial_state_trie: Some(21) };
+        assert_eq!(finish_checkpoint.partial_state_trie(), None);
+
+        let checkpoint = StageCheckpoint::new(42).with_finish_stage_checkpoint(finish_checkpoint);
+        checkpoint.to_compact(&mut Vec::new());
+    }
+
+    #[cfg(not(feature = "partial-persistence"))]
+    #[test]
+    #[should_panic(
+        expected = "deserializing FinishCheckpoint requires the `partial-persistence` feature"
+    )]
+    fn finish_checkpoint_deserialization_requires_partial_persistence() {
+        let _ = FinishCheckpoint::from_compact(&[], 0);
     }
 }

--- a/crates/stages/types/src/lib.rs
+++ b/crates/stages/types/src/lib.rs
@@ -18,7 +18,7 @@ pub use id::StageId;
 mod checkpoints;
 pub use checkpoints::{
     AccountHashingCheckpoint, CheckpointBlockRange, EntitiesCheckpoint, ExecutionCheckpoint,
-    HeadersCheckpoint, IndexHistoryCheckpoint, MerkleCheckpoint, StageCheckpoint,
+    FinishCheckpoint, HeadersCheckpoint, IndexHistoryCheckpoint, MerkleCheckpoint, StageCheckpoint,
     StageUnitCheckpoint, StorageHashingCheckpoint, StorageRootMerkleCheckpoint,
 };
 


### PR DESCRIPTION
Extracts the Finish checkpoint schema from #24100 by adding partial_state_trie and gating its Compact representation behind the partial-persistence feature. Feature-disabled builds panic if a Finish unit checkpoint is encoded or decoded, preventing accidental database writes. Both reth and reth-bb expose the feature; the Finish stage does not populate or consume the field yet.