### PR TITLE
fix(rpc): restore evm2 parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "eyre",
  "ruint",
@@ -3631,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8#ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3875,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=e46647fa1a81cf26bb4772cdf3db01960db02705)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "eyre",
  "ruint",
@@ -3631,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3875,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=e46647fa1a81cf26bb4772cdf3db01960db02705)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "eyre",
  "ruint",
@@ -3631,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=e46647fa1a81cf26bb4772cdf3db01960db02705#e46647fa1a81cf26bb4772cdf3db01960db02705"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e#2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3875,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=e46647fa1a81cf26bb4772cdf3db01960db02705)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",
@@ -3886,7 +3886,9 @@ dependencies = [
 name = "example-custom-inspector"
 version = "0.0.0"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
+ "alloy-rpc-types-eth",
  "clap",
  "evm2",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705" }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8" }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "ea9a1cc7f7467c05d971d4c8e4254c23aa7bcae8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,10 +429,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e" }
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -694,4 +694,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "e46647fa1a81cf26bb4772cdf3db01960db02705" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "2e5cd6f4d25d2bac450fed5382a48fa1baf1e13e" }

--- a/bin/reth-bb/src/evm_config.rs
+++ b/bin/reth-bb/src/evm_config.rs
@@ -12,8 +12,7 @@ use reth_ethereum_forks::Hardforks;
 use reth_ethereum_primitives::{Block, EthPrimitives, TransactionSigned};
 use reth_evm::{
     BlockAssembler, BlockAssemblerInput, BlockExecutionError, ConfigureEngineEvm, ConfigureEvm,
-    DynDatabase, EvmEnvFor, EvmState, ExecutableTxIterator, ExecutionCtxFor,
-    NextBlockEnvAttributes,
+    EvmEnvFor, ExecutableTxIterator, ExecutionCtxFor, NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::{
     EthBigBlockExecutorFactory, EthBigBlockPlan, EthBigBlockSegment, EthEvmConfig,
@@ -145,21 +144,6 @@ where
             Vec::new(),
             0,
         ))
-    }
-
-    fn pre_block_state_changes<'a, DB>(
-        &self,
-        db: DB,
-        evm_env: EvmEnvFor<Self>,
-        block_number: u64,
-        ctx: ExecutionCtxFor<'a, Self>,
-    ) -> Result<EvmState, Box<dyn core::error::Error + Send + Sync>>
-    where
-        Self: 'a,
-        DB: DynDatabase + 'a,
-    {
-        let segment = ctx.segments.first().expect("big-block context has a segment");
-        self.inner.pre_block_state_changes(db, evm_env, block_number, segment.ctx.clone())
     }
 }
 

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -1203,6 +1203,8 @@ mod tests {
                 address,
                 original: original.as_ref().map(account_info_ref),
                 current: None,
+                created: false,
+                selfdestructed: false,
             })
             .unwrap();
         accumulator.storage_wipe(address).unwrap();

--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -189,7 +189,7 @@ impl InvalidTxError for EthInvalidTxError {
     }
 
     fn as_any(&self) -> &(dyn Any + 'static) {
-        self
+        &self.0
     }
 }
 

