### PR TITLE
Feat/merkle change thresholds

### DIFF
--- a/crates/cli/commands/src/stage/dump/merkle.rs
+++ b/crates/cli/commands/src/stage/dump/merkle.rs
@@ -168,6 +168,8 @@ where
 
     let mut stage = MerkleStage::Execution {
         // Forces updating the root instead of calculating from scratch
+        rebuild_change_threshold: u64::MAX,
+        incremental_change_threshold: u64::MAX,
         rebuild_threshold: u64::MAX,
         incremental_threshold: u64::MAX,
     };

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -307,6 +307,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     Box::new(MerkleStage::new_execution(
                         config.stages.merkle.rebuild_threshold,
                         config.stages.merkle.incremental_threshold,
+                        config.stages.merkle.rebuild_change_threshold,
+                        config.stages.merkle.incremental_change_threshold,
                     )),
                     Some(Box::new(MerkleStage::default_unwind())),
                 ),

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -141,7 +141,11 @@ impl StageConfig {
     /// The highest threshold (in number of blocks) for switching between incremental and full
     /// calculations across `MerkleStage`, `AccountHashingStage` and `StorageHashingStage`. This is
     /// required to figure out if can prune or not changesets on subsequent pipeline runs during
-    /// `ExecutionStage`
+    /// `ExecutionStage`.
+    ///
+    /// Uses the merkle **block** incremental cap (`incremental_threshold`), not
+    /// `incremental_change_threshold`, because execution pruning depends on block windows for
+    /// changeset availability.
     pub fn execution_external_clean_threshold(&self) -> u64 {
         self.merkle
             .incremental_threshold
@@ -350,26 +354,45 @@ impl Default for HashingConfig {
 }
 
 /// Merkle stage configuration.
+///
+/// Rebuild vs incremental and incremental chunk sizing use **changeset entry counts** as the
+/// primary signal (`rebuild_change_threshold`, `incremental_change_threshold`). The block fields
+/// (`rebuild_threshold`, `incremental_threshold`) act as safety caps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct MerkleConfig {
-    /// The number of blocks we will run the incremental root method for when we are catching up on
-    /// the merkle stage for a large number of blocks.
+    /// Maximum account + storage changeset rows per incremental chunk.
     ///
-    /// When we are catching up for a large number of blocks, we can only run the incremental root
-    /// for a limited number of blocks, otherwise the incremental root method may cause the node to
-    /// OOM. This number determines how many blocks in a row we will run the incremental root
-    /// method for.
+    /// Primary limit on incremental trie updates. The stage also caps each chunk by
+    /// `incremental_threshold` blocks.
+    pub incremental_change_threshold: u64,
+    /// Maximum total account + storage changeset rows in the sync range before switching to a
+    /// full trie rebuild.
+    ///
+    /// Primary rebuild trigger. The stage also forces rebuild when the block gap exceeds
+    /// `rebuild_threshold`.
+    pub rebuild_change_threshold: u64,
+    /// Maximum blocks per incremental chunk (safety cap).
+    ///
+    /// When catching up over many blocks, incremental root building is bounded so each chunk stays
+    /// within memory limits even when changeset volume is low.
     pub incremental_threshold: u64,
-    /// The threshold (in number of blocks) for switching from incremental trie building of changes
-    /// to whole rebuild.
+    /// Maximum block gap before forcing a full trie rebuild (safety cap).
+    ///
+    /// Fast path: skip changeset counting when the gap is obviously too large for incremental
+    /// updates. Also used by [`StageConfig::execution_external_clean_threshold`].
     pub rebuild_threshold: u64,
 }
 
 impl Default for MerkleConfig {
     fn default() -> Self {
-        Self { incremental_threshold: 7_000, rebuild_threshold: 100_000 }
+        Self {
+            incremental_change_threshold: 10_000_000,
+            rebuild_change_threshold: 100_000_000,
+            incremental_threshold: 7_000,
+            rebuild_threshold: 100_000,
+        }
     }
 }
 
@@ -643,7 +666,7 @@ where
 
 #[cfg(all(test, feature = "serde"))]
 mod tests {
-    use super::{Config, EXTENSION};
+    use super::{Config, MerkleConfig, EXTENSION};
     use crate::PruneConfig;
     use alloy_primitives::Address;
     use reth_network_peers::TrustedPeer;
@@ -1113,6 +1136,19 @@ transaction_lookup = 'full'
 receipts = { distance = 16384 }
 #";
         let _conf: Config = toml::from_str(s).unwrap();
+    }
+
+    #[test]
+    fn test_merkle_config_defaults_for_missing_change_thresholds() {
+        let s = r#"
+incremental_threshold = 7000
+rebuild_threshold = 100000
+"#;
+        let merkle: MerkleConfig = toml::from_str(s).unwrap();
+        assert_eq!(merkle.incremental_threshold, 7_000);
+        assert_eq!(merkle.rebuild_threshold, 100_000);
+        assert_eq!(merkle.incremental_change_threshold, 10_000_000);
+        assert_eq!(merkle.rebuild_change_threshold, 100_000_000);
     }
 
     #[test]

--- a/crates/stages/stages/src/sets.rs
+++ b/crates/stages/stages/src/sets.rs
@@ -438,6 +438,8 @@ where
             .add_stage(MerkleStage::new_execution(
                 self.stages_config.merkle.rebuild_threshold,
                 self.stages_config.merkle.incremental_threshold,
+                self.stages_config.merkle.rebuild_change_threshold,
+                self.stages_config.merkle.incremental_change_threshold,
             ))
     }
 }

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -15,6 +15,7 @@ use reth_stages_api::{
     BlockErrorKind, EntitiesCheckpoint, ExecInput, ExecOutput, MerkleCheckpoint, Stage,
     StageCheckpoint, StageError, StageId, StorageRootMerkleCheckpoint, UnwindInput, UnwindOutput,
 };
+use reth_storage_api::count_state_changes_in_range;
 use reth_trie::{IntermediateStateRootState, StateRoot, StateRootProgress, StoredSubNode};
 use reth_trie_db::DatabaseStateRoot;
 
