### PR TITLE
feat(net): accept discv5 ENR bootnodes via CLI

### DIFF
--- a/crates/net/peers/src/trusted_peer.rs
+++ b/crates/net/peers/src/trusted_peer.rs
@@ -116,6 +116,18 @@ impl FromStr for TrustedPeer {
     type Err = NodeRecordParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[cfg(feature = "secp256k1")]
+        if s.starts_with("enr:") {
+            let enr = enr::Enr::<secp256k1::SecretKey>::from_str(s)
+                .map_err(NodeRecordParseError::InvalidUrl)?;
+            let mut record = NodeRecord::try_from(&enr)?;
+            if record.tcp_port == 0 {
+                // Discovery-only ENRs commonly share their UDP port with the RLPx listener.
+                record.tcp_port = record.udp_port;
+            }
+            return Ok(record.into())
+        }
+
         use url::Url;
 
         // Parse the URL with enode prefix replaced with http.
@@ -177,6 +189,23 @@ mod tests {
             udp_port: 30301,
             id: "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0".parse().unwrap(),
         })
+    }
+
+    #[cfg(feature = "secp256k1")]
+    #[test]
+    fn test_enr_parse() {
+        let enr = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+        let node: TrustedPeer = enr.parse().unwrap();
+
+        assert_eq!(node, TrustedPeer {
+            host: Host::Ipv4([127, 0, 0, 1].into()),
+            tcp_port: 30303,
+            udp_port: 30303,
+            id: "ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"
+                .parse()
+                .unwrap(),
+        });
+        assert!("enr:garbage".parse::<TrustedPeer>().is_err());
     }
 
     #[test]

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -32,7 +32,7 @@ reth-discv4.workspace = true
 reth-discv5.workspace = true
 reth-net-nat.workspace = true
 reth-net-banlist.workspace = true
-reth-network-peers.workspace = true
+reth-network-peers = { workspace = true, features = ["secp256k1"] }
 reth-prune-types.workspace = true
 reth-stages-types.workspace = true
 reth-ethereum-forks.workspace = true

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -45,7 +45,7 @@ use reth_network::{
     },
     HelloMessageWithProtocols, NetworkConfigBuilder, NetworkPrimitives,
 };
-use reth_network_peers::{mainnet_nodes, TrustedPeer};
+use reth_network_peers::{mainnet_nodes, AnyNode, TrustedPeer};
 use reth_tasks::Runtime;
 use secp256k1::SecretKey;
 use std::str::FromStr;
@@ -242,20 +242,20 @@ pub struct NetworkArgs {
     pub discovery: DiscoveryArgs,
 
     #[expect(clippy::doc_markdown)]
-    /// Comma separated enode URLs of trusted peers for P2P connections.
+    /// Comma separated enode URLs or ENRs of trusted peers for P2P connections.
     ///
     /// --trusted-peers enode://abcd@192.168.0.1:30303
-    #[arg(long, value_delimiter = ',')]
+    #[arg(long, value_delimiter = ',', value_parser = parse_peer)]
     pub trusted_peers: Vec<TrustedPeer>,
 
     /// Connect to or accept from trusted peers only
     #[arg(long)]
     pub trusted_only: bool,
 
-    /// Comma separated enode URLs for P2P discovery bootstrap.
+    /// Comma separated enode URLs or ENRs for P2P discovery bootstrap.
     ///
     /// Will fall back to a network-specific default if not specified.
-    #[arg(long, value_delimiter = ',')]
+    #[arg(long, value_delimiter = ',', value_parser = parse_peer)]
     pub bootnodes: Option<Vec<TrustedPeer>>,
 
     /// Amount of DNS resolution requests retries to perform when peering.
@@ -1144,6 +1144,34 @@ impl Default for DiscoveryArgs {
     }
 }
 
