### PR TITLE
fix(bench): seed run summary with config

### DIFF
--- a/.github/scripts/bench-job-summary.js
+++ b/.github/scripts/bench-job-summary.js
@@ -157,5 +157,5 @@ module.exports = async function ({ core, context, chartSha, grafanaUrl, logsUrl,
     if (errors.trim()) md += '\n' + errors + '\n';
   } catch {}
 
-  await core.summary.addRaw(md).write();
+  await core.summary.addRaw(md).write({ overwrite: true });
 };

--- a/.github/scripts/bench-update-status.js
+++ b/.github/scripts/bench-update-status.js
@@ -2,7 +2,7 @@
 //
 // Reads from environment:
 //   BENCH_COMMENT_ID  – GitHub comment ID to update
-//   BENCH_JOB_URL     – URL to the Actions job page
+//   BENCH_RUN_URL     – URL to the Actions run summary
 //   BENCH_CONFIG      – Config line (blocks, warmup, refs)
 //   BENCH_ACTOR       – User who triggered the benchmark
 //
@@ -11,7 +11,7 @@
 //   await s({github, context, status: 'Building baseline binary...'});
 
 function buildBody(status) {
-  return `cc @${process.env.BENCH_ACTOR}\n\n🚀 Benchmark started! [View job](${process.env.BENCH_JOB_URL})\n\n⏳ **Status:** ${status}\n\n${process.env.BENCH_CONFIG}`;
+  return `cc @${process.env.BENCH_ACTOR}\n\n🚀 Benchmark started! [View run](${process.env.BENCH_RUN_URL})\n\n⏳ **Status:** ${status}\n\n${process.env.BENCH_CONFIG}`;
 }
 
 async function updateStatus({ github, context, status }) {

--- a/.github/scripts/bench-update-status.sh
+++ b/.github/scripts/bench-update-status.sh
@@ -7,7 +7,7 @@
 #   BENCH_COMMENT_ID  – GitHub comment ID to update
 #   BENCH_GH_TOKEN    – GitHub token for API auth
 #   BENCH_ACTOR       – User who triggered the benchmark
-#   BENCH_JOB_URL     – URL to the Actions job page
+#   BENCH_RUN_URL     – URL to the Actions run summary
 #   BENCH_CONFIG      – Config line (blocks, warmup, refs)
 #   GITHUB_REPOSITORY – owner/repo
 
@@ -19,8 +19,8 @@ if [ -z "${BENCH_COMMENT_ID:-}" ] || [ -z "${BENCH_GH_TOKEN:-}" ]; then
   exit 0
 fi
 
-BODY=$(printf 'cc @%s\n\n🚀 Benchmark started! [View job](%s)\n\n⏳ **Status:** %s\n\n%s' \
-  "${BENCH_ACTOR:-}" "${BENCH_JOB_URL:-}" "$STATUS" "${BENCH_CONFIG:-}")
+BODY=$(printf 'cc @%s\n\n🚀 Benchmark started! [View run](%s)\n\n⏳ **Status:** %s\n\n%s' \
+  "${BENCH_ACTOR:-}" "${BENCH_RUN_URL:-}" "$STATUS" "${BENCH_CONFIG:-}")
 
 PAYLOAD=$(jq -n --arg body "$BODY" '{body: $body}')
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -665,8 +665,6 @@ jobs:
             const runPairsNote = `, run-pairs: \`${runPairs}\`${runOrder ? ` (${runOrder})` : ''}`;
             const otlpEnabled = '${{ steps.args.outputs.otlp }}' !== 'false';
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
-            const metricsEnabled = '${{ steps.args.outputs.metrics }}' === 'true';
-            const metricsNote = metricsEnabled ? ', metrics: `enabled`' : '';
             const waitTimeVal = '${{ steps.args.outputs.wait-time }}';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
             const blockTimeVal = '${{ steps.args.outputs.block-time }}';
@@ -676,7 +674,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${metricsNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -720,8 +718,6 @@ jobs:
             const runPairsNote = `, run-pairs: \`${runPairs}\`${runOrder ? ` (${runOrder})` : ''}`;
             const otlpEnabled = '${{ steps.args.outputs.otlp }}' !== 'false';
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
-            const metricsEnabled = '${{ steps.args.outputs.metrics }}' === 'true';
-            const metricsNote = metricsEnabled ? ', metrics: `enabled`' : '';
             const waitTimeVal = '${{ steps.args.outputs.wait-time }}';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
             const blockTimeVal = '${{ steps.args.outputs.block-time }}';
@@ -731,7 +727,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${metricsNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
@@ -900,8 +896,6 @@ jobs:
             const runPairsNote = `, run-pairs: \`${runPairs}\`${runOrder ? ` (${runOrder})` : ''}`;
             const otlpEnabled = (process.env.BENCH_OTLP || 'false') !== 'false';
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
-            const metricsEnabled = process.env.BENCH_METRICS === 'true';
-            const metricsNote = metricsEnabled ? ', metrics: `enabled`' : '';
             const waitTimeVal = process.env.BENCH_WAIT_TIME || '';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
             const blockTimeVal = process.env.BENCH_BLOCK_TIME || '';
@@ -911,7 +905,7 @@ jobs:
             const featureArgsVal = process.env.BENCH_FEATURE_ARGS || '';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${metricsNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
             core.exportVariable('BENCH_CONFIG', config);
 
             const pr = process.env.BENCH_PR;

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -665,6 +665,8 @@ jobs:
             const runPairsNote = `, run-pairs: \`${runPairs}\`${runOrder ? ` (${runOrder})` : ''}`;
             const otlpEnabled = '${{ steps.args.outputs.otlp }}' !== 'false';
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
+            const metricsEnabled = '${{ steps.args.outputs.metrics }}' === 'true';
+            const metricsNote = metricsEnabled ? ', metrics: `enabled`' : '';
             const waitTimeVal = '${{ steps.args.outputs.wait-time }}';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
             const blockTimeVal = '${{ steps.args.outputs.block-time }}';
@@ -674,7 +676,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${metricsNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
 
             const { data: comment } = await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -718,6 +720,8 @@ jobs:
             const runPairsNote = `, run-pairs: \`${runPairs}\`${runOrder ? ` (${runOrder})` : ''}`;
             const otlpEnabled = '${{ steps.args.outputs.otlp }}' !== 'false';
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
+            const metricsEnabled = '${{ steps.args.outputs.metrics }}' === 'true';
+            const metricsNote = metricsEnabled ? ', metrics: `enabled`' : '';
             const waitTimeVal = '${{ steps.args.outputs.wait-time }}';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
             const blockTimeVal = '${{ steps.args.outputs.block-time }}';
@@ -727,7 +731,7 @@ jobs:
             const featureArgsVal = '${{ steps.args.outputs.feature-args }}';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${metricsNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const numRunners = parseInt(process.env.BENCH_RUNNERS) || 1;
@@ -855,8 +859,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.checkout-ref.outputs.ref }}
 
-      - name: Resolve job URL and update status
-        if: env.BENCH_COMMENT_ID
+      - name: Initialize run summary and update status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.DEREK_PAT }}
@@ -869,7 +872,9 @@ jobs:
             const expectedJobName = 'bench-txgen';
             const job = jobs.jobs.find(j => j.name === expectedJobName);
             const jobUrl = job ? job.html_url : `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             core.exportVariable('BENCH_JOB_URL', jobUrl);
+            core.exportVariable('BENCH_RUN_URL', runUrl);
 
             const blocks = process.env.BENCH_BLOCKS;
             const warmup = process.env.BENCH_WARMUP_BLOCKS;
@@ -895,6 +900,8 @@ jobs:
             const runPairsNote = `, run-pairs: \`${runPairs}\`${runOrder ? ` (${runOrder})` : ''}`;
             const otlpEnabled = (process.env.BENCH_OTLP || 'false') !== 'false';
             const otlpNote = !otlpEnabled ? ', otlp: `disabled`' : '';
+            const metricsEnabled = process.env.BENCH_METRICS === 'true';
+            const metricsNote = metricsEnabled ? ', metrics: `enabled`' : '';
             const waitTimeVal = process.env.BENCH_WAIT_TIME || '';
             const waitTimeNote = waitTimeVal ? `, wait-time: \`${waitTimeVal}\`` : '';
             const blockTimeVal = process.env.BENCH_BLOCK_TIME || '';
@@ -904,15 +911,27 @@ jobs:
             const featureArgsVal = process.env.BENCH_FEATURE_ARGS || '';
             const featureArgsNote = featureArgsVal ? `, feature-args: \`${featureArgsVal}\`` : '';
             const blocksDesc = bigBlocks ? `${blocks} big blocks, ${warmup} warmup blocks` : `${blocks} blocks, ${warmup} warmup blocks`;
-            core.exportVariable('BENCH_CONFIG', `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`);
+            const config = `**Config:** ${blocksDesc}, baseline: \`${baseline}\`, feature: \`${feature}\`${modeNote}${samplyNote}${tracingChromeNote}${slackNote}${reorgNote}${balNote}${coresNote}${runPairsNote}${otlpNote}${metricsNote}${waitTimeNote}${blockTimeNote}${baselineArgsNote}${featureArgsNote}`;
+            core.exportVariable('BENCH_CONFIG', config);
 
-            const { buildBody } = require('./.github/scripts/bench-update-status.js');
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: parseInt(process.env.BENCH_COMMENT_ID),
-              body: buildBody('Building binaries...'),
-            });
+            const pr = process.env.BENCH_PR;
+            const metadata = pr
+              ? `**[PR #${pr}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${pr})** · triggered by @${process.env.BENCH_ACTOR}`
+              : `Triggered by @${process.env.BENCH_ACTOR}`;
+            await core.summary
+              .addHeading('⏳ Benchmark in progress')
+              .addRaw(`${metadata}\n\n${config}\n`)
+              .write();
+
+            if (process.env.BENCH_COMMENT_ID) {
+              const { buildBody } = require('./.github/scripts/bench-update-status.js');
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: parseInt(process.env.BENCH_COMMENT_ID),
+                body: buildBody('Building binaries...'),
+              });
+            }
 
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: dtolnay/rust-toolchain@stable
@@ -1785,8 +1804,8 @@ jobs:
               }
             } catch (e) {}
 
-            const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Benchmark complete! [View job](${jobUrl})\n\n${comment}`;
+            const runUrl = process.env.BENCH_RUN_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n✅ Benchmark complete! [View run](${runUrl})\n\n${comment}`;
             const ackCommentId = process.env.BENCH_COMMENT_ID;
 
             if (ackCommentId) {


### PR DESCRIPTION
## Summary
- link Derek status comments to the workflow run summary instead of the job log
- seed the Actions summary at startup with PR, actor, and effective benchmark config
- retain the seed on failure and replace it with the full report on success

## Validation
- `git diff --check`
- `node --check .github/scripts/bench-update-status.js`
- `node --check .github/scripts/bench-job-summary.js`
- exercised `buildBody` with a workflow run URL and benchmark config

Prompted by: @pepyakin