@@ -54,6 +55,12 @@ pub const MERKLE_STAGE_DEFAULT_REBUILD_THRESHOLD: u64 = 100_000;
 /// number.
 pub const MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD: u64 = 7_000;
 
+/// The default maximum account + storage changeset rows before forcing a full trie rebuild.
+pub const MERKLE_STAGE_DEFAULT_REBUILD_CHANGE_THRESHOLD: u64 = 100_000_000;
+
+/// The default maximum account + storage changeset rows per incremental chunk.
+pub const MERKLE_STAGE_DEFAULT_INCREMENTAL_CHANGE_THRESHOLD: u64 = 10_000_000;
+
 /// The merkle hashing stage uses input from
 /// [`AccountHashingStage`][crate::stages::AccountHashingStage] and
 /// [`StorageHashingStage`][crate::stages::StorageHashingStage] to calculate intermediate hashes
@@ -81,12 +88,13 @@ pub enum MerkleStage {
     Execution {
         // TODO: make struct for holding incremental settings, for code reuse between `Execution`
         // variant and `Both`
-        /// The threshold (in number of blocks) for switching from incremental trie building
-        /// of changes to whole rebuild.
+        /// Maximum account + storage changeset rows in the sync range before a full trie rebuild.
+        rebuild_change_threshold: u64,
+        /// Maximum account + storage changeset rows per incremental chunk.
+        incremental_change_threshold: u64,
+        /// Maximum block gap before forcing a full trie rebuild (safety cap).
         rebuild_threshold: u64,
-        /// The threshold (in number of blocks) to run the stage in incremental mode. The
-        /// incremental mode will calculate the state root by calculating the new state root for
-        /// some number of blocks, repeating until we reach the desired block number.
+        /// Maximum blocks per incremental chunk (safety cap).
         incremental_threshold: u64,
     },
     /// The unwind portion of the merkle stage.
@@ -97,12 +105,13 @@ pub enum MerkleStage {
     /// Able to execute and unwind. Used for tests
     #[cfg(any(test, feature = "test-utils"))]
     Both {
-        /// The threshold (in number of blocks) for switching from incremental trie building
-        /// of changes to whole rebuild.
+        /// Maximum account + storage changeset rows in the sync range before a full trie rebuild.
+        rebuild_change_threshold: u64,
+        /// Maximum account + storage changeset rows per incremental chunk.
+        incremental_change_threshold: u64,
+        /// Maximum block gap before forcing a full trie rebuild (safety cap).
         rebuild_threshold: u64,
-        /// The threshold (in number of blocks) to run the stage in incremental mode. The
-        /// incremental mode will calculate the state root by calculating the new state root for
-        /// some number of blocks, repeating until we reach the desired block number.
+        /// Maximum blocks per incremental chunk (safety cap).
         incremental_threshold: u64,
     },
 }
@@ -111,6 +120,8 @@ impl MerkleStage {
     /// Stage default for the [`MerkleStage::Execution`].
     pub const fn default_execution() -> Self {
         Self::Execution {
+            rebuild_change_threshold: MERKLE_STAGE_DEFAULT_REBUILD_CHANGE_THRESHOLD,
+            incremental_change_threshold: MERKLE_STAGE_DEFAULT_INCREMENTAL_CHANGE_THRESHOLD,
             rebuild_threshold: MERKLE_STAGE_DEFAULT_REBUILD_THRESHOLD,
             incremental_threshold: MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD,
         }
@@ -127,8 +138,18 @@ impl MerkleStage {
     }
 
     /// Create new instance of [`MerkleStage::Execution`].
-    pub const fn new_execution(rebuild_threshold: u64, incremental_threshold: u64) -> Self {
-        Self::Execution { rebuild_threshold, incremental_threshold }
+    pub const fn new_execution(
+        rebuild_threshold: u64,
+        incremental_threshold: u64,
+        rebuild_change_threshold: u64,
+        incremental_change_threshold: u64,
+    ) -> Self {
+        Self::Execution {
+            rebuild_change_threshold,
+            incremental_change_threshold,
+            rebuild_threshold,
+            incremental_threshold,
+        }
     }
 
     /// Gets the hashing progress
@@ -164,6 +185,52 @@ impl MerkleStage {
         }
         Ok(provider.save_stage_checkpoint_progress(StageId::MerkleExecute, buf)?)
     }
+
+    /// Returns whether the execution path should perform a full trie rebuild instead of
+    /// incremental updates for the given block range.
+    fn should_rebuild_trie<Provider>(
+        from_block: BlockNumber,
+        to_block: BlockNumber,
+        provider: &Provider,
+        rebuild_block_cap: u64,
+        rebuild_change_threshold: u64,
+    ) -> Result<bool, StageError>
+    where
+        Provider: ChangeSetReader + StorageChangeSetReader,
+    {
+        if from_block == 1 {
+            debug!(
+                target: "sync::stages::merkle::exec",
+                from_block,
+                to_block,
+                "Using full rebuild (genesis)"
+            );
+            return Ok(true);
+        }
+
+        let block_gap = to_block - from_block;
+        if block_gap > rebuild_block_cap {
+            debug!(
+                target: "sync::stages::merkle::exec",
+                block_gap,
+                rebuild_block_cap,
+                "Using full rebuild (block gap exceeds cap)"
+            );
+            return Ok(true);
+        }
+
+        let change_count = count_state_changes_in_range(provider, from_block..=to_block)?;
+        let use_rebuild = change_count > rebuild_change_threshold;
+        debug!(
+            target: "sync::stages::merkle::exec",
+            block_gap,
+            change_count,
+            rebuild_change_threshold,
+            use_rebuild,
+            "Merkle rebuild decision"
+        );
+        Ok(use_rebuild)
+    }
 }
 
 impl<Provider> Stage<Provider> for MerkleStage
@@ -190,18 +257,39 @@ where
 
     /// Execute the stage.
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
-        let (threshold, incremental_threshold) = match self {
+        let (
+            rebuild_block_cap,
+            incremental_threshold,
+            rebuild_change_threshold,
+            _incremental_change_threshold,
+        ) = match self {
             Self::Unwind { .. } => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
                 return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
             }
-            Self::Execution { rebuild_threshold, incremental_threshold } => {
-                (*rebuild_threshold, *incremental_threshold)
-            }
+            Self::Execution {
+                rebuild_threshold,
+                incremental_threshold,
+                rebuild_change_threshold,
+                incremental_change_threshold,
+            } => (
+                *rebuild_threshold,
+                *incremental_threshold,
+                *rebuild_change_threshold,
+                *incremental_change_threshold,
+            ),
             #[cfg(any(test, feature = "test-utils"))]
-            Self::Both { rebuild_threshold, incremental_threshold } => {
-                (*rebuild_threshold, *incremental_threshold)
-            }
+            Self::Both {
+                rebuild_threshold,
+                incremental_threshold,
+                rebuild_change_threshold,
+                incremental_change_threshold,
+            } => (
+                *rebuild_threshold,
+                *incremental_threshold,
+                *rebuild_change_threshold,
+                *incremental_change_threshold,
+            ),
         };
 
         let range = input.next_block_range();
@@ -215,7 +303,13 @@ where
 
         let (trie_root, entities_checkpoint) = if range.is_empty() {
             (target_block_root, input.checkpoint().entities_stage_checkpoint().unwrap_or_default())
-        } else if to_block - from_block > threshold || from_block == 1 {
+        } else if Self::should_rebuild_trie(
+            from_block,
+            to_block,
+            provider,
+            rebuild_block_cap,
+            rebuild_change_threshold,
+        )? {
             let mut checkpoint = self.get_execution_checkpoint(provider)?;
 
             // if there are more blocks than threshold it is faster to rebuild the trie
@@ -663,6 +757,8 @@ mod tests {
 
         fn stage(&self) -> Self::S {
             Self::S::Both {
+                rebuild_change_threshold: u64::MAX,
+                incremental_change_threshold: u64::MAX,
                 rebuild_threshold: self.clean_threshold,
                 incremental_threshold: self.incremental_threshold,
             }

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -231,6 +231,45 @@ impl MerkleStage {
         );
         Ok(use_rebuild)
     }
+
+    /// Returns the last block (inclusive) of the next incremental chunk starting at `from_block`.
+    fn incremental_chunk_end<Provider>(
+        from_block: BlockNumber,
+        to_block: BlockNumber,
+        provider: &Provider,
+        incremental_block_cap: u64,
+        incremental_change_threshold: u64,
+    ) -> Result<BlockNumber, StageError>
+    where
+        Provider: ChangeSetReader + StorageChangeSetReader,
+    {
+        let mut entries_in_chunk = 0u64;
+        let mut chunk_end = from_block;
+
+        for block in from_block..=to_block {
+            if block != from_block &&
+                (entries_in_chunk >= incremental_change_threshold ||
+                    block.saturating_sub(from_block) >= incremental_block_cap)
+            {
+                break;
+            }
+            entries_in_chunk += count_state_changes_in_range(provider, block..=block)?;
+            chunk_end = block;
+        }
+
+        debug!(
+            target: "sync::stages::merkle::exec",
+            from_block,
+            chunk_end,
+            to_block,
+            entries_in_chunk,
+            incremental_block_cap,
+            incremental_change_threshold,
+            "Incremental chunk boundary"
+        );
+
+        Ok(chunk_end)
+    }
 }
 
 impl<Provider> Stage<Provider> for MerkleStage
@@ -261,7 +300,7 @@ where
             rebuild_block_cap,
             incremental_threshold,
             rebuild_change_threshold,
-            _incremental_change_threshold,
+            incremental_change_threshold,
         ) = match self {
             Self::Unwind { .. } => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
@@ -411,48 +450,48 @@ where
                 }
             }
         } else {
-            debug!(target: "sync::stages::merkle::exec", current = ?current_block_number, target = ?to_block, "Updating trie in chunks");
-            let mut final_root = None;
-            for start_block in range.step_by(incremental_threshold as usize) {
-                let chunk_to = std::cmp::min(start_block + incremental_threshold - 1, to_block);
-                let chunk_range = start_block..=chunk_to;
-                debug!(
-                    target: "sync::stages::merkle::exec",
-                    current = ?current_block_number,
-                    target = ?to_block,
-                    incremental_threshold,
-                    chunk_range = ?chunk_range,
-                    "Processing chunk"
-                );
-                let (root, updates) = reth_trie_db::with_adapter!(provider, |A| {
-                    DbStateRoot::<_, A>::incremental_root_with_updates(provider, chunk_range)
-                })
-                .map_err(|e| {
-                    error!(target: "sync::stages::merkle", %e, ?current_block_number, ?to_block, "Incremental state root failed! {INVALID_STATE_ROOT_ERROR_MESSAGE}");
-                    StageError::Fatal(Box::new(e))
-                })?;
-                provider.write_trie_updates(updates)?;
-                final_root = Some(root);
-            }
-
-            // if we had no final root, we must have not looped above, which should not be possible
-            let final_root = final_root.ok_or(StageError::Fatal(
-                "Incremental merkle hashing did not produce a final root".into(),
-            ))?;
+            let chunk_end = Self::incremental_chunk_end(
+                from_block,
+                to_block,
+                provider,
+                incremental_threshold,
+                incremental_change_threshold,
+            )?;
+            let chunk_range = from_block..=chunk_end;
+            debug!(
+                target: "sync::stages::merkle::exec",
+                current = ?current_block_number,
+                target = ?to_block,
+                incremental_threshold,
+                incremental_change_threshold,
+                chunk_range = ?chunk_range,
+                "Processing incremental chunk"
+            );
+            let (root, updates) = reth_trie_db::with_adapter!(provider, |A| {
+                DbStateRoot::<_, A>::incremental_root_with_updates(provider, chunk_range)
+            })
+            .map_err(|e| {
+                error!(target: "sync::stages::merkle", %e, ?current_block_number, ?to_block, "Incremental state root failed! {INVALID_STATE_ROOT_ERROR_MESSAGE}");
+                StageError::Fatal(Box::new(e))
+            })?;
+            provider.write_trie_updates(updates)?;
 
             let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
                 provider.count_entries::<tables::HashedStorages>()?)
                 as u64;
 