+/// Parse an `enode://` URL or a base64 encoded `enr:` record into a [`TrustedPeer`].
+///
+/// A discovery-only ENR omits the tcp key, in which case the udp port is used for the `RLPx` dial
+/// guess, the same fallback as [`reth_discv5::Discv5::try_into_reachable`].
+fn parse_peer(s: &str) -> Result<TrustedPeer, String> {
+    let unprefixed = !s.starts_with("enode://") && !s.starts_with("enr:");
+    let node = AnyNode::from_str(s).map_err(|err| {
+        if unprefixed {
+            "expected an enode:// URL or a base64 encoded enr: record".to_string()
+        } else {
+            err
+        }
+    })?;
+
+    match node {
+        AnyNode::TrustedPeer(peer) => Ok(peer),
+        AnyNode::NodeRecord(record) => Ok(record.into()),
+        AnyNode::Enr(enr) => {
+            let mut record = NodeRecord::try_from(&enr).map_err(|err| err.to_string())?;
+            if record.tcp_port == 0 {
+                record.tcp_port = record.udp_port;
+            }
+            Ok(record.into())
+        }
+        AnyNode::PeerId(_) => Err("no ip address and port specified".to_string()),
+    }
+}
+
 /// Parse a block number=hash pair or just a hash into `BlockNumHash`
 fn parse_block_num_hash(s: &str) -> Result<BlockNumHash, String> {
     if let Some((num_str, hash_str)) = s.split_once('=') {
@@ -1163,7 +1191,7 @@ mod tests {
     use clap::Parser;
     use reth_chainspec::MAINNET;
     use reth_config::Config;
-    use reth_network_peers::NodeRecord;
+    use reth_network_peers::{NodeRecord, PeerId};
     use secp256k1::SecretKey;
     use std::{
         fs,
@@ -1223,6 +1251,39 @@ mod tests {
             "enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303".parse().unwrap()
             ]
         );
+    }
+
+    #[test]
+    fn parse_enr_bootnode_args() {
+        let enr = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+        let args = CommandParser::<NetworkArgs>::parse_from(["reth", "--bootnodes", enr]).args;
+
+        let resolved = args.resolved_bootnodes().unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].address, "127.0.0.1".parse::<std::net::IpAddr>().unwrap());
+        assert_eq!(resolved[0].udp_port, 30303);
+        assert_eq!(resolved[0].tcp_port, 30303);
+        assert_eq!(
+            resolved[0].id,
+            "0xca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"
+                .parse::<PeerId>()
+                .unwrap()
+        );
+
+        let args = CommandParser::<NetworkArgs>::parse_from(["reth", "--trusted-peers", enr]).args;
+        assert_eq!(args.trusted_peers, vec![TrustedPeer::from(resolved[0])]);
+    }
+
+    #[test]
+    fn parse_peer_rejects_unknown_format() {
+        let err = parse_peer("127.0.0.1:30303").unwrap_err();
+        assert_eq!(err, "expected an enode:// URL or a base64 encoded enr: record");
+
+        assert!(parse_peer("enr:garbage").is_err());
+        assert!(parse_peer(
+            "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666"
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -45,7 +45,7 @@ use reth_network::{
     },
     HelloMessageWithProtocols, NetworkConfigBuilder, NetworkPrimitives,
 };
-use reth_network_peers::{mainnet_nodes, AnyNode, TrustedPeer};
+use reth_network_peers::{mainnet_nodes, TrustedPeer};
 use reth_tasks::Runtime;
 use secp256k1::SecretKey;
 use std::str::FromStr;
@@ -245,7 +245,7 @@ pub struct NetworkArgs {
     /// Comma separated enode URLs or ENRs of trusted peers for P2P connections.
     ///
     /// --trusted-peers enode://abcd@192.168.0.1:30303
-    #[arg(long, value_delimiter = ',', value_parser = parse_peer)]
+    #[arg(long, value_delimiter = ',')]
     pub trusted_peers: Vec<TrustedPeer>,
 
     /// Connect to or accept from trusted peers only
@@ -255,7 +255,7 @@ pub struct NetworkArgs {
     /// Comma separated enode URLs or ENRs for P2P discovery bootstrap.
     ///
     /// Will fall back to a network-specific default if not specified.
-    #[arg(long, value_delimiter = ',', value_parser = parse_peer)]
+    #[arg(long, value_delimiter = ',')]
     pub bootnodes: Option<Vec<TrustedPeer>>,
 
     /// Amount of DNS resolution requests retries to perform when peering.
@@ -1144,34 +1144,6 @@ impl Default for DiscoveryArgs {
     }
 }
 
-/// Parse an `enode://` URL or a base64 encoded `enr:` record into a [`TrustedPeer`].
-///
-/// A discovery-only ENR omits the tcp key, in which case the udp port is used for the `RLPx` dial
-/// guess, the same fallback as [`reth_discv5::Discv5::try_into_reachable`].
-fn parse_peer(s: &str) -> Result<TrustedPeer, String> {
-    let unprefixed = !s.starts_with("enode://") && !s.starts_with("enr:");
-    let node = AnyNode::from_str(s).map_err(|err| {
-        if unprefixed {
-            "expected an enode:// URL or a base64 encoded enr: record".to_string()
-        } else {
-            err
-        }
-    })?;
-
-    match node {
-        AnyNode::TrustedPeer(peer) => Ok(peer),
-        AnyNode::NodeRecord(record) => Ok(record.into()),
-        AnyNode::Enr(enr) => {
-            let mut record = NodeRecord::try_from(&enr).map_err(|err| err.to_string())?;
-            if record.tcp_port == 0 {
-                record.tcp_port = record.udp_port;
-            }
-            Ok(record.into())
-        }
-        AnyNode::PeerId(_) => Err("no ip address and port specified".to_string()),
-    }
-}
-
 /// Parse a block number=hash pair or just a hash into `BlockNumHash`
 fn parse_block_num_hash(s: &str) -> Result<BlockNumHash, String> {
     if let Some((num_str, hash_str)) = s.split_once('=') {
@@ -1191,7 +1163,7 @@ mod tests {
     use clap::Parser;
     use reth_chainspec::MAINNET;
     use reth_config::Config;
-    use reth_network_peers::{NodeRecord, PeerId};
+    use reth_network_peers::NodeRecord;
     use secp256k1::SecretKey;
     use std::{
         fs,
@@ -1257,33 +1229,9 @@ mod tests {
     fn parse_enr_bootnode_args() {
         let enr = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
         let args = CommandParser::<NetworkArgs>::parse_from(["reth", "--bootnodes", enr]).args;
-
-        let resolved = args.resolved_bootnodes().unwrap();
-        assert_eq!(resolved.len(), 1);
-        assert_eq!(resolved[0].address, "127.0.0.1".parse::<std::net::IpAddr>().unwrap());
-        assert_eq!(resolved[0].udp_port, 30303);
-        assert_eq!(resolved[0].tcp_port, 30303);
-        assert_eq!(
-            resolved[0].id,
-            "0xca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"
-                .parse::<PeerId>()
-                .unwrap()
-        );
-
-        let args = CommandParser::<NetworkArgs>::parse_from(["reth", "--trusted-peers", enr]).args;
-        assert_eq!(args.trusted_peers, vec![TrustedPeer::from(resolved[0])]);
-    }
-
-    #[test]
-    fn parse_peer_rejects_unknown_format() {
-        let err = parse_peer("127.0.0.1:30303").unwrap_err();
-        assert_eq!(err, "expected an enode:// URL or a base64 encoded enr: record");
-
-        assert!(parse_peer("enr:garbage").is_err());
-        assert!(parse_peer(
-            "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666"
-        )
-        .is_err());
+        let trusted =
+            CommandParser::<NetworkArgs>::parse_from(["reth", "--trusted-peers", enr]).args;
+        assert_eq!(args.bootnodes, Some(trusted.trusted_peers));
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -139,7 +139,7 @@ Networking:
           [default: 200]
 
       --trusted-peers <TRUSTED_PEERS>
-          Comma separated enode URLs of trusted peers for P2P connections.
+          Comma separated enode URLs or ENRs of trusted peers for P2P connections.
 
           --trusted-peers enode://abcd@192.168.0.1:30303
 
@@ -147,7 +147,7 @@ Networking:
           Connect to or accept from trusted peers only
 
       --bootnodes <BOOTNODES>
-          Comma separated enode URLs for P2P discovery bootstrap.
+          Comma separated enode URLs or ENRs for P2P discovery bootstrap.
 
           Will fall back to a network-specific default if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -79,7 +79,7 @@ Networking:
           [default: 200]
 
       --trusted-peers <TRUSTED_PEERS>
-          Comma separated enode URLs of trusted peers for P2P connections.
+          Comma separated enode URLs or ENRs of trusted peers for P2P connections.
 
           --trusted-peers enode://abcd@192.168.0.1:30303
 
@@ -87,7 +87,7 @@ Networking:
           Connect to or accept from trusted peers only
 
       --bootnodes <BOOTNODES>
-          Comma separated enode URLs for P2P discovery bootstrap.
+          Comma separated enode URLs or ENRs for P2P discovery bootstrap.
 
           Will fall back to a network-specific default if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -79,7 +79,7 @@ Networking:
           [default: 200]
 
       --trusted-peers <TRUSTED_PEERS>
-          Comma separated enode URLs of trusted peers for P2P connections.
+          Comma separated enode URLs or ENRs of trusted peers for P2P connections.
 
           --trusted-peers enode://abcd@192.168.0.1:30303
 
@@ -87,7 +87,7 @@ Networking:
           Connect to or accept from trusted peers only
 
       --bootnodes <BOOTNODES>
-          Comma separated enode URLs for P2P discovery bootstrap.
+          Comma separated enode URLs or ENRs for P2P discovery bootstrap.
 
           Will fall back to a network-specific default if not specified.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -238,7 +238,7 @@ Networking:
           [default: 200]
 
       --trusted-peers <TRUSTED_PEERS>
-          Comma separated enode URLs of trusted peers for P2P connections.
+          Comma separated enode URLs or ENRs of trusted peers for P2P connections.
 
           --trusted-peers enode://abcd@192.168.0.1:30303
 
@@ -246,7 +246,7 @@ Networking:
           Connect to or accept from trusted peers only
 
       --bootnodes <BOOTNODES>
-          Comma separated enode URLs for P2P discovery bootstrap.
+          Comma separated enode URLs or ENRs for P2P discovery bootstrap.
 
           Will fall back to a network-specific default if not specified.
 


### PR DESCRIPTION
`--bootnodes`, `--trusted-peers`, and `peers.trusted_nodes` now accept `enr:` records through `TrustedPeer::from_str`, alongside enode URLs. Discovery-only ENRs fall back to their UDP port for the RLPx dial guess, which enables bootstrapping from discv5-only nodes such as bootnodoor.

ENRs are still down-converted to `NodeRecord`; #26496 should land first so partial dual-stack endpoints are derived from one address family.