### PR TITLE
refactor: decouple evm references

### DIFF
--- a/crates/cli/commands/src/test_vectors/compact.rs
+++ b/crates/cli/commands/src/test_vectors/compact.rs
@@ -114,7 +114,7 @@ compact_types!(
         StaticFileBlockWithdrawals,
         // Manual implementations
         TransactionSigned,
-        // Bytecode, // todo revm arbitrary
+        // Bytecode, // todo bytecode arbitrary
         StorageEntry,
         // MerkleCheckpoint, // todo storedsubnode -> branchnodecompact arbitrary
         AccountBeforeTx,

--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -1,8 +1,6 @@
 //! Errors for the BAL execution path.
 
-use alloy_evm::block::BlockExecutionError;
-use reth_consensus::ConsensusError;
-use reth_provider::ProviderError;
+use reth_errors::{BlockExecutionError, ConsensusError, ProviderError};
 
 /// Errors surfaced by `execute_block`.
 #[derive(Debug, thiserror::Error)]

--- a/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/mod.rs
@@ -1,7 +1,7 @@
 //! BAL-driven parallel block execution.
 //!
 //! The engine uses this path when an Amsterdam block carries a decoded EIP-7928
-//! Block-Level Access List (BAL). Workers execute transactions against revm's BAL state. The
+//! Block-Level Access List (BAL). Workers execute transactions against the EVM's BAL state. The
 //! main thread commits worker results to a canonical executor in transaction order.
 //!
 //! Consensus validation checks the BAL item-cost bound before this path runs. This path validates

--- a/crates/node/core/src/args/jit.rs
+++ b/crates/node/core/src/args/jit.rs
@@ -1,10 +1,10 @@
-//! clap [Args](clap::Args) for revmc JIT configuration.
+//! clap [Args](clap::Args) for JIT configuration.
 
 use clap::Args;
 use humantime::parse_duration;
 use std::time::Duration;
 
-/// Parameters for JIT compilation of EVM bytecode via revmc.
+/// Parameters for JIT compilation of EVM bytecode.
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "JIT")]
 pub struct JitArgs {

--- a/crates/node/core/src/args/rpc_state_cache.rs
+++ b/crates/node/core/src/args/rpc_state_cache.rs
@@ -30,7 +30,7 @@ pub struct RpcStateCacheArgs {
     )]
     pub max_headers: u32,
 
-    /// Max number of revm block access lists in cache.
+    /// Max number of block access lists in cache.
     #[arg(
         long = "rpc-cache.max-bals",
         default_value_t = DEFAULT_BAL_CACHE_MAX_LEN,

--- a/crates/rpc/rpc-api/src/reth.rs
+++ b/crates/rpc/rpc-api/src/reth.rs
@@ -29,7 +29,7 @@ pub trait RethApi {
         count: Option<U64>,
     ) -> RpcResult<Option<serde_json::Value>>;
 
-    /// Controls the revmc JIT backend.
+    /// Controls the JIT backend, if one is configured.
     #[method(name = "jit")]
     async fn reth_jit(&self, action: RethJitAction) -> RpcResult<()>;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -310,7 +310,7 @@ pub trait LoadState:
         }
     }
 
-    /// Returns the revm evm env for the given sealed header.
+    /// Returns the EVM environment for the given sealed header.
     fn evm_env_for_header(
         &self,
         header: &SealedHeaderFor<Self::Primitives>,
@@ -321,7 +321,7 @@ pub trait LoadState:
             .map_err(Self::Error::from_eth_err)
     }
 
-    /// Returns the revm evm env for the requested [`BlockId`]
+    /// Returns the EVM environment for the requested [`BlockId`]
     ///
     /// If the [`BlockId`] this will return the [`BlockId`] of the block the env was configured
     /// for.
@@ -353,7 +353,8 @@ pub trait LoadState:
         }
     }
 
-    /// Returns the recovered block, revm evm env, and state block id for the requested [`BlockId`].
+    /// Returns the recovered block, EVM environment, and state block id for the requested
+    /// [`BlockId`].
     ///
     /// For pending blocks, this preserves the state id returned by [`Self::evm_env_at`], which can
     /// be the pending tag for an actual pending block or the latest block hash when the pending env

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -51,7 +51,7 @@ use std::{sync::Arc, time::Duration};
 /// There are subtle differences between when transacting [`RpcTxReq`]:
 ///
 /// The endpoints `eth_call` and `eth_estimateGas` and `eth_createAccessList` should always
-/// __disable__ the base fee check in the [`CfgEnv`](revm::context::CfgEnv).
+/// __disable__ the base fee check in the EVM environment.
 ///
 /// The behaviour for tracing endpoints is not consistent across clients.
 /// Geth also disables the basefee check for tracing: <https://github.com/ethereum/go-ethereum/blob/bc0b87ca196f92e5af49bd33cc190ef0ec32b197/eth/tracers/api.go#L955-L955>

--- a/crates/rpc/rpc-eth-types/src/cache/config.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/config.rs
@@ -23,7 +23,7 @@ pub struct EthStateCacheConfig {
     ///
     /// Default is 1000.
     pub max_headers: u32,
-    /// Max number of revm BALs in cache.
+    /// Max number of EVM BALs in cache.
     ///
     /// Default is 1000.
     pub max_bals: u32,

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -123,7 +123,7 @@ pub mod cache {
     /// Default cache size for the header cache: 1000 headers.
     pub const DEFAULT_HEADER_CACHE_MAX_LEN: u32 = 1000;
 
-    /// Default cache size for the revm BAL cache: 1000 block access lists.
+    /// Default cache size for the EVM BAL cache: 1000 block access lists.
     pub const DEFAULT_BAL_CACHE_MAX_LEN: u32 = 1000;
 
     /// Default number of concurrent database requests.

--- a/crates/storage/storage-api/src/block_writer.rs
+++ b/crates/storage/storage-api/src/block_writer.rs
@@ -78,7 +78,7 @@ pub trait BlockWriter {
     /// updates the post-state.
     ///
     /// Inserts the blocks into the database and updates the state with
-    /// provided `BundleState`. The database's trie state is _not_ updated.
+    /// provided execution state. The database's trie state is _not_ updated.
     ///
     /// # Parameters
     ///

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -11,7 +11,7 @@ use reth_trie_common::{
 /// A type that can compute the state root of a given post state.
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateRootProvider {
-    /// Returns the state root of the `BundleState` on top of the current state.
+    /// Returns the state root of the execution state on top of the current state.
     ///
     /// # Note
     ///

--- a/crates/trie/common/src/trie_data.rs
+++ b/crates/trie/common/src/trie_data.rs
@@ -271,9 +271,8 @@ mod tests {
     use crate::HashedStorage;
 
     use super::*;
-    use alloy_primitives::{B256, U256};
+    use alloy_primitives::{map::B256Map, B256, U256};
     use reth_primitives_traits::Account;
-    use revm::primitives::B256Map;
     use std::{
         thread,
         time::{Duration, Instant},

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -527,7 +527,7 @@ RPC State Cache:
           [default: 1000]
 
       --rpc-cache.max-bals <MAX_BALS>
-          Max number of revm block access lists in cache
+          Max number of block access lists in cache
 
           [default: 1000]
 


### PR DESCRIPTION
Moves backend-independent imports to Reth and Alloy paths and removes revm-specific wording from generic EVM interfaces.

These hunks are independent of the evm2 integration and can be reviewed separately to reduce churn in #25002.