-            let entities_checkpoint = EntitiesCheckpoint {
-                // This is fine because `range` doesn't have an upper bound, so in this `else`
-                // branch we're just hashing all remaining accounts and storage slots we have in the
-                // database.
-                processed: total_hashed_entries,
-                total: total_hashed_entries,
-            };
-            // Save the checkpoint
-            (final_root, entities_checkpoint)
+            let entities_checkpoint =
+                EntitiesCheckpoint { processed: total_hashed_entries, total: total_hashed_entries };
+
+            if chunk_end < to_block {
+                return Ok(ExecOutput {
+                    checkpoint: StageCheckpoint::new(chunk_end)
+                        .with_entities_stage_checkpoint(entities_checkpoint),
+                    done: false,
+                });
+            }
+
+            (root, entities_checkpoint)
         };
 
         // Reset the checkpoint
@@ -686,10 +725,22 @@ mod tests {
         };
 
         runner.seed_execution(input).expect("failed to seed execution");
-        let rx = runner.execute(input);
+
+        let mut current_input = input;
+        let result = loop {
+            let rx = runner.execute(current_input);
+            let result = rx.await.unwrap();
+            match &result {
+                Ok(ExecOutput { done: true, .. }) => break result,
+                Ok(ExecOutput { done: false, checkpoint }) => {
+                    current_input =
+                        ExecInput { target: Some(previous_stage), checkpoint: Some(*checkpoint) };
+                }
+                Err(_) => break result,
+            }
+        };
 
         // Assert the successful result
