### PR TITLE
refactor(evm): generalize block executor transaction types

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -387,7 +387,7 @@ mod tests {
         executor.apply_pre_execution_changes().expect("serial pre-exec");
         for (index, tx) in txs.iter().cloned().enumerate() {
             executor
-                .execute_transaction(tx.into())
+                .execute_transaction(tx)
                 .unwrap_or_else(|err| panic!("serial tx {index} failed: {err:?}"));
         }
         let (output, bal) = executor.finish_with_block_access_list().expect("serial post-exec");

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -81,10 +81,9 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 };
                 let tx = tx.map_err(|err| BalWorkerError::Transaction(Box::new(err)))?;
                 let signer = *tx.signer();
-                let (tx_env, _) = tx.into_parts();
                 executor.set_block_access_index(BlockAccessIndex::new(index as u64 + 1));
                 let result = executor
-                    .execute_transaction_without_commit(tx_env)
+                    .execute_transaction_without_commit(tx)
                     .map_err(BalWorkerError::Execution)?;
 
                 if result_tx.send(Ok(BalWorkerOutput { index, signer, result })).is_err() {

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -12,7 +12,7 @@ use prewarm::PrewarmMetrics;
 use rayon::prelude::*;
 use reth_evm::{
     ConfigureEvm, ConvertTx, ExecutableTxFor, ExecutableTxIterator, ExecutableTxParts,
-    ExecutableTxTuple, TxFor, WithTxEnv,
+    ExecutableTxTuple, TxEnvFor, WithTxEnv,
 };
 use reth_execution_types::EvmState;
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
@@ -45,7 +45,7 @@ pub mod receipt_root_task;
 pub const SMALL_BLOCK_TX_THRESHOLD: usize = 5;
 
 /// Type alias for [`PayloadHandle`] returned by payload processor spawn methods.
-type IteratorTx<Evm, I> = RecoveredTx<TxFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
+type IteratorTx<Evm, I> = RecoveredTx<TxEnvFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
 
 type IteratorPayloadHandle<Evm, I> = PayloadHandle<
     IteratorTx<Evm, I>,
@@ -54,10 +54,10 @@ type IteratorPayloadHandle<Evm, I> = PayloadHandle<
 >;
 
 type IteratorPrewarmTxReceiver<Evm, I> =
-    PrewarmTxReceiver<TxFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
+    PrewarmTxReceiver<TxEnvFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
 
 type IteratorExecuteTxReceiver<Evm, I> = ExecuteTxReceiver<
-    TxFor<Evm>,
+    TxEnvFor<Evm>,
     <I as ExecutableTxIterator<Evm>>::Recovered,
     <I as ExecutableTxTuple>::Error,
 >;

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -131,8 +131,8 @@ use reth_engine_primitives::{
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
-    database::StateProviderDatabase, BlockExecutor, BlockExecutorFactory, ConfigureEvm, EvmEnvFor,
-    ExecutableTxFor, ExecutionCtxFor, RecoveredTx, TxFor,
+    database::StateProviderDatabase, BlockExecutor, BlockExecutorFactory, BlockExecutorFor,
+    ConfigureEvm, EvmEnvFor, ExecutableTxFor, ExecutionCtxFor,
 };
 use reth_execution_cache::{CacheFillMode, CacheStats, SavedCache};
 use reth_payload_primitives::{
@@ -1131,9 +1131,9 @@ where
     /// - Executing each transaction with timing metrics
     /// - Streaming receipts to the receipt root computation task
     /// - Collecting transaction senders for later use
-    fn execute_transactions<Tx, Err, Executor>(
+    fn execute_transactions<Tx, Err>(
         &self,
-        executor: &mut Executor,
+        executor: &mut BlockExecutorFor<'_, Evm>,
         transaction_count: usize,
         transactions: impl Iterator<Item = Result<Tx, Err>>,
         receipt_tx: &ReceiptRootSender<N>,
@@ -1142,7 +1142,6 @@ where
     where
         Tx: ExecutableTxFor<Evm>,
         Err: core::error::Error + Send + Sync + 'static,
-        Executor: BlockExecutor<Primitives = N, Transaction = TxFor<Evm>>,
     {
         let pre_exec_start = Instant::now();
         debug_span!(target: "engine::tree", "pre_execution").in_scope(|| {
@@ -1159,7 +1158,6 @@ where
             let Some(tx_result) = transactions.next() else { break };
             self.metrics.record_transaction_wait(wait_start.elapsed());
             let tx = tx_result.map_err(BlockExecutionError::other)?;
-            let (tx_env, tx) = tx.into_parts();
             senders.push(*tx.signer());
 
             let _enter = tracing::enabled!(target: "engine::tree", Level::TRACE).then(|| {
@@ -1175,7 +1173,7 @@ where
             }
 
             let tx_start = Instant::now();
-            executor.execute_transaction(tx_env).map_err(BlockExecutionError::other)?;
+            executor.execute_transaction(tx).map_err(BlockExecutionError::other)?;
             self.metrics.record_transaction_execution(tx_start.elapsed());
             executed_tx_index.store(senders.len(), Ordering::Relaxed);
 

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -6,12 +6,11 @@ use alloy_consensus::{
 use alloy_eips::{eip4895::Withdrawals, merge::BEACON_NONCE};
 use alloy_primitives::{Bloom, B256};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_ethereum_primitives::{Receipt, TransactionSigned};
 #[cfg(feature = "std")]
 use reth_evm::BlockAssembler;
 use reth_evm::{BlockAssemblerInput, BlockExecutionError, BlockExecutorFactory};
 use reth_execution_types::BlockExecutionResult;
-use reth_primitives_traits::logs_bloom as calculate_logs_bloom;
+use reth_primitives_traits::{logs_bloom as calculate_logs_bloom, Receipt, SignedTransaction};
 
 use crate::{EthBlockEnv, EthBlockExecutionCtx, EthEvmEnvLike};
 
@@ -44,12 +43,12 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBlockAssembler<ChainSpec> {
         transactions_root: Option<B256>,
         receipts_root: Option<B256>,
         logs_bloom: Option<Bloom>,
-    ) -> Result<Block<TransactionSigned>, BlockExecutionError>
+    ) -> Result<Block<F::Transaction>, BlockExecutionError>
     where
         F: for<'a> BlockExecutorFactory<
-                Transaction = TransactionSigned,
-                Receipt = Receipt,
                 ExecutionCtx<'a> = EthBlockExecutionCtx<'a>,
+                Transaction: SignedTransaction,
+                Receipt: Receipt,
             > + 'static,
         F::EvmEnv: EthEvmEnvLike,
     {
@@ -141,14 +140,14 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBlockAssembler<ChainSpec> {
 impl<F, ChainSpec> BlockAssembler<F> for EthBlockAssembler<ChainSpec>
 where
     F: for<'a> BlockExecutorFactory<
-            Transaction = TransactionSigned,
-            Receipt = Receipt,
+            Transaction: SignedTransaction,
+            Receipt: Receipt,
             ExecutionCtx<'a> = EthBlockExecutionCtx<'a>,
         > + 'static,
     F::EvmEnv: EthEvmEnvLike,
-    ChainSpec: EthChainSpec<Header = Header> + EthereumHardforks + 'static,
+    ChainSpec: EthChainSpec + EthereumHardforks + 'static,
 {
-    type Block = Block<TransactionSigned>;
+    type Block = Block<F::Transaction>;
 
     fn assemble_block(
         &self,

--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{
 use alloy_eips::{eip4895::Withdrawals, merge::BEACON_NONCE};
 use alloy_primitives::{Bloom, B256};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
-use reth_ethereum_primitives::TransactionSigned;
+use reth_ethereum_primitives::{Receipt, TransactionSigned};
 #[cfg(feature = "std")]
 use reth_evm::BlockAssembler;
 use reth_evm::{BlockAssemblerInput, BlockExecutionError, BlockExecutorFactory};
@@ -47,7 +47,8 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBlockAssembler<ChainSpec> {
     ) -> Result<Block<TransactionSigned>, BlockExecutionError>
     where
         F: for<'a> BlockExecutorFactory<
-                Primitives = crate::EthPrimitives,
+                Transaction = TransactionSigned,
+                Receipt = Receipt,
                 ExecutionCtx<'a> = EthBlockExecutionCtx<'a>,
             > + 'static,
         F::EvmEnv: EthEvmEnvLike,
@@ -140,7 +141,8 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBlockAssembler<ChainSpec> {
 impl<F, ChainSpec> BlockAssembler<F> for EthBlockAssembler<ChainSpec>
 where
     F: for<'a> BlockExecutorFactory<
-            Primitives = crate::EthPrimitives,
+            Transaction = TransactionSigned,
+            Receipt = Receipt,
             ExecutionCtx<'a> = EthBlockExecutionCtx<'a>,
         > + 'static,
     F::EvmEnv: EthEvmEnvLike,

--- a/crates/ethereum/evm/src/convert.rs
+++ b/crates/ethereum/evm/src/convert.rs
@@ -174,11 +174,11 @@ impl RecoveredTx<TransactionSigned> for ExecutableRecoveredTx {
     }
 }
 
-impl ExecutableTxParts<EthTxEnv, TransactionSigned> for ExecutableRecoveredTx {
+impl ExecutableTxParts<RecoveredTxEnvelope, TransactionSigned> for ExecutableRecoveredTx {
     type Recovered = Recovered<TransactionSigned>;
 
-    fn into_parts(self) -> (EthTxEnv, Self::Recovered) {
-        (self.tx_env, self.tx)
+    fn into_parts(self) -> (RecoveredTxEnvelope, Self::Recovered) {
+        (self.tx_env.into_envelope(), self.tx)
     }
 }
 

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -8,7 +8,7 @@ use crate::{
         transaction_blob_gas_used, BlockExecutionContext, BlockSystemCalls, EthExecutionError,
     },
     factory::{EthBlockExecutorFactory, EvmFactory},
-    EthBlockExecutionCtx, EthEvmEnv, EthTxEnv, RethReceiptBuilder,
+    EthBlockExecutionCtx, EthEvmEnv, RethReceiptBuilder,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Transaction, TxType};
@@ -22,10 +22,10 @@ use evm2::{
     BaseEvmTypes, Evm, EvmTypes, TxResult, TxResultWithState,
 };
 use reth_ethereum_forks::EthereumHardforks;
-use reth_ethereum_primitives::{EthPrimitives, Receipt};
+use reth_ethereum_primitives::{Receipt, TransactionSigned};
 use reth_evm::{
     BlockExecutionError, BlockExecutionOutput, BlockExecutor, BlockTransactionResult,
-    BlockValidationError, GasOutput, ReceiptBuilder, ReceiptBuilderCtx,
+    BlockValidationError, ExecutorTx, GasOutput, ReceiptBuilder, ReceiptBuilderCtx, RecoveredTx,
 };
 use reth_trie_common::HashedPostState;
 
@@ -166,9 +166,9 @@ where
     T::Tx: Typed2718,
     T::TxResultExt: Send,
 {
-    type Primitives = EthPrimitives;
+    type Transaction = TransactionSigned;
+    type Receipt = Receipt;
     type Evm = Evm<'a, T>;
-    type Transaction = EthTxEnv;
     type TransactionResultWithState = EthTransactionResultWithState<T>;
     type BlockAccessList = Bal;
 
@@ -238,10 +238,10 @@ where
 
     fn execute_transaction_without_commit(
         &mut self,
-        transaction: Self::Transaction,
+        transaction: impl ExecutorTx<Self>,
     ) -> Result<Self::TransactionResultWithState, BlockExecutionError> {
-        let tx_hash = transaction.tx_hash();
-        let transaction = transaction.into_envelope();
+        let (transaction, tx) = transaction.into_parts();
+        let tx_hash = *tx.tx().tx_hash();
         self.set_transaction_block_access_index();
         let transaction_gas_limit = transaction.gas_limit();
         let block_gas_limit = self.evm.block_env().gas_limit.to::<u64>();
@@ -712,9 +712,9 @@ where
     <F::Types as evm2::EvmTypesHost>::Tx: Typed2718,
     <F::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {
-    type Primitives = EthPrimitives;
+    type Transaction = TransactionSigned;
+    type Receipt = Receipt;
     type Evm = Evm<'a, F::Types>;
-    type Transaction = EthTxEnv;
     type TransactionResultWithState = EthTransactionResultWithState<F::Types>;
     type BlockAccessList = Bal;
 
@@ -788,7 +788,7 @@ where
 
     fn execute_transaction_without_commit(
         &mut self,
-        transaction: Self::Transaction,
+        transaction: impl ExecutorTx<Self>,
     ) -> Result<Self::TransactionResultWithState, BlockExecutionError> {
         self.initialize()?;
         self.inner.execute_transaction_without_commit(transaction)
@@ -951,7 +951,7 @@ mod tests {
         }
     }
 
-    fn transfer(from: Address, to: Address, nonce: u64) -> super::EthTxEnv {
+    fn transfer(from: Address, to: Address, nonce: u64) -> Recovered<TransactionSigned> {
         let tx = TransactionSigned::Legacy(
             TxLegacy {
                 chain_id: Some(1),
@@ -964,7 +964,7 @@ mod tests {
             }
             .into_signed(Signature::test_signature()),
         );
-        Recovered::new_unchecked(tx, from).into()
+        Recovered::new_unchecked(tx, from)
     }
 
     #[test]

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -17,8 +17,9 @@ pub use evm2_jit::{
 
 use crate::{
     executor::{EthBigBlockExecutor, EthBigBlockPlan, HashedStateMode},
-    EthBlockExecutionCtx, EthBlockExecutor, EthEvmEnv, EthPrimitives, EthTxEnv,
+    EthBlockExecutionCtx, EthBlockExecutor, EthEvmEnv,
 };
+use reth_ethereum_primitives::{Receipt, TransactionSigned};
 
 /// Factory used to construct an evm2-backed EVM.
 ///
@@ -158,11 +159,10 @@ where
     C: EthChainSpec<Header = Header> + EthereumHardforks,
     F: EvmFactory,
 {
-    type Primitives = EthPrimitives;
     type EvmFactory = F;
     type EvmTypes = F::Types;
-    type EvmTransaction = evm2::ethereum::TxEnvelope;
-    type Transaction = EthTxEnv;
+    type Transaction = TransactionSigned;
+    type Receipt = Receipt;
     type Evm<'a> = evm2::Evm<'a, F::Types>;
     type EvmEnv = EthEvmEnv<F::Types>;
     type ExecutionCtx<'a>
@@ -358,11 +358,10 @@ where
     C: EthChainSpec<Header = Header> + EthereumHardforks,
     F: EvmFactory,
 {
-    type Primitives = EthPrimitives;
     type EvmFactory = F;
     type EvmTypes = F::Types;
-    type EvmTransaction = evm2::ethereum::TxEnvelope;
-    type Transaction = EthTxEnv;
+    type Transaction = TransactionSigned;
+    type Receipt = Receipt;
     type Evm<'a> = evm2::Evm<'a, F::Types>;
     type EvmEnv = EthEvmEnv<F::Types>;
     type ExecutionCtx<'a>

--- a/crates/evm/evm/src/aliases.rs
+++ b/crates/evm/evm/src/aliases.rs
@@ -24,11 +24,9 @@ pub type EvmTypesFor<Evm> =
 pub type TxResultWithStateFor<Evm> = evm2::TxResultWithState<EvmTypesFor<Evm>>;
 
 /// Type alias for the configured transaction environment.
-pub type TxEnvFor<Evm> = Recovered<
-    <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::EvmTransaction,
->;
+pub type TxEnvFor<Evm> = Recovered<<EvmTypesFor<Evm> as evm2::EvmTypesHost>::Tx>;
 
-/// Type alias for the transaction consumed by the configured block executor.
+/// Type alias for the consensus transaction consumed by the configured block executor.
 pub type TxFor<Evm> =
     <<Evm as ConfigureEvm>::BlockExecutorFactory as BlockExecutorFactory>::Transaction;
 

--- a/crates/evm/evm/src/engine.rs
+++ b/crates/evm/evm/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::{
     execute::{ExecutableTxFor, ExecutableTxParts, RecoveredTx},
-    ConfigureEvm, EvmEnvFor, ExecutionCtxFor, TxFor,
+    ConfigureEvm, EvmEnvFor, ExecutionCtxFor, TxEnvFor,
 };
 use alloy_consensus::transaction::Either;
 use rayon::prelude::*;
@@ -136,7 +136,7 @@ impl<T, Evm: ConfigureEvm> ExecutableTxIterator<Evm> for T
 where
     T: ExecutableTxTuple<Tx: ExecutableTxFor<Evm, Recovered: Send + Sync>>,
 {
-    type Recovered = <T::Tx as ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>>>::Recovered;
+    type Recovered = <T::Tx as ExecutableTxParts<TxEnvFor<Evm>, TxTy<Evm::Primitives>>>::Recovered;
 }
 
 /// Wraps `Either<L, R>` to implement both [`IntoParallelIterator`] and [`IntoIterator`],

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -1,6 +1,6 @@
 //! Traits for execution.
 
-use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxFor};
+use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxEnvFor};
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
     transaction::{Either, Recovered, Transaction as AlloyTransaction},
@@ -323,12 +323,12 @@ fn resolve_transaction<T: evm2::EvmTypes>(
 
 /// A configured block executor.
 pub trait BlockExecutor: Sized {
-    /// The primitive types used by the executor.
-    type Primitives: NodePrimitives;
+    /// Consensus transaction type executed by this executor.
+    type Transaction;
+    /// Receipt type produced by this executor.
+    type Receipt;
     /// EVM instance used by this executor.
     type Evm: Evm;
-    /// Transaction environment consumed by this executor.
-    type Transaction: FromTxWithEncoded<TxTy<Self::Primitives>>;
     /// Owned transaction execution result and detached state changes.
     type TransactionResultWithState: BlockTransactionResult<<Self::Evm as Evm>::EvmTypes> + Send;
     /// EVM-native block access list used for indexed reads.
@@ -371,7 +371,7 @@ pub trait BlockExecutor: Sized {
     /// changes when `f` returns [`CommitChanges::Yes`].
     fn execute_transaction_with_commit_condition(
         &mut self,
-        transaction: Self::Transaction,
+        transaction: impl ExecutorTx<Self>,
         f: impl FnOnce(&Self::TransactionResultWithState) -> CommitChanges,
     ) -> Result<Option<GasOutput>, BlockExecutionError> {
         let output = self.execute_transaction_without_commit(transaction)?;
@@ -385,7 +385,7 @@ pub trait BlockExecutor: Sized {
     /// Executes a transaction and detaches its state changes without committing them.
     fn execute_transaction_without_commit(
         &mut self,
-        transaction: Self::Transaction,
+        transaction: impl ExecutorTx<Self>,
     ) -> Result<Self::TransactionResultWithState, BlockExecutionError>;
 
     /// Commits detached transaction state and records its receipt and gas accounting.
@@ -398,7 +398,7 @@ pub trait BlockExecutor: Sized {
     /// changes.
     fn execute_transaction_with_result_closure(
         &mut self,
-        transaction: Self::Transaction,
+        transaction: impl ExecutorTx<Self>,
         f: impl FnOnce(&Self::TransactionResultWithState),
     ) -> Result<GasOutput, BlockExecutionError> {
         self.execute_transaction_with_commit_condition(transaction, |result| {
@@ -411,45 +411,40 @@ pub trait BlockExecutor: Sized {
     /// Executes a transaction and commits changes.
     fn execute_transaction(
         &mut self,
-        transaction: Self::Transaction,
+        transaction: impl ExecutorTx<Self>,
     ) -> Result<GasOutput, BlockExecutionError> {
         self.execute_transaction_with_result_closure(transaction, |_| {})
     }
 
     /// Returns receipts accumulated so far.
-    fn receipts(&self) -> &[ReceiptTy<Self::Primitives>];
+    fn receipts(&self) -> &[Self::Receipt];
 
     /// Finishes block execution and returns the output.
-    #[expect(clippy::type_complexity)]
     fn finish_with_block_access_list(
         self,
-    ) -> Result<
-        (BlockExecutionOutput<ReceiptTy<Self::Primitives>>, Option<BlockAccessList>),
-        BlockExecutionError,
-    >;
+    ) -> Result<(BlockExecutionOutput<Self::Receipt>, Option<BlockAccessList>), BlockExecutionError>;
 
     /// Finishes block execution and returns the output.
-    fn finish(
-        self,
-    ) -> Result<BlockExecutionOutput<ReceiptTy<Self::Primitives>>, BlockExecutionError> {
+    fn finish(self) -> Result<BlockExecutionOutput<Self::Receipt>, BlockExecutionError> {
         self.finish_with_block_access_list().map(|(output, _)| output)
     }
 }
 
 /// A type that creates configured block executors.
 pub trait BlockExecutorFactory {
-    /// The primitive types used by the factory.
-    type Primitives: NodePrimitives;
     /// Additional EVM factory configuration owned by this executor factory.
     type EvmFactory;
-    /// Transaction environment consumed by the configured EVM instance.
-    type EvmTypes: evm2::EvmTypes<Tx = Self::EvmTransaction, TxResultExt: Send>;
-    /// Transaction environment consumed by the configured EVM instance.
-    type EvmTransaction: AlloyTransaction;
-    /// Transaction environment consumed by executors from this factory.
+    /// Runtime EVM type family.
+    type EvmTypes: evm2::EvmTypes<Tx: AlloyTransaction + Clone, TxResultExt: Send>;
+    /// Consensus transaction type consumed by executors from this factory.
     type Transaction: Debug + Clone + Send + Sync + 'static;
+    /// Receipt type produced by executors from this factory.
+    type Receipt;
     /// EVM instance consumed by executors from this factory.
-    type Evm<'a>: Evm<EvmTypes = Self::EvmTypes, Transaction = Self::EvmTransaction>;
+    type Evm<'a>: Evm<
+        EvmTypes = Self::EvmTypes,
+        Transaction = <Self::EvmTypes as evm2::EvmTypesHost>::Tx,
+    >;
     /// EVM environment consumed by this factory.
     type EvmEnv: EvmEnv<EvmTypes = Self::EvmTypes>;
     /// Execution context for a block or payload.
@@ -458,9 +453,9 @@ pub trait BlockExecutorFactory {
         Self: 'a;
     /// Block executor returned by this factory.
     type Executor<'a>: BlockExecutor<
-        Primitives = Self::Primitives,
-        Evm = Self::Evm<'a>,
         Transaction = Self::Transaction,
+        Receipt = Self::Receipt,
+        Evm = Self::Evm<'a>,
     >
     where
         Self: 'a;
@@ -503,9 +498,9 @@ pub struct BlockAssemblerInput<'a, 'b, F: BlockExecutorFactory + 'a, H = Header>
     /// Parent block header.
     pub parent: &'a SealedHeader<H>,
     /// Transactions that were executed in this block.
-    pub transactions: Vec<TxTy<F::Primitives>>,
+    pub transactions: Vec<F::Transaction>,
     /// Output of block execution.
-    pub output: &'b BlockExecutionResult<ReceiptTy<F::Primitives>>,
+    pub output: &'b BlockExecutionResult<F::Receipt>,
     /// Execution state after block execution.
     pub execution_state: &'b EvmState,
     /// Provider with access to state.
@@ -523,8 +518,8 @@ impl<'a, 'b, F: BlockExecutorFactory + 'a, H> BlockAssemblerInput<'a, 'b, F, H> 
         evm_env: F::EvmEnv,
         execution_ctx: F::ExecutionCtx<'a>,
         parent: &'a SealedHeader<H>,
-        transactions: Vec<TxTy<F::Primitives>>,
-        output: &'b BlockExecutionResult<ReceiptTy<F::Primitives>>,
+        transactions: Vec<F::Transaction>,
+        output: &'b BlockExecutionResult<F::Receipt>,
         execution_state: &'b EvmState,
         state_provider: &'b dyn StateProvider,
         state_root: B256,
@@ -553,7 +548,7 @@ pub trait BlockAssembler<F: BlockExecutorFactory> {
     /// Builds a block. see [`BlockAssemblerInput`] documentation for more details.
     fn assemble_block(
         &self,
-        input: BlockAssemblerInput<'_, '_, F, HeaderTy<F::Primitives>>,
+        input: BlockAssemblerInput<'_, '_, F, <Self::Block as Block>::Header>,
     ) -> Result<Self::Block, BlockExecutionError>;
 }
 
@@ -579,7 +574,11 @@ pub trait BlockBuilder: Sized {
     /// The primitive types used by the inner [`BlockExecutor`].
     type Primitives: NodePrimitives;
     /// Inner block executor.
-    type Executor: BlockExecutor<Primitives = Self::Primitives>;
+    type Executor: BlockExecutor<
+        Transaction = TxTy<Self::Primitives>,
+        Receipt = ReceiptTy<Self::Primitives>,
+        Evm: Evm<Transaction: From<TxTy<Self::Primitives>>>,
+    >;
     /// EVM environment used for block execution.
     type EvmEnv: EvmEnv;
 
@@ -687,7 +686,7 @@ where
 
 impl<'a, F, Assembler, N> BasicBlockBuilder<'a, F, F::Executor<'a>, Assembler, N>
 where
-    F: BlockExecutorFactory<Primitives = N> + 'a,
+    F: BlockExecutorFactory<Transaction = TxTy<N>, Receipt = ReceiptTy<N>> + 'a,
     Assembler: BlockAssembler<F, Block = N::Block> + 'a,
     N: NodePrimitives,
 {
@@ -711,39 +710,32 @@ where
     }
 }
 
-/// Conversions for executable transactions consumed by a block executor.
-pub trait ExecutorTx<Executor: BlockExecutor> {
-    /// Recovered transaction accessor type.
-    type Recovered: RecoveredTx<TxTy<Executor::Primitives>>;
-
-    /// Converts the transaction into executor transaction input and recovered accessor.
-    fn into_parts(self) -> (Executor::Transaction, Self::Recovered);
+/// Executable transaction consumed by a block executor.
+pub trait ExecutorTx<Executor: BlockExecutor>:
+    ExecutableTxParts<Recovered<<Executor::Evm as Evm>::Transaction>, Executor::Transaction>
+{
 }
 
 impl<T, Executor> ExecutorTx<Executor> for T
 where
     Executor: BlockExecutor,
-    T: ExecutableTxParts<Executor::Transaction, TxTy<Executor::Primitives>>,
+    T: ExecutableTxParts<Recovered<<Executor::Evm as Evm>::Transaction>, Executor::Transaction>,
 {
-    type Recovered = T::Recovered;
-
-    fn into_parts(self) -> (Executor::Transaction, Self::Recovered) {
-        ExecutableTxParts::into_parts(self)
-    }
 }
 
 impl<'a, F, Executor, Assembler, N> BlockBuilder
     for BasicBlockBuilder<'a, F, Executor, Assembler, N>
 where
-    F: BlockExecutorFactory<Primitives = N>,
+    F: BlockExecutorFactory<Transaction = TxTy<N>, Receipt = ReceiptTy<N>>,
     Executor: BlockExecutor<
-        Primitives = N,
+        Transaction = TxTy<N>,
+        Receipt = ReceiptTy<N>,
         Evm: Evm<EvmTypes = F::EvmTypes>,
-        Transaction = F::Transaction,
     >,
     Assembler: BlockAssembler<F, Block = N::Block>,
     N: NodePrimitives,
     TxTy<N>: Clone,
+    <<Executor as BlockExecutor>::Evm as Evm>::Transaction: From<TxTy<N>>,
 {
     type Primitives = N;
     type Executor = Executor;
@@ -763,8 +755,11 @@ where
         f: impl FnOnce(&<Self::Executor as BlockExecutor>::TransactionResultWithState) -> CommitChanges,
     ) -> Result<Option<GasOutput>, BlockExecutionError> {
         let (tx_env, tx) = tx.into_parts();
-        if let Some(output) = self.executor.execute_transaction_with_commit_condition(tx_env, f)? {
-            self.transactions.push(tx.to_recovered());
+        let tx = tx.to_recovered();
+        if let Some(output) =
+            self.executor.execute_transaction_with_commit_condition((tx_env, &tx), f)?
+        {
+            self.transactions.push(tx);
             Ok(Some(output))
         } else {
             Ok(None)
@@ -1031,11 +1026,7 @@ where
 
         executor.apply_pre_execution_changes()?;
         for transaction in block.transactions_recovered() {
-            let (tx_env, _) =
-                <_ as ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>>>::into_parts(
-                    transaction,
-                );
-            executor.execute_transaction(tx_env)?;
+            executor.execute_transaction(transaction)?;
         }
         let (output, block_access_list) = executor.finish_with_block_access_list()?;
         Ok((output, block_access_list))
@@ -1341,6 +1332,8 @@ pub trait FromTxWithEncoded<T>: FromRecoveredTx<T> {
     }
 }
 
+impl<T, TxEnv> FromTxWithEncoded<T> for Recovered<TxEnv> where TxEnv: From<T> {}
+
 /// Converts transaction wrappers into the configured transaction environment.
 pub trait IntoTxEnv<TxEnv> {
     /// Converts this transaction wrapper into the configured transaction environment.
@@ -1398,6 +1391,17 @@ where
     }
 }
 
+impl<TxEnv, Tx, T> ExecutableTxParts<TxEnv, Tx> for (TxEnv, T)
+where
+    T: RecoveredTx<Tx>,
+{
+    type Recovered = T;
+
+    fn into_parts(self) -> (TxEnv, Self::Recovered) {
+        self
+    }
+}
+
 impl<L, R, TxEnv, T> ExecutableTxParts<TxEnv, T> for Either<L, R>
 where
     L: ExecutableTxParts<TxEnv, T>,
@@ -1422,12 +1426,12 @@ where
 /// A helper trait marking a type that can be converted into an [`ExecutableTxParts`] for block
 /// executor.
 pub trait ExecutableTxFor<Evm: ConfigureEvm>:
-    ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
+    ExecutableTxParts<TxEnvFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
 {
 }
 
 impl<T, Evm: ConfigureEvm> ExecutableTxFor<Evm> for T where
-    T: ExecutableTxParts<TxFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
+    T: ExecutableTxParts<TxEnvFor<Evm>, TxTy<Evm::Primitives>> + RecoveredTx<TxTy<Evm::Primitives>>
 {
 }
 

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -17,7 +17,9 @@ use alloc::string::String;
 use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::{Address, Bytes, B256};
 use core::{error::Error, fmt::Debug};
-use reth_primitives_traits::{BlockTy, HeaderTy, NodePrimitives, SealedBlock, SealedHeader, TxTy};
+use reth_primitives_traits::{
+    BlockTy, HeaderTy, NodePrimitives, ReceiptTy, SealedBlock, SealedHeader, TxTy,
+};
 
 pub use evm2::{
     debug_unreachable,
@@ -236,9 +238,9 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
 
     /// Configured block executor factory.
     type BlockExecutorFactory: crate::execute::BlockExecutorFactory<
-        Primitives = Self::Primitives,
-        EvmTransaction: From<TxTy<Self::Primitives>>,
-        Transaction: FromTxWithEncoded<TxTy<Self::Primitives>>,
+        Transaction = TxTy<Self::Primitives>,
+        Receipt = ReceiptTy<Self::Primitives>,
+        EvmTypes: evm2::EvmTypes<Tx: From<TxTy<Self::Primitives>>>,
     >;
 
     /// Configured block assembler.

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -4,10 +4,7 @@ use alloy_eip7928::{bal::DecodedBal, BlockAccessList};
 use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::BlockId;
 use reth_errors::RethError;
-use reth_evm::{
-    database::StateProviderDatabase, BlockExecutor, ConfigureEvm, ExecutableTxParts, TxFor,
-};
-use reth_primitives_traits::TxTy;
+use reth_evm::{database::StateProviderDatabase, BlockExecutor, ConfigureEvm};
 use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
 use reth_storage_api::StateProviderFactory;
 
@@ -50,11 +47,7 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock + RpcNodeCoreExt {
                 executor.enable_block_access_list_builder();
                 executor.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
                 for block_tx in block.transactions_recovered() {
-                    let (tx_env, _) = <_ as ExecutableTxParts<
-                        TxFor<Self::Evm>,
-                        TxTy<Self::Primitives>,
-                    >>::into_parts(block_tx);
-                    executor.execute_transaction(tx_env).map_err(Self::Error::from_eth_err)?;
+                    executor.execute_transaction(block_tx).map_err(Self::Error::from_eth_err)?;
                 }
                 let (_, bal) =
                     executor.finish_with_block_access_list().map_err(Self::Error::from_eth_err)?;


### PR DESCRIPTION
Makes BlockExecutor and BlockExecutorFactory generic over their consensus transaction and receipt types instead of coupling them to NodePrimitives. Executable transaction inputs retain both the EVM environment and recovered consensus transaction, while the redundant factory EvmTransaction type is projected from EvmTypes.

Checks: cargo +nightly fmt --all --check; cargo check for reth-evm, reth-evm-ethereum, reth-engine-tree, and reth-rpc-eth-api; focused all-features Clippy; 191 applicable focused tests passed (two inherited BAL gas-accounting failures excluded).