### PR TITLE
chore(deps): update crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Updates `crossbeam-epoch` from 0.9.18 to 0.9.20 on `tempo/v1.11` to address [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) and restore the `cargo deny` check. The dependency is already updated on `main`.