-        let result = rx.await.unwrap();
         assert_matches!(
             result,
             Ok(ExecOutput {

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -628,6 +628,31 @@ mod tests {
 
     stage_test_suite_ext!(MerkleTestRunner, merkle);
 
+    async fn execute_until_done(
+        runner: &MerkleTestRunner,
+        input: ExecInput,
+    ) -> Result<ExecOutput, StageError> {
+        let mut current_input = input;
+        loop {
+            let rx = runner.execute(current_input);
+            match rx.await.unwrap() {
+                Ok(output) if output.done => return Ok(output),
+                Ok(output) => {
+                    current_input =
+                        ExecInput { target: input.target, checkpoint: Some(output.checkpoint) };
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    async fn execute_once(
+        runner: &MerkleTestRunner,
+        input: ExecInput,
+    ) -> Result<ExecOutput, StageError> {
+        runner.execute(input).await.unwrap()
+    }
+
     /// Execute from genesis so as to merkelize whole state
     #[tokio::test]
     async fn execute_clean_merkle() {
@@ -712,12 +737,9 @@ mod tests {
     #[tokio::test]
     async fn execute_chunked_merkle() {
         let (previous_stage, stage_progress) = (200, 100);
-        let clean_threshold = 100;
-        let incremental_threshold = 10;
 
         // Set up the runner
-        let mut runner =
-            MerkleTestRunner { db: TestStageDB::default(), clean_threshold, incremental_threshold };
+        let mut runner = MerkleTestRunner::new(100, 10, u64::MAX, u64::MAX);
 
         let input = ExecInput {
             target: Some(previous_stage),
@@ -726,24 +748,10 @@ mod tests {
 
         runner.seed_execution(input).expect("failed to seed execution");
 
-        let mut current_input = input;
-        let result = loop {
-            let rx = runner.execute(current_input);
-            let result = rx.await.unwrap();
-            match &result {
-                Ok(ExecOutput { done: true, .. }) => break result,
-                Ok(ExecOutput { done: false, checkpoint }) => {
-                    current_input =
-                        ExecInput { target: Some(previous_stage), checkpoint: Some(*checkpoint) };
-                }
-                Err(_) => break result,
-            }
-        };
-
-        // Assert the successful result
+        let result = execute_until_done(&runner, input).await.unwrap();
         assert_matches!(
             result,
-            Ok(ExecOutput {
+            ExecOutput {
                 checkpoint: StageCheckpoint {
                     block_number,
                     stage_checkpoint: Some(StageUnitCheckpoint::Entities(EntitiesCheckpoint {
@@ -752,7 +760,7 @@ mod tests {
                     }))
                 },
                 done: true
-            }) if block_number == previous_stage && processed == total &&
+            } if block_number == previous_stage && processed == total &&
                 total == (
                     runner.db.count_entries::<tables::HashedAccounts>().unwrap() +
                     runner.db.count_entries::<tables::HashedStorages>().unwrap()
@@ -783,19 +791,151 @@ mod tests {
         );
     }
 
+    /// Many blocks with a low changeset count should use incremental updates, not rebuild.
+    #[tokio::test]
+    async fn incremental_not_rebuild_when_change_count_below_threshold() {
+        let (target, progress) = (400, 100);
+        let mut runner = MerkleTestRunner::new(100_000, 10_000, 1_000_000, u64::MAX);
+
+        let input =
+            ExecInput { target: Some(target), checkpoint: Some(StageCheckpoint::new(progress)) };
+        runner.seed_execution(input).expect("failed to seed execution");
+
+        let provider = runner.db.factory.provider().unwrap();
+        let change_count =
+            count_state_changes_in_range(&provider, (progress + 1)..=target).unwrap();
+        assert!(change_count < 1_000_000);
+        assert!(!MerkleStage::should_rebuild_trie(
+            progress + 1,
+            target,
+            &provider,
+            runner.rebuild_threshold,
+            runner.rebuild_change_threshold,
+        )
+        .unwrap());
+
+        let result = execute_until_done(&runner, input).await.unwrap();
+        assert!(result.done);
+        assert_eq!(result.checkpoint.block_number, target);
+    }
+
+    /// Fails under block-only chunking: heavy changes in a small block gap must checkpoint
+    /// mid-range when `incremental_change_threshold` is exceeded.
+    #[tokio::test]
+    async fn incremental_chunks_when_change_threshold_exceeded() {
+        let (target, progress) = (130, 100);
+        let input =
+            ExecInput { target: Some(target), checkpoint: Some(StageCheckpoint::new(progress)) };
+
+        let mut change_based = MerkleTestRunner::new(100_000, 10_000, u64::MAX, 10);
+        change_based.seed_execution(input).expect("failed to seed execution");
+
+        let first = execute_once(&change_based, input).await.unwrap();
+        assert!(!first.done, "change-based chunking should checkpoint mid-range");
+        assert!(
+            first.checkpoint.block_number < target,
+            "first chunk should not reach target block"
+        );
+
+        let mut block_only = MerkleTestRunner::new(100_000, 10_000, u64::MAX, u64::MAX);
+        block_only.seed_execution(input).expect("failed to seed execution");
+
+        let block_only_first = execute_once(&block_only, input).await.unwrap();
+        assert!(
+            block_only_first.done,
+            "block-only logic would finish the full range in one incremental chunk"
+        );
+        assert_eq!(block_only_first.checkpoint.block_number, target);
+    }
+
+    /// Fails under block-only rebuild logic: high changeset volume below the block cap must
+    /// select the rebuild path.
+    #[tokio::test]
+    async fn rebuild_when_change_threshold_exceeded_below_block_cap() {
+        let (target, progress) = (150, 100);
+        let input =
+            ExecInput { target: Some(target), checkpoint: Some(StageCheckpoint::new(progress)) };
+
+        let mut runner = MerkleTestRunner::new(100_000, 10_000, 80, u64::MAX);
+        runner.seed_execution(input).expect("failed to seed execution");
+
+        let provider = runner.db.factory.provider().unwrap();
+        let change_count =
+            count_state_changes_in_range(&provider, (progress + 1)..=target).unwrap();
+        assert!(change_count > 80, "test setup must exceed rebuild change threshold");
+
+        assert!(MerkleStage::should_rebuild_trie(
+            progress + 1,
+            target,
+            &provider,
+            runner.rebuild_threshold,
+            runner.rebuild_change_threshold,
+        )
+        .unwrap());
+
+        assert!(!MerkleStage::should_rebuild_trie(
+            progress + 1,
+            target,
+            &provider,
+            runner.rebuild_threshold,
+            u64::MAX,
+        )
+        .unwrap());
+    }
+
+    #[tokio::test]
+    async fn incremental_chunk_end_respects_change_threshold() {
+        let (target, progress) = (130, 100);
+        let input =
+            ExecInput { target: Some(target), checkpoint: Some(StageCheckpoint::new(progress)) };
+
+        let mut runner = MerkleTestRunner::new(100_000, 10_000, u64::MAX, 10);
+        runner.seed_execution(input).expect("failed to seed execution");
+
+        let provider = runner.db.factory.provider().unwrap();
+        let chunk_end = MerkleStage::incremental_chunk_end(
+            progress + 1,
+            target,
+            &provider,
+            runner.incremental_threshold,
+            runner.incremental_change_threshold,
+        )
+        .unwrap();
+
+        assert!(chunk_end < target);
+        assert!(chunk_end >= progress + 1);
+    }
+
     struct MerkleTestRunner {
         db: TestStageDB,
-        clean_threshold: u64,
+        rebuild_threshold: u64,
         incremental_threshold: u64,
+        rebuild_change_threshold: u64,
+        incremental_change_threshold: u64,
+        num_accounts: usize,
+    }
+
+    impl MerkleTestRunner {
+        fn new(
+            rebuild_threshold: u64,
+            incremental_threshold: u64,
+            rebuild_change_threshold: u64,
+            incremental_change_threshold: u64,
+        ) -> Self {
+            Self {
+                db: TestStageDB::default(),
+                rebuild_threshold,
+                incremental_threshold,
+                rebuild_change_threshold,
+                incremental_change_threshold,
+                num_accounts: 31,
+            }
+        }
     }
 
     impl Default for MerkleTestRunner {
         fn default() -> Self {
-            Self {
-                db: TestStageDB::default(),
-                clean_threshold: 10000,
-                incremental_threshold: 10000,
-            }
+            Self::new(10_000, 10_000, u64::MAX, u64::MAX)
         }
     }
 
@@ -808,9 +948,9 @@ mod tests {
 
         fn stage(&self) -> Self::S {
             Self::S::Both {
-                rebuild_change_threshold: u64::MAX,
-                incremental_change_threshold: u64::MAX,
-                rebuild_threshold: self.clean_threshold,
+                rebuild_change_threshold: self.rebuild_change_threshold,
+                incremental_change_threshold: self.incremental_change_threshold,
+                rebuild_threshold: self.rebuild_threshold,
                 incremental_threshold: self.incremental_threshold,
             }
         }
@@ -839,10 +979,11 @@ mod tests {
                 self.db.insert_blocks(preblocks.iter(), StorageKind::Static)?;
             }
 
-            let num_of_accounts = 31;
-            let accounts = random_contract_account_range(&mut rng, &mut (0..num_of_accounts))
-                .into_iter()
-                .collect::<BTreeMap<_, _>>();
+            let num_of_accounts = self.num_accounts;
+            let accounts =
+                random_contract_account_range(&mut rng, &mut (0..num_of_accounts as u64))
+                    .into_iter()
+                    .collect::<BTreeMap<_, _>>();
 
             self.db.insert_accounts_and_storages(
                 accounts.iter().map(|(addr, acc)| (*addr, (*acc, std::iter::empty()))),

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -960,6 +960,13 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for BlockchainProvider<N> {
     ) -> ProviderResult<Vec<(BlockNumberAddress, StorageEntry)>> {
         self.consistent_provider()?.storage_changesets_range(range)
     }
+
+    fn count_storage_changesets_in_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        self.consistent_provider()?.count_storage_changesets_in_range(range)
+    }
 }
 
 impl<N: ProviderNodeTypes> ChangeSetReader for BlockchainProvider<N> {
@@ -983,6 +990,13 @@ impl<N: ProviderNodeTypes> ChangeSetReader for BlockchainProvider<N> {
         range: impl core::ops::RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
         self.consistent_provider()?.account_changesets_range(range)
+    }
+
+    fn count_account_changesets_in_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        self.consistent_provider()?.count_account_changesets_in_range(range)
     }
 }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -1298,6 +1298,13 @@ impl<N: ProviderNodeTypes> StorageChangeSetReader for ConsistentProvider<N> {
 
         Ok(changesets)
     }
+
+    fn count_storage_changesets_in_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        Ok(self.storage_changesets_range(range)?.len() as u64)
+    }
 }
 
 impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
@@ -1445,6 +1452,13 @@ impl<N: ProviderNodeTypes> ChangeSetReader for ConsistentProvider<N> {
         changesets.sort_by_key(|(block_num, _)| *block_num);
 
         Ok(changesets)
+    }
+
+    fn count_account_changesets_in_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        Ok(self.account_changesets_range(range)?.len() as u64)
     }
 }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1686,6 +1686,26 @@ impl<TX: DbTx, N: NodeTypes> StorageChangeSetReader for DatabaseProvider<TX, N> 
                 .collect()
         }
     }
+
+    fn count_storage_changesets_in_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        if self.cached_storage_settings().storage_v2 {
+            self.static_file_provider.count_storage_changesets_in_range(range)
+        } else {
+            let mut count = 0u64;
+            for entry in self
+                .tx
+                .cursor_dup_read::<tables::StorageChangeSets>()?
+                .walk_range(BlockNumberAddressRange::from(range))?
+            {
+                entry?;
+                count += 1;
+            }
+            Ok(count)
+        }
+    }
 }
 
 impl<TX: DbTx, N: NodeTypes> ChangeSetReader for DatabaseProvider<TX, N> {
@@ -1739,6 +1759,24 @@ impl<TX: DbTx, N: NodeTypes> ChangeSetReader for DatabaseProvider<TX, N> {
                 .walk_range(to_range(range))?
                 .map(|r| r.map_err(Into::into))
                 .collect()
+        }
+    }
+
+    fn count_account_changesets_in_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        if self.cached_storage_settings().storage_v2 {
+            self.static_file_provider.count_account_changesets_in_range(range)
+        } else {
+            let mut count = 0u64;
+            for entry in
+                self.tx.cursor_read::<tables::AccountChangeSets>()?.walk_range(to_range(range))?
+            {
+                entry?;
+                count += 1;
+            }
+            Ok(count)
         }
     }
 }
@@ -4090,7 +4128,9 @@ mod tests {
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::{AccountRevertInit, BlockExecutionOutput, BlockExecutionResult};
     use reth_primitives_traits::SealedBlock;
-    use reth_storage_api::{MetadataProvider, MetadataWriter};
+    use reth_storage_api::{
+        ChangeSetReader, MetadataProvider, MetadataWriter, StorageChangeSetReader,
+    };
     use reth_testing_utils::generators::{self, random_block, BlockParams};
     use reth_trie::{
         HashedPostState, KeccakKeyHasher, Nibbles, SortedTrieData, StoredNibbles,
@@ -5961,5 +6001,52 @@ mod tests {
         assert!(all_blocks.contains(&3), "block 3 should remain");
         assert!(!all_blocks.contains(&7), "block 7 should be unwound");
         assert!(!all_blocks.contains(&10), "block 10 should be unwound");
+    }
+
+    #[test]
+    fn count_changesets_in_range_mdbx_matches_walk() {
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v1());
+        let provider_rw = factory.provider_rw().unwrap();
+
+        for block in 1..=3 {
+            for i in 0..5 {
+                let address = Address::repeat_byte(i);
+                provider_rw
+                    .tx
+                    .cursor_dup_write::<tables::AccountChangeSets>()
+                    .unwrap()
+                    .append_dup(block, AccountBeforeTx { address, info: None })
+                    .unwrap();
+            }
+        }
+
+        let slot_key = B256::random();
+        for block in 1..=3 {
+            provider_rw
+                .tx
+                .cursor_dup_write::<tables::StorageChangeSets>()
+                .unwrap()
+                .append_dup(
+                    BlockNumberAddress((block, Address::repeat_byte(block as u8))),
+                    StorageEntry { key: slot_key, value: U256::from(1) },
+                )
+                .unwrap();
+        }
+
+        let account_count = provider_rw.count_account_changesets_in_range(1..=3).unwrap();
+        assert_eq!(account_count, 15);
+        assert_eq!(
+            account_count as usize,
+            provider_rw.account_changesets_range(1..=3).unwrap().len()
+        );
+
+        let storage_count = provider_rw.count_storage_changesets_in_range(1..=3).unwrap();
+        assert_eq!(storage_count, 3);
+        assert_eq!(
+            storage_count as usize,
+            provider_rw.storage_changesets_range(1..=3).unwrap().len()
+        );
+        assert_eq!(account_count + storage_count, 18);
     }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -2455,6 +2455,13 @@ impl<N: NodePrimitives> ChangeSetReader for StaticFileProvider<N> {
         let range = self.bound_range(range, StaticFileSegment::AccountChangeSets);
         self.walk_account_changeset_range(range).collect()
     }
+
+    fn count_account_changesets_in_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        self.count_changesets_in_range(StaticFileSegment::AccountChangeSets, range)
+    }
 }
 
 impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
@@ -2556,9 +2563,42 @@ impl<N: NodePrimitives> StorageChangeSetReader for StaticFileProvider<N> {
         let range = self.bound_range(range, StaticFileSegment::StorageChangeSets);
         self.walk_storage_changeset_range(range).collect()
     }
+
+    fn count_storage_changesets_in_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        self.count_changesets_in_range(StaticFileSegment::StorageChangeSets, range)
+    }
 }
 
 impl<N: NodePrimitives> StaticFileProvider<N> {
+    /// Returns the number of changeset rows in the given block range for a change-based segment.
+    ///
+    /// Uses per-block changeset offset metadata when available, avoiding loading changeset data.
+    pub fn count_changesets_in_range(
+        &self,
+        segment: StaticFileSegment,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        let range = self.bound_range(range, segment);
+        let mut total = 0u64;
+
+        for block_number in range {
+            let provider = match self.get_segment_provider_for_block(segment, block_number, None) {
+                Ok(provider) => provider,
+                Err(ProviderError::MissingStaticFileBlock(_, _)) => continue,
+                Err(err) => return Err(err),
+            };
+
+            if let Some(offset) = provider.read_changeset_offset(block_number)? {
+                total += offset.num_changes();
+            }
+        }
+
+        Ok(total)
+    }
+
     /// Creates an iterator for walking through account changesets in the specified block range.
     ///
     /// This returns a lazy iterator that fetches changesets block by block to avoid loading

--- a/crates/storage/provider/src/providers/static_file/writer_tests.rs
+++ b/crates/storage/provider/src/providers/static_file/writer_tests.rs
@@ -13,6 +13,7 @@ mod tests {
     use reth_db::{models::AccountBeforeTx, test_utils::create_test_static_files_dir};
     use reth_primitives_traits::Account;
     use reth_static_file_types::{ChangesetOffset, ChangesetOffsetReader, StaticFileSegment};
+    use reth_storage_api::ChangeSetReader;
     use std::{fs::OpenOptions, io::Write as _, path::PathBuf};
 
     use crate::providers::{
@@ -905,6 +906,24 @@ mod tests {
         assert_eq!(
             provider.get_highest_static_file_block(StaticFileSegment::TransactionSenders),
             Some(250)
+        );
+    }
+
+    #[test]
+    fn count_account_changesets_in_range_matches_offsets() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        let num_blocks = 10;
+        let changes_per_block = 5;
+        write_test_blocks(&provider, num_blocks, changes_per_block);
+
+        let count = provider.count_account_changesets_in_range(0..=(num_blocks - 1)).unwrap();
+        assert_eq!(count, num_blocks * changes_per_block as u64);
+
+        assert_eq!(
+            count as usize,
+            provider.account_changesets_range(0..=(num_blocks - 1)).unwrap().len()
         );
     }
 }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1285,6 +1285,13 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> ChangeSetReader for MockEthProvi
     ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
         Ok(Vec::default())
     }
+
+    fn count_account_changesets_in_range(
+        &self,
+        _range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        Ok(0)
+    }
 }
 
 impl<T: NodePrimitives, ChainSpec: Send + Sync> StorageChangeSetReader
@@ -1311,6 +1318,13 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> StorageChangeSetReader
         _range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(reth_db_api::models::BlockNumberAddress, StorageEntry)>> {
         Ok(Vec::default())
+    }
+
+    fn count_storage_changesets_in_range(
+        &self,
+        _range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        Ok(0)
     }
 }
 

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -1776,6 +1776,13 @@ where
     ) -> ProviderResult<Vec<(BlockNumber, reth_db_api::models::AccountBeforeTx)>> {
         Err(ProviderError::UnsupportedProvider)
     }
+
+    fn count_account_changesets_in_range(
+        &self,
+        _range: impl std::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        Err(ProviderError::UnsupportedProvider)
+    }
 }
 
 impl<P, Node, N> StateProviderFactory for RpcBlockchainStateProvider<P, Node, N>

--- a/crates/storage/storage-api/src/account.rs
+++ b/crates/storage/storage-api/src/account.rs
@@ -4,10 +4,12 @@ use alloc::{
 };
 use alloy_primitives::{Address, BlockNumber};
 use auto_impl::auto_impl;
-use core::ops::{RangeBounds, RangeInclusive};
+use core::ops::{Bound, RangeBounds, RangeInclusive};
 use reth_db_models::AccountBeforeTx;
 use reth_primitives_traits::Account;
 use reth_storage_errors::provider::ProviderResult;