--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -84,7 +84,7 @@ sol! {
 
 /// Error returned by EVM-backed Ethereum execution.
 #[derive(Debug)]
-pub enum EthExecutionError<E = DynamicDatabaseError> {
+pub enum EthExecutionError<E = evm2::AnyError> {
     /// EVM rejected the transaction during validation.
     InvalidTx(EthInvalidTxError),
     /// EVM rejected or halted transaction execution before producing a Reth output.
@@ -109,24 +109,6 @@ pub enum EthExecutionError<E = DynamicDatabaseError> {
     /// Deposit request logs could not be decoded.
     DepositRequestDecode(String),
 }
-
-/// Database error returned through evm2's dynamic database interface.
-#[derive(Debug)]
-pub struct DynamicDatabaseError(String);
-
-impl DynamicDatabaseError {
-    fn new(error: impl core::fmt::Display) -> Self {
-        Self(error.to_string())
-    }
-}
-
-impl core::fmt::Display for DynamicDatabaseError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl core::error::Error for DynamicDatabaseError {}
 
 impl<E> core::fmt::Display for EthExecutionError<E>
 where
@@ -157,7 +139,17 @@ where
     }
 }
 
-impl<E> core::error::Error for EthExecutionError<E> where E: core::error::Error + Send + 'static {}
+impl<E> core::error::Error for EthExecutionError<E>
+where
+    E: core::error::Error + Send + 'static,
+{
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Database(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Ethereum transaction validation error returned by evm2 handlers.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -606,8 +598,8 @@ fn map_handler_error<T: EvmTypes>(evm: &mut Evm<'_, T>, err: HandlerError) -> Et
     }
 }
 
-fn take_database_error<T: EvmTypes>(evm: &mut Evm<'_, T>, code: ErrorCode) -> DynamicDatabaseError {
-    DynamicDatabaseError::new(evm.database_mut().error(code))
+fn take_database_error<T: EvmTypes>(evm: &mut Evm<'_, T>, code: ErrorCode) -> evm2::AnyError {
+    evm.database_mut().error(code)
 }
 
 struct RethStateSink<'a> {

--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -38,8 +38,8 @@ use evm2::{
     bytecode::Bytecode as ExecutableBytecode,
     ethereum::RecoveredTxEnvelope,
     evm::{
-        AccountChange, AccountChangeRef, AccountInfo, BlockStateAccumulator, StateChangeSink,
-        StateChangeSource, StateChanges, StorageChange, SystemTx, BEACON_ROOTS_ADDRESS,
+        AccountChangeRef, AccountInfo, AccountInfoRef, BlockStateAccumulator, StateChangeSink,
+        StateChangeSource, StorageChange, SystemTx, BEACON_ROOTS_ADDRESS,
         BUILDER_DEPOSIT_REQUEST_ADDRESS, BUILDER_EXIT_REQUEST_ADDRESS,
         CONSOLIDATION_REQUEST_ADDRESS, HISTORY_STORAGE_ADDRESS, WITHDRAWAL_REQUEST_ADDRESS,
     },
@@ -803,9 +803,9 @@ pub(crate) fn commit_detached_transaction<T: EvmTypes>(
     on_hashed_state_update: &mut impl FnMut(HashedPostState),
     output: TxResultWithState<T>,
 ) -> TxResult<T> {
-    let state_changes = output.state_changes;
+    let state_changes = output.pending_state;
     if evm.state().bal_builder().is_some() {
-        evm.state_mut().overlay_db_mut().bal_context.commit_bal(&state_changes);
+        evm.state_mut().overlay_db_mut().bal_context.commit_pending(&state_changes);
     }
 
     let result = {
@@ -1044,10 +1044,14 @@ fn commit_state_changes<T: EvmTypes>(
     block_state: &mut BlockStateAccumulator,
     stream_hashed_state: bool,
     on_hashed_state_update: &mut impl FnMut(HashedPostState),
-    changes: &StateChanges,
+    changes: &[(Address, Option<AccountInfo>, Option<AccountInfo>)],
 ) {
-    if evm.state().bal_builder().is_some() {
-        evm.state_mut().overlay_db_mut().bal_context.commit_bal(changes);
+    for (address, original, current) in changes {
+        evm.state_mut().overlay_db_mut().bal_context.commit_account_change(
+            *address,
+            original.as_ref(),
+            current.as_ref(),
+        );
     }
     let result = {
         let mut sink = RethStateSink::new(
@@ -1055,7 +1059,15 @@ fn commit_state_changes<T: EvmTypes>(
             block_state,
             stream_hashed_state,
         );
-        let result = changes.visit(&mut sink);
+        let result = changes.iter().try_for_each(|(address, original, current)| {
+            sink.account(AccountChangeRef {
+                address: *address,
+                original: original.as_ref().map(AccountInfoRef::from_info),
+                current: current.as_ref().map(AccountInfoRef::from_info),
+                created: false,
+                selfdestructed: false,
+            })
+        });
         if result.is_ok() {
             sink.flush_streamed_hashed_state(on_hashed_state_update);
         }
@@ -1099,7 +1111,7 @@ pub(crate) fn post_block_balance_state_changes<T: EvmTypes>(
         return Ok(());
     }
 
-    let mut changes = StateChanges::default();
+    let mut changes = Vec::new();
 
     for (address, increment) in balance_increments {
         let original =
@@ -1115,10 +1127,7 @@ pub(crate) fn post_block_balance_state_changes<T: EvmTypes>(
         if original == current {
             continue
         }
-        let mut change = AccountChange::default();
-        change.original = original;
-        change.current = current;
-        changes.accounts.insert(address, change);
+        changes.push((address, original, current));
     }
 
     commit_state_changes(evm, block_state, stream_hashed_state, on_hashed_state_update, &changes);

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -248,6 +248,10 @@ where
         &mut self.evm
     }
 
+    fn execution_state(&self) -> reth_execution_types::EvmState {
+        self.block_state.clone()
+    }
+
     fn set_state_hook(&mut self, hook: impl FnMut(HashedPostState) + Send + 'static) -> bool {
         if self.hashed_state_mode == HashedStateMode::OutputOnly {
             self.hashed_state_mode = HashedStateMode::StreamOnly;
@@ -788,6 +792,12 @@ where
 
     fn evm_mut(&mut self) -> &mut Self::Evm {
         self.inner.evm_mut()
+    }
+
+    fn execution_state(&self) -> reth_execution_types::EvmState {
+        let mut state = self.state.clone();
+        let Ok(()) = self.inner.block_state.visit(&mut state);
+        state
     }
 
     fn set_state_hook(&mut self, hook: impl FnMut(HashedPostState) + Send + 'static) -> bool {

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -337,24 +337,6 @@ pub struct EthBlockExecutionCtx<'a> {
     pub slot_number: Option<u64>,
 }
 
-impl EthBlockExecutionCtx<'_> {
-    #[cfg_attr(not(feature = "std"), allow(dead_code))]
-    fn block_execution_context(
-        &self,
-        deposit_contract_address: Option<Address>,
-    ) -> crate::execution::BlockExecutionContext<'_> {
-        crate::execution::BlockExecutionContext {
-            system_calls: Some(crate::execution::BlockSystemCalls {
-                parent_hash: self.parent_hash,
-                parent_beacon_block_root: self.parent_beacon_block_root,
-            }),
-            ommers: Some(self.ommers),
-            withdrawals: self.withdrawals.as_deref(),
-            deposit_contract_address,
-        }
-    }
-}
-
 /// Helper type with backwards compatible methods to obtain Ethereum executor providers.
 #[doc(hidden)]
 pub mod execute {
@@ -604,36 +586,6 @@ where
             extra_data: attributes.extra_data,
             slot_number: attributes.slot_number,
         })
-    }
-
-    #[cfg(feature = "std")]
-    fn pre_block_state_changes<'a, DB>(
-        &self,
-        db: DB,
-        env: EvmEnvFor<Self>,
-        block_number: u64,
-        ctx: EthBlockExecutionCtx<'a>,
-    ) -> Result<reth_evm::EvmState, Box<dyn core::error::Error + Send + Sync>>
-    where
-        Self: 'a,
-        DB: evm2::evm::DynDatabase + 'a,
-    {
-        let spec_id = env.spec.into();
-        let mut evm = self.block_executor_factory().build_evm_with_env(db, env);
-        let mut block_state = evm2::evm::BlockStateAccumulator::new();
-        crate::execution::pre_execution_system_call_state_changes(
-            &mut evm,
-            &mut block_state,
-            false,
-            &mut |_| {},
-            spec_id,
-            block_number,
-            ctx.block_execution_context(
-                self.chain_spec().deposit_contract().map(|contract| contract.address),
-            ),
-        )
-        .map_err(|err| -> Box<dyn core::error::Error + Send + Sync> { Box::new(err) })?;
-        Ok(block_state)
     }
 }
 

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -477,6 +477,7 @@ async fn test_eth_config() -> eyre::Result<()> {
 
     assert_eq!(config.last.unwrap().activation_time, osaka_timestamp);
     assert_eq!(config.current.activation_time, prague_timestamp);
+    assert_eq!(config.current.precompiles.get("ID"), Some(&Address::with_last_byte(4)));
     assert_eq!(config.next.unwrap().activation_time, osaka_timestamp);
 
     Ok(())

--- a/crates/evm/evm/src/database.rs
+++ b/crates/evm/evm/src/database.rs
@@ -15,7 +15,7 @@ use reth_storage_errors::provider::ProviderError;
 use reth_storage_errors::provider::ProviderResult;
 
 /// A helper trait responsible for providing state necessary for EVM execution.
-pub(crate) trait EvmStateProvider {
+pub trait EvmStateProvider {
     /// Get basic account information.
     ///
     /// Returns [`None`] if the account doesn't exist.

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -151,10 +151,10 @@ pub trait Evm {
     fn transact_with_inspector<I>(
         &mut self,
         transaction: &Recovered<Self::Transaction>,
-        inspector: I,
-    ) -> Result<(I, evm2::TxResultWithState<Self::EvmTypes>), BlockExecutionError>
+        inspector: &mut I,
+    ) -> Result<evm2::TxResultWithState<Self::EvmTypes>, BlockExecutionError>
     where
-        I: evm2::Inspector<Self::EvmTypes> + 'static;
+        I: evm2::Inspector<Self::EvmTypes>;
 
     /// Sets the inspector used by subsequent transactions.
     fn set_inspector<I>(&mut self, inspector: I)
@@ -203,19 +203,19 @@ impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + AlloyTransaction>> Evm for evm2::Evm<
         resolve_transaction(self, resolution)
     }
 
-    fn transact_with_inspector<I: evm2::Inspector<T> + 'a>(
+    fn transact_with_inspector<I: evm2::Inspector<T>>(
         &mut self,
         transaction: &Recovered<Self::Transaction>,
-        inspector: I,
-    ) -> Result<(I, evm2::TxResultWithState<T>), BlockExecutionError> {
-        // TODO(dani): use either `&mut Inspector` or `clear_inspector_as`.
-        evm2::Evm::set_inspector(self, inspector);
-        let resolution = transaction_resolution(evm2::Evm::transact(self, transaction));
-        let result = resolve_transaction(self, resolution);
-        let inspector = self.clear_inspector().expect("inspector was set before execution");
-        // SAFETY: the boxed inspector was created from `I` immediately above and was not replaced.
-        let inspector = unsafe { Box::from_raw(Box::into_raw(inspector).cast::<I>()) };
-        result.map(|result| (*inspector, result))
+        inspector: &mut I,
+    ) -> Result<evm2::TxResultWithState<T>, BlockExecutionError> {
+        let resolution = match evm2::Evm::transact_with_inspector(self, transaction, inspector) {
+            Ok(result) => match result.result.error_code {
+                Some(code) => TransactionResolution::DatabaseError(code),
+                None => TransactionResolution::Result(result),
+            },
+            Err(err) => TransactionResolution::HandlerError(err),
+        };
+        resolve_transaction(self, resolution)
     }
 
     fn set_inspector<I: evm2::Inspector<T> + 'a>(&mut self, inspector: I) {
@@ -244,11 +244,7 @@ impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + AlloyTransaction>> Evm for evm2::Evm<
         &mut self,
         moves: impl IntoIterator<Item = (Address, Address)>,
     ) -> Result<(), evm2::precompiles::MovePrecompileError> {
-        // TODO(dani): precompiles_as_mut
-        let mut precompiles = evm2::Precompiles::<T>::base(self.spec_id());
-        precompiles.as_map_mut().move_precompiles(moves)?;
-        self.set_precompiles(precompiles);
-        Ok(())
+        self.precompiles_mut().move_precompiles(&moves.into_iter().collect::<Vec<_>>())
     }
 
     fn transact_and_discard<S>(

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -156,6 +156,12 @@ pub trait Evm {
     where
         I: evm2::Inspector<Self::EvmTypes>;
 
+    /// Commits detached transaction state into the accepted state overlay.
+    fn commit_state(&mut self, state: &evm2::PendingState);
+
+    /// Returns the accepted state overlay database.
+    fn accepted_db_mut(&mut self) -> &mut dyn DynDatabase;
+
     /// Sets the inspector used by subsequent transactions.
     fn set_inspector<I>(&mut self, inspector: I)
     where
@@ -216,6 +222,14 @@ impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + AlloyTransaction>> Evm for evm2::Evm<
             Err(err) => TransactionResolution::HandlerError(err),
         };
         resolve_transaction(self, resolution)
+    }
+
+    fn commit_state(&mut self, state: &evm2::PendingState) {
+        self.commit_source(state);
+    }
+
+    fn accepted_db_mut(&mut self) -> &mut dyn DynDatabase {
+        self.overlay_db_mut()
     }
 
     fn set_inspector<I: evm2::Inspector<T> + 'a>(&mut self, inspector: I) {
@@ -333,6 +347,9 @@ pub trait BlockExecutor: Sized {
 
     /// Returns the underlying EVM mutably.
     fn evm_mut(&mut self) -> &mut Self::Evm;
+
+    /// Returns state changes accumulated by the executor so far.
+    fn execution_state(&self) -> EvmState;
 
     /// Sets a hook for streamed hashed state updates emitted during block execution.
     ///

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -448,22 +448,6 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         let ctx = self.context_for_next_block(parent, attributes)?;
         Ok(self.create_block_builder(evm, evm_env, parent, ctx))
     }
-
-    /// Applies block-level state changes required before transaction execution.
-    #[cfg(feature = "std")]
-    fn pre_block_state_changes<'a, DB>(
-        &self,
-        _db: DB,
-        _evm_env: EvmEnvFor<Self>,
-        _block_number: u64,
-        _ctx: ExecutionCtxFor<'a, Self>,
-    ) -> Result<EvmState, Box<dyn Error + Send + Sync>>
-    where
-        Self: 'a,
-        DB: DynDatabase + 'a,
-    {
-        Ok(EvmState::default())
-    }
 }
 
 /// JIT backend controls exposed by an EVM configuration.

--- a/crates/evm/evm/src/precompile_cache.rs
+++ b/crates/evm/evm/src/precompile_cache.rs
@@ -197,8 +197,21 @@ where
         self.inner.addresses()
     }
 
+    fn precompile_ids(&self) -> Vec<(Address, evm2::precompiles::PrecompileId)> {
+        self.inner.precompile_ids()
+    }
+
     fn contains(&self, address: &Address) -> bool {
         self.inner.contains(address)
+    }
+
+    fn move_precompiles(
+        &mut self,
+        moves: &[(Address, Address)],
+    ) -> Result<(), evm2::precompiles::MovePrecompileError> {
+        self.inner.move_precompiles(moves)?;
+        self.cache_map = Default::default();
+        Ok(())
     }
 
     fn execute(
@@ -346,6 +359,7 @@ mod tests {
             NoPrecompiles::default(),
         );
         let address = Address::with_last_byte(4);
+        assert!(provider.precompile_ids().iter().any(|(precompile, _)| *precompile == address));
         let message = Message {
             kind: MessageKind::Call,
             gas_limit: 30_000,
@@ -378,5 +392,15 @@ mod tests {
             .expect("cached identity precompile succeeds");
         assert_eq!(output.bytes(), b"cached-input");
         assert_eq!(hit_gas.spent(), 18);
+
+        let moved = Address::with_last_byte(0xf0);
+        provider.move_precompiles(&[(address, moved)]).unwrap();
+        assert!(!provider.contains(&address));
+        assert!(provider.contains(&moved));
+        assert!(provider
+            .cache_map
+            .cache_for_address(address)
+            .get(message.input.as_ref(), SpecId::OSAKA)
+            .is_none());
     }
 }

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -283,6 +283,8 @@ mod tests {
                     code_hash,
                     code: Some(&bytecode),
                 }),
+                created: false,
+                selfdestructed: false,
             })
             .unwrap();
         state.storage_wipe(wiped_address).unwrap();
@@ -317,7 +319,13 @@ mod tests {
             AccountInfoRef { balance: U256::from(1), nonce: 1, code_hash: B256::ZERO, code: None };
         let mut state = BlockStateAccumulator::new();
         state
-            .account(AccountChangeRef { address, original: Some(original), current: None })
+            .account(AccountChangeRef {
+                address,
+                original: Some(original),
+                current: None,
+                created: false,
+                selfdestructed: false,
+            })
             .unwrap();
 
         let indexed = IndexedBlockState::new(state);

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -7,7 +7,7 @@ use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::{
     logs_bloom,
-    map::{AddressMap, B256Map, HashMap},
+    map::{AddressMap, AddressSet, B256Map, HashMap},
     Address, BlockNumber, Bloom, Log, B256, U256,
 };
 use evm2::evm::{
@@ -208,6 +208,8 @@ impl<T> ExecutionOutcome<T> {
                     address,
                     original: original.as_ref().map(account_info_ref_from_reth),
                     current: current.as_ref().map(account_info_ref_from_reth),
+                    created: false,
+                    selfdestructed: false,
                 })
                 .expect("infallible");
             for (slot, (original, current)) in storage {
@@ -476,6 +478,14 @@ impl<T> ExecutionOutcome<T> {
         // remove requests
         self.requests.truncate(new_len);
         // Revert last n reverts.
+        if self.block_states.is_empty() {
+            let state = Self::revert_state(
+                self.state.inner(),
+                &self.block_reverts,
+                &self.block_reverts[new_len..],
+            );
+            self.state = state.into();
+        }
         self.block_reverts.truncate(new_len);
         self.truncate_block_states(new_len);
 
@@ -554,8 +564,102 @@ impl<T> ExecutionOutcome<T> {
     fn drop_first_block_states(&mut self, n: usize) {
         if !self.block_states.is_empty() {
             self.block_states.drain(..n.min(self.block_states.len()));
-            self.state = Self::aggregate_block_states(&self.block_states).into();
         }
+    }
+
+    fn revert_state(
+        state: &EvmState,
+        all_reverts: &[BlockReverts],
+        removed_reverts: &[BlockReverts],
+    ) -> EvmState {
+        let mut accounts = state
+            .accounts()
+            .map(|(address, account)| (address, account.clone()))
+            .collect::<AddressMap<_>>();
+        let mut storage_wipes = state.storage_wipes().collect::<AddressSet>();
+        let mut storage = state
+            .storage()
+            .map(|(key, value)| ((key.address(), key.key()), *value))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut account_originals = AddressMap::default();
+        let mut storage_originals = BTreeMap::new();
+        for reverts in all_reverts {
+            for (&address, account) in &reverts.accounts {
+                account_originals
+                    .entry(address)
+                    .or_insert_with(|| account.as_ref().map(RevertAccount::to_account_info));
+            }
+            for (&address, storage_reverts) in &reverts.storage {
+                for (&key, &value) in &storage_reverts.slots {
+                    storage_originals.entry((address, key)).or_insert(value);
+                }
+            }
+        }
+
+        for reverts in removed_reverts.iter().rev() {
+            for (&address, account) in &reverts.accounts {
+                let original = accounts
+                    .get(&address)
+                    .map(|account| account.original.clone())
+                    .unwrap_or_else(|| account_originals[&address].clone());
+                let current = account.as_ref().map(RevertAccount::to_account_info);
+                if original == current {
+                    accounts.remove(&address);
+                } else {
+                    accounts.insert(address, Tracked::from_parts(original, current));
+                }
+            }
+            for (&address, storage_reverts) in &reverts.storage {
+                if storage_reverts.wiped {
+                    if storage_reverts.previous_wipe {
+                        storage_wipes.insert(address);
+                    } else {
+                        storage_wipes.remove(&address);
+                    }
+                }
+                for (&key, &current) in &storage_reverts.slots {
+                    let original = storage
+                        .get(&(address, key))
+                        .map(|value| value.original)
+                        .unwrap_or_else(|| storage_originals[&(address, key)]);
+                    if (storage_wipes.contains(&address) && current.is_zero()) ||
+                        (!storage_wipes.contains(&address) && original == current)
+                    {
+                        storage.remove(&(address, key));
+                    } else {
+                        storage.insert((address, key), Tracked::from_parts(original, current));
+                    }
+                }
+            }
+        }
+
+        let mut reverted = BlockStateAccumulator::new();
+        for (&code_hash, code) in state.code() {
+            reverted.bytecode(code_hash, code).expect("infallible");
+        }
+        for address in storage_wipes {
+            reverted.storage_wipe(address).expect("infallible");
+        }
+        for ((address, key), value) in storage {
+            StateChangeSink::storage(
+                &mut reverted,
+                StorageChange { address, key, original: value.original, current: value.current },
+            )
+            .expect("infallible");
+        }
+        for (address, account) in accounts {
+            reverted
+                .account(AccountChangeRef {
+                    address,
+                    original: account.original.as_ref().map(AccountInfoRef::from_info),
+                    current: account.current.as_ref().map(AccountInfoRef::from_info),
+                    created: false,
+                    selfdestructed: false,
+                })
+                .expect("infallible");
+        }
+        reverted
     }
 
     fn extend_block_states(&mut self, other: Vec<EvmState>, other_receipts_len: usize) {
@@ -673,6 +777,8 @@ fn multi_block_outcome_for_serde() -> ExecutionOutcome {
                 code_hash: KECCAK_EMPTY,
                 code: None,
             }),
+            created: false,
+            selfdestructed: false,
         })
         .unwrap();
     StateChangeSink::storage(
@@ -697,6 +803,8 @@ fn multi_block_outcome_for_serde() -> ExecutionOutcome {
                 code_hash: KECCAK_EMPTY,
                 code: None,
             }),
+            created: false,
+            selfdestructed: false,
         })
         .unwrap();
     block2.storage_wipe(address).unwrap();
@@ -947,6 +1055,22 @@ mod tests {
         requests: Vec<Requests>,
     ) -> ExecutionOutcome<T> {
         ExecutionOutcome::new_empty(first_block).with_receipts(receipts).with_requests(requests)
+    }
+
+    fn balance_state(address: Address, original: u64, current: u64) -> EvmState {
+        let original = AccountInfo::default().with_balance(U256::from(original));
+        let current = AccountInfo::default().with_balance(U256::from(current));
+        let mut state = BlockStateAccumulator::new();
+        state
+            .account(AccountChangeRef {
+                address,
+                original: Some(AccountInfoRef::from_info(&original)),
+                current: Some(AccountInfoRef::from_info(&current)),
+                created: false,
+                selfdestructed: false,
+            })
+            .unwrap();
+        state
     }
 
     #[cfg(feature = "serde")]
@@ -1200,6 +1324,44 @@ mod tests {
         // Assert that the revert_to method returns false when attempting to revert to a block
         // number less than the initial block number.
         assert!(!exec_res.revert_to(10));
+    }
+
+    #[test]
+    fn revert_to_restores_state_loaded_with_reverts() {
+        let address = Address::repeat_byte(0x42);
+        let states = [balance_state(address, 0, 1), balance_state(address, 1, 2)];
+        let state = ExecutionOutcomeState::from_block_states(states);
+        let (state, _, block_reverts) = state.into_parts();
+        let mut outcome =
+            ExecutionOutcome::<reth_ethereum_primitives::Receipt>::from_state_and_reverts(
+                state,
+                block_reverts,
+                vec![vec![], vec![]],
+                1,
+                vec![],
+            );
+
+        assert!(outcome.revert_to(1));
+        assert_eq!(
+            outcome.state.account_state(&address).unwrap().current.as_ref().unwrap().balance,
+            U256::from(1)
+        );
+    }
+
+    #[test]
+    fn split_retains_full_state_in_higher_outcome() {
+        let address = Address::repeat_byte(0x42);
+        let results = vec![BlockExecutionResult::default(), BlockExecutionResult::default()];
+        let outcome = ExecutionOutcome::<reth_ethereum_primitives::Receipt>::from_block_states(
+            1,
+            [balance_state(address, 0, 1), balance_state(address, 1, 2)],
+            results,
+        );
+
+        let (_, higher) = outcome.split_at(2);
+        let account = higher.state.account_state(&address).unwrap();
+        assert_eq!(account.original.as_ref().unwrap().balance, U256::ZERO);
+        assert_eq!(account.current.as_ref().unwrap().balance, U256::from(2));
     }
 
     #[test]

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -113,6 +113,8 @@ pub struct ExecutionOutcome<T = reth_ethereum_primitives::Receipt> {
     block_states: Vec<EvmState>,
     /// Per-block reverts.
     block_reverts: Vec<BlockReverts>,
+    /// Revert context retained when this outcome is split.
+    revert_prefix: Vec<BlockReverts>,
     /// The collection of receipts.
     /// Outer vector stores receipts for each block sequentially.
     /// The inner vector stores receipts ordered by transaction number.
@@ -134,6 +136,7 @@ impl<T> Default for ExecutionOutcome<T> {
             state: Default::default(),
             block_states: Default::default(),
             block_reverts: Default::default(),
+            revert_prefix: Default::default(),
             receipts: Default::default(),
             first_block: Default::default(),
             requests: Default::default(),
@@ -158,7 +161,31 @@ impl<T> ExecutionOutcome<T> {
         first_block: BlockNumber,
         requests: Vec<Requests>,
     ) -> Self {
-        Self { state: state.into(), block_states, block_reverts, receipts, first_block, requests }
+        Self {
+            state: state.into(),
+            block_states,
+            block_reverts,
+            revert_prefix: Vec::new(),
+            receipts,
+            first_block,
+            requests,
+        }
+    }
+
+    #[cfg(any(feature = "serde", feature = "serde-bincode-compat"))]
+    fn from_serialized_parts(
+        state: EvmState,
+        block_states: Vec<EvmState>,
+        block_reverts: Vec<BlockReverts>,
+        revert_prefix: Vec<BlockReverts>,
+        receipts: Vec<Vec<T>>,
+        first_block: BlockNumber,
+        requests: Vec<Requests>,
+    ) -> Self {
+        let mut value =
+            Self::from_parts(state, block_states, block_reverts, receipts, first_block, requests);
+        value.revert_prefix = revert_prefix;
+        value
     }
 
     /// Creates a new `ExecutionOutcome` from aggregate execution state and per-block reverts.
@@ -258,6 +285,7 @@ impl<T> ExecutionOutcome<T> {
             state: output.state,
             block_states: vec![block_state],
             block_reverts: vec![block_reverts],
+            revert_prefix: Vec::new(),
             receipts: vec![output.result.receipts],
             first_block: block_number,
             requests: vec![output.result.requests],
@@ -484,6 +512,7 @@ impl<T> ExecutionOutcome<T> {
         if self.block_states.is_empty() {
             let state = Self::revert_state(
                 self.state.inner(),
+                &self.revert_prefix,
                 &self.block_reverts,
                 &self.block_reverts[revert_index..],
             );
@@ -524,7 +553,8 @@ impl<T> ExecutionOutcome<T> {
         if at_idx < higher_state.requests.len() {
             higher_state.requests = higher_state.requests.split_off(at_idx);
         }
-        higher_state.block_reverts.drain(..at_idx.min(higher_state.block_reverts.len()));
+        let revert_count = at_idx.min(higher_state.block_reverts.len());
+        higher_state.revert_prefix.extend(higher_state.block_reverts.drain(..revert_count));
         higher_state.first_block = at;
 
         (Some(lower_state), higher_state)
@@ -540,6 +570,7 @@ impl<T> ExecutionOutcome<T> {
             state: other_state,
             block_states: other_block_states,
             mut block_reverts,
+            revert_prefix: _,
             receipts,
             requests,
             ..
@@ -578,6 +609,7 @@ impl<T> ExecutionOutcome<T> {
 
     fn revert_state(
         state: &EvmState,
+        revert_prefix: &[BlockReverts],
         all_reverts: &[BlockReverts],
         removed_reverts: &[BlockReverts],
     ) -> EvmState {
@@ -593,7 +625,7 @@ impl<T> ExecutionOutcome<T> {
 
         let mut account_originals = AddressMap::default();
         let mut storage_originals = BTreeMap::new();
-        for reverts in all_reverts {
+        for reverts in revert_prefix.iter().chain(all_reverts) {
             for (&address, account) in &reverts.accounts {
                 account_originals
                     .entry(address)
@@ -834,6 +866,17 @@ fn multi_block_outcome_for_serde() -> ExecutionOutcome {
 }
 
 #[cfg(all(test, any(feature = "serde", feature = "serde-bincode-compat")))]
+fn receiptless_outcome_for_serde() -> ExecutionOutcome {
+    ExecutionOutcome::from_state_and_reverts(
+        EvmState::default(),
+        vec![BlockReverts::default()],
+        Vec::new(),
+        10,
+        Vec::new(),
+    )
+}
+
+#[cfg(all(test, any(feature = "serde", feature = "serde-bincode-compat")))]
 fn assert_serde_preserves_block_operations(expected: ExecutionOutcome, actual: ExecutionOutcome) {
     assert_eq!(actual, expected);
 
@@ -862,6 +905,7 @@ mod serde_impl {
         receipts: &'a Vec<Vec<T>>,
         first_block: BlockNumber,
         requests: &'a Vec<Requests>,
+        revert_prefix: &'a [BlockReverts],
     }
 
     #[derive(Deserialize)]
@@ -872,6 +916,8 @@ mod serde_impl {
         receipts: Vec<Vec<T>>,
         first_block: BlockNumber,
         requests: Vec<Requests>,
+        #[serde(default)]
+        revert_prefix: Vec<BlockReverts>,
     }
 
     impl<T> Serialize for ExecutionOutcome<T>
@@ -885,10 +931,11 @@ mod serde_impl {
             ExecutionOutcomeSerde {
                 state: self.state.inner(),
                 block_states: &self.block_states,
-                block_reverts: self.block_reverts(),
+                block_reverts: &self.block_reverts,
                 receipts: &self.receipts,
                 first_block: self.first_block,
                 requests: &self.requests,
+                revert_prefix: &self.revert_prefix,
             }
             .serialize(serializer)
         }
@@ -903,10 +950,11 @@ mod serde_impl {
             D: Deserializer<'de>,
         {
             let value = ExecutionOutcomeSerdeOwned::<T>::deserialize(deserializer)?;
-            Ok(Self::from_parts(
+            Ok(Self::from_serialized_parts(
                 value.state,
                 value.block_states,
                 value.block_reverts,
+                value.revert_prefix,
                 value.receipts,
                 value.first_block,
                 value.requests,
@@ -948,6 +996,8 @@ pub(super) mod serde_bincode_compat {
         first_block: BlockNumber,
         #[expect(clippy::owned_cow)]
         requests: Cow<'a, Vec<Requests>>,
+        #[serde(default)]
+        revert_prefix: Vec<super::BlockReverts>,
     }
 
     impl<'a, T> From<&'a super::ExecutionOutcome<T>> for ExecutionOutcome<'a>
@@ -968,6 +1018,7 @@ pub(super) mod serde_bincode_compat {
                     .collect(),
                 first_block: value.first_block,
                 requests: Cow::Borrowed(&value.requests),
+                revert_prefix: value.revert_prefix.clone(),
             }
         }
     }
@@ -977,10 +1028,11 @@ pub(super) mod serde_bincode_compat {
         T: Receipt,
     {
         fn from(value: ExecutionOutcome<'_>) -> Self {
-            Self::from_parts(
+            Self::from_serialized_parts(
                 value.state.into_owned(),
                 value.block_states,
                 value.block_reverts,
+                value.revert_prefix,
                 value
                     .receipts
                     .into_iter()
@@ -1030,7 +1082,7 @@ pub(super) mod serde_bincode_compat {
     mod tests {
         use super::super::{
             assert_serde_preserves_block_operations, multi_block_outcome_for_serde,
-            serde_bincode_compat, ExecutionOutcome,
+            receiptless_outcome_for_serde, serde_bincode_compat, ExecutionOutcome,
         };
         use reth_ethereum_primitives::Receipt;
         use serde::{Deserialize, Serialize};
@@ -1050,6 +1102,14 @@ pub(super) mod serde_bincode_compat {
             let encoded = bincode::serialize(&data).unwrap();
             let decoded = bincode::deserialize::<Data<Receipt>>(&encoded).unwrap();
             assert_serde_preserves_block_operations(data.data, decoded.data);
+
+            for expected in
+                [multi_block_outcome_for_serde().split_at(11).1, receiptless_outcome_for_serde()]
+            {
+                let encoded = bincode::serialize(&Data { data: expected.clone() }).unwrap();
+                let decoded = bincode::deserialize::<Data<Receipt>>(&encoded).unwrap();
+                assert_eq!(decoded.data, expected);
+            }
         }
     }
 }
@@ -1093,6 +1153,14 @@ mod tests {
         let actual = bincode::deserialize(&encoded).unwrap();
 
         assert_serde_preserves_block_operations(expected, actual);
+
+        for expected in
+            [multi_block_outcome_for_serde().split_at(11).1, receiptless_outcome_for_serde()]
+        {
+            let encoded = bincode::serialize(&expected).unwrap();
+            let actual = bincode::deserialize::<ExecutionOutcome>(&encoded).unwrap();
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]
@@ -1395,6 +1463,53 @@ mod tests {
         let account = higher.state.account_state(&address).unwrap();
         assert_eq!(account.original.as_ref().unwrap().balance, U256::ZERO);
         assert_eq!(account.current.as_ref().unwrap().balance, U256::from(2));
+    }
+
+    #[test]
+    fn split_then_revert_retains_prefix_without_block_states() {
+        let address = Address::repeat_byte(0x42);
+        let key = U256::from(1);
+        let block_reverts = [10, 11, 12]
+            .map(|value| BlockReverts {
+                accounts: AddressMap::from_iter([(
+                    address,
+                    Some(RevertAccount {
+                        balance: U256::from(value),
+                        code_hash: KECCAK_EMPTY,
+                        ..Default::default()
+                    }),
+                )]),
+                storage: AddressMap::from_iter([(
+                    address,
+                    StorageReverts {
+                        slots: BTreeMap::from([(key, U256::from(value))]),
+                        ..Default::default()
+                    },
+                )]),
+            })
+            .to_vec();
+        let outcome = ExecutionOutcome::<reth_ethereum_primitives::Receipt>::from_state_and_reverts(
+            EvmState::default(),
+            block_reverts,
+            vec![vec![], vec![], vec![]],
+            1,
+            vec![],
+        );
+
+        let (_, mut higher) = outcome.split_at(2);
+        assert_eq!(higher.block_reverts().len(), 2);
+        assert!(higher.revert_to(2));
+
+        let account = higher.state.account_state(&address).unwrap();
+        assert_eq!(account.original.as_ref().unwrap().balance, U256::from(10));
+        assert_eq!(account.current.as_ref().unwrap().balance, U256::from(12));
+        let (_, storage) = higher
+            .execution_state_ref()
+            .storage()
+            .find(|(storage_key, _)| storage_key.address() == address && storage_key.key() == key)
+            .unwrap();
+        assert_eq!(storage.original, U256::from(10));
+        assert_eq!(storage.current, U256::from(12));
     }
 
     #[test]

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -169,7 +169,7 @@ impl<T> ExecutionOutcome<T> {
         first_block: BlockNumber,
         requests: Vec<Requests>,
     ) -> Self {
-        let block_states = if block_reverts.len() <= 1 { vec![state.clone()] } else { Vec::new() };
+        let block_states = if receipts.len() == 1 { vec![state.clone()] } else { Vec::new() };
         Self::from_parts(state, block_states, block_reverts, receipts, first_block, requests)
     }
 
@@ -197,9 +197,7 @@ impl<T> ExecutionOutcome<T> {
         first_block: BlockNumber,
         requests: Vec<Requests>,
     ) -> Self {
-        // sort reverts by block number
-        let mut reverts = revert_init.into_iter().collect::<Vec<_>>();
-        reverts.sort_unstable_by_key(|a| a.0);
+        let mut reverts = revert_init;
 
         let mut accumulator = BlockStateAccumulator::new();
         for (address, (original, current, storage)) in state_init {
@@ -224,9 +222,11 @@ impl<T> ExecutionOutcome<T> {
             accumulator.bytecode(code_hash, &bytecode.into()).expect("infallible");
         }
 
-        let block_reverts = reverts
-            .into_iter()
-            .map(|(_, reverts)| BlockReverts {
+        let block_reverts = (0..receipts.len())
+            .map(|offset| {
+                reverts.remove(&first_block.saturating_add(offset as u64)).unwrap_or_default()
+            })
+            .map(|reverts| BlockReverts {
                 accounts: reverts
                     .iter()
                     .filter_map(|(address, (original, _))| {
@@ -473,21 +473,24 @@ impl<T> ExecutionOutcome<T> {
 
         // +1 is for number of blocks that we have as index is included.
         let new_len = index + 1;
+        let removed_blocks = self.receipts.len() - new_len;
+        let block_state_prefix = self.block_states.len().saturating_sub(self.receipts.len());
         // remove receipts
         self.receipts.truncate(new_len);
         // remove requests
         self.requests.truncate(new_len);
         // Revert last n reverts.
+        let revert_index = self.block_reverts.len().saturating_sub(removed_blocks);
         if self.block_states.is_empty() {
             let state = Self::revert_state(
                 self.state.inner(),
                 &self.block_reverts,
-                &self.block_reverts[new_len..],
+                &self.block_reverts[revert_index..],
             );
             self.state = state.into();
         }
-        self.block_reverts.truncate(new_len);
-        self.truncate_block_states(new_len);
+        self.block_reverts.truncate(revert_index);
+        self.truncate_block_states(block_state_prefix + new_len);
 
         true
     }
@@ -522,7 +525,6 @@ impl<T> ExecutionOutcome<T> {
             higher_state.requests = higher_state.requests.split_off(at_idx);
         }
         higher_state.block_reverts.drain(..at_idx.min(higher_state.block_reverts.len()));
-        higher_state.drop_first_block_states(at_idx);
         higher_state.first_block = at;
 
         (Some(lower_state), higher_state)
@@ -554,16 +556,23 @@ impl<T> ExecutionOutcome<T> {
         self.requests.extend(requests);
     }
 
+    /// Prepends state changes without overriding existing changes.
+    ///
+    /// Reverts, receipts, and requests are not updated.
+    pub fn prepend_state(&mut self, other: EvmState) {
+        if !self.block_states.is_empty() {
+            self.block_states.insert(0, other.clone());
+        }
+        let mut accumulator = BlockStateAccumulator::new();
+        state::extend_execution_state(&mut accumulator, &other);
+        state::extend_execution_state(&mut accumulator, self.state.inner());
+        self.state = accumulator.into();
+    }
+
     fn truncate_block_states(&mut self, new_len: usize) {
         if !self.block_states.is_empty() {
             self.block_states.truncate(new_len);
             self.state = Self::aggregate_block_states(&self.block_states).into();
-        }
-    }
-
-    fn drop_first_block_states(&mut self, n: usize) {
-        if !self.block_states.is_empty() {
-            self.block_states.drain(..n.min(self.block_states.len()));
         }
     }
 
@@ -663,7 +672,10 @@ impl<T> ExecutionOutcome<T> {
     }
 
     fn extend_block_states(&mut self, other: Vec<EvmState>, other_receipts_len: usize) {
-        if self.block_states.len() == self.receipts.len() && other.len() == other_receipts_len {
+        if !self.block_states.is_empty() &&
+            self.block_states.len() >= self.receipts.len() &&
+            other.len() == other_receipts_len
+        {
             self.block_states.extend(other);
         } else {
             self.block_states.clear();
@@ -763,7 +775,7 @@ fn account_info_to_reth(info: &AccountInfo) -> Account {
     Account { nonce: info.nonce, balance: info.balance, bytecode_hash }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "serde", feature = "serde-bincode-compat")))]
 fn multi_block_outcome_for_serde() -> ExecutionOutcome {
     let address = Address::repeat_byte(0x42);
     let mut block1 = BlockStateAccumulator::new();
@@ -821,7 +833,7 @@ fn multi_block_outcome_for_serde() -> ExecutionOutcome {
     ExecutionOutcome::from_block_states(10, [block1, block2], results)
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "serde", feature = "serde-bincode-compat")))]
 fn assert_serde_preserves_block_operations(expected: ExecutionOutcome, actual: ExecutionOutcome) {
     assert_eq!(actual, expected);
 
@@ -1362,6 +1374,65 @@ mod tests {
         let account = higher.state.account_state(&address).unwrap();
         assert_eq!(account.original.as_ref().unwrap().balance, U256::ZERO);
         assert_eq!(account.current.as_ref().unwrap().balance, U256::from(2));
+    }
+
+    #[test]
+    fn split_then_revert_retains_prefix_original() {
+        let address = Address::repeat_byte(0x42);
+        let results = vec![BlockExecutionResult::default(); 3];
+        let outcome = ExecutionOutcome::<reth_ethereum_primitives::Receipt>::from_block_states(
+            1,
+            [
+                balance_state(address, 0, 1),
+                balance_state(address, 1, 2),
+                balance_state(address, 2, 0),
+            ],
+            results,
+        );
+
+        let (_, mut higher) = outcome.split_at(2);
+        assert!(higher.revert_to(2));
+        let account = higher.state.account_state(&address).unwrap();
+        assert_eq!(account.original.as_ref().unwrap().balance, U256::ZERO);
+        assert_eq!(account.current.as_ref().unwrap().balance, U256::from(2));
+    }
+
+    #[test]
+    fn prepend_state_preserves_newer_changes() {
+        let address = Address::repeat_byte(0x42);
+        let mut outcome = ExecutionOutcome::<reth_ethereum_primitives::Receipt>::from_block_states(
+            1,
+            [balance_state(address, 1, 2)],
+            vec![BlockExecutionResult::default()],
+        );
+
+        outcome.prepend_state(balance_state(address, 0, 1));
+
+        let account = outcome.state.account_state(&address).unwrap();
+        assert_eq!(account.original.as_ref().unwrap().balance, U256::ZERO);
+        assert_eq!(account.current.as_ref().unwrap().balance, U256::from(2));
+        assert_eq!(outcome.receipts.len(), 1);
+    }
+
+    #[test]
+    fn new_init_aligns_sparse_reverts() {
+        let address = Address::repeat_byte(0x42);
+        let original = Account { balance: U256::from(5), ..Default::default() };
+        let current = Account { balance: U256::from(7), ..Default::default() };
+        let state_init =
+            AddressMap::from_iter([(address, (Some(original), Some(current), B256Map::default()))]);
+        let revert = AddressMap::from_iter([(address, (Some(Some(original)), vec![]))]);
+        let mut outcome = ExecutionOutcome::<reth_ethereum_primitives::Receipt>::new_init(
+            state_init,
+            HashMap::from_iter([(2, revert)]),
+            [],
+            vec![vec![], vec![]],
+            1,
+            vec![],
+        );
+
+        assert!(outcome.revert_to(1));
+        assert!(outcome.state.account_state(&address).is_none());
     }
 
     #[test]

--- a/crates/evm/execution-types/src/state.rs
+++ b/crates/evm/execution-types/src/state.rs
@@ -153,6 +153,8 @@ pub fn execution_state_from_init(
                 address,
                 original: original.as_ref().map(account_ref_to_info_ref),
                 current: current.as_ref().map(account_ref_to_info_ref),
+                created: false,
+                selfdestructed: false,
             })
             .expect("infallible");
         for (slot, (original, current)) in storage {
@@ -293,13 +295,13 @@ impl StateChangeSink for StateAndRevertsSink<'_> {
     }
 
     fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
-        let deletes_pre_aggregate_account = change.deleted() &&
+        let deletes_pre_aggregate_account = change.current.is_none() &&
             self.accumulator
                 .accounts()
                 .find(|(address, _)| *address == change.address)
                 .is_none_or(|(_, account)| account.original.is_some());
         self.reverts.account(change)?;
-        if change.deleted() && !self.block_wipes.contains(&change.address) {
+        if change.current.is_none() && !self.block_wipes.contains(&change.address) {
             self.record_storage_wipe(change.address)?;
         }
         self.accumulator.account(change)?;
@@ -527,7 +529,13 @@ mod tests {
             AccountInfoRef { balance: U256::from(1), nonce: 1, code_hash: B256::ZERO, code: None };
         let mut source = BlockStateAccumulator::new();
         source
-            .account(AccountChangeRef { address, original: Some(original), current: None })
+            .account(AccountChangeRef {
+                address,
+                original: Some(original),
+                current: None,
+                created: false,
+                selfdestructed: false,
+            })
             .unwrap();
         let mut aggregate = BlockStateAccumulator::new();
 
@@ -544,11 +552,23 @@ mod tests {
             AccountInfoRef { balance: U256::from(1), nonce: 1, code_hash: B256::ZERO, code: None };
         let mut creation = BlockStateAccumulator::new();
         creation
-            .account(AccountChangeRef { address, original: None, current: Some(account) })
+            .account(AccountChangeRef {
+                address,
+                original: None,
+                current: Some(account),
+                created: false,
+                selfdestructed: false,
+            })
             .unwrap();
         let mut deletion = BlockStateAccumulator::new();
         deletion
-            .account(AccountChangeRef { address, original: Some(account), current: None })
+            .account(AccountChangeRef {
+                address,
+                original: Some(account),
+                current: None,
+                created: false,
+                selfdestructed: false,
+            })
             .unwrap();
         let mut aggregate = BlockStateAccumulator::new();
 
@@ -613,8 +633,14 @@ mod tests {
                 },
             )
             .unwrap();
-            tee.account(AccountChangeRef { address, original: Some(original), current: None })
-                .unwrap();
+            tee.account(AccountChangeRef {
+                address,
+                original: Some(original),
+                current: None,
+                created: false,
+                selfdestructed: false,
+            })
+            .unwrap();
         }
 
         let recomputed =
@@ -645,8 +671,14 @@ mod tests {
                 },
             )
             .unwrap();
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
+            tee.account(AccountChangeRef {
+                address,
+                original: None,
+                current: Some(current),
+                created: false,
+                selfdestructed: false,
+            })
+            .unwrap();
         }
 
         let recomputed =
@@ -666,8 +698,14 @@ mod tests {
         let mut sink = HashedPostStateSink::<KeccakKeyHasher>::default();
         {
             let mut tee = Tee::new(&mut accumulator, &mut sink);
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
+            tee.account(AccountChangeRef {
+                address,
+                original: None,
+                current: Some(current),
+                created: false,
+                selfdestructed: false,
+            })
+            .unwrap();
             StateChangeSink::storage(
                 &mut tee,
                 StorageChange {
@@ -700,12 +738,20 @@ mod tests {
         let mut sink = HashedPostStateSink::<KeccakKeyHasher>::default();
         {
             let mut tee = Tee::new(&mut accumulator, &mut sink);
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
+            tee.account(AccountChangeRef {
+                address,
+                original: None,
+                current: Some(current),
+                created: false,
+                selfdestructed: false,
+            })
+            .unwrap();
             tee.account(AccountChangeRef {
                 address,
                 original: Some(current),
                 current: Some(updated),
+                created: false,
+                selfdestructed: false,
             })
             .unwrap();
             tee.storage_wipe(address).unwrap();
@@ -730,8 +776,14 @@ mod tests {
         let mut sink = HashedPostStateSink::<KeccakKeyHasher>::default();
         {
             let mut tee = Tee::new(&mut accumulator, &mut sink);
-            tee.account(AccountChangeRef { address, original: Some(original), current: None })
-                .unwrap();
+            tee.account(AccountChangeRef {
+                address,
+                original: Some(original),
+                current: None,
+                created: false,
+                selfdestructed: false,
+            })
+            .unwrap();
             tee.storage_wipe(address).unwrap();
             StateChangeSink::storage(
                 &mut tee,
@@ -743,8 +795,14 @@ mod tests {
                 },
             )
             .unwrap();
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
+            tee.account(AccountChangeRef {
+                address,
+                original: None,
+                current: Some(current),
+                created: false,
+                selfdestructed: false,
+            })
+            .unwrap();
         }
 
         let recomputed =

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -9,7 +9,7 @@ use alloy_consensus::{
     transaction::{Transaction, TxHashRef},
     BlockHeader,
 };
-use alloy_eips::{eip1559::calc_effective_gas_price, eip2930::AccessListResult};
+use alloy_eips::eip2930::AccessListResult;
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types_eth::{
@@ -17,7 +17,7 @@ use alloy_rpc_types_eth::{
     state::{EvmOverrides, StateOverride},
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
-use evm2::evm::{CacheDB, DynDatabase, StateChangeSink, StateChangeSource};
+use evm2::evm::{CacheDB, OverrideBlockHashes, StateChangeSink, StateChangeSource};
 use evm2_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use futures::Future;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
@@ -26,10 +26,11 @@ use reth_evm::{
     cancelled::CancelOnDrop,
     database::StateProviderDatabase,
     execute::{BlockBuilder, BlockExecutorFactory},
-    ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, EvmTypesFor, TxEnvFor, TxResultWithStateFor,
+    BlockExecutor, ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, EvmTypesFor, ExecutableTxParts,
+    TxEnvFor, TxFor, TxResultWithStateFor,
 };
 use reth_node_api::BlockBody;
-use reth_primitives_traits::Recovered;
+use reth_primitives_traits::{Recovered, TxTy};
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
     cache::db::{apply_block_overrides, apply_state_overrides, StateProviderTraitObjWrapper},
@@ -343,21 +344,17 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let mut all_results = Vec::with_capacity(bundles.len());
 
                 if replay_block_txs {
-                    let ctx = this
-                        .evm_config()
-                        .context_for_block(block.sealed_block())
+                    let mut executor = RpcNodeCore::evm_config(&this)
+                        .executor_for_block(&mut db, block.sealed_block())
                         .map_err(RethError::other)
                         .map_err(Self::Error::from_eth_err)?;
-                    let changes = this
-                        .evm_config()
-                        .pre_block_state_changes(&mut db, evm_env.clone(), block.number(), ctx)
-                        .map_err(|err| EthApiError::EvmCustom(err.to_string()))
-                        .map_err(Self::Error::from_eth_err)?;
-                    db.commit_source(&changes);
+                    executor.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
                     for tx in block.transactions_recovered().take(num_txs) {
-                        let tx_env = this.evm_config().tx_env(tx.cloned());
-                        let result = this.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit_source(&result.state_changes);
+                        let (tx_env, _) = <_ as ExecutableTxParts<
+                            TxFor<Self::Evm>,
+                            TxTy<Self::Primitives>,
+                        >>::into_parts(tx);
+                        executor.execute_transaction(tx_env).map_err(Self::Error::from_eth_err)?;
                     }
                 }
 
@@ -413,7 +410,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                         // Commit state changes after each transaction to allow subsequent calls to
                         // see the updates
-                        db.commit_source(&res.state_changes);
+                        db.commit_source(&res.pending_state);
                     }
 
                     all_results.push(bundle_results);
@@ -498,20 +495,18 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             evm_env.version_mut().tx_gas_limit_cap = u64::MAX;
 
             let tx_env = this.create_txn_env(&evm_env, request.clone(), &mut db)?;
-            if !request_has_gas_limit &&
-                request_gas_price(request.as_ref(), evm_env.block_base_fee()) > 0
-            {
+            if !request_has_gas_limit && tx_env.max_fee_per_gas() > 0 {
                 let cap = this.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
                 // no gas limit was provided in the request, so we need to cap the request's gas
                 // limit
                 request.as_mut().set_gas_limit(cap.min(evm_env.block_env().gas_limit.to::<u64>()));
             }
 
-            let inspector = AccessListInspector::new(initial);
+            let mut inspector = AccessListInspector::new(initial);
             let tx_env = this.create_txn_env(&evm_env, request.clone(), &mut db)?;
 
-            let (inspector, result) =
-                this.transact_with_inspector(&mut db, evm_env.clone(), tx_env, inspector)?;
+            let result =
+                this.transact_with_inspector(&mut db, evm_env.clone(), tx_env, &mut inspector)?;
             let access_list = inspector.into_access_list();
             let gas_used = result.result.tx_gas_used();
             if let Err(err) = Self::Error::ensure_success(result.result) {
@@ -624,11 +619,11 @@ pub trait Call:
         db: DB,
         evm_env: EvmEnvFor<Self::Evm>,
         tx_env: TxEnvFor<Self::Evm>,
-        inspector: I,
-    ) -> Result<(I, TxResultWithStateFor<Self::Evm>), Self::Error>
+        inspector: &mut I,
+    ) -> Result<TxResultWithStateFor<Self::Evm>, Self::Error>
     where
         DB: Database + fmt::Debug,
-        I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
+        I: evm2::Inspector<EvmTypesFor<Self::Evm>>,
     {
         let mut evm = self.evm_config().block_executor_factory().evm_with_database(db, evm_env);
         let res =
@@ -771,35 +766,32 @@ pub trait Call:
             // we need to get the state of the parent block because we're essentially replaying the
             // block the transaction is included in
             let parent_block = block.parent_hash();
-            let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
 
             self.spawn_with_state_at_block(parent_block, move |this, mut db| {
                 let block_txs = block.transactions_recovered();
 
-                let ctx = this
-                    .evm_config()
-                    .context_for_block(block.sealed_block())
+                let mut executor = RpcNodeCore::evm_config(&this)
+                    .executor_for_block(&mut db, block.sealed_block())
                     .map_err(RethError::other)
                     .map_err(Self::Error::from_eth_err)?;
-                let changes = this
-                    .evm_config()
-                    .pre_block_state_changes(&mut db, evm_env.clone(), block.number(), ctx)
-                    .map_err(|err| EthApiError::EvmCustom(err.to_string()))
-                    .map_err(Self::Error::from_eth_err)?;
-                db.commit_source(&changes);
+                executor.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
 
                 // replay all transactions prior to the targeted transaction
                 for block_tx in block_txs {
                     if block_tx.tx_hash() == tx.tx_hash() {
                         break;
                     }
-                    let tx_env = this.evm_config().tx_env(block_tx.cloned());
-                    let result = this.transact(&mut db, evm_env.clone(), tx_env)?;
-                    db.commit_source(&result.state_changes);
+                    let (tx_env, _) = <_ as ExecutableTxParts<
+                        TxFor<Self::Evm>,
+                        TxTy<Self::Primitives>,
+                    >>::into_parts(block_tx);
+                    executor.execute_transaction(tx_env).map_err(Self::Error::from_eth_err)?;
                 }
 
                 let tx_env = RpcNodeCore::evm_config(&this).tx_env(tx);
-                let res = this.transact(&mut db, evm_env, tx_env)?;
+                let res =
+                    executor.evm_mut().transact(&tx_env).map_err(Self::Error::from_evm_err)?;
+                drop(executor);
                 f(tx_info, res, db)
             })
             .await
@@ -834,7 +826,7 @@ pub trait Call:
 
             let tx_env = self.evm_config().tx_env(tx.cloned());
             let result = self.transact(&mut *db, evm_env.clone(), tx_env)?;
-            result.state_changes.visit(db).expect("infallible state cache update");
+            result.pending_state.visit(db).expect("infallible state cache update");
             index += 1;
         }
         Ok(index)
@@ -880,11 +872,12 @@ pub trait Call:
         &self,
         mut evm_env: EvmEnvFor<Self::Evm>,
         mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
-        db: &mut CacheDB<DB>,
+        db: &mut DB,
         overrides: EvmOverrides,
     ) -> Result<(EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>), Self::Error>
     where
-        DB: DynDatabase,
+        DB: Database + OverrideBlockHashes + StateChangeSink<Error = core::convert::Infallible>,
+        EthApiError: From<<DB as Database>::Error>,
     {
         // track whether the request has a gas limit set
         let request_has_gas_limit = request.as_ref().gas_limit().is_some();
@@ -934,8 +927,8 @@ pub trait Call:
                 .map_err(EthApiError::from_state_overrides_err)?;
         }
 
-        let gas_price = request_gas_price(request.as_ref(), evm_env.block_base_fee());
         let tx_env = self.create_txn_env(&evm_env, request.clone(), &mut *db)?;
+        let gas_price = tx_env.max_fee_per_gas();
 
         // lower the basefee to 0 to avoid breaking EVM invariants (basefee < gasprice): <https://github.com/ethereum/go-ethereum/blob/355228b011ef9a85ebc0f21e7196f892038d49f0/internal/ethapi/api.go#L700-L704>
         if gas_price == 0 {
@@ -955,23 +948,5 @@ pub trait Call:
 
         let tx_env = self.create_txn_env(&evm_env, request, &mut *db)?;
         Ok((evm_env, tx_env))
-    }
-}
-
-pub(super) fn request_gas_price(
-    request: &alloy_rpc_types_eth::TransactionRequest,
-    block_base_fee: u64,
-) -> u128 {
-    if let Some(gas_price) = request.gas_price {
-        return gas_price
-    }
-
-    match (request.max_fee_per_gas, request.max_priority_fee_per_gas) {
-        (None, None) => 0,
-        (max_fee, priority_fee) => calc_effective_gas_price(
-            max_fee.unwrap_or(u128::MAX),
-            priority_fee.unwrap_or_default(),
-            Some(block_base_fee),
-        ),
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -17,7 +17,9 @@ use alloy_rpc_types_eth::{
     state::{EvmOverrides, StateOverride},
     BlockId, Bundle, EthCallResponse, StateContext, TransactionInfo,
 };
-use evm2::evm::{CacheDB, OverrideBlockHashes, StateChangeSink, StateChangeSource};
+use evm2::evm::{
+    BlockStateAccumulator, CacheDB, OverrideBlockHashes, StateChangeSink, StateChangeSource,
+};
 use evm2_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};
 use futures::Future;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
@@ -243,6 +245,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         .map_err(map_err)?
                     };
 
+                    db.commit_source(&result.execution_state);
                     let simulated_header = result.block.clone_sealed_header();
                     db.insert_block_hash(
                         &U256::from(simulated_header.number()),
@@ -356,6 +359,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         >>::into_parts(tx);
                         executor.execute_transaction(tx_env).map_err(Self::Error::from_eth_err)?;
                     }
+                    let state = executor.execution_state();
+                    drop(executor);
+                    db.commit_source(&state);
                 }
 
                 // transact all bundles
@@ -791,7 +797,9 @@ pub trait Call:
                 let tx_env = RpcNodeCore::evm_config(&this).tx_env(tx);
                 let res =
                     executor.evm_mut().transact(&tx_env).map_err(Self::Error::from_evm_err)?;
+                let state = executor.execution_state();
                 drop(executor);
+                db.commit_source(&state);
                 f(tx_info, res, db)
             })
             .await
@@ -818,6 +826,9 @@ pub trait Call:
         I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
         let mut index = 0;
+        let mut state = BlockStateAccumulator::new();
+        let mut evm =
+            self.evm_config().block_executor_factory().evm_with_database(&mut *db, evm_env);
         for tx in transactions {
             if *tx.tx_hash() == target_tx_hash {
                 // reached the target transaction
@@ -825,10 +836,13 @@ pub trait Call:
             }
 
             let tx_env = self.evm_config().tx_env(tx.cloned());
-            let result = self.transact(&mut *db, evm_env.clone(), tx_env)?;
-            result.pending_state.visit(db).expect("infallible state cache update");
+            let result = evm.transact(&tx_env).map_err(Self::Error::from_evm_err)?;
+            result.pending_state.visit(&mut state).expect("infallible state update");
+            evm.commit_state(&result.pending_state);
             index += 1;
         }
+        drop(evm);
+        state.visit(db).expect("infallible state cache update");
         Ok(index)
     }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -120,6 +120,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                 let call_gas_limit = this.call_gas_limit();
                 let mut remaining_call_gas_limit = (call_gas_limit > 0).then_some(call_gas_limit);
+                let mut simulation_state = BlockStateAccumulator::new();
 
                 for block in block_state_calls {
                     let SimBlock { block_overrides, state_overrides, calls } = block;
@@ -169,8 +170,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         apply_block_overrides(block_overrides, &mut db, &mut evm_env);
                     }
                     if let Some(ref state_overrides) = state_overrides {
-                        apply_state_overrides(state_overrides.clone(), &mut db)
+                        let state = apply_state_overrides(state_overrides.clone(), &mut db)
                             .map_err(Self::Error::from_eth_err)?;
+                        state.visit(&mut simulation_state).expect("infallible");
                     }
 
                     let chain_id = evm_env.chain_id();
@@ -210,6 +212,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             &state_provider,
+                            &mut simulation_state,
                             calls,
                             &mut remaining_call_gas_limit,
                             chain_id,
@@ -236,6 +239,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                         simulate::execute_transactions(
                             builder,
                             &state_provider,
+                            &mut simulation_state,
                             calls,
                             &mut remaining_call_gas_limit,
                             chain_id,

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -1,7 +1,7 @@
 //! Estimate gas needed implementation
 
 use super::{Call, LoadPendingBlock};
-use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
+use crate::{AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError};
 use alloy_consensus::Transaction;
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{TxKind, KECCAK256_EMPTY, U256};
@@ -9,7 +9,7 @@ use alloy_rpc_types_eth::{state::EvmOverrides, BlockId};
 use evm2::{EvmFeatures, TxResult};
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
-use reth_evm::{database::EvmStateProvider, Database, EvmEnv, EvmEnvFor};
+use reth_evm::{database::EvmStateProvider, ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor};
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
     cache::db::{apply_block_overrides, apply_state_overrides},
@@ -118,11 +118,13 @@ pub trait EstimateCall: Call {
             highest_gas_limit = highest_gas_limit.min(allowance);
         }
 
+        request.as_mut().set_nonce(tx_env.nonce());
+        let mut evm = self.evm_config().evm_with_env(&mut db, evm_env.clone());
         let mut execute = |gas_limit| {
             let mut request = request.clone();
             request.as_mut().set_gas_limit(gas_limit);
-            let tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
-            self.transact(&mut db, evm_env.clone(), tx_env).map(|res| res.result)
+            let tx_env = self.converter().tx_env(request, &evm_env)?;
+            evm.transact(&tx_env).map_err(Self::Error::from_evm_err).map(|res| res.result)
         };
 
         // For basic transfers, try using minimum gas before running full binary search

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -1,22 +1,22 @@
 //! Estimate gas needed implementation
 
-use super::{call::request_gas_price, Call, LoadPendingBlock};
+use super::{Call, LoadPendingBlock};
 use crate::{AsEthApiError, FromEthApiError, IntoEthApiError};
+use alloy_consensus::Transaction;
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{TxKind, KECCAK256_EMPTY, U256};
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockId};
-use evm2::{evm::DynDatabase, EvmFeatures, TxResult};
+use evm2::{EvmFeatures, TxResult};
 use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
-use reth_evm::{EvmEnv, EvmEnvFor};
+use reth_evm::{database::EvmStateProvider, Database, EvmEnv, EvmEnvFor};
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
-    cache::db::{apply_block_overrides, apply_state_overrides, StateProviderTraitObjWrapper},
+    cache::db::{apply_block_overrides, apply_state_overrides},
     error::api::{FromEvmHalt, FromRevert},
     EthApiError, RpcInvalidTransactionError,
 };
 use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GAS_ERROR_RATIO};
-use reth_storage_api::{StateProvider, StateProviderBox};
 use tracing::trace;
 
 /// Gas execution estimates
@@ -41,7 +41,7 @@ pub trait EstimateCall: Call {
         overrides: EvmOverrides,
     ) -> Result<U256, Self::Error>
     where
-        S: StateProvider + Send + 'static,
+        S: EvmStateProvider,
     {
         // Disabled because eth_estimateGas is sometimes used with eoa senders
         // See <https://github.com/paradigmxyz/reth/issues/1959>
@@ -64,9 +64,8 @@ pub trait EstimateCall: Call {
         let tx_request_gas_price = request.as_ref().gas_price();
 
         // Configure the evm env
-        let state: StateProviderBox = Box::new(state);
         let mut db = evm2::evm::CacheDB::new(evm2::evm::Db::new(
-            reth_evm::database::StateProviderDatabase::new(StateProviderTraitObjWrapper(state)),
+            reth_evm::database::StateProviderDatabase::new(state),
         ));
 
         // Apply any block overrides before deriving block-derived limits and the tx env so
@@ -97,9 +96,11 @@ pub trait EstimateCall: Call {
             .map(|tx_gas_limit| tx_gas_limit.min(max_gas_limit))
             .unwrap_or(max_gas_limit);
 
+        let tx_env = self.create_txn_env(&evm_env, request.clone(), &mut db)?;
+
         // Check if this is a basic transfer (no input data to account with no code)
-        let is_basic_transfer = if request.as_ref().input().is_none_or(|input| input.is_empty()) &&
-            let Some(TxKind::Call(to)) = request.as_ref().kind()
+        let is_basic_transfer = if tx_env.input().is_empty() &&
+            let TxKind::Call(to) = tx_env.kind()
         {
             match db.get_account(&to) {
                 Ok(Some(account)) => account.code_hash == KECCAK256_EMPTY,
@@ -109,12 +110,10 @@ pub trait EstimateCall: Call {
             false
         };
 
-        let tx_env = self.create_txn_env(&evm_env, request.clone(), &mut db)?;
-
         // Check funds of the sender (only useful to check if transaction gas price is more than 0).
         //
         // The caller allowance is check by doing `(account.balance - tx.value) / tx.gas_price`
-        if request_gas_price(request.as_ref(), evm_env.block_base_fee()) > 0 {
+        if tx_env.max_fee_per_gas() > 0 {
             let allowance = self.caller_gas_allowance(&mut db, &evm_env, &tx_env)?;
             highest_gas_limit = highest_gas_limit.min(allowance);
         }

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -9,11 +9,11 @@ use evm2_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use futures::Future;
 use reth_errors::RethError;
 use reth_evm::{
-    execute::BlockExecutorFactory, ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, EvmTypesFor,
-    TxEnvFor, TxResultWithStateFor,
+    execute::BlockExecutorFactory, BlockExecutor, ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor,
+    EvmTypesFor, TxEnvFor, TxResultWithStateFor,
 };
 use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock};
-use reth_rpc_eth_types::{EthApiError, StateCacheDb};
+use reth_rpc_eth_types::StateCacheDb;
 use reth_storage_api::{ProviderBlock, ProviderTx};
 use std::{mem, sync::Arc};
 
@@ -26,7 +26,7 @@ pub struct TracingCtx<'a, Tx, Insp, EvmTypes: evm2::EvmTypes> {
     /// Detached state changes for the transaction.
     pub state: &'a evm2::PendingState,
     /// Database pointing to the transaction pre-state.
-    pub db: &'a mut StateCacheDb,
+    pub db: &'a mut dyn evm2::evm::DynDatabase,
     /// Inspector used while executing the transaction.
     pub inspector: &'a mut Insp,
     fused_inspector: &'a Insp,
@@ -229,10 +229,16 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                 let mut results = Vec::new();
                 let mut inspector = inspector_setup();
                 let fused_inspector = inspector.clone();
+                let mut evm = this
+                    .evm_config()
+                    .block_executor_factory()
+                    .evm_with_database(&mut db, evm_env.clone());
 
                 for (idx, tx) in block.transactions_recovered().take(max_transactions).enumerate() {
                     let tx_env = this.evm_config().tx_env(tx.cloned());
-                    let result = this.inspect(&mut db, evm_env.clone(), &tx_env, &mut inspector)?;
+                    let result = evm
+                        .transact_with_inspector(&tx_env, &mut inspector)
+                        .map_err(Self::Error::from_evm_err)?;
                     let tx_info = TransactionInfo {
                         hash: Some(*tx.tx_hash()),
                         index: Some(idx as u64),
@@ -249,7 +255,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                             tx,
                             result,
                             state: &pending_state,
-                            db: &mut db,
+                            db: evm.accepted_db_mut(),
                             inspector: &mut inspector,
                             fused_inspector: &fused_inspector,
                             was_fused: &mut was_fused,
@@ -258,7 +264,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                     if !was_fused {
                         inspector.clone_from(&fused_inspector);
                     }
-                    db.commit_source(&pending_state);
+                    evm.commit_state(&pending_state);
                     results.push(item);
                 }
 
@@ -361,19 +367,16 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         &self,
         block: &RecoveredBlock<ProviderBlock<Self::Provider>>,
         db: &mut StateCacheDb,
-    ) -> Result<reth_evm::EvmState, Self::Error> {
-        let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
-        let ctx = self
+    ) -> Result<evm2::evm::BlockStateAccumulator, Self::Error> {
+        let mut executor = self
             .evm_config()
-            .context_for_block(block.sealed_block())
+            .executor_for_block(&mut *db, block.sealed_block())
             .map_err(RethError::other)
             .map_err(Self::Error::from_eth_err)?;
-        let changes = self
-            .evm_config()
-            .pre_block_state_changes(&mut *db, evm_env, block.number(), ctx)
-            .map_err(|err| EthApiError::EvmCustom(err.to_string()))
-            .map_err(Self::Error::from_eth_err)?;
-        db.commit_source(&changes);
-        Ok(changes)
+        executor.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
+        let state = executor.execution_state();
+        drop(executor);
+        db.commit_source(&state);
+        Ok(state)
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -9,34 +9,41 @@ use evm2_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use futures::Future;
 use reth_errors::RethError;
 use reth_evm::{
-    execute::BlockExecutorFactory, ConfigureEvm, Database, Evm, EvmEnvFor, EvmTypesFor, TxEnvFor,
-    TxResultWithStateFor,
+    execute::BlockExecutorFactory, ConfigureEvm, Database, Evm, EvmEnv, EvmEnvFor, EvmTypesFor,
+    TxEnvFor, TxResultWithStateFor,
 };
-use reth_primitives_traits::{BlockBody, RecoveredBlock};
+use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock};
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
-use reth_storage_api::ProviderBlock;
-use std::sync::Arc;
+use reth_storage_api::{ProviderBlock, ProviderTx};
+use std::{mem, sync::Arc};
 
 /// Context passed to per-transaction trace callbacks.
-pub struct TracingCtx<'a, Insp, EvmTypes: evm2::EvmTypes> {
-    /// Execution result and detached state changes for the transaction.
-    pub result: evm2::TxResultWithState<EvmTypes>,
+pub struct TracingCtx<'a, Tx, Insp, EvmTypes: evm2::EvmTypes> {
+    /// Transaction being traced.
+    pub tx: Tx,
+    /// Execution result for the transaction.
+    pub result: evm2::TxResult<EvmTypes>,
+    /// Detached state changes for the transaction.
+    pub state: &'a evm2::PendingState,
     /// Database pointing to the transaction pre-state.
     pub db: &'a mut StateCacheDb,
     /// Inspector used while executing the transaction.
-    pub inspector: Insp,
+    pub inspector: &'a mut Insp,
+    fused_inspector: &'a Insp,
+    was_fused: &'a mut bool,
 }
 
-impl<Insp, EvmTypes: evm2::EvmTypes> core::fmt::Debug for TracingCtx<'_, Insp, EvmTypes> {
+impl<Tx, Insp, EvmTypes: evm2::EvmTypes> core::fmt::Debug for TracingCtx<'_, Tx, Insp, EvmTypes> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TracingCtx").finish_non_exhaustive()
     }
 }
 
-impl<Insp, EvmTypes: evm2::EvmTypes> TracingCtx<'_, Insp, EvmTypes> {
-    /// Consumes this context and returns the inspector.
-    pub fn take_inspector(self) -> Insp {
-        self.inspector
+impl<Tx, Insp: Clone, EvmTypes: evm2::EvmTypes> TracingCtx<'_, Tx, Insp, EvmTypes> {
+    /// Returns the inspector, leaving a pristine inspector for the next transaction.
+    pub fn take_inspector(&mut self) -> Insp {
+        *self.was_fused = true;
+        mem::replace(self.inspector, self.fused_inspector.clone())
     }
 }
 
@@ -48,11 +55,11 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         db: DB,
         evm_env: EvmEnvFor<Self::Evm>,
         tx_env: &TxEnvFor<Self::Evm>,
-        inspector: I,
-    ) -> Result<(I, TxResultWithStateFor<Self::Evm>), Self::Error>
+        inspector: &mut I,
+    ) -> Result<TxResultWithStateFor<Self::Evm>, Self::Error>
     where
         DB: Database,
-        I: evm2::Inspector<EvmTypesFor<Self::Evm>> + 'static,
+        I: evm2::Inspector<EvmTypesFor<Self::Evm>>,
     {
         let mut evm = self.evm_config().block_executor_factory().evm_with_database(db, evm_env);
         evm.transact_with_inspector(tx_env, inspector).map_err(Self::Error::from_evm_err)
@@ -75,8 +82,8 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             + 'static,
     {
         self.spawn_with_state_at_block(at, move |this, mut db| {
-            let (inspector, result) =
-                this.inspect(&mut db, evm_env, &tx_env, TracingInspector::new(config))?;
+            let mut inspector = TracingInspector::new(config);
+            let result = this.inspect(&mut db, evm_env, &tx_env, &mut inspector)?;
             f(inspector, result)
         })
     }
@@ -101,8 +108,8 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         R: Send + 'static,
     {
         self.spawn_with_state_at_block(at, move |this, mut db| {
-            let (inspector, result) =
-                this.inspect(&mut db, evm_env, &tx_env, TracingInspector::new(config))?;
+            let mut inspector = TracingInspector::new(config);
+            let result = this.inspect(&mut db, evm_env, &tx_env, &mut inspector)?;
             f(inspector, result, db)
         })
     }
@@ -133,7 +140,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     fn spawn_trace_transaction_in_block_with_inspector<Insp, F, R>(
         &self,
         hash: B256,
-        inspector: Insp,
+        mut inspector: Insp,
         f: F,
     ) -> impl Future<Output = Result<Option<R>, Self::Error>> + Send
     where
@@ -169,7 +176,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                 )?;
 
                 let tx_env = this.evm_config().tx_env(target_tx);
-                let (inspector, result) = this.inspect(&mut db, evm_env, &tx_env, inspector)?;
+                let result = this.inspect(&mut db, evm_env, &tx_env, &mut inspector)?;
                 f(tx_info, inspector, result, db)
             })
             .await
@@ -190,7 +197,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         Self: LoadBlock,
         F: Fn(
                 TransactionInfo,
-                TracingCtx<'_, Insp, EvmTypesFor<Self::Evm>>,
+                TracingCtx<'_, Recovered<&ProviderTx<Self::Provider>>, Insp, EvmTypesFor<Self::Evm>>,
             ) -> Result<R, Self::Error>
             + Send
             + 'static,
@@ -210,9 +217,9 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
 
             self.spawn_with_state_at_block(block.parent_hash(), move |this, mut db| {
                 let block_hash = block.hash();
-                let block_number = block.number();
-                let block_timestamp = block.timestamp();
-                let base_fee = block.base_fee_per_gas();
+                let block_number = evm_env.block_env().number.saturating_to();
+                let block_timestamp = evm_env.block_env().timestamp.saturating_to();
+                let base_fee = Some(evm_env.block_base_fee());
 
                 this.apply_pre_execution_changes(&block, &mut db)?;
 
@@ -220,11 +227,12 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                     .map(|highest| highest as usize + 1)
                     .unwrap_or_else(|| block.body().transaction_count());
                 let mut results = Vec::new();
+                let mut inspector = inspector_setup();
+                let fused_inspector = inspector.clone();
 
                 for (idx, tx) in block.transactions_recovered().take(max_transactions).enumerate() {
                     let tx_env = this.evm_config().tx_env(tx.cloned());
-                    let (inspector, result) =
-                        this.inspect(&mut db, evm_env.clone(), &tx_env, inspector_setup())?;
+                    let result = this.inspect(&mut db, evm_env.clone(), &tx_env, &mut inspector)?;
                     let tx_info = TransactionInfo {
                         hash: Some(*tx.tx_hash()),
                         index: Some(idx as u64),
@@ -233,9 +241,24 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                         block_timestamp: Some(block_timestamp),
                         base_fee,
                     };
-                    let state_changes = result.state_changes.clone();
-                    let item = f(tx_info, TracingCtx { result, db: &mut db, inspector })?;
-                    db.commit_source(&state_changes);
+                    let evm2::TxResultWithState { result, pending_state, .. } = result;
+                    let mut was_fused = false;
+                    let item = f(
+                        tx_info,
+                        TracingCtx {
+                            tx,
+                            result,
+                            state: &pending_state,
+                            db: &mut db,
+                            inspector: &mut inspector,
+                            fused_inspector: &fused_inspector,
+                            was_fused: &mut was_fused,
+                        },
+                    )?;
+                    if !was_fused {
+                        inspector.clone_from(&fused_inspector);
+                    }
+                    db.commit_source(&pending_state);
                     results.push(item);
                 }
 
@@ -258,7 +281,12 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         Self: LoadBlock,
         F: Fn(
                 TransactionInfo,
-                TracingCtx<'_, TracingInspector, EvmTypesFor<Self::Evm>>,
+                TracingCtx<
+                    '_,
+                    Recovered<&ProviderTx<Self::Provider>>,
+                    TracingInspector,
+                    EvmTypesFor<Self::Evm>,
+                >,
             ) -> Result<R, Self::Error>
             + Send
             + 'static,
@@ -285,7 +313,12 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         Self: LoadBlock,
         F: Fn(
                 TransactionInfo,
-                TracingCtx<'_, TracingInspector, EvmTypesFor<Self::Evm>>,
+                TracingCtx<
+                    '_,
+                    Recovered<&ProviderTx<Self::Provider>>,
+                    TracingInspector,
+                    EvmTypesFor<Self::Evm>,
+                >,
             ) -> Result<R, Self::Error>
             + Send
             + 'static,
@@ -312,7 +345,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         Self: LoadBlock,
         F: Fn(
                 TransactionInfo,
-                TracingCtx<'_, Insp, EvmTypesFor<Self::Evm>>,
+                TracingCtx<'_, Recovered<&ProviderTx<Self::Provider>>, Insp, EvmTypesFor<Self::Evm>>,
             ) -> Result<R, Self::Error>
             + Send
             + 'static,

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -9,7 +9,7 @@ use evm2::{
     bytecode::Bytecode,
     evm::{
         AccountChangeRef, AccountInfoRef, CacheDB, Database, Db, OverrideBlockHashes,
-        StateChangeSink, StorageChange,
+        StateChangeSink, StorageChange, Tee,
     },
 };
 use reth_errors::ProviderResult;
@@ -76,10 +76,11 @@ where
 pub fn apply_state_overrides<DB>(
     overrides: StateOverride,
     db: &mut DB,
-) -> Result<(), StateOverrideError<<DB as Database>::Error>>
+) -> Result<EvmState, StateOverrideError<<DB as Database>::Error>>
 where
     DB: Database + StateChangeSink<Error = core::convert::Infallible>,
 {
+    let mut state = EvmState::default();
     for (address, account_override) in overrides {
         let original = db.get_account(&address).map_err(StateOverrideError::Database)?;
         let mut account = original.clone().unwrap_or_default();
@@ -103,10 +104,11 @@ where
             (None, None) => (None, false),
         };
 
+        let mut sink = Tee::new(&mut *db, &mut state);
         if let Some(code) = &account.code {
-            db.bytecode(account.code_hash, code).expect("infallible state override update");
+            sink.bytecode(account.code_hash, code).expect("infallible state override update");
         }
-        db.account(AccountChangeRef {
+        sink.account(AccountChangeRef {
             address,
             original: original.as_ref().map(AccountInfoRef::from_info),
             current: Some(AccountInfoRef::from_info(&account)),
@@ -123,15 +125,15 @@ where
                 changes.push(StorageChange { address, key, original: !current, current });
             }
             if wipe_storage {
-                db.storage_wipe(address).expect("infallible state override update");
+                sink.storage_wipe(address).expect("infallible state override update");
             }
             for change in changes {
-                db.storage(change).expect("infallible state override update");
+                sink.storage(change).expect("infallible state override update");
             }
         }
     }
 
-    Ok(())
+    Ok(state)
 }
 
 /// Hack to get around 'higher-ranked lifetime error', see

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -119,14 +119,8 @@ where
             let mut changes = Vec::with_capacity(storage.len());
             for (key, value) in storage {
                 let key = U256::from_be_bytes(key.0);
-                let original =
-                    db.get_storage(&address, &key).map_err(StateOverrideError::Database)?;
-                changes.push(StorageChange {
-                    address,
-                    key,
-                    original,
-                    current: U256::from_be_bytes(value.0),
-                });
+                let current = U256::from_be_bytes(value.0);
+                changes.push(StorageChange { address, key, original: !current, current });
             }
             if wipe_storage {
                 db.storage_wipe(address).expect("infallible state override update");

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -7,7 +7,10 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types_eth::{state::StateOverride, BlockOverrides};
 use evm2::{
     bytecode::Bytecode,
-    evm::{CacheDB, Db, DynDatabase},
+    evm::{
+        AccountChangeRef, AccountInfoRef, CacheDB, Database, Db, OverrideBlockHashes,
+        StateChangeSink, StorageChange,
+    },
 };
 use reth_errors::ProviderResult;
 use reth_evm::{database::StateProviderDatabase, EvmEnv};
@@ -19,11 +22,10 @@ use reth_trie::{HashedPostState, HashedStorage, MultiProofTargets};
 pub type StateCacheDb = CacheDB<Db<StateProviderDatabase<StateProviderTraitObjWrapper>>>;
 
 /// Applies RPC block overrides to an evm2 environment and state cache.
-pub fn apply_block_overrides<DB>(
-    overrides: BlockOverrides,
-    db: &mut CacheDB<DB>,
-    evm_env: &mut impl EvmEnv,
-) {
+pub fn apply_block_overrides<DB>(overrides: BlockOverrides, db: &mut DB, evm_env: &mut impl EvmEnv)
+where
+    DB: OverrideBlockHashes,
+{
     let BlockOverrides {
         number,
         difficulty,
@@ -71,15 +73,16 @@ pub fn apply_block_overrides<DB>(
 }
 
 /// Applies RPC state overrides to an evm2 state cache.
-pub fn apply_state_overrides<DB: DynDatabase>(
+pub fn apply_state_overrides<DB>(
     overrides: StateOverride,
-    db: &mut CacheDB<DB>,
-) -> Result<(), StateOverrideError<evm2::AnyError>> {
+    db: &mut DB,
+) -> Result<(), StateOverrideError<<DB as Database>::Error>>
+where
+    DB: Database + StateChangeSink<Error = core::convert::Infallible>,
+{
     for (address, account_override) in overrides {
-        let mut account = db
-            .get_account(&address)
-            .map_err(|code| StateOverrideError::Database(db.error(code)))?
-            .unwrap_or_default();
+        let original = db.get_account(&address).map_err(StateOverrideError::Database)?;
+        let mut account = original.clone().unwrap_or_default();
 
         if let Some(nonce) = account_override.nonce {
             account.nonce = nonce;
@@ -93,24 +96,43 @@ pub fn apply_state_overrides<DB: DynDatabase>(
             account.balance = balance;
         }
 
-        let storage = match (account_override.state, account_override.state_diff) {
+        let (storage, wipe_storage) = match (account_override.state, account_override.state_diff) {
             (Some(_), Some(_)) => return Err(StateOverrideError::BothStateAndStateDiff(address)),
-            (Some(state), None) => {
-                db.cache.storage.entry(address).or_default().wipe();
-                Some(state)
-            }
-            (None, Some(state)) => Some(state),
-            (None, None) => None,
+            (Some(state), None) => (Some(state), true),
+            (None, Some(state)) => (Some(state), false),
+            (None, None) => (None, false),
         };
 
-        db.insert_account_info(&address, account);
+        if let Some(code) = &account.code {
+            db.bytecode(account.code_hash, code).expect("infallible state override update");
+        }
+        db.account(AccountChangeRef {
+            address,
+            original: original.as_ref().map(AccountInfoRef::from_info),
+            current: Some(AccountInfoRef::from_info(&account)),
+            created: original.is_none(),
+            selfdestructed: false,
+        })
+        .expect("infallible state override update");
+
         if let Some(storage) = storage {
+            let mut changes = Vec::with_capacity(storage.len());
             for (key, value) in storage {
-                db.insert_account_storage(
-                    &address,
-                    &U256::from_be_bytes(key.0),
-                    &U256::from_be_bytes(value.0),
-                );
+                let key = U256::from_be_bytes(key.0);
+                let original =
+                    db.get_storage(&address, &key).map_err(StateOverrideError::Database)?;
+                changes.push(StorageChange {
+                    address,
+                    key,
+                    original,
+                    current: U256::from_be_bytes(value.0),
+                });
+            }
+            if wipe_storage {
+                db.storage_wipe(address).expect("infallible state override update");
+            }
+            for change in changes {
+                db.storage(change).expect("infallible state override update");
             }
         }
     }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -10,7 +10,7 @@ pub use api::{AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError};
 use core::time::Duration;
 use evm2::{interpreter::InstrStop, registry::HandlerError};
 use evm2_inspectors::tracing::{DebugInspectorError, MuxError};
-use reth_errors::{BlockExecutionError, BlockValidationError, RethError};
+use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError, RethError};
 use reth_primitives_traits::transaction::{error::InvalidTransactionError, signed::RecoveryError};
 use reth_rpc_convert::{CallFeesError, EthTxEnvError, TransactionConversionError};
 use reth_rpc_server_types::result::{
@@ -490,7 +490,11 @@ impl From<BlockExecutionError> for EthApiError {
         match error {
             BlockExecutionError::Validation(validation_error) => match validation_error {
                 BlockValidationError::InvalidTx { error, .. } => {
-                    if let Some(invalid_tx) =
+                    if let Some(invalid_tx) = error.as_any().downcast_ref::<HandlerError>() {
+                        Self::InvalidTransaction(RpcInvalidTransactionError::from(
+                            invalid_tx.clone(),
+                        ))
+                    } else if let Some(invalid_tx) =
                         error.as_any().downcast_ref::<InvalidTransactionError>()
                     {
                         Self::InvalidTransaction(RpcInvalidTransactionError::from(
@@ -524,6 +528,9 @@ impl From<BlockExecutionError> for EthApiError {
 
 impl From<evm2::AnyError> for EthApiError {
     fn from(error: evm2::AnyError) -> Self {
+        if let Some(error) = error.downcast_ref::<ProviderError>() {
+            return error.clone().into()
+        }
         Self::EvmCustom(error.to_string())
     }
 }
@@ -1095,6 +1102,23 @@ mod tests {
     use alloy_primitives::b256;
     use alloy_sol_types::{Revert, SolError};
 
+    #[derive(Debug)]
+    struct HandlerValidationError(HandlerError);
+
+    impl core::fmt::Display for HandlerValidationError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    impl core::error::Error for HandlerValidationError {}
+
+    impl reth_evm::InvalidTxError for HandlerValidationError {
+        fn as_any(&self) -> &(dyn core::any::Any + 'static) {
+            &self.0
+        }
+    }
+
     #[test]
     fn timed_out_error() {
         let err = EthApiError::ExecutionTimedOut(Duration::from_secs(10));
@@ -1114,6 +1138,28 @@ mod tests {
                 cost: actual_cost,
                 balance: actual_balance,
             } if actual_cost == cost && actual_balance == balance
+        ));
+    }
+
+    #[test]
+    fn block_execution_handler_error_preserves_rpc_error() {
+        let cost = U256::from(2);
+        let balance = U256::from(1);
+        let error = BlockValidationError::InvalidTx {
+            hash: B256::ZERO,
+            error: Box::new(HandlerValidationError(HandlerError::InsufficientFunds {
+                cost,
+                balance,
+            })),
+        };
+        let error = EthApiError::from(BlockExecutionError::Validation(error));
+
+        assert!(matches!(
+            error,
+            EthApiError::InvalidTransaction(RpcInvalidTransactionError::InsufficientFunds {
+                cost: actual_cost,
+                balance: actual_balance,
+            }) if actual_cost == cost && actual_balance == balance
         ));
     }
 

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -467,9 +467,7 @@ impl From<DebugInspectorError> for EthApiError {
                 Self::Unsupported("JS Tracer is not enabled")
             }
             DebugInspectorError::MuxInspector(err) => err.into(),
-            DebugInspectorError::Database(err) => {
-                Self::Internal(RethError::msg(format!("{err:?}")))
-            }
+            DebugInspectorError::Database(err) => Self::Internal(RethError::other(err)),
             #[cfg(feature = "js-tracer")]
             DebugInspectorError::JsInspector(err) => err.into(),
             #[allow(unreachable_patterns)]
@@ -841,9 +839,10 @@ impl From<HandlerError> for RpcInvalidTransactionError {
                 Self::InvalidChainId
             }
             HandlerError::IntrinsicGasTooLow { .. } => Self::GasTooLow,
-            HandlerError::InsufficientFunds | HandlerError::OutOfFunds => {
-                Self::InsufficientFundsForTransfer
+            HandlerError::InsufficientFunds { cost, balance } => {
+                Self::InsufficientFunds { cost, balance }
             }
+            HandlerError::OutOfFunds => Self::InsufficientFundsForTransfer,
             HandlerError::RejectCallerWithCode => Self::SenderNoEOA,
             HandlerError::NonceOverflow => Self::NonceMaxValue,
             HandlerError::GasLimitMoreThanBlock { .. } |
@@ -1100,6 +1099,22 @@ mod tests {
     fn timed_out_error() {
         let err = EthApiError::ExecutionTimedOut(Duration::from_secs(10));
         assert_eq!(err.to_string(), "execution aborted (timeout = 10s)");
+    }
+
+    #[test]
+    fn handler_insufficient_funds_preserves_cost_and_balance() {
+        let cost = U256::from(2);
+        let balance = U256::from(1);
+        let err =
+            RpcInvalidTransactionError::from(HandlerError::InsufficientFunds { cost, balance });
+
+        assert!(matches!(
+            err,
+            RpcInvalidTransactionError::InsufficientFunds {
+                cost: actual_cost,
+                balance: actual_balance,
+            } if actual_cost == cost && actual_balance == balance
+        ));
     }
 
     #[test]

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -7,10 +7,11 @@ use alloy_rpc_types_eth::{error::EthRpcErrorCode, request::TransactionInputError
 use alloy_sol_types::{ContractError, RevertReason};
 use alloy_transport::{RpcError, TransportErrorKind};
 pub use api::{AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError};
-use core::time::Duration;
+use core::{error::Error, time::Duration};
 use evm2::{interpreter::InstrStop, registry::HandlerError};
 use evm2_inspectors::tracing::{DebugInspectorError, MuxError};
 use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError, RethError};
+use reth_evm::InternalBlockExecutionError;
 use reth_primitives_traits::transaction::{error::InvalidTransactionError, signed::RecoveryError};
 use reth_rpc_convert::{CallFeesError, EthTxEnvError, TransactionConversionError};
 use reth_rpc_server_types::result::{
@@ -520,6 +521,13 @@ impl From<BlockExecutionError> for EthApiError {
                 ))),
             },
             BlockExecutionError::Internal(internal_error) => {
+                let error: &(dyn Error + 'static) = match &internal_error {
+                    InternalBlockExecutionError::EVM { error, .. } |
+                    InternalBlockExecutionError::Other(error) => &**error,
+                };
+                if let Some(error) = find_provider_error(error) {
+                    return error.clone().into()
+                }
                 Self::Internal(RethError::Execution(BlockExecutionError::Internal(internal_error)))
             }
         }
@@ -528,10 +536,28 @@ impl From<BlockExecutionError> for EthApiError {
 
 impl From<evm2::AnyError> for EthApiError {
     fn from(error: evm2::AnyError) -> Self {
-        if let Some(error) = error.downcast_ref::<ProviderError>() {
+        if let Some(error) = find_provider_error(&error) {
             return error.clone().into()
         }
         Self::EvmCustom(error.to_string())
+    }
+}
+
+fn find_provider_error<'a>(mut error: &'a (dyn Error + 'static)) -> Option<&'a ProviderError> {
+    loop {
+        if let Some(error) = error.downcast_ref::<ProviderError>() {
+            return Some(error)
+        }
+        if let Some(mut error) = error.downcast_ref::<evm2::AnyError>() {
+            loop {
+                if let Some(provider_error) = error.downcast_ref::<ProviderError>() {
+                    return Some(provider_error)
+                }
+                let Some(nested) = error.downcast_ref::<evm2::AnyError>() else { break };
+                error = nested;
+            }
+        }
+        error = error.source()?;
     }
 }
 
@@ -1119,6 +1145,21 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct DatabaseExecutionError(evm2::AnyError);
+
+    impl core::fmt::Display for DatabaseExecutionError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    impl core::error::Error for DatabaseExecutionError {
+        fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+
     #[test]
     fn timed_out_error() {
         let err = EthApiError::ExecutionTimedOut(Duration::from_secs(10));
@@ -1161,6 +1202,24 @@ mod tests {
                 balance: actual_balance,
             }) if actual_cost == cost && actual_balance == balance
         ));
+    }
+
+    #[test]
+    fn block_execution_database_error_preserves_provider_error() {
+        let provider_error = ProviderError::BlockExpired { requested: 1, earliest_available: 2 };
+        let error = evm2::AnyError::new(evm2::AnyError::new(provider_error));
+        let error = EthApiError::from(BlockExecutionError::other(error));
+
+        assert!(matches!(error, EthApiError::PrunedHistoryUnavailable));
+
+        let provider_error = ProviderError::BlockExpired { requested: 1, earliest_available: 2 };
+        let error = InternalBlockExecutionError::EVM {
+            hash: B256::ZERO,
+            error: Box::new(DatabaseExecutionError(evm2::AnyError::new(provider_error))),
+        };
+        let error = EthApiError::from(BlockExecutionError::Internal(error));
+
+        assert!(matches!(error, EthApiError::PrunedHistoryUnavailable));
     }
 
     #[test]

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -14,10 +14,14 @@ use alloy_rpc_types_eth::{
     state::StateOverride,
     BlockId, BlockOverrides, BlockTransactionsKind,
 };
-use evm2::{precompiles::MovePrecompileError, EvmFeatures, TxResult};
+use evm2::{
+    evm::{BlockStateAccumulator, StateChangeSource},
+    precompiles::MovePrecompileError,
+    EvmFeatures, TxResult,
+};
 use jsonrpsee_types::{error::INTERNAL_ERROR_CODE, ErrorObject};
 use reth_evm::{
-    execute::{BlockBuilder, BlockBuilderOutcome},
+    execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionError},
     Database, Evm as RethEvm, EvmEnv,
 };
 use reth_primitives_traits::{
@@ -294,10 +298,11 @@ pub fn apply_precompile_overrides(
 /// geth's per-call `sanitizeCall` behavior.
 ///
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
-#[expect(clippy::type_complexity)]
+#[expect(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn execute_transactions<S, T, EvmTypes>(
     mut builder: S,
     state_provider: impl StateProvider,
+    accumulated_state: &mut BlockStateAccumulator,
     calls: Vec<RpcTxReq<T::Network>>,
     remaining_call_gas_limit: &mut Option<u64>,
     chain_id: u64,
@@ -394,9 +399,22 @@ where
     }
 
     let result = if compute_state_root {
-        builder.finish(state_provider, None)?
+        let mut cumulative_hashed_state = None;
+        let mut result = builder.finish_with_state_root(&state_provider, |output| {
+            output.state.inner().visit(accumulated_state).expect("infallible");
+            let hashed_state = state_provider.hashed_post_state(accumulated_state);
+            let state_root = state_provider
+                .state_root_with_updates(hashed_state.clone())
+                .map_err(BlockExecutionError::other)?;
+            cumulative_hashed_state = Some(hashed_state);
+            Ok(Some(state_root))
+        })?;
+        result.hashed_state = cumulative_hashed_state.expect("state root was computed");
+        result
     } else {
-        builder.finish(NoopProvider::default(), None)?
+        let result = builder.finish(NoopProvider::default(), None)?;
+        result.execution_state.inner().visit(accumulated_state).expect("infallible");
+        result
     };
 
     Ok((result, results))

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -20,10 +20,13 @@ use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::ConsensusEngineEvent;
 use reth_errors::RethError;
-use reth_evm::{execute::Executor, ConfigureEvm, DynDatabase, EvmEnv, EvmEnvFor};
+use reth_evm::{
+    execute::Executor, BlockExecutor, ConfigureEvm, DynDatabase, EvmEnv, EvmEnvFor,
+    ExecutableTxParts, TxFor,
+};
 use reth_primitives_traits::{
     Account as PrimitiveAccount, Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom,
-    RecoveredBlock,
+    RecoveredBlock, TxTy,
 };
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
@@ -128,9 +131,7 @@ where
                     let tx_hash = *tx.tx_hash();
                     let tx_env = eth_api.evm_config().tx_env(tx.cloned());
 
-                    let (next_inspector, res) =
-                        eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
-                    inspector = next_inspector;
+                    let res = eth_api.inspect(&mut db, evm_env.clone(), &tx_env, &mut inspector)?;
                     let result = inspector
                         .get_result(
                             Some(TransactionContext {
@@ -150,7 +151,7 @@ where
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit_source(&res.state_changes)
+                        db.commit_source(&res.pending_state)
                     }
                 }
 
@@ -247,9 +248,8 @@ where
 
                 let tx_env = eth_api.evm_config().tx_env(tx);
 
-                let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                let (mut inspector, res) =
-                    eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
+                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
+                let res = eth_api.inspect(&mut db, evm_env.clone(), &tx_env, &mut inspector)?;
                 let trace = inspector
                     .get_result(
                         Some(TransactionContext {
@@ -303,10 +303,10 @@ where
         let this = self.clone();
         self.eth_api()
             .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                let inspector =
+                let mut inspector =
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
-                let (mut inspector, res) =
-                    this.eth_api().inspect(&mut *db, evm_env.clone(), &tx_env, inspector)?;
+                let res =
+                    this.eth_api().inspect(&mut *db, evm_env.clone(), &tx_env, &mut inspector)?;
                 let trace = inspector
                     .get_result(None, &tx_env, evm_env.block_env(), &res, db)
                     .map_err(Eth::Error::from_eth_err)?;
@@ -365,10 +365,9 @@ where
                 let (evm_env, tx_env) =
                     eth_api.prepare_call_env(evm_env, call, &mut db, overrides)?;
 
-                let inspector =
+                let mut inspector =
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
-                let (mut inspector, res) =
-                    eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
+                let res = eth_api.inspect(&mut db, evm_env.clone(), &tx_env, &mut inspector)?;
                 let trace = inspector
                     .get_result(None, &tx_env, evm_env.block_env(), &res, &mut db)
                     .map_err(Eth::Error::from_eth_err)?;
@@ -438,7 +437,7 @@ where
                     for tx in transactions {
                         let tx_env = eth_api.evm_config().tx_env(tx.cloned());
                         let res = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit_source(&res.state_changes);
+                        db.commit_source(&res.pending_state);
                     }
                 }
 
@@ -461,9 +460,8 @@ where
                         let (evm_env, tx_env) =
                             eth_api.prepare_call_env(evm_env.clone(), tx, &mut db, overrides)?;
 
-                        let (next_inspector, res) =
-                            eth_api.inspect(&mut db, evm_env.clone(), &tx_env, inspector)?;
-                        inspector = next_inspector;
+                        let res =
+                            eth_api.inspect(&mut db, evm_env.clone(), &tx_env, &mut inspector)?;
                         let trace = inspector
                             .get_result(None, &tx_env, evm_env.block_env(), &res, &mut db)
                             .map_err(Eth::Error::from_eth_err)?;
@@ -472,7 +470,7 @@ where
                         // If there is no transactions, but more bundles, commit to the database too
                         if transactions.peek().is_some() || bundles.peek().is_some() {
                             inspector.fuse().map_err(Eth::Error::from_eth_err)?;
-                            db.commit_source(&res.state_changes);
+                            db.commit_source(&res.pending_state);
                         }
                         results.push(trace);
                     }
@@ -658,17 +656,23 @@ where
             ))
             .into())
         }
-        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
-
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+                let mut executor = eth_api
+                    .evm_config()
+                    .executor_for_block(&mut db, block.sealed_block())
+                    .map_err(RethError::other)
+                    .map_err(Eth::Error::from_eth_err)?;
+                executor.apply_pre_execution_changes().map_err(Eth::Error::from_eth_err)?;
 
                 for tx in block.transactions_recovered().take(tx_index + 1) {
-                    let tx_env = eth_api.evm_config().tx_env(tx.cloned());
-                    let result = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                    db.commit_source(&result.state_changes);
+                    let (tx_env, _) = <_ as ExecutableTxParts<
+                        TxFor<Eth::Evm>,
+                        TxTy<Eth::Primitives>,
+                    >>::into_parts(tx);
+                    executor.execute_transaction(tx_env).map_err(Eth::Error::from_eth_err)?;
                 }
+                drop(executor);
 
                 f(&mut db)
             })
@@ -773,10 +777,10 @@ where
                     let tx_env = eth_api.evm_config().tx_env(tx.cloned());
                     let result = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
                     result
-                        .state_changes
+                        .pending_state
                         .visit(&mut state)
                         .expect("state accumulator is infallible");
-                    db.commit_source(&result.state_changes);
+                    db.commit_source(&result.pending_state);
                     let hashed_state = db.db.inner().hashed_post_state(&state);
                     let root =
                         db.db.inner().state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -535,7 +535,6 @@ where
                     .executor(&mut db)
                     .execute(&block)
                     .map_err(|err| EthApiError::Internal(err.into()))?;
-                db.commit_source(output.state.inner());
 
                 let mut codes = db
                     .cache
@@ -546,7 +545,10 @@ where
                     .collect::<Vec<_>>();
                 if mode.is_canonical() {
                     codes.sort_unstable();
+                } else {
+                    codes.extend(output.state.code().map(|(_, code)| code.original_bytes()));
                 }
+                db.commit_source(output.state.inner());
                 let mut hashed_state = HashedPostState::default();
                 let mut keys = Vec::new();
                 for (address, account) in &db.cache.accounts {
@@ -672,7 +674,9 @@ where
                     >>::into_parts(tx);
                     executor.execute_transaction(tx_env).map_err(Eth::Error::from_eth_err)?;
                 }
+                let state = executor.execution_state();
                 drop(executor);
+                db.commit_source(&state);
 
                 f(&mut db)
             })
@@ -684,7 +688,7 @@ where
     fn account(db: &mut StateCacheDb, address: Address) -> Result<Option<Account>, Eth::Error> {
         let account = db
             .get_account(&address)
-            .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+            .map_err(|code| EthApiError::from(db.error(code)))
             .map_err(Eth::Error::from_eth_err)?;
         let Some(account) = account else { return Ok(None) };
 
@@ -705,19 +709,19 @@ where
     }
 
     /// Retrieves the account's balance, nonce, and code from the given state.
-    fn account_info(db: &mut StateCacheDb, address: Address) -> Result<AccountInfo, Eth::Error> {
-        let account = db
-            .get_account(&address)
-            .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
-            .map_err(Eth::Error::from_eth_err)?
-            .unwrap_or_default();
+    fn account_info<DB>(db: &mut DB, address: Address) -> Result<AccountInfo, Eth::Error>
+    where
+        DB: reth_evm::Database,
+        EthApiError: From<DB::Error>,
+    {
+        let account =
+            db.get_account(&address).map_err(Eth::Error::from_eth_err)?.unwrap_or_default();
         let code = if account.code_hash == KECCAK_EMPTY {
             Default::default()
         } else if let Some(code) = account.code {
             code.original_bytes()
         } else {
             db.get_code_by_hash(&account.code_hash)
-                .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
                 .map_err(Eth::Error::from_eth_err)?
                 .original_bytes()
         };

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -131,7 +131,7 @@ where
         evm_env.block_env_mut().gas_limit = U256::from(gas_limit.unwrap_or(call_gas_limit));
 
         if let Some(base_fee) = base_fee {
-            evm_env.block_env_mut().basefee = U256::from(base_fee);
+            evm_env.block_env_mut().basefee = U256::from(base_fee.try_into().unwrap_or(u64::MAX));
         }
 
         let state_block_number = evm_env.block_env().number;
@@ -181,7 +181,7 @@ where
                     let tx_env = eth_api.evm_config().tx_env(tx.clone());
                     let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
                     let result = result_and_state.result;
-                    let state = result_and_state.state_changes;
+                    let state = result_and_state.pending_state;
 
                     let gas_price = tx
                         .effective_tip_per_gas(basefee)
@@ -194,9 +194,7 @@ where
 
                     // coinbase is always present in the result state
                     coinbase_balance_after_tx = state
-                        .accounts
-                        .get(&coinbase)
-                        .and_then(|acc| acc.current.as_ref())
+                        .account_info(&coinbase)
                         .map(|acc| acc.balance)
                         .unwrap_or(coinbase_balance_before_tx);
                     let coinbase_diff =

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -7,10 +7,10 @@ use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTra
 use evm2::evm::DynDatabase;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
-use reth_evm::{ConfigureEvm, EvmEnv};
+use reth_evm::{ConfigureEvm, Evm, EvmEnv};
 use reth_rpc_eth_api::{
     helpers::{Call, EthTransactions, LoadPendingBlock},
-    EthCallBundleApiServer, FromEthApiError,
+    EthCallBundleApiServer, FromEthApiError, FromEvmError,
 };
 use reth_rpc_eth_types::{utils::recover_raw_transaction, EthApiError, RpcInvalidTransactionError};
 use reth_tasks::pool::BlockingTaskGuard;
@@ -145,9 +145,7 @@ where
 
                 let initial_coinbase = db
                     .get_account(&coinbase)
-                    .map_err(|code| {
-                        Eth::Error::from_eth_err(EthApiError::EvmCustom(db.error(code).to_string()))
-                    })?
+                    .map_err(|code| Eth::Error::from_eth_err(EthApiError::from(db.error(code))))?
                     .map(|acc| acc.balance)
                     .unwrap_or_default();
                 let mut coinbase_balance_before_tx = initial_coinbase;
@@ -158,6 +156,7 @@ where
 
                 let mut results = Vec::with_capacity(transactions.len());
                 let mut transactions = transactions.into_iter().peekable();
+                let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
 
                 while let Some(tx) = transactions.next() {
                     let signer = tx.signer();
@@ -179,7 +178,8 @@ where
 
                     hasher.update(*tx.tx_hash());
                     let tx_env = eth_api.evm_config().tx_env(tx.clone());
-                    let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
+                    let result_and_state =
+                        evm.transact(&tx_env).map_err(Eth::Error::from_evm_err)?;
                     let result = result_and_state.result;
                     let state = result_and_state.pending_state;
 
@@ -230,9 +230,7 @@ where
                     // need to apply the state changes of this call before executing the
                     // next call
                     if transactions.peek().is_some() {
-                        // need to apply the state changes of this call before executing
-                        // the next call
-                        db.commit_source(&state);
+                        evm.commit_state(&state);
                     }
                 }
 

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -335,7 +335,7 @@ where
                     let tx_env = eth_api.evm_config().tx_env(item.tx.clone());
                     let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
                     let result = result_and_state.result;
-                    let state = result_and_state.state_changes;
+                    let state = result_and_state.pending_state;
 
                     if !result.status && !item.can_revert {
                         return Err(EthApiError::InvalidParams(
@@ -349,9 +349,7 @@ where
 
                     // coinbase is always present in the result state
                     let coinbase_balance_after_tx = state
-                        .accounts
-                        .get(&coinbase)
-                        .and_then(|acc| acc.current.as_ref())
+                        .account_info(&coinbase)
                         .map(|acc| acc.balance)
                         .unwrap_or(coinbase_balance_before_tx);
 

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -10,10 +10,13 @@ use alloy_rpc_types_mev::{
 };
 use evm2::evm::DynDatabase;
 use jsonrpsee::core::RpcResult;
-use reth_evm::{ConfigureEvm, EvmEnv};
+use reth_evm::{ConfigureEvm, Evm, EvmEnv};
 use reth_primitives_traits::Recovered;
 use reth_rpc_api::MevSimApiServer;
-use reth_rpc_eth_api::helpers::{block::LoadBlock, Call, EthTransactions};
+use reth_rpc_eth_api::{
+    helpers::{block::LoadBlock, Call, EthTransactions},
+    FromEvmError,
+};
 use reth_rpc_eth_types::{
     cache::db::apply_block_overrides, utils::recover_raw_transaction, EthApiError,
 };
@@ -305,7 +308,7 @@ where
 
                 let initial_coinbase_balance = db
                     .get_account(&coinbase)
-                    .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))?
+                    .map_err(|code| EthApiError::from(db.error(code)))?
                     .map(|acc| acc.balance)
                     .unwrap_or_default();
 
@@ -316,6 +319,7 @@ where
                 let mut flat_logs: Vec<Vec<Log>> = Vec::new();
 
                 let mut log_index = 0;
+                let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
 
                 for (tx_index, item) in flattened_bundle.iter().enumerate() {
                     // Check inclusion constraints
@@ -333,7 +337,8 @@ where
                     }
 
                     let tx_env = eth_api.evm_config().tx_env(item.tx.clone());
-                    let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
+                    let result_and_state =
+                        evm.transact(&tx_env).map_err(Eth::Error::from_evm_err)?;
                     let result = result_and_state.result;
                     let state = result_and_state.pending_state;
 
@@ -390,7 +395,7 @@ where
                     }
 
                     // Apply state changes
-                    db.commit_source(&state);
+                    evm.commit_state(&state);
                 }
 
                 let body_logs =

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -338,7 +338,7 @@ where
                 num.into(),
                 None,
                 TracingInspectorConfig::default_parity(),
-                |tx_info, ctx| {
+                |tx_info, mut ctx| {
                     Ok(ctx
                         .take_inspector()
                         .into_parity_builder()

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -102,15 +102,11 @@ where
         let config = TracingInspectorConfig::from_parity_config(&trace_request.trace_types);
         let overrides =
             EvmOverrides::new(trace_request.state_overrides, trace_request.block_overrides);
+        let mut inspector = TracingInspector::new(config);
         let this = self.clone();
         self.eth_api()
             .spawn_with_call_at(trace_request.call, at, overrides, move |db, evm_env, tx_env| {
-                let (inspector, res) = this.eth_api().inspect(
-                    &mut *db,
-                    evm_env,
-                    &tx_env,
-                    TracingInspector::new(config),
-                )?;
+                let res = this.eth_api().inspect(&mut *db, evm_env, &tx_env, &mut inspector)?;
                 let trace_res = inspector
                     .into_parity_builder()
                     .into_trace_results_with_state(&res, &trace_request.trace_types, &mut *db)
@@ -178,12 +174,8 @@ where
                         Default::default(),
                     )?;
                     let config = TracingInspectorConfig::from_parity_config(&trace_types);
-                    let (inspector, res) = eth_api.inspect(
-                        &mut db,
-                        evm_env,
-                        &tx_env,
-                        TracingInspector::new(config),
-                    )?;
+                    let mut inspector = TracingInspector::new(config);
+                    let res = eth_api.inspect(&mut db, evm_env, &tx_env, &mut inspector)?;
 
                     let trace_res = inspector
                         .into_parity_builder()
@@ -196,7 +188,7 @@ where
                     // need to apply the state changes of this call before executing the
                     // next call
                     if calls.peek().is_some() {
-                        db.commit_source(&res.state_changes)
+                        db.commit_source(&res.pending_state)
                     }
                 }
 
@@ -442,7 +434,7 @@ where
                                 Some(block.clone()),
                                 None,
                                 TracingInspectorConfig::default_parity(),
-                                move |tx_info, ctx| {
+                                move |tx_info, mut ctx| {
                                     // Keep the block replay permit inside the spawned replay task.
                                     let _block_replay_permit = &permit;
                                     let mut traces = ctx
@@ -524,7 +516,7 @@ where
                 block_id,
                 Some(block.clone()),
                 TracingInspectorConfig::default_parity(),
-                |tx_info, ctx| {
+                |tx_info, mut ctx| {
                     let traces = ctx
                         .take_inspector()
                         .into_parity_builder()
@@ -560,19 +552,17 @@ where
                 block_id,
                 None,
                 TracingInspectorConfig::from_parity_config(&trace_types),
-                move |tx_info, ctx| {
-                    let result = ctx.result;
-                    let db = ctx.db;
+                move |tx_info, mut ctx| {
                     let mut full_trace = ctx
-                        .inspector
+                        .take_inspector()
                         .into_parity_builder()
-                        .into_trace_results(&result.result, &trace_types);
+                        .into_trace_results(&ctx.result, &trace_types);
 
                     // If statediffs were requested, populate them with the account balance and
                     // nonce from pre-state
                     if let Some(ref mut state_diff) = full_trace.state_diff {
-                        populate_state_diff(state_diff, db, &result.state_changes)
-                            .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+                        populate_state_diff(state_diff, ctx.db, ctx.state)
+                            .map_err(|code| EthApiError::EvmCustom(ctx.db.error(code).to_string()))
                             .map_err(Eth::Error::from_eth_err)?;
                     }
 
@@ -640,7 +630,7 @@ where
                 block_id,
                 Some(block.clone()),
                 StorageInspector::default,
-                move |tx_info, ctx| {
+                move |tx_info, mut ctx| {
                     let unique_loads = ctx.inspector.unique_loads();
                     let warm_loads = ctx.inspector.warm_loads();
                     let trace = TransactionStorageAccess {

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -110,7 +110,7 @@ where
                 let trace_res = inspector
                     .into_parity_builder()
                     .into_trace_results_with_state(&res, &trace_request.trace_types, &mut *db)
-                    .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+                    .map_err(|code| EthApiError::from(db.error(code)))
                     .map_err(Eth::Error::from_eth_err)?;
                 Ok(trace_res)
             })
@@ -141,7 +141,7 @@ where
                     inspector
                         .into_parity_builder()
                         .into_trace_results_with_state(&res, &trace_types, &mut db)
-                        .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+                        .map_err(|code| EthApiError::from(db.error(code)))
                         .map_err(Eth::Error::from_eth_err)
                 },
             )
@@ -180,7 +180,7 @@ where
                     let trace_res = inspector
                         .into_parity_builder()
                         .into_trace_results_with_state(&res, &trace_types, &mut db)
-                        .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+                        .map_err(|code| EthApiError::from(db.error(code)))
                         .map_err(Eth::Error::from_eth_err)?;
 
                     results.push(trace_res);
@@ -209,7 +209,7 @@ where
                 let trace_res = inspector
                     .into_parity_builder()
                     .into_trace_results_with_state(&res, &trace_types, &mut db)
-                    .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
+                    .map_err(|code| EthApiError::from(db.error(code)))
                     .map_err(Eth::Error::from_eth_err)?;
                 Ok(trace_res)
             })
@@ -562,7 +562,7 @@ where
                     // nonce from pre-state
                     if let Some(ref mut state_diff) = full_trace.state_diff {
                         populate_state_diff(state_diff, ctx.db, ctx.state)
-                            .map_err(|code| EthApiError::EvmCustom(ctx.db.error(code).to_string()))
+                            .map_err(|code| EthApiError::from(ctx.db.error(code)))
                             .map_err(Eth::Error::from_eth_err)?;
                     }
 

--- a/examples/custom-inspector/Cargo.toml
+++ b/examples/custom-inspector/Cargo.toml
@@ -7,7 +7,9 @@ license.workspace = true
 
 [dependencies]
 reth-ethereum = { workspace = true, features = ["node", "evm", "pool", "cli"] }
+alloy-rpc-types-eth.workspace = true
 clap = { workspace = true, features = ["derive"] }
 evm2.workspace = true
 futures-util.workspace = true
 alloy-primitives.workspace = true
+alloy-eips.workspace = true

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -10,21 +10,20 @@
 
 #![warn(unused_crate_dependencies)]
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::Address;
+use alloy_rpc_types_eth::{state::EvmOverrides, TransactionRequest};
 use clap::Parser;
 use evm2::{
-    evm::{CacheDB, Db},
     interpreter::{opcode::OpCode, Interpreter},
     BaseEvmTypes, Inspector,
 };
 use futures_util::StreamExt;
 use reth_ethereum::{
     cli::{chainspec::EthereumChainSpecParser, interface::Cli},
-    evm::primitives::{database::StateProviderDatabase, ConfigureEvm},
     node::{builder::NodeHandle, EthereumNode},
     pool::TransactionPool,
-    rpc::api::eth::helpers::Trace,
-    storage::{BlockReaderIdExt, StateProviderFactory},
+    rpc::api::eth::helpers::{Call, Trace},
 };
 
 fn main() {
@@ -52,36 +51,23 @@ fn main() {
                     if let Some(recipient) = tx.to() &&
                         args.is_match(&recipient)
                     {
-                        let Some(header) = (match node.provider.latest_header() {
-                            Ok(header) => header,
-                            Err(err) => {
-                                eprintln!("failed to load latest header: {err}");
-                                continue;
-                            }
-                        }) else {
-                            eprintln!("latest header is unavailable");
-                            continue;
-                        };
+                        let call_request =
+                            TransactionRequest::from_recovered_transaction(tx.to_consensus());
+                        let inspect_api = eth_api.clone();
+                        let result = eth_api
+                            .spawn_with_call_at(
+                                call_request,
+                                BlockNumberOrTag::Latest.into(),
+                                EvmOverrides::default(),
+                                move |db, evm_env, tx_env| {
+                                    let mut inspector = DummyInspector::default();
+                                    inspect_api.inspect(db, evm_env, &tx_env, &mut inspector)?;
+                                    Ok(inspector)
+                                },
+                            )
+                            .await;
 
-                        let state = match node.provider.latest() {
-                            Ok(state) => state,
-                            Err(err) => {
-                                eprintln!("failed to load latest state: {err}");
-                                continue;
-                            }
-                        };
-
-                        let evm_env = match node.evm_config.evm_env(header.header()) {
-                            Ok(env) => env,
-                            Err(err) => match err {},
-                        };
-                        let tx_env = node.evm_config.tx_env(tx.to_consensus());
-
-                        let mut db = CacheDB::new(Db::new(StateProviderDatabase::new(state)));
-                        let mut inspector = DummyInspector::default();
-                        let result = eth_api.inspect(&mut db, evm_env, &tx_env, &mut inspector);
-
-                        if result.is_ok() {
+                        if let Ok(inspector) = result {
                             let hash = tx.hash();
                             println!(
                                 "Inspector result for transaction {}:\n{}",
@@ -121,7 +107,8 @@ struct DummyInspector {
 
 impl Inspector<BaseEvmTypes> for DummyInspector {
     fn step(&mut self, interp: &mut Interpreter<'_, '_, BaseEvmTypes>) {
-        let opcode = OpCode::new_or_unknown(interp.opcode());
-        self.ret_val.push(format!("{}: {}", interp.pc(), opcode));
+        if let Some(opcode) = OpCode::new(interp.opcode()) {
+            self.ret_val.push(format!("{}: {}", interp.pc(), opcode));
+        }
     }
 }

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -78,10 +78,10 @@ fn main() {
                         let tx_env = node.evm_config.tx_env(tx.to_consensus());
 
                         let mut db = CacheDB::new(Db::new(StateProviderDatabase::new(state)));
-                        let result =
-                            eth_api.inspect(&mut db, evm_env, &tx_env, DummyInspector::default());
+                        let mut inspector = DummyInspector::default();
+                        let result = eth_api.inspect(&mut db, evm_env, &tx_env, &mut inspector);
 
-                        if let Ok((inspector, _)) = result {
+                        if result.is_ok() {
                             let hash = tx.hash();
                             println!(
                                 "Inspector result for transaction {}:\n{}",

--- a/examples/custom-inspector/src/main.rs
+++ b/examples/custom-inspector/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
             // get an instance of the `eth_` API handler
             let eth_api = node.rpc_registry.eth_api().clone();
 
-            println!("Spawning inspect task!");
+            println!("Spawning trace task!");
 
             // Spawn an async block to listen for transactions.
             node.task_executor.spawn_task(async move {
@@ -51,6 +51,7 @@ fn main() {
                     if let Some(recipient) = tx.to() &&
                         args.is_match(&recipient)
                     {
+                        // convert the pool transaction
                         let call_request =
                             TransactionRequest::from_recovered_transaction(tx.to_consensus());
                         let inspect_api = eth_api.clone();
@@ -60,19 +61,26 @@ fn main() {
                                 BlockNumberOrTag::Latest.into(),
                                 EvmOverrides::default(),
                                 move |db, evm_env, tx_env| {
-                                    let mut inspector = DummyInspector::default();
-                                    inspect_api.inspect(db, evm_env, &tx_env, &mut inspector)?;
-                                    Ok(inspector)
+                                    let mut dummy_inspector = DummyInspector::default();
+                                    // execute the transaction on a blocking task and await the
+                                    // inspector result
+                                    inspect_api.inspect(
+                                        db,
+                                        evm_env,
+                                        &tx_env,
+                                        &mut dummy_inspector,
+                                    )?;
+                                    Ok(dummy_inspector)
                                 },
                             )
                             .await;
 
-                        if let Ok(inspector) = result {
+                        if let Ok(ret_val) = result {
                             let hash = tx.hash();
                             println!(
-                                "Inspector result for transaction {}:\n{}",
+                                "Inspector result for transaction {}: \n {}",
                                 hash,
-                                inspector.ret_val.join("\n")
+                                ret_val.ret_val.join("\n")
                             );
                         }
                     }
@@ -99,13 +107,17 @@ impl RethCliTxpoolExt {
     }
 }
 
-/// A dummy inspector that logs the opcodes and their corresponding program counter.
+/// A dummy inspector that logs the opcodes and their corresponding program counter for a
+/// transaction
 #[derive(Default, Debug, Clone)]
 struct DummyInspector {
     ret_val: Vec<String>,
 }
 
 impl Inspector<BaseEvmTypes> for DummyInspector {
+    /// This method is called at each step of the EVM execution.
+    /// It checks if the current opcode is valid and if so, it stores the opcode and its
+    /// corresponding program counter in the `ret_val` vector.
     fn step(&mut self, interp: &mut Interpreter<'_, '_, BaseEvmTypes>) {
         if let Some(opcode) = OpCode::new(interp.opcode()) {
             self.ret_val.push(format!("{}: {}", interp.pc(), opcode));


### PR DESCRIPTION
Restores the generic RPC execution, tracing, override, precompile, and error paths from main while using evm2. It preserves accumulated state across replay and multi-block simulation, retains typed provider errors, and pins the companion evm2 APIs from https://github.com/alloy-rs/evm2/pull/308.

# Per-file diff stats

Files are selected from `origin/codex/excise-revm...HEAD`. Each line shows `origin/main...origin/codex/excise-revm` -> `origin/main...HEAD`.

## Full diff vs main

- 🔴 `221 files, +16211 / -12763` -> `221 files, +16718 / -12711`
- Difference: `+0 files`, `+507 insertions`, `-52 deletions`, and `+455 total changed lines`

🟢 means the total changed-line count went down, 🔴 means it went up, and ⚪ means it stayed equal.

- 🟢 `Cargo.lock` — `+1091 / -1229` -> `+1091 / -1227`
- ⚪ `Cargo.toml` — `+14 / -12` -> `+14 / -12`
- 🟢 `bin/reth-bb/src/evm_config.rs` — `+120 / -243` -> `+108 / -247`
- 🔴 `crates/engine/execution-cache/src/cached_state.rs` — `+160 / -195` -> `+162 / -195`
- 🔴 `crates/ethereum/evm/src/execution.rs` — `+1943 / -0` -> `+1944 / -0`
- 🔴 `crates/ethereum/evm/src/executor.rs` — `+1143 / -0` -> `+1153 / -0`
- 🟢 `crates/ethereum/evm/src/lib.rs` — `+507 / -338` -> `+459 / -338`
- 🔴 `crates/ethereum/node/tests/e2e/rpc.rs` — `+3 / -1` -> `+4 / -1`
- ⚪ `crates/evm/evm/src/database.rs` — `+143 / -0` -> `+143 / -0`
- 🔴 `crates/evm/evm/src/execute.rs` — `+1152 / -467` -> `+1163 / -465`
- 🟢 `crates/evm/evm/src/lib.rs` — `+320 / -373` -> `+307 / -376`
- 🔴 `crates/evm/evm/src/precompile_cache.rs` — `+382 / -0` -> `+406 / -0`
- 🔴 `crates/evm/execution-types/src/execute.rs` — `+272 / -10` -> `+280 / -10`
- 🔴 `crates/evm/execution-types/src/execution_outcome.rs` — `+609 / -266` -> `+960 / -269`
- 🔴 `crates/evm/execution-types/src/state.rs` — `+756 / -0` -> `+814 / -0`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/call.rs` — `+176 / -121` -> `+160 / -112`
- 🟢 `crates/rpc/rpc-eth-api/src/helpers/estimate.rs` — `+101 / -159` -> `+98 / -155`
- 🔴 `crates/rpc/rpc-eth-api/src/helpers/trace.rs` — `+143 / -221` -> `+170 / -212`
- 🔴 `crates/rpc/rpc-eth-types/src/cache/db.rs` — `+113 / -7` -> `+131 / -7`
- 🔴 `crates/rpc/rpc-eth-types/src/error/mod.rs` — `+126 / -178` -> `+247 / -179`
- 🔴 `crates/rpc/rpc-eth-types/src/simulate.rs` — `+145 / -89` -> `+166 / -92`
- 🟢 `crates/rpc/rpc/src/debug.rs` — `+147 / -102` -> `+142 / -89`
- 🟢 `crates/rpc/rpc/src/eth/bundle.rs` — `+34 / -32` -> `+31 / -33`
- 🟢 `crates/rpc/rpc/src/eth/sim_bundle.rs` — `+24 / -23` -> `+25 / -21`
- 🟢 `crates/rpc/rpc/src/otterscan.rs` — `+7 / -9` -> `+6 / -8`
- 🟢 `crates/rpc/rpc/src/trace.rs` — `+69 / -32` -> `+51 / -24`
- 🟢 `examples/custom-inspector/Cargo.toml` — `+1 / -3` -> `+1 / -1`
- 🟢 `examples/custom-inspector/src/main.rs` — `+50 / -63` -> `+22 / -48`