### PR TITLE
feat(metrics): engine thread resource usage

### DIFF
--- a/.github/config/bench-metrics-targets.json
+++ b/.github/config/bench-metrics-targets.json
@@ -15,6 +15,54 @@
   ],
   "histograms": [
     {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_user_cpu_seconds",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_system_cpu_seconds",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_minor_page_faults",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_major_page_faults",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_voluntary_context_switches",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_involuntary_context_switches",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_block_input_operations",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
+      "query": "reth_consensus_engine_beacon_new_payload_thread_block_output_operations",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
       "query": "reth_sync_block_validation_state_root_histogram",
       "target": "decrease",
       "floor_pct": 5.0,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9032,6 +9032,7 @@ name = "reth-metrics"
 version = "2.4.1"
 dependencies = [
  "futures",
+ "libc",
  "metrics",
  "metrics-derive",
  "reth-primitives-traits",

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -6,6 +6,7 @@ use reth_evm::metrics::ExecutorMetrics;
 use reth_execution_types::BlockExecutionOutput;
 use reth_metrics::{
     metrics::{Counter, Gauge, Histogram},
+    thread::{ThreadResourceUsage, ThreadResourceUsageDelta},
     Metrics,
 };
 use reth_primitives_traits::{constants::gas_units::MEGAGAS, FastInstant as Instant};
@@ -391,6 +392,9 @@ pub(crate) struct NewPayloadStatusMetrics {
     /// Gas-bucket-labeled latency and gas/s histograms.
     #[metric(skip)]
     pub(crate) gas_bucket: GasBucketMetrics,
+    /// Resource usage on the engine thread while processing new payloads.
+    #[metric(skip)]
+    thread_resource_usage: NewPayloadThreadResourceMetrics,
     /// The total count of new payload messages received.
     pub(crate) new_payload_messages: Counter,
     /// The total count of new payload messages that we responded to with
@@ -429,6 +433,11 @@ pub(crate) struct NewPayloadStatusMetrics {
 }
 
 impl NewPayloadStatusMetrics {
+    /// Starts measuring resource usage on the current thread.
+    pub(crate) fn measure_thread_resource_usage(&self) -> NewPayloadThreadResourceGuard {
+        self.thread_resource_usage.measure()
+    }
+
     /// Increment the newPayload counter based on the given result
     pub(crate) fn update_response_metrics(
         &mut self,
@@ -474,6 +483,64 @@ impl NewPayloadStatusMetrics {
         if let Some(latest_forkchoice_updated_at) = latest_forkchoice_updated_at.take() {
             self.forkchoice_updated_new_payload_time_diff
                 .record(start - latest_forkchoice_updated_at);
+        }
+    }
+}
+
+/// Per-newPayload engine thread resource usage metrics.
+#[derive(Clone, Metrics)]
+#[metrics(scope = "consensus.engine.beacon")]
+struct NewPayloadThreadResourceMetrics {
+    /// User-mode CPU time used while processing a new payload.
+    new_payload_thread_user_cpu_seconds: Histogram,
+    /// Kernel-mode CPU time used while processing a new payload.
+    new_payload_thread_system_cpu_seconds: Histogram,
+    /// Minor page faults incurred while processing a new payload.
+    new_payload_thread_minor_page_faults: Histogram,
+    /// Major page faults incurred while processing a new payload.
+    new_payload_thread_major_page_faults: Histogram,
+    /// Voluntary context switches while processing a new payload.
+    new_payload_thread_voluntary_context_switches: Histogram,
+    /// Involuntary context switches while processing a new payload.
+    new_payload_thread_involuntary_context_switches: Histogram,
+    /// Block input operations while processing a new payload.
+    new_payload_thread_block_input_operations: Histogram,
+    /// Block output operations while processing a new payload.
+    new_payload_thread_block_output_operations: Histogram,
+}
+
+impl NewPayloadThreadResourceMetrics {
+    fn measure(&self) -> NewPayloadThreadResourceGuard {
+        let metrics = self.clone();
+        let start = ThreadResourceUsage::now();
+        NewPayloadThreadResourceGuard { start, metrics }
+    }
+
+    fn record(&self, usage: &ThreadResourceUsageDelta) {
+        self.new_payload_thread_user_cpu_seconds.record(usage.user_cpu_time);
+        self.new_payload_thread_system_cpu_seconds.record(usage.system_cpu_time);
+        self.new_payload_thread_minor_page_faults.record(usage.minor_page_faults as f64);
+        self.new_payload_thread_major_page_faults.record(usage.major_page_faults as f64);
+        self.new_payload_thread_voluntary_context_switches
+            .record(usage.voluntary_context_switches as f64);
+        self.new_payload_thread_involuntary_context_switches
+            .record(usage.involuntary_context_switches as f64);
+        self.new_payload_thread_block_input_operations.record(usage.block_input_operations as f64);
+        self.new_payload_thread_block_output_operations
+            .record(usage.block_output_operations as f64);
+    }
+}
+
+/// Records engine thread resource usage when dropped.
+pub(crate) struct NewPayloadThreadResourceGuard {
+    start: ThreadResourceUsage,
+    metrics: NewPayloadThreadResourceMetrics,
+}
+
+impl Drop for NewPayloadThreadResourceGuard {
+    fn drop(&mut self) {
+        if let Some(usage) = self.start.elapsed() {
+            self.metrics.record(&usage);
         }
     }
 }
@@ -599,19 +666,33 @@ mod tests {
         };
 
         metrics.record_block_execution(&output, Duration::from_millis(100));
+        metrics.engine.new_payload.thread_resource_usage.record(&ThreadResourceUsageDelta {
+            user_cpu_time: Duration::from_millis(1),
+            system_cpu_time: Duration::from_millis(2),
+            minor_page_faults: 3,
+            major_page_faults: 4,
+            voluntary_context_switches: 5,
+            involuntary_context_switches: 6,
+            block_input_operations: 7,
+            block_output_operations: 8,
+        });
 
         let snapshot = snapshotter.snapshot().into_vec();
 
         // Verify that metrics were registered
-        let mut found_metrics = false;
+        let mut found_execution_metrics = false;
+        let mut found_thread_resource_metrics = false;
         for (key, _unit, _desc, _value) in snapshot {
             let metric_name = key.key().name();
             if metric_name.starts_with("sync.execution") {
-                found_metrics = true;
-                break;
+                found_execution_metrics = true;
+            }
+            if metric_name == "consensus.engine.beacon.new_payload_thread_major_page_faults" {
+                found_thread_resource_metrics = true;
             }
         }
 
-        assert!(found_metrics, "Expected to find sync.execution metrics");
+        assert!(found_execution_metrics, "Expected to find sync.execution metrics");
+        assert!(found_thread_resource_metrics, "Expected to find thread resource metrics");
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -751,6 +751,8 @@ where
         &mut self,
         payload: T::ExecutionData,
     ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> {
+        let _thread_resource_usage =
+            self.metrics.engine.new_payload.measure_thread_resource_usage();
         trace!(target: "engine::tree", "invoked new payload");
 
         // start timing for the new payload process

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -24,5 +24,8 @@ tokio = { workspace = true, features = ["full"], optional = true }
 futures = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+
 [features]
 common = ["tokio", "futures", "tokio-util", "reth-primitives-traits"]

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -22,3 +22,6 @@ pub mod common;
 
 /// Re-export core metrics crate.
 pub use metrics;
+
+/// Per-thread resource usage measurement.
+pub mod thread;

--- a/crates/metrics/src/thread.rs
+++ b/crates/metrics/src/thread.rs
@@ -1,0 +1,253 @@
+//! Per-thread resource usage measurement.
+
+use std::{marker::PhantomData, rc::Rc, time::Duration};
+
+/// A snapshot used to measure resource usage on the current thread.
+///
+/// This type is thread-bound because [`Self::elapsed`] must sample the same thread as
+/// [`Self::now`].
+#[derive(Debug)]
+#[must_use = "call elapsed() to obtain the resource usage delta"]
+pub struct ThreadResourceUsage {
+    start: Option<ThreadResourceUsageSnapshot>,
+    _not_send: PhantomData<Rc<()>>,
+}
+
+impl ThreadResourceUsage {
+    /// Captures the current thread's resource usage.
+    pub fn now() -> Self {
+        Self { start: platform::current_thread_resource_usage(), _not_send: PhantomData }
+    }
+
+    /// Returns the resource usage accumulated by the current thread since this snapshot.
+    ///
+    /// Returns `None` when per-thread resource usage is unsupported or could not be sampled.
+    pub fn elapsed(&self) -> Option<ThreadResourceUsageDelta> {
+        let start = self.start?;
+        Some(platform::current_thread_resource_usage()?.saturating_delta(start))
+    }
+}
+
+/// Resource usage accumulated by a thread over a measured interval.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ThreadResourceUsageDelta {
+    /// Time spent executing in user mode.
+    pub user_cpu_time: Duration,
+    /// Time spent executing in kernel mode.
+    pub system_cpu_time: Duration,
+    /// Page faults serviced without I/O.
+    pub minor_page_faults: u64,
+    /// Page faults that required I/O.
+    pub major_page_faults: u64,
+    /// Voluntary context switches.
+    pub voluntary_context_switches: u64,
+    /// Involuntary context switches.
+    pub involuntary_context_switches: u64,
+    /// Block input operations.
+    pub block_input_operations: u64,
+    /// Block output operations.
+    pub block_output_operations: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ThreadResourceUsageSnapshot {
+    user_cpu_time: Duration,
+    system_cpu_time: Duration,
+    minor_page_faults: u64,
+    major_page_faults: u64,
+    voluntary_context_switches: u64,
+    involuntary_context_switches: u64,
+    block_input_operations: u64,
+    block_output_operations: u64,
+}
+
+impl ThreadResourceUsageSnapshot {
+    const fn saturating_delta(self, earlier: Self) -> ThreadResourceUsageDelta {
+        ThreadResourceUsageDelta {
+            user_cpu_time: self.user_cpu_time.saturating_sub(earlier.user_cpu_time),
+            system_cpu_time: self.system_cpu_time.saturating_sub(earlier.system_cpu_time),
+            minor_page_faults: self.minor_page_faults.saturating_sub(earlier.minor_page_faults),
+            major_page_faults: self.major_page_faults.saturating_sub(earlier.major_page_faults),
+            voluntary_context_switches: self
+                .voluntary_context_switches
+                .saturating_sub(earlier.voluntary_context_switches),
+            involuntary_context_switches: self
+                .involuntary_context_switches
+                .saturating_sub(earlier.involuntary_context_switches),
+            block_input_operations: self
+                .block_input_operations
+                .saturating_sub(earlier.block_input_operations),
+            block_output_operations: self
+                .block_output_operations
+                .saturating_sub(earlier.block_output_operations),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::ThreadResourceUsageSnapshot;
+    use std::{mem::MaybeUninit, time::Duration};
+
+    pub(super) fn current_thread_resource_usage() -> Option<ThreadResourceUsageSnapshot> {
+        let mut usage = MaybeUninit::<libc::rusage>::uninit();
+        // SAFETY: `usage` is a valid writable pointer and is only initialized when getrusage
+        // succeeds.
+        if unsafe { libc::getrusage(libc::RUSAGE_THREAD, usage.as_mut_ptr()) } != 0 {
+            return None
+        }
+        // SAFETY: getrusage returned success and initialized the structure.
+        let usage = unsafe { usage.assume_init() };
+
+        Some(ThreadResourceUsageSnapshot {
+            user_cpu_time: timeval_to_duration(usage.ru_utime)?,
+            system_cpu_time: timeval_to_duration(usage.ru_stime)?,
+            minor_page_faults: usage.ru_minflt.try_into().ok()?,
+            major_page_faults: usage.ru_majflt.try_into().ok()?,
+            voluntary_context_switches: usage.ru_nvcsw.try_into().ok()?,
+            involuntary_context_switches: usage.ru_nivcsw.try_into().ok()?,
+            block_input_operations: usage.ru_inblock.try_into().ok()?,
+            block_output_operations: usage.ru_oublock.try_into().ok()?,
+        })
+    }
+
+    fn timeval_to_duration(timeval: libc::timeval) -> Option<Duration> {
+        let seconds = timeval.tv_sec.try_into().ok()?;
+        let microseconds: u32 = timeval.tv_usec.try_into().ok()?;
+        if microseconds >= 1_000_000 {
+            return None
+        }
+        Some(Duration::new(seconds, microseconds * 1_000))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::thread::ThreadResourceUsage;
+
+        #[test]
+        fn samples_current_thread() {
+            assert!(ThreadResourceUsage::now().elapsed().is_some());
+        }
+
+        #[test]
+        fn measures_forced_minor_page_fault() {
+            let mapping_len = 4096;
+            // SAFETY: The mapping is private and anonymous, has a non-zero length, and the returned
+            // address is checked before use.
+            let mapping = unsafe {
+                libc::mmap(
+                    std::ptr::null_mut(),
+                    mapping_len,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    -1,
+                    0,
+                )
+            };
+            assert_ne!(mapping, libc::MAP_FAILED);
+
+            let usage = ThreadResourceUsage::now();
+            // SAFETY: `mapping` points to a valid writable mapping. Its first write requires Linux
+            // to populate the anonymous page, which incurs a minor page fault.
+            unsafe { mapping.cast::<u8>().write_volatile(1) };
+            let elapsed = usage.elapsed();
+
+            // SAFETY: `mapping` and `mapping_len` identify the live mapping created above.
+            assert_eq!(unsafe { libc::munmap(mapping, mapping_len) }, 0);
+            let elapsed = elapsed.expect("per-thread resource usage is supported on Linux");
+            assert!(
+                elapsed.minor_page_faults >= 1,
+                "expected a minor page fault after touching a new anonymous mapping: {elapsed:?}"
+            );
+        }
+
+        #[test]
+        fn converts_timeval_to_duration() {
+            let timeval = libc::timeval { tv_sec: 2, tv_usec: 345_678 };
+            assert_eq!(timeval_to_duration(timeval), Some(Duration::new(2, 345_678_000)));
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod platform {
+    use super::ThreadResourceUsageSnapshot;
+
+    #[allow(clippy::missing_const_for_fn)]
+    pub(super) fn current_thread_resource_usage() -> Option<ThreadResourceUsageSnapshot> {
+        None
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::thread::ThreadResourceUsage;
+
+        #[test]
+        fn unsupported_platform_returns_none() {
+            assert!(ThreadResourceUsage::now().elapsed().is_none());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn computes_resource_usage_delta() {
+        let earlier = ThreadResourceUsageSnapshot {
+            user_cpu_time: Duration::from_micros(10),
+            system_cpu_time: Duration::from_micros(20),
+            minor_page_faults: 30,
+            major_page_faults: 40,
+            voluntary_context_switches: 50,
+            involuntary_context_switches: 60,
+            block_input_operations: 70,
+            block_output_operations: 80,
+        };
+        let current = ThreadResourceUsageSnapshot {
+            user_cpu_time: Duration::from_micros(11),
+            system_cpu_time: Duration::from_micros(22),
+            minor_page_faults: 33,
+            major_page_faults: 44,
+            voluntary_context_switches: 55,
+            involuntary_context_switches: 66,
+            block_input_operations: 77,
+            block_output_operations: 88,
+        };
+
+        assert_eq!(
+            current.saturating_delta(earlier),
+            ThreadResourceUsageDelta {
+                user_cpu_time: Duration::from_micros(1),
+                system_cpu_time: Duration::from_micros(2),
+                minor_page_faults: 3,
+                major_page_faults: 4,
+                voluntary_context_switches: 5,
+                involuntary_context_switches: 6,
+                block_input_operations: 7,
+                block_output_operations: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn resource_usage_delta_saturates() {
+        let earlier = ThreadResourceUsageSnapshot {
+            user_cpu_time: Duration::from_secs(1),
+            system_cpu_time: Duration::from_secs(1),
+            minor_page_faults: 1,
+            major_page_faults: 1,
+            voluntary_context_switches: 1,
+            involuntary_context_switches: 1,
+            block_input_operations: 1,
+            block_output_operations: 1,
+        };
+
+        assert_eq!(
+            ThreadResourceUsageSnapshot::default().saturating_delta(earlier),
+            ThreadResourceUsageDelta::default()
+        );
+    }
+}


### PR DESCRIPTION
This adds a measure tool for the resource usage, and instruments engine thread's newPayload call. Of particular interest is:

1. major page faults. those page faults and involve IO. Each IO might incur hundreds of microseconds of latency.
2. raised involuntary context switches might indicate oversubscription.

I deliberately scoped it only for Linux
since it supports RUSAGE_THREAD. macOS doesn't and requires dropping down to mach which is not worth it IMO.