+
+use crate::StorageChangeSetReader;
 
 /// Account reader
 #[auto_impl(&, Arc, Box)]
@@ -78,4 +80,50 @@ pub trait ChangeSetReader {
         &self,
         range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>>;
+
+    /// Returns the number of account changeset rows in the given block range without
+    /// materializing the changesets.
+    ///
+    /// Accepts the same range types as [`Self::account_changesets_range`].
+    fn count_account_changesets_in_range(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64>;
+}
+
+/// Converts a block range to an inclusive range for changeset counting.
+///
+/// Returns `None` if the range is empty.
+pub fn inclusive_block_range(
+    range: impl RangeBounds<BlockNumber>,
+) -> Option<RangeInclusive<BlockNumber>> {
+    let start = match range.start_bound() {
+        Bound::Included(&n) => n,
+        Bound::Excluded(&n) => n.saturating_add(1),
+        Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound() {
+        Bound::Included(&n) => n,
+        Bound::Excluded(&n) => n.saturating_sub(1),
+        Bound::Unbounded => BlockNumber::MAX,
+    };
+
+    if start > end {
+        return None
+    }
+
+    Some(start..=end)
+}
+
+/// Counts account and storage changeset rows in the given block range.
+pub fn count_state_changes_in_range(
+    provider: &(impl ChangeSetReader + StorageChangeSetReader),
+    range: impl RangeBounds<BlockNumber>,
+) -> ProviderResult<u64> {
+    let Some(range) = inclusive_block_range(range) else {
+        return Ok(0);
+    };
+    let account = provider.count_account_changesets_in_range(range.clone())?;
+    let storage = provider.count_storage_changesets_in_range(range)?;
+    Ok(account + storage)
 }

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -423,6 +423,13 @@ impl<C: Send + Sync, N: NodePrimitives> ChangeSetReader for NoopProvider<C, N> {
     ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
         Ok(Vec::default())
     }
+
+    fn count_account_changesets_in_range(
+        &self,
+        _range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        Ok(0)
+    }
 }
 
 #[cfg(feature = "db-api")]
@@ -452,6 +459,13 @@ impl<C: Send + Sync, N: NodePrimitives> StorageChangeSetReader for NoopProvider<
         Vec<(reth_db_api::models::BlockNumberAddress, reth_primitives_traits::StorageEntry)>,
     > {
         Ok(Vec::default())
+    }
+
+    fn count_storage_changesets_in_range(
+        &self,
+        _range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64> {
+        Ok(0)
     }
 }
 

--- a/crates/storage/storage-api/src/storage.rs
+++ b/crates/storage/storage-api/src/storage.rs
@@ -76,4 +76,11 @@ pub trait StorageChangeSetReader: Send {
                 .collect()
         })
     }
