### PR TITLE
refactor(trie): remove unused stack printer

### DIFF
--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -119,15 +119,6 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
         self.removed_keys.take().unwrap_or_default()
     }
 
-    /// Prints the current stack of trie nodes.
-    pub fn print_stack(&self) {
-        println!("====================== STACK ======================");
-        for node in &self.stack {
-            println!("{node:?}");
-        }
-        println!("====================== END STACK ======================\n");
-    }
-
     /// The current length of the removed keys.
     pub fn removed_keys_len(&self) -> usize {
         self.removed_keys.as_ref().map_or(0, |u| u.len())


### PR DESCRIPTION
`cargo-hawk` identified `TrieWalker::print_stack` as dead public surface; repository-wide and GitHub code searches found no call sites, so this removes the ad hoc stdout debugger. A second Hawk pass reduced the dead-public count from 1,791 to 1,790, and all 72 `reth-trie` tests pass with all features. AI assistance: Codex performed the analysis and prepared this change.
