### PR TITLE
fix(discv5): advertise fork ENR entry on custom chain ids

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -182,6 +182,14 @@ impl ConfigBuilder {
         self
     }
 
+    /// Same as [`Self::fork`], but keeps an already configured fork ID kv-pair.
+    pub const fn fork_if_unset(mut self, fork_key: &'static [u8], fork_id: ForkId) -> Self {
+        if self.fork.is_none() {
+            self.fork = Some((fork_key, fork_id));
+        }
+        self
+    }
+
     /// Sets the tcp socket to advertise in the local [`Enr`](discv5::enr::Enr). The IP address of
     /// this socket will overwrite the discovery address of the same IP version, if one is
     /// configured.

--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -182,7 +182,7 @@ impl ConfigBuilder {
         self
     }
 
-    /// Same as [`Self::fork`], but keeps an already configured fork ID kv-pair.
+    /// Sets the fork ID kv-pair if none has already been configured.
     pub const fn fork_if_unset(mut self, fork_key: &'static [u8], fork_id: ForkId) -> Self {
         if self.fork.is_none() {
             self.fork = Some((fork_key, fork_id));

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -685,9 +685,15 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
         let advertised_ip = nat.clone().and_then(|nat| nat.as_external_ip(listener_addr.port()));
 
         discovery_v5_builder = discovery_v5_builder.map(|mut builder| {
+            let fork_id = chain_spec.fork_id(&head);
             if let Some(network_stack_id) = NetworkStackId::id(&chain_spec) {
-                let fork_id = chain_spec.fork_id(&head);
                 builder = builder.fork(network_stack_id, fork_id)
+            } else {
+                // Discv4 advertises the fork entry unconditionally; without it fork-aware
+                // bootnodes reject the discv5 ENR of custom-chain-id (devnet) nodes. `id`
+                // returning `None` implies not optimism, hence the "eth" key. An explicitly
+                // configured fork kv-pair takes precedence.
+                builder = builder.fork_if_unset(NetworkStackId::ETH, fork_id)
             }
 
             if let Some(ip) = advertised_ip {
@@ -914,6 +920,45 @@ mod tests {
         let advertised_fork_id = *local_enr
             .get_decodable::<Vec<ForkId>>(fork_key)
             .expect("should read 'odyssey'")
+            .expect("should decode fork id list")
+            .first()
+            .expect("should be non-empty");
+
+        assert_eq!(advertised_fork_id, fork_id);
+    }
+
+    #[test]
+    fn test_discv5_fork_id_custom_chain_id_fallback() {
+        const GENESIS_TIME: u64 = 151_515;
+
+        let genesis = Genesis::default().with_timestamp(GENESIS_TIME);
+
+        let chain_spec = ChainSpecBuilder::default()
+            .chain(Chain::from_id(3151908))
+            .genesis(genesis)
+            .with_fork(EthereumHardfork::Shanghai, ForkCondition::Timestamp(GENESIS_TIME))
+            .build();
+
+        let fork_id = chain_spec.fork_id(&Head {
+            hash: chain_spec.genesis_hash(),
+            number: 0,
+            timestamp: GENESIS_TIME,
+            difficulty: U256::ZERO,
+            total_difficulty: U256::ZERO,
+        });
+
+        let config = builder()
+            .discovery_v5(reth_discv5::Config::builder((Ipv4Addr::LOCALHOST, 30303).into()))
+            .build_with_noop_provider(Arc::new(chain_spec));
+
+        let (local_enr, _, _, _) = build_local_enr(
+            &config.secret_key,
+            &config.discovery_v5_config.expect("should build config"),
+        );
+
+        let advertised_fork_id = *local_enr
+            .get_decodable::<Vec<ForkId>>(NetworkStackId::ETH)
+            .expect("should read 'eth'")
             .expect("should decode fork id list")
             .first()
             .expect("should be non-empty");

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -689,10 +689,8 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
             if let Some(network_stack_id) = NetworkStackId::id(&chain_spec) {
                 builder = builder.fork(network_stack_id, fork_id)
             } else {
-                // Discv4 advertises the fork entry unconditionally; without it fork-aware
-                // bootnodes reject the discv5 ENR of custom-chain-id (devnet) nodes. `id`
-                // returning `None` implies not optimism, hence the "eth" key. An explicitly
-                // configured fork kv-pair takes precedence.
+                // Custom Ethereum chains are not recognized by `NetworkStackId::id`, but still
+                // use the `eth` key for fork-aware discovery. Preserve any explicit override.
                 builder = builder.fork_if_unset(NetworkStackId::ETH, fork_id)
             }
 


### PR DESCRIPTION
## Description

On chains whose id isn't a recognized named chain (`NetworkStackId::id` returns `None` — i.e. every devnet with a custom chain id), the local **discv5** ENR carries no `eth` fork entry, while the **discv4** EIP-868 ENR advertises it unconditionally (`NetworkManager::new`).

Fork-aware discv5 bootnodes (e.g. [ethpandaops/bootnodoor](https://github.com/ethpandaops/bootnodoor)) classify EL nodes by the `eth` entry and silently drop records without it. On devnets, reth completes the discv5 handshake with the bootnode but is never admitted to its table nor served to other peers via FINDNODE, and sits at 0 peers — while geth/nethermind/besu (which advertise the entry on custom chains) mesh fine.

Fix: when `NetworkStackId::id` returns `None`, advertise the fork entry under the `eth` key via a new `ConfigBuilder::fork_if_unset`, so an explicitly configured fork kv-pair still takes precedence (covered by `test_discv5_fork_id_default`). `id()` returning `None` implies the chain is not optimism, so `eth` is always the right key here.

Behavior note: with the entry set, discv5-discovered peers advertising an `eth` entry are now fork-id-validated on custom chains, matching long-standing discv4 semantics on the same path; peers without the entry are admitted exactly as before.

Verified on a kurtosis devnet with a fork-aware bootnode: before, reth was tracked only via discv4 and had 0 peers; after, it is admitted via discv5 and fully meshes with nethermind and besu. Independent of #26448 (ENR bootnodes via CLI), but together they enable bootstrapping devnets from a discv5 ENR bootnode.