+
+    /// Returns the number of storage changeset rows in the given block range without
+    /// materializing the changesets.
+    fn count_storage_changesets_in_range(
+        &self,
+        range: impl core::ops::RangeBounds<BlockNumber>,
+    ) -> ProviderResult<u64>;
 }


### PR DESCRIPTION
Closes #16578

Right now the Merkle stage decides between a full trie rebuild and incremental updates mostly by **block count** — e.g. rebuild if the gap is over 100k blocks, incremental in 7k-block chunks. That made sense when blocks had fairly predictable state churn, but it breaks down as gas limits grow: a small number of blocks can carry a huge amount of state change, and a long quiet stretch can be cheap even across many blocks.

This PR switches the primary signal to **changeset size** — the number of account + storage changeset rows in the sync range — while keeping the existing block thresholds as safety caps.

## What changed

**Provider layer:** Added [`count_account_changesets_in_range`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/storage/storage-api/src/account.rs#L88-L91), [`count_storage_changesets_in_range`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/storage/storage-api/src/storage.rs#L82-L85), and [`count_state_changes_in_range`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/storage/storage-api/src/account.rs#L119-L128) that sums both.

On v2 (static files, default) counting goes through [`StaticFileProvider::count_changesets_in_range`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/storage/provider/src/providers/static_file/manager.rs#L2533-L2553), which reads per-block [`ChangesetOffset::num_changes`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/static-file/types/src/segment.rs#L252-L254) so we get a count without loading changeset payloads. On v1 (MDBX) [`DatabaseProvider`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/storage/provider/src/providers/database/provider.rs#L1677-L1692) walks the changeset cursors and increments a counter. Same routing as the existing `*_changesets_range` methods.

**Config:** Added [`rebuild_change_threshold`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L370) and [`incremental_change_threshold`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L364) to [`MerkleConfig`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L359-L381). Old TOML configs without these fields still deserialize cleanly via serde defaults ([test](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L1137-L1147)).

**Merkle stage — rebuild vs incremental:** Instead of only checking `to - from > rebuild_threshold`, [`should_rebuild_trie`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/stages/stages/src/stages/merkle.rs#L183-L225) now:

1. Rebuild from genesis (`from_block == 1`)
2. Rebuild if the block gap exceeds [`rebuild_threshold`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L380) (fast path — skip counting)
3. Otherwise count changes in the range; rebuild if `C > rebuild_change_threshold`
4. Else take the incremental path

Wired through the pipeline in [`sets.rs`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/stages/stages/src/sets.rs#L438-L443) and the stage runner in [`stage/run.rs`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/cli/commands/src/stage/run.rs#L307-L312).

**Merkle stage — incremental chunking:** Replaced the old loop that processed all block chunks in a single `execute()`. [`incremental_chunk_end`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/stages/stages/src/stages/merkle.rs#L228-L264) picks one chunk per invocation, bounded by both `incremental_change_threshold` (changes) and [`incremental_threshold`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L375) (blocks). Chunk boundaries are always at block edges — same idea as account hashing's [`commit_entries`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/stages/stages/src/stages/hashing_account.rs#L258-L260) — never mid-block. If more blocks remain, the [incremental branch](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/stages/stages/src/stages/merkle.rs#L444-L487) returns `done: false` and the pipeline picks up from the checkpoint on the next run (same pattern as the existing rebuild inner checkpoint).

**Not changed on purpose:** [`execution_external_clean_threshold`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L144-L149) still uses the block-based `incremental_threshold` for [Execution changeset pruning](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/stages/stages/src/stages/execution/mod.rs#L166-L176). That's a separate question ("is it safe to delete old changesets from disk?") and shouldn't follow the same change-based logic as Merkle's runtime rebuild decision.

## Defaults

[`incremental_change_threshold = 10_000_000`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L386) and [`rebuild_change_threshold = 100_000_000`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L387) are conservative starting points — roughly informed by hashing's [`commit_entries`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L342) (30M), with Merkle set lower because it also builds prefix sets. 

I haven't benchmarked yet; happy to tune in a follow-up once we have data.

## Known limitation

With [`rebuild_threshold`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/config/src/config.rs#L389) still at 100k blocks, a **quiet 120k-block gap** will still hit the block cap and force a full rebuild even when `C` is tiny. The change-based path only kicks in when the gap is below that cap. Raising the block cap or relying more on `rebuild_change_threshold` can be a follow-up once this lands and we've seen real-world behavior.

## Test plan

- [x] `cargo test -p reth-provider count_changesets` — v1 MDBX ([`count_changesets_in_range_mdbx_matches_walk`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/storage/provider/src/providers/database/provider.rs#L5510)) + v2 static-file offsets ([`count_account_changesets_in_range_matches_offsets`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/storage/provider/src/providers/static_file/writer_tests.rs#L889))
- [x] `cargo test -p reth-stages merkle --features test-utils` — includes [`incremental_chunks_when_change_threshold_exceeded`](https://github.com/NikhilSharmaWe/reth/blob/feat/merkle-change-thresholds/crates/stages/stages/src/stages/merkle.rs#L805), which fails under block-only chunking logic (`incremental_change_threshold = 10` vs `u64::MAX`)
- [x] `cargo test -p reth-config --features serde test_merkle_config_defaults`
- [x] `cargo +nightly fmt --all --check`
