### PR TITLE
refactor(evm): generalize ethereum block executor types

### DIFF
--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -13,11 +13,11 @@ use alloc::{
     vec::Vec,
 };
 #[cfg(test)]
+use alloy_consensus::Transaction;
+#[cfg(test)]
 use alloy_consensus::TxType;
 use alloy_consensus::{
-    constants::ETH_TO_WEI,
-    transaction::{Recovered, Transaction},
-    BlockHeader, Header,
+    constants::ETH_TO_WEI, transaction::Recovered, BlockHeader, Header, TxReceipt,
 };
 use alloy_eips::{
     eip2718::Typed2718,
@@ -27,7 +27,7 @@ use alloy_eips::{
     eip7251::CONSOLIDATION_REQUEST_TYPE,
     eip7685::Requests,
 };
-use alloy_primitives::{map::AddressMap, Address, Bytes, B256, KECCAK256_EMPTY, U256};
+use alloy_primitives::{map::AddressMap, Address, Bytes, Log, B256, KECCAK256_EMPTY, U256};
 use alloy_sol_types::{sol, SolEvent};
 use core::{any::Any, convert::Infallible};
 #[cfg(test)]
@@ -36,7 +36,6 @@ use evm2::evm::Db;
 use evm2::Precompiles;
 use evm2::{
     bytecode::Bytecode as ExecutableBytecode,
-    ethereum::RecoveredTxEnvelope,
     evm::{
         AccountChange, AccountChangeRef, AccountInfo, BlockStateAccumulator, StateChangeSink,
         StateChangeSource, StateChanges, StorageChange, SystemTx, BEACON_ROOTS_ADDRESS,
@@ -49,20 +48,21 @@ use evm2::{
 #[cfg(test)]
 use evm2::{
     env::BlockEnv,
-    ethereum::ethereum_tx_registry,
+    ethereum::{ethereum_tx_registry, RecoveredTxEnvelope},
     evm::{precompile::PrecompileProvider, Database, DynDatabase},
     BaseEvmTypes, ExecutionConfig, Version,
 };
 use reth_ethereum_forks::EthereumHardforks;
+#[cfg(test)]
 use reth_ethereum_primitives::Receipt;
 #[cfg(test)]
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::{BlockExecutionError, BlockValidationError, EvmError, InvalidTxError};
 #[cfg(test)]
 use reth_evm::{ReceiptBuilder, ReceiptBuilderCtx};
-#[cfg(test)]
-use reth_execution_types::BlockExecutionOutput;
 use reth_execution_types::HashedPostStateSink;
+#[cfg(test)]
+use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_trie_common::{HashedPostState, KeccakKeyHasher};
 
 const DEPOSIT_BYTES_SIZE: usize = 48 + 32 + 8 + 96 + 8;
@@ -459,16 +459,17 @@ where
             context.withdrawals,
         )?;
 
-        let mut output = <RethReceiptBuilder as ReceiptBuilder<
-            TxType,
-            TxResult<BaseEvmTypes>,
-        >>::build_block_output(&RethReceiptBuilder, receipts, block_state, blob_gas_used);
-        output.result.requests = requests;
+        let gas_used = receipts.last().map_or(0, TxReceipt::cumulative_gas_used);
+        let output = BlockExecutionOutput::new(
+            BlockExecutionResult { receipts, requests, gas_used, blob_gas_used },
+            block_state,
+        );
 
         Ok(output)
     }
 }
 
+#[cfg(test)]
 pub(crate) fn transaction_blob_gas_used(transaction: &RecoveredTxEnvelope) -> u64 {
     transaction.as_eip4844().map(|tx| tx.blob_gas_used().unwrap_or_default()).unwrap_or_default()
 }
@@ -828,11 +829,14 @@ pub(crate) fn pre_execution_system_call_state_changes<T: EvmTypes>(
     Ok(())
 }
 
-pub(crate) fn block_requests_from_receipts(
+pub(crate) fn block_requests_from_receipts<R>(
     spec_id: SpecId,
     context: BlockExecutionContext<'_>,
-    receipts: &[Receipt],
-) -> Result<Requests, EthExecutionError> {
+    receipts: &[R],
+) -> Result<Requests, EthExecutionError>
+where
+    R: TxReceipt<Log = Log>,
+{
     let mut requests = Requests::default();
     if context.system_calls.is_none() || !spec_id.enables(SpecId::PRAGUE) {
         return Ok(requests)
@@ -847,13 +851,16 @@ pub(crate) fn block_requests_from_receipts(
     Ok(requests)
 }
 
-fn parse_deposit_requests_from_receipts(
+fn parse_deposit_requests_from_receipts<R>(
     deposit_contract_address: Address,
-    receipts: &[Receipt],
-) -> Result<Vec<u8>, EthExecutionError> {
+    receipts: &[R],
+) -> Result<Vec<u8>, EthExecutionError>
+where
+    R: TxReceipt<Log = Log>,
+{
     let mut out = Vec::new();
     for receipt in receipts {
-        for log in &receipt.logs {
+        for log in receipt.logs() {
             if log.address != deposit_contract_address ||
                 log.topics().first() != Some(&DepositEvent::SIGNATURE_HASH)
             {

--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -3,8 +3,6 @@
 #[cfg(test)]
 use crate::convert::recovered_tx_envelope;
 #[cfg(test)]
-use crate::executor::HashedStateMode;
-#[cfg(test)]
 use crate::RethReceiptBuilder;
 use alloc::{
     boxed::Box,
@@ -351,7 +349,7 @@ where
     ) -> Result<BlockExecutionOutput<Receipt>, EthExecutionError> {
         match self.execute_fallible_envelopes::<Infallible, Infallible, _, _, _, _>(
             transactions.into_iter().map(recovered_tx_envelope).map(Ok::<_, Infallible>),
-            ExecutionHooks::new(|_| {}, ignore_receipt, |_| {}, HashedStateMode::OutputOnly),
+            ExecutionHooks::new(|_| {}, ignore_receipt, |_| {}, false),
         ) {
             Ok(output) => Ok(output),
             Err(PayloadExecutionError::Execution(err)) => Err(err),
@@ -384,7 +382,7 @@ where
             mut on_transaction_executed,
             mut on_receipt,
             mut on_hashed_state_update,
-            hashed_state_mode,
+            stream_hashed_state,
         } = hooks;
 
         let block_beneficiary = block_env.beneficiary;
@@ -402,7 +400,7 @@ where
         pre_execution_system_call_state_changes(
             &mut evm,
             &mut block_state,
-            hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut on_hashed_state_update,
             spec_id,
             block_number,
@@ -420,7 +418,7 @@ where
             let outcome = execute_transaction(
                 &mut evm,
                 &mut block_state,
-                hashed_state_mode.stream(),
+                stream_hashed_state,
                 &mut on_hashed_state_update,
                 &transaction,
             )?;
@@ -440,7 +438,7 @@ where
         post_execution_system_call_state_changes(
             &mut evm,
             &mut block_state,
-            hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut on_hashed_state_update,
             spec_id,
             context,
@@ -450,7 +448,7 @@ where
         post_block_balance_state_changes(
             &mut evm,
             &mut block_state,
-            hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut on_hashed_state_update,
             base_block_reward_for_spec_id(spec_id),
             block_number,
@@ -480,7 +478,7 @@ pub(crate) struct ExecutionHooks<F, R, H> {
     on_transaction_executed: F,
     on_receipt: R,
     on_hashed_state_update: H,
-    hashed_state_mode: HashedStateMode,
+    stream_hashed_state: bool,
 }
 
 #[cfg(test)]
@@ -490,9 +488,9 @@ impl<F, R, H> ExecutionHooks<F, R, H> {
         on_transaction_executed: F,
         on_receipt: R,
         on_hashed_state_update: H,
-        hashed_state_mode: HashedStateMode,
+        stream_hashed_state: bool,
     ) -> Self {
-        Self { on_transaction_executed, on_receipt, on_hashed_state_update, hashed_state_mode }
+        Self { on_transaction_executed, on_receipt, on_hashed_state_update, stream_hashed_state }
     }
 }
 
@@ -1271,12 +1269,7 @@ mod tests {
         )
         .execute_fallible_envelopes::<TestTxError, Infallible, _, _, _, _>(
             [Ok(recovered_tx_envelope(transaction)), Err(TestTxError)],
-            ExecutionHooks::new(
-                |count| executed = count,
-                ignore_receipt,
-                |_| {},
-                HashedStateMode::OutputOnly,
-            ),
+            ExecutionHooks::new(|count| executed = count, ignore_receipt, |_| {}, false),
         );
 
         assert_eq!(executed, 1);
@@ -1316,7 +1309,7 @@ mod tests {
                     Ok::<(), Infallible>(())
                 },
                 |_| {},
-                HashedStateMode::OutputOnly,
+                false,
             ),
         )
         .expect("EVM execution succeeds");
@@ -1333,7 +1326,7 @@ mod tests {
     }
 
     #[test]
-    fn streams_hashed_state_without_output_hashed_state() {
+    fn hashed_state_hook_streams_updates() {
         let caller = address!("0000000000000000000000000000000000000001");
         let target = address!("0000000000000000000000000000000000001000");
         let mut database = TestDatabase::default();
@@ -1357,7 +1350,7 @@ mod tests {
                 |_| {},
                 ignore_receipt,
                 |update| streamed_updates.push(update),
-                HashedStateMode::StreamOnly,
+                true,
             ),
         )
         .expect("EVM execution succeeds");
@@ -1367,7 +1360,7 @@ mod tests {
     }
 
     #[test]
-    fn output_only_hashed_state_does_not_stream_updates() {
+    fn disabled_hashed_state_stream_does_not_emit_updates() {
         let caller = address!("0000000000000000000000000000000000000001");
         let target = address!("0000000000000000000000000000000000001000");
         let mut database = TestDatabase::default();
@@ -1391,7 +1384,7 @@ mod tests {
                 |_| {},
                 ignore_receipt,
                 |update| streamed_updates.push(update),
-                HashedStateMode::OutputOnly,
+                false,
             ),
         )
         .expect("EVM execution succeeds");

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -48,7 +48,6 @@ where
     base_block_reward: Option<u128>,
     deposit_contract_address: Option<Address>,
     block_state: BlockStateAccumulator,
-    hashed_state_mode: HashedStateMode,
     hashed_state_update_hook: HashedStateUpdateHook,
     receipts: Vec<R::Receipt>,
     cumulative_gas_used: u64,
@@ -77,22 +76,6 @@ impl<T: EvmTypes, TxType> BlockTransactionResult<T> for EthTransactionResultWith
 }
 
 type HashedStateUpdateHook = Option<Box<dyn FnMut(HashedPostState) + Send>>;
-
-/// Controls whether Ethereum execution streams trie-ready hashed post-state updates.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum HashedStateMode {
-    /// Do not stream hashed state updates.
-    OutputOnly,
-    /// Stream hashed state updates to the provided hook.
-    StreamOnly,
-}
-
-impl HashedStateMode {
-    /// Returns true if execution should stream hashed state updates.
-    pub(crate) const fn stream(self) -> bool {
-        matches!(self, Self::StreamOnly)
-    }
-}
 
 impl<'a, T, R> EthBlockExecutor<'a, T, R>
 where
@@ -126,7 +109,6 @@ where
                 .deposit_contract()
                 .map(|contract| contract.address),
             block_state: BlockStateAccumulator::new(),
-            hashed_state_mode: HashedStateMode::OutputOnly,
             hashed_state_update_hook: None,
             receipts: Vec::new(),
             cumulative_gas_used: 0,
@@ -187,10 +169,6 @@ where
     }
 
     fn set_state_hook(&mut self, hook: impl FnMut(HashedPostState) + Send + 'static) -> bool {
-        if self.hashed_state_mode == HashedStateMode::OutputOnly {
-            self.hashed_state_mode = HashedStateMode::StreamOnly;
-        }
-
         self.hashed_state_update_hook = Some(Box::new(hook));
         true
     }
@@ -230,10 +208,11 @@ where
             None,
         );
         let block_number = self.evm.block_env().number.to::<u64>();
+        let stream_hashed_state = self.hashed_state_update_hook.is_some();
         pre_execution_system_call_state_changes(
             &mut self.evm,
             &mut self.block_state,
-            self.hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut |state| emit_hashed_state(&mut self.hashed_state_update_hook, state),
             self.spec_id,
             block_number,
@@ -285,10 +264,11 @@ where
         output: Self::TransactionResultWithState,
     ) -> Result<GasOutput, BlockExecutionError> {
         let EthTransactionResultWithState { result, tx_type, blob_gas_used } = output;
+        let stream_hashed_state = self.hashed_state_update_hook.is_some();
         let outcome = commit_detached_transaction(
             &mut self.evm,
             &mut self.block_state,
-            self.hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut |state| emit_hashed_state(&mut self.hashed_state_update_hook, state),
             result,
         );
@@ -324,10 +304,11 @@ where
             None,
         );
         let mut requests = block_requests_from_receipts(self.spec_id, context, &self.receipts)?;
+        let stream_hashed_state = self.hashed_state_update_hook.is_some();
         post_execution_system_call_state_changes(
             &mut self.evm,
             &mut self.block_state,
-            self.hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut |state| emit_hashed_state(&mut self.hashed_state_update_hook, state),
             self.spec_id,
             context,
@@ -348,7 +329,7 @@ where
         post_block_balance_state_changes(
             &mut self.evm,
             &mut self.block_state,
-            self.hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut |state| emit_hashed_state(&mut self.hashed_state_update_hook, state),
             self.base_block_reward,
             block_number,
@@ -624,10 +605,11 @@ where
         );
         let receipts = &self.inner.receipts[self.segment_receipt_start..];
         let mut requests = block_requests_from_receipts(self.inner.spec_id, context, receipts)?;
+        let stream_hashed_state = self.inner.hashed_state_update_hook.is_some();
         post_execution_system_call_state_changes(
             &mut self.inner.evm,
             &mut self.inner.block_state,
-            self.inner.hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut |state| emit_hashed_state(&mut self.inner.hashed_state_update_hook, state),
             self.inner.spec_id,
             context,
@@ -648,7 +630,7 @@ where
         post_block_balance_state_changes(
             &mut self.inner.evm,
             &mut self.inner.block_state,
-            self.inner.hashed_state_mode.stream(),
+            stream_hashed_state,
             &mut |state| emit_hashed_state(&mut self.inner.hashed_state_update_hook, state),
             self.inner.base_block_reward,
             block_number,

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -5,13 +5,16 @@ use crate::{
         base_block_reward, block_requests_from_receipts, commit_detached_transaction,
         execute_transaction_without_commit, post_block_balance_state_changes,
         post_execution_system_call_state_changes, pre_execution_system_call_state_changes,
-        transaction_blob_gas_used, BlockExecutionContext, BlockSystemCalls, EthExecutionError,
+        BlockExecutionContext, BlockSystemCalls, EthExecutionError,
     },
     factory::{EthBlockExecutorFactory, EvmFactory},
     EthBlockExecutionCtx, EthEvmEnv, RethReceiptBuilder,
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use alloy_consensus::{Header, Transaction, TxType};
+use alloy_consensus::{
+    transaction::{TransactionEnvelope, TxHashRef},
+    Header, Transaction, TxType as EthTxType,
+};
 use alloy_eip7928::{BlockAccessIndex, BlockAccessList};
 use alloy_eips::{eip2718::Typed2718, eip4895::Withdrawal, eip7685::Requests};
 use alloy_primitives::{Address, B256};
@@ -19,7 +22,7 @@ use evm2::{
     ethereum::TxEnvelope,
     evm::{Bal, BlockStateAccumulator, StateChangeSource},
     interpreter::Host,
-    BaseEvmTypes, Evm, EvmTypes, TxResult, TxResultWithState,
+    BaseEvmTypes, Evm, EvmTypes, TxResultWithState,
 };
 use reth_ethereum_forks::EthereumHardforks;
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
@@ -27,25 +30,28 @@ use reth_evm::{
     BlockExecutionError, BlockExecutionOutput, BlockExecutor, BlockTransactionResult,
     BlockValidationError, ExecutorTx, GasOutput, ReceiptBuilder, ReceiptBuilderCtx, RecoveredTx,
 };
+use reth_execution_types::BlockExecutionResult;
 use reth_trie_common::HashedPostState;
 
 /// Configured Ethereum block executor backed by evm2.
 #[expect(missing_debug_implementations)]
-pub struct EthBlockExecutor<'a, T = BaseEvmTypes>
+pub struct EthBlockExecutor<'a, T = BaseEvmTypes, R = RethReceiptBuilder>
 where
-    T: EvmTypes<Tx = TxEnvelope>,
+    T: EvmTypes,
     T::Tx: Typed2718,
     T::TxResultExt: Send,
+    R: ReceiptBuilder,
 {
     evm: Evm<'a, T>,
     ctx: EthBlockExecutionCtx<'a>,
+    receipt_builder: R,
     spec_id: evm2::SpecId,
     base_block_reward: Option<u128>,
     deposit_contract_address: Option<Address>,
     block_state: BlockStateAccumulator,
     hashed_state_mode: HashedStateMode,
     hashed_state_update_hook: HashedStateUpdateHook,
-    receipts: Vec<Receipt>,
+    receipts: Vec<R::Receipt>,
     cumulative_gas_used: u64,
     block_regular_gas_used: u64,
     block_state_gas_used: u64,
@@ -56,7 +62,7 @@ where
 
 /// Detached Ethereum transaction result with the metadata needed for canonical receipt commit.
 #[derive(Debug)]
-pub struct EthTransactionResultWithState<T = BaseEvmTypes>
+pub struct EthTransactionResultWithState<T = BaseEvmTypes, TxType = EthTxType>
 where
     T: EvmTypes,
 {
@@ -65,7 +71,7 @@ where
     blob_gas_used: u64,
 }
 
-impl<T: EvmTypes> BlockTransactionResult<T> for EthTransactionResultWithState<T> {
+impl<T: EvmTypes, TxType> BlockTransactionResult<T> for EthTransactionResultWithState<T, TxType> {
     fn result(&self) -> &TxResultWithState<T> {
         &self.result
     }
@@ -89,11 +95,12 @@ impl HashedStateMode {
     }
 }
 
-impl<'a, T> EthBlockExecutor<'a, T>
+impl<'a, T, R> EthBlockExecutor<'a, T, R>
 where
-    T: EvmTypes<Tx = TxEnvelope>,
+    T: EvmTypes,
     T::Tx: Typed2718,
     T::TxResultExt: Send,
+    R: ReceiptBuilder,
 {
     /// Creates a configured Ethereum block executor.
     pub(crate) fn new<C>(
@@ -102,6 +109,7 @@ where
         chain_spec: &C,
         deposit_contract_address: Option<alloy_primitives::Address>,
         hashed_state_mode: HashedStateMode,
+        receipt_builder: R,
     ) -> Self
     where
         C: EthereumHardforks + ?Sized,
@@ -116,6 +124,7 @@ where
         Self {
             evm,
             ctx,
+            receipt_builder,
             spec_id,
             base_block_reward: base_block_reward(chain_spec, block_number),
             deposit_contract_address,
@@ -152,24 +161,29 @@ where
     }
 
     #[inline]
-    fn set_transaction_block_access_index(&mut self) {
+    const fn set_transaction_block_access_index(&mut self) {
         if self.block_access_list_builder_enabled() {
             let index = self.receipts.len() as u64 + 1 + self.bal_index_offset;
-            self.set_block_access_index(BlockAccessIndex::new(index));
+            self.evm.state_mut().set_bal_index(BlockAccessIndex::new(index));
         }
     }
 }
 
-impl<'a, T> BlockExecutor for EthBlockExecutor<'a, T>
+impl<'a, T, R> BlockExecutor for EthBlockExecutor<'a, T, R>
 where
-    T: EvmTypes<Tx = TxEnvelope>,
-    T::Tx: Typed2718,
+    T: EvmTypes,
+    T::Tx: Transaction + Typed2718,
     T::TxResultExt: Send,
+    R: ReceiptBuilder,
+    R::Transaction: TxHashRef,
+    R::Receipt: alloy_consensus::TxReceipt<Log = alloy_primitives::Log>,
+    <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
 {
-    type Transaction = TransactionSigned;
-    type Receipt = Receipt;
+    type Transaction = R::Transaction;
+    type Receipt = R::Receipt;
     type Evm = Evm<'a, T>;
-    type TransactionResultWithState = EthTransactionResultWithState<T>;
+    type TransactionResultWithState =
+        EthTransactionResultWithState<T, <R::Transaction as TransactionEnvelope>::TxType>;
     type BlockAccessList = Bal;
 
     fn evm(&self) -> &Self::Evm {
@@ -267,9 +281,8 @@ where
             }
             .into())
         }
-        let blob_gas_used = transaction_blob_gas_used(&transaction);
-        let tx_type =
-            TxType::try_from(transaction.ty()).expect("transaction envelope has valid type");
+        let blob_gas_used = tx.tx().blob_gas_used().unwrap_or_default();
+        let tx_type = tx.tx().tx_type();
         let result = execute_transaction_without_commit(&mut self.evm, &transaction)
             .map_err(|err| map_transaction_execution_error(err, tx_hash))?;
         Ok(EthTransactionResultWithState { result, tx_type, blob_gas_used })
@@ -294,7 +307,7 @@ where
         self.block_state_gas_used = self.block_state_gas_used.saturating_add(state_gas_used);
         self.cumulative_gas_used += tx_gas_used;
         self.blob_gas_used += blob_gas_used;
-        self.receipts.push(RethReceiptBuilder.build_receipt(ReceiptBuilderCtx {
+        self.receipts.push(self.receipt_builder.build_receipt(ReceiptBuilderCtx {
             tx_type,
             result: outcome,
             cumulative_gas_used: self.cumulative_gas_used,
@@ -302,13 +315,14 @@ where
         Ok(GasOutput::new_with_regular(tx_gas_used, regular_gas_used, state_gas_used))
     }
 
-    fn receipts(&self) -> &[Receipt] {
+    fn receipts(&self) -> &[Self::Receipt] {
         &self.receipts
     }
 
     fn finish_with_block_access_list(
         mut self,
-    ) -> Result<(BlockExecutionOutput<Receipt>, Option<BlockAccessList>), BlockExecutionError> {
+    ) -> Result<(BlockExecutionOutput<Self::Receipt>, Option<BlockAccessList>), BlockExecutionError>
+    {
         self.set_transaction_block_access_index();
         let context = Self::block_context(
             self.deposit_contract_address,
@@ -359,15 +373,15 @@ where
             self.block_regular_gas_used,
             self.block_state_gas_used,
         );
-        let mut output =
-            <RethReceiptBuilder as ReceiptBuilder<TxType, TxResult<T>>>::build_block_output(
-                &RethReceiptBuilder,
-                self.receipts,
-                self.block_state,
-                self.blob_gas_used,
-            );
-        output.result.gas_used = block_gas_used;
-        output.result.requests = requests;
+        let output = BlockExecutionOutput::new(
+            BlockExecutionResult {
+                receipts: self.receipts,
+                requests,
+                gas_used: block_gas_used,
+                blob_gas_used: self.blob_gas_used,
+            },
+            self.block_state,
+        );
 
         Ok((output, block_access_list))
     }
@@ -503,8 +517,8 @@ where
     <F::Types as evm2::EvmTypesHost>::Tx: Typed2718,
     <F::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {
-    inner: EthBlockExecutor<'a, F::Types>,
-    factory: &'a EthBlockExecutorFactory<C, F>,
+    inner: EthBlockExecutor<'a, F::Types, &'a RethReceiptBuilder>,
+    factory: &'a EthBlockExecutorFactory<RethReceiptBuilder, C, F>,
     chain_spec: Arc<C>,
     plan: EthBigBlockPlan<'a, F::Types>,
     next_segment: usize,
@@ -527,8 +541,8 @@ where
     <F::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {
     pub(crate) fn new(
-        inner: EthBlockExecutor<'a, F::Types>,
-        factory: &'a EthBlockExecutorFactory<C, F>,
+        inner: EthBlockExecutor<'a, F::Types, &'a RethReceiptBuilder>,
+        factory: &'a EthBlockExecutorFactory<RethReceiptBuilder, C, F>,
         chain_spec: Arc<C>,
         plan: EthBigBlockPlan<'a, F::Types>,
     ) -> Self {

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -24,6 +24,7 @@ use evm2::{
     interpreter::Host,
     BaseEvmTypes, Evm, EvmTypes, TxResultWithState,
 };
+use reth_chainspec::EthChainSpec;
 use reth_ethereum_forks::EthereumHardforks;
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
 use reth_evm::{
@@ -99,16 +100,14 @@ where
     R: ReceiptBuilder,
 {
     /// Creates a configured Ethereum block executor.
-    pub(crate) fn new<C>(
+    pub fn new<C>(
         mut evm: Evm<'a, T>,
         ctx: EthBlockExecutionCtx<'a>,
         chain_spec: &C,
-        deposit_contract_address: Option<alloy_primitives::Address>,
-        hashed_state_mode: HashedStateMode,
         receipt_builder: R,
     ) -> Self
     where
-        C: EthereumHardforks + ?Sized,
+        C: EthChainSpec + EthereumHardforks + ?Sized,
     {
         // The executor stores evm2's base spec ID, while custom type families may expose a
         // richer host spec ID that converts into it.
@@ -123,9 +122,11 @@ where
             receipt_builder,
             spec_id,
             base_block_reward: base_block_reward(chain_spec, block_number),
-            deposit_contract_address,
+            deposit_contract_address: chain_spec
+                .deposit_contract()
+                .map(|contract| contract.address),
             block_state: BlockStateAccumulator::new(),
-            hashed_state_mode,
+            hashed_state_mode: HashedStateMode::OutputOnly,
             hashed_state_update_hook: None,
             receipts: Vec::new(),
             cumulative_gas_used: 0,

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -172,7 +172,7 @@ where
 impl<'a, T, R> BlockExecutor for EthBlockExecutor<'a, T, R>
 where
     T: EvmTypes,
-    T::Tx: Transaction + Typed2718,
+    T::Tx: Typed2718,
     T::TxResultExt: Send,
     R: ReceiptBuilder,
     R::Transaction: TxHashRef,
@@ -257,7 +257,7 @@ where
         let (transaction, tx) = transaction.into_parts();
         let tx_hash = *tx.tx().tx_hash();
         self.set_transaction_block_access_index();
-        let transaction_gas_limit = transaction.gas_limit();
+        let transaction_gas_limit = tx.tx().gas_limit();
         let block_gas_limit = self.evm.block_env().gas_limit.to::<u64>();
         let unavailable = if self.separate_block_gas {
             let regular_available = block_gas_limit.saturating_sub(self.block_regular_gas_used);

--- a/crates/ethereum/evm/src/executor.rs
+++ b/crates/ethereum/evm/src/executor.rs
@@ -37,9 +37,7 @@ use reth_trie_common::HashedPostState;
 #[expect(missing_debug_implementations)]
 pub struct EthBlockExecutor<'a, T = BaseEvmTypes, R = RethReceiptBuilder>
 where
-    T: EvmTypes,
-    T::Tx: Typed2718,
-    T::TxResultExt: Send,
+    T: EvmTypes<Tx: Typed2718, TxResultExt: Send>,
     R: ReceiptBuilder,
 {
     evm: Evm<'a, T>,
@@ -97,9 +95,7 @@ impl HashedStateMode {
 
 impl<'a, T, R> EthBlockExecutor<'a, T, R>
 where
-    T: EvmTypes,
-    T::Tx: Typed2718,
-    T::TxResultExt: Send,
+    T: EvmTypes<Tx: Typed2718, TxResultExt: Send>,
     R: ReceiptBuilder,
 {
     /// Creates a configured Ethereum block executor.
@@ -171,13 +167,8 @@ where
 
 impl<'a, T, R> BlockExecutor for EthBlockExecutor<'a, T, R>
 where
-    T: EvmTypes,
-    T::Tx: Typed2718,
-    T::TxResultExt: Send,
+    T: EvmTypes<Tx: Typed2718, TxResultExt: Send>,
     R: ReceiptBuilder,
-    R::Transaction: TxHashRef,
-    R::Receipt: alloy_consensus::TxReceipt<Log = alloy_primitives::Log>,
-    <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
 {
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "jit")]
 use alloc::string::String;
 use alloc::{boxed::Box, sync::Arc};
-use alloy_consensus::Header;
+use alloy_consensus::{
+    transaction::{TransactionEnvelope, TxHashRef},
+    Header,
+};
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks};
 #[cfg(feature = "std")]
 use reth_evm::precompile_cache::{CachedPrecompileProvider, PrecompileCacheMap};
@@ -17,25 +20,22 @@ pub use evm2_jit::{
 
 use crate::{
     executor::{EthBigBlockExecutor, EthBigBlockPlan, HashedStateMode},
-    EthBlockExecutionCtx, EthBlockExecutor, EthEvmEnv,
+    EthBlockExecutionCtx, EthBlockExecutor, EthEvmEnv, RethReceiptBuilder,
 };
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
+use reth_evm::ReceiptBuilder;
 
 /// Factory used to construct an evm2-backed EVM.
 ///
-/// The transaction type defaults to Ethereum's envelope so the standard block
-/// executor remains ergonomic. Custom-node integrations can select a different evm2 transaction
-/// type by implementing `EvmFactory<CustomTx>` and using that factory with their own executor and
-/// primitives.
-pub trait EvmFactory<Tx = evm2::ethereum::TxEnvelope>:
-    Clone + core::fmt::Debug + Send + Sync + Unpin + 'static
+/// Custom-node integrations can select a different evm2 transaction type through [`Self::Types`].
+pub trait EvmFactory: Clone + core::fmt::Debug + Send + Sync + Unpin + 'static
 where
     <Self::Types as evm2::EvmTypesHost>::BlockEnvExt: Send + Sync,
     <Self::Types as evm2::EvmTypesHost>::EvmExt: Default,
     <Self::Types as evm2::EvmTypesHost>::TxResultExt: Send,
 {
     /// Runtime evm2 type family used by the EVM.
-    type Types: evm2::EvmTypes<Tx = Tx> + evm2::EvmTypesHost<SpecId = Self::SpecId>;
+    type Types: evm2::EvmTypes + evm2::EvmTypesHost<SpecId = Self::SpecId>;
 
     /// Runtime specification identifier used by the EVM type family.
     type SpecId: Copy
@@ -117,10 +117,12 @@ impl EvmFactory for () {
 
 /// Ethereum block executor factory.
 #[derive(Debug)]
-pub struct EthBlockExecutorFactory<C = ChainSpec, F = RethEvmFactory>
+pub struct EthBlockExecutorFactory<R = RethReceiptBuilder, C = ChainSpec, F = RethEvmFactory>
 where
     F: EvmFactory,
 {
+    /// Receipt builder.
+    receipt_builder: R,
     /// Chain specification.
     chain_spec: Arc<C>,
     /// Shared precompile cache.
@@ -139,17 +141,17 @@ pub struct EthBigBlockExecutorFactory<C = ChainSpec, F = RethEvmFactory>
 where
     F: EvmFactory,
 {
-    inner: EthBlockExecutorFactory<C, F>,
+    inner: EthBlockExecutorFactory<RethReceiptBuilder, C, F>,
 }
 
 impl<C, F: EvmFactory> EthBigBlockExecutorFactory<C, F> {
     /// Creates a big-block executor factory from the standard Ethereum factory.
-    pub const fn new(inner: EthBlockExecutorFactory<C, F>) -> Self {
+    pub const fn new(inner: EthBlockExecutorFactory<RethReceiptBuilder, C, F>) -> Self {
         Self { inner }
     }
 
     /// Returns the wrapped Ethereum executor factory.
-    pub const fn inner(&self) -> &EthBlockExecutorFactory<C, F> {
+    pub const fn inner(&self) -> &EthBlockExecutorFactory<RethReceiptBuilder, C, F> {
         &self.inner
     }
 }
@@ -158,6 +160,7 @@ impl<C, F> reth_evm::BlockExecutorFactory for EthBigBlockExecutorFactory<C, F>
 where
     C: EthChainSpec<Header = Header> + EthereumHardforks,
     F: EvmFactory,
+    F::Types: evm2::EvmTypes<Tx = evm2::ethereum::TxEnvelope>,
 {
     type EvmFactory = F;
     type EvmTypes = F::Types;
@@ -198,9 +201,10 @@ where
     }
 }
 
-impl<C, F: EvmFactory> Clone for EthBlockExecutorFactory<C, F> {
+impl<R: Clone, C, F: EvmFactory> Clone for EthBlockExecutorFactory<R, C, F> {
     fn clone(&self) -> Self {
         Self {
+            receipt_builder: self.receipt_builder.clone(),
             chain_spec: self.chain_spec.clone(),
             #[cfg(feature = "std")]
             precompile_cache_map: self.precompile_cache_map.clone(),
@@ -211,17 +215,29 @@ impl<C, F: EvmFactory> Clone for EthBlockExecutorFactory<C, F> {
     }
 }
 
-impl<C> EthBlockExecutorFactory<C> {
+impl<C> EthBlockExecutorFactory<RethReceiptBuilder, C> {
     /// Creates a new Ethereum block executor factory.
     pub fn new(chain_spec: Arc<C>) -> Self {
         Self::new_with_evm_factory(chain_spec, RethEvmFactory::default())
     }
 }
 
-impl<C, F: EvmFactory> EthBlockExecutorFactory<C, F> {
+impl<C, F: EvmFactory> EthBlockExecutorFactory<RethReceiptBuilder, C, F> {
     /// Creates a new Ethereum block executor factory with the given EVM factory configuration.
     pub fn new_with_evm_factory(chain_spec: Arc<C>, evm_factory: F) -> Self {
+        Self::new_with_receipt_builder(RethReceiptBuilder, chain_spec, evm_factory)
+    }
+}
+
+impl<R, C, F: EvmFactory> EthBlockExecutorFactory<R, C, F> {
+    /// Creates a new Ethereum block executor factory with the given receipt and EVM factories.
+    pub fn new_with_receipt_builder(
+        receipt_builder: R,
+        chain_spec: Arc<C>,
+        evm_factory: F,
+    ) -> Self {
         Self {
+            receipt_builder,
             chain_spec,
             #[cfg(feature = "std")]
             precompile_cache_map: PrecompileCacheMap::default(),
@@ -234,6 +250,11 @@ impl<C, F: EvmFactory> EthBlockExecutorFactory<C, F> {
     /// Returns the chain spec associated with this factory.
     pub const fn chain_spec(&self) -> &Arc<C> {
         &self.chain_spec
+    }
+
+    /// Returns the configured receipt builder.
+    pub const fn receipt_builder(&self) -> &R {
+        &self.receipt_builder
     }
 
     /// Returns the configured EVM factory state.
@@ -267,9 +288,11 @@ impl<C, F: EvmFactory> EthBlockExecutorFactory<C, F> {
         &'a self,
         evm: evm2::Evm<'a, F::Types>,
         ctx: EthBlockExecutionCtx<'a>,
-    ) -> EthBlockExecutor<'a, F::Types>
+    ) -> EthBlockExecutor<'a, F::Types, &'a R>
     where
         C: EthChainSpec<Header = Header> + EthereumHardforks,
+        R: ReceiptBuilder,
+        <F::Types as evm2::EvmTypesHost>::Tx: alloy_eips::eip2718::Typed2718,
     {
         EthBlockExecutor::new(
             evm,
@@ -277,6 +300,7 @@ impl<C, F: EvmFactory> EthBlockExecutorFactory<C, F> {
             self.chain_spec.as_ref(),
             self.chain_spec.deposit_contract().map(|contract| contract.address),
             HashedStateMode::OutputOnly,
+            &self.receipt_builder,
         )
     }
 
@@ -353,15 +377,23 @@ impl<C, F: EvmFactory> EthBlockExecutorFactory<C, F> {
     }
 }
 
-impl<C, F> reth_evm::BlockExecutorFactory for EthBlockExecutorFactory<C, F>
+impl<R, C, F> reth_evm::BlockExecutorFactory for EthBlockExecutorFactory<R, C, F>
 where
     C: EthChainSpec<Header = Header> + EthereumHardforks,
     F: EvmFactory,
+    R: ReceiptBuilder,
+    R::Transaction: TxHashRef + core::fmt::Debug + Clone + Send + Sync + 'static,
+    R::Receipt: alloy_consensus::TxReceipt<Log = alloy_primitives::Log>,
+    <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
+    <F::Types as evm2::EvmTypesHost>::Tx: alloy_consensus::Transaction
+        + alloy_eips::eip2718::Typed2718
+        + Clone
+        + From<R::Transaction>,
 {
     type EvmFactory = F;
     type EvmTypes = F::Types;
-    type Transaction = TransactionSigned;
-    type Receipt = Receipt;
+    type Transaction = R::Transaction;
+    type Receipt = R::Receipt;
     type Evm<'a> = evm2::Evm<'a, F::Types>;
     type EvmEnv = EthEvmEnv<F::Types>;
     type ExecutionCtx<'a>
@@ -369,7 +401,7 @@ where
     where
         Self: 'a;
     type Executor<'a>
-        = EthBlockExecutor<'a, F::Types>
+        = EthBlockExecutor<'a, F::Types, &'a R>
     where
         Self: 'a;
 

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -16,7 +16,7 @@ pub use evm2_jit::{
 };
 
 use crate::{
-    executor::{EthBigBlockExecutor, EthBigBlockPlan, HashedStateMode},
+    executor::{EthBigBlockExecutor, EthBigBlockPlan},
     EthBlockExecutionCtx, EthBlockExecutor, EthEvmEnv, RethReceiptBuilder,
 };
 use reth_ethereum_primitives::{Receipt, TransactionSigned};
@@ -182,7 +182,12 @@ where
     where
         Self: 'a,
     {
-        let executor = self.inner.create_eth_executor(evm, ctx.segments[0].ctx.clone());
+        let executor = EthBlockExecutor::new(
+            evm,
+            ctx.segments[0].ctx.clone(),
+            self.inner.chain_spec().as_ref(),
+            self.inner.receipt_builder(),
+        );
         EthBigBlockExecutor::new(executor, &self.inner, self.inner.chain_spec().clone(), ctx)
     }
 
@@ -278,27 +283,6 @@ impl<R, C, F: EvmFactory> EthBlockExecutorFactory<R, C, F> {
             let _ = disabled;
             self
         }
-    }
-
-    /// Creates a configured Ethereum block executor.
-    pub(crate) fn create_eth_executor<'a>(
-        &'a self,
-        evm: evm2::Evm<'a, F::Types>,
-        ctx: EthBlockExecutionCtx<'a>,
-    ) -> EthBlockExecutor<'a, F::Types, &'a R>
-    where
-        C: EthChainSpec<Header = Header> + EthereumHardforks,
-        R: ReceiptBuilder,
-        <F::Types as evm2::EvmTypesHost>::Tx: alloy_eips::eip2718::Typed2718,
-    {
-        EthBlockExecutor::new(
-            evm,
-            ctx,
-            self.chain_spec.as_ref(),
-            self.chain_spec.deposit_contract().map(|contract| contract.address),
-            HashedStateMode::OutputOnly,
-            &self.receipt_builder,
-        )
     }
 
     /// Creates an EVM instance with the configured Ethereum execution environment.
@@ -405,7 +389,7 @@ where
     where
         Self: 'a,
     {
-        self.create_eth_executor(evm, ctx)
+        EthBlockExecutor::new(evm, ctx, self.chain_spec.as_ref(), &self.receipt_builder)
     }
 
     fn evm_factory(&self) -> &Self::EvmFactory {

--- a/crates/ethereum/evm/src/factory.rs
+++ b/crates/ethereum/evm/src/factory.rs
@@ -1,10 +1,7 @@
 #[cfg(feature = "jit")]
 use alloc::string::String;
 use alloc::{boxed::Box, sync::Arc};
-use alloy_consensus::{
-    transaction::{TransactionEnvelope, TxHashRef},
-    Header,
-};
+use alloy_consensus::Header;
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks};
 #[cfg(feature = "std")]
 use reth_evm::precompile_cache::{CachedPrecompileProvider, PrecompileCacheMap};
@@ -382,13 +379,8 @@ where
     C: EthChainSpec<Header = Header> + EthereumHardforks,
     F: EvmFactory,
     R: ReceiptBuilder,
-    R::Transaction: TxHashRef + core::fmt::Debug + Clone + Send + Sync + 'static,
-    R::Receipt: alloy_consensus::TxReceipt<Log = alloy_primitives::Log>,
-    <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
-    <F::Types as evm2::EvmTypesHost>::Tx: alloy_consensus::Transaction
-        + alloy_eips::eip2718::Typed2718
-        + Clone
-        + From<R::Transaction>,
+
+    <F::Types as evm2::EvmTypesHost>::Tx: alloy_eips::eip2718::Typed2718,
 {
     type EvmFactory = F;
     type EvmTypes = F::Types;

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -402,7 +402,7 @@ where
     F: EvmFactory,
 {
     /// Inner Ethereum block executor factory.
-    pub executor_factory: EthBlockExecutorFactory<C, F>,
+    pub executor_factory: EthBlockExecutorFactory<RethReceiptBuilder, C, F>,
     /// Ethereum block assembler.
     pub block_assembler: EthBlockAssembler<C>,
 }
@@ -469,11 +469,15 @@ impl<ChainSpec, EvmF> ConfigureEvm for EthEvmConfig<ChainSpec, EvmF>
 where
     ChainSpec: EthChainSpec<Header = Header> + EthereumHardforks + Hardforks + 'static,
     EvmF: EvmFactory,
+    <EvmF::Types as evm2::EvmTypesHost>::Tx: alloy_consensus::Transaction
+        + alloy_eips::eip2718::Typed2718
+        + Clone
+        + From<reth_ethereum_primitives::TransactionSigned>,
 {
     type Primitives = EthPrimitives;
     type Error = Infallible;
     type NextBlockEnvCtx = NextBlockEnvAttributes;
-    type BlockExecutorFactory = EthBlockExecutorFactory<ChainSpec, EvmF>;
+    type BlockExecutorFactory = EthBlockExecutorFactory<RethReceiptBuilder, ChainSpec, EvmF>;
     #[cfg(feature = "std")]
     type BlockAssembler = EthBlockAssembler<ChainSpec>;
 
@@ -642,6 +646,7 @@ impl<ChainSpec, EvmF> ConfigureEngineEvm<ExecutionData> for EthEvmConfig<ChainSp
 where
     ChainSpec: EthChainSpec<Header = Header> + EthereumHardforks + Hardforks + 'static,
     EvmF: EvmFactory,
+    EvmF::Types: evm2::EvmTypes<Tx = evm2::ethereum::TxEnvelope>,
 {
     fn evm_env_for_payload(&self, payload: &ExecutionData) -> Result<EvmEnvFor<Self>, Self::Error> {
         let spec = spec_id_by_timestamp_and_block_number(

--- a/crates/ethereum/evm/src/receipt.rs
+++ b/crates/ethereum/evm/src/receipt.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::TxType;
 use evm2::{EvmTypes, TxResult};
-use reth_ethereum_primitives::Receipt;
+use reth_ethereum_primitives::{Receipt, TransactionSigned};
 use reth_evm::{ReceiptBuilder, ReceiptBuilderCtx};
 
 /// A builder that produces Reth [`Receipt`] values from evm2 transaction results.
@@ -8,10 +8,11 @@ use reth_evm::{ReceiptBuilder, ReceiptBuilderCtx};
 #[non_exhaustive]
 pub struct RethReceiptBuilder;
 
-impl<T: EvmTypes> ReceiptBuilder<TxType, TxResult<T>> for RethReceiptBuilder {
+impl ReceiptBuilder for RethReceiptBuilder {
+    type Transaction = TransactionSigned;
     type Receipt = Receipt;
 
-    fn build_receipt(&self, ctx: ReceiptBuilderCtx<TxType, TxResult<T>>) -> Receipt {
+    fn build_receipt<T: EvmTypes>(&self, ctx: ReceiptBuilderCtx<TxType, TxResult<T>>) -> Receipt {
         let ReceiptBuilderCtx { tx_type, result, cumulative_gas_used } = ctx;
         Receipt { tx_type, success: result.status, cumulative_gas_used, logs: result.logs }
     }

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -134,7 +134,7 @@ pub trait Evm {
     /// Runtime EVM type family.
     type EvmTypes: evm2::EvmTypes<Tx = Self::Transaction>;
     /// Transaction environment consumed by this EVM.
-    type Transaction: AlloyTransaction;
+    type Transaction;
 
     /// Executes a transaction without committing its state changes.
     fn transact(
@@ -186,7 +186,7 @@ pub trait Evm {
         S::Error: Debug;
 }
 
-impl<'a, T: evm2::EvmTypes<Tx: Typed2718 + AlloyTransaction>> Evm for evm2::Evm<'a, T> {
+impl<'a, T: evm2::EvmTypes<Tx: Typed2718>> Evm for evm2::Evm<'a, T> {
     type EvmTypes = T;
     type Transaction = T::Tx;
 

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -4,7 +4,7 @@ use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxEnvFor};
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
     transaction::{Either, Recovered, Transaction as AlloyTransaction, TransactionEnvelope},
-    BlockHeader as _, Header, TxReceipt,
+    BlockHeader as _, Header,
 };
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessIndex, BlockAccessList};
 use alloy_eips::eip2718::{Typed2718, WithEncoded};
@@ -24,7 +24,8 @@ use reth_execution_types::{
 #[cfg(feature = "std")]
 use reth_primitives_traits::BlockTy;
 use reth_primitives_traits::{
-    Block, HeaderTy, NodePrimitives, ReceiptTy, RecoveredBlock, SealedHeader, TxTy,
+    Block, HeaderTy, NodePrimitives, ReceiptTy, RecoveredBlock, SealedHeader, SignedTransaction,
+    TxTy,
 };
 use reth_storage_api::StateProvider;
 use reth_trie_common::updates::TrieUpdates;
@@ -92,9 +93,9 @@ pub struct ReceiptBuilderCtx<TxType, TransactionResult> {
 #[auto_impl::auto_impl(&, Arc)]
 pub trait ReceiptBuilder {
     /// Consensus transaction type accepted by the executor.
-    type Transaction: TransactionEnvelope;
+    type Transaction: SignedTransaction + TransactionEnvelope<TxType: Send + 'static>;
     /// Receipt produced by this builder.
-    type Receipt: TxReceipt;
+    type Receipt: reth_primitives_traits::Receipt;
 
     /// Builds a receipt for the transaction execution result.
     fn build_receipt<T: evm2::EvmTypes>(

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -3,7 +3,7 @@
 use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxEnvFor};
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
-    transaction::{Either, Recovered, Transaction as AlloyTransaction},
+    transaction::{Either, Recovered, Transaction as AlloyTransaction, TransactionEnvelope},
     BlockHeader as _, Header, TxReceipt,
 };
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessIndex, BlockAccessList};
@@ -12,7 +12,7 @@ use alloy_primitives::{Address, B256};
 use core::fmt::Debug;
 #[cfg(feature = "std")]
 use evm2::evm::{CacheDB, Db};
-use evm2::{evm::BlockStateAccumulator, registry::HandlerError, ErrorCode};
+use evm2::{registry::HandlerError, ErrorCode};
 pub use reth_execution_errors::{
     BlockExecutionError, BlockValidationError, EvmError, InternalBlockExecutionError,
     InvalidTxError,
@@ -89,32 +89,21 @@ pub struct ReceiptBuilderCtx<TxType, TransactionResult> {
 }
 
 /// Builds chain-specific receipts from raw transaction execution results.
-pub trait ReceiptBuilder<TxType, TransactionResult> {
+#[auto_impl::auto_impl(&, Arc)]
+pub trait ReceiptBuilder {
+    /// Consensus transaction type accepted by the executor.
+    type Transaction: TransactionEnvelope;
     /// Receipt produced by this builder.
     type Receipt: TxReceipt;
 
     /// Builds a receipt for the transaction execution result.
-    fn build_receipt(&self, ctx: ReceiptBuilderCtx<TxType, TransactionResult>) -> Self::Receipt;
-
-    /// Builds a block execution output from already-built receipts and execution state.
-    fn build_block_output(
+    fn build_receipt<T: evm2::EvmTypes>(
         &self,
-        receipts: Vec<Self::Receipt>,
-        state: BlockStateAccumulator,
-        blob_gas_used: u64,
-    ) -> BlockExecutionOutput<Self::Receipt> {
-        let gas_used = receipts.last().map_or(0, TxReceipt::cumulative_gas_used);
-
-        BlockExecutionOutput::new(
-            BlockExecutionResult {
-                receipts,
-                requests: Default::default(),
-                gas_used,
-                blob_gas_used,
-            },
-            state,
-        )
-    }
+        ctx: ReceiptBuilderCtx<
+            <Self::Transaction as TransactionEnvelope>::TxType,
+            evm2::TxResult<T>,
+        >,
+    ) -> Self::Receipt;
 }
 
 /// Marks whether transaction changes should be committed into block executor state.

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -3,7 +3,7 @@
 use crate::{ConfigureEvm, Database, DynDatabase, EvmEnv, TxEnvFor};
 use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use alloy_consensus::{
-    transaction::{Either, Recovered, Transaction as AlloyTransaction, TransactionEnvelope},
+    transaction::{Either, Recovered, TransactionEnvelope},
     BlockHeader as _, Header,
 };
 use alloy_eip7928::{compute_block_access_list_hash, BlockAccessIndex, BlockAccessList};
@@ -425,7 +425,7 @@ pub trait BlockExecutorFactory {
     /// Additional EVM factory configuration owned by this executor factory.
     type EvmFactory;
     /// Runtime EVM type family.
-    type EvmTypes: evm2::EvmTypes<Tx: AlloyTransaction + Clone, TxResultExt: Send>;
+    type EvmTypes: evm2::EvmTypes<TxResultExt: Send>;
     /// Consensus transaction type consumed by executors from this factory.
     type Transaction: Debug + Clone + Send + Sync + 'static;
     /// Receipt type produced by executors from this factory.

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 use crate::execute::{BasicBlockBuilder, BasicBlockExecutor};
 use alloc::string::String;
+use alloy_consensus::Transaction;
 use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::{Address, Bytes, B256};
 use core::{error::Error, fmt::Debug};
@@ -240,7 +241,7 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
     type BlockExecutorFactory: crate::execute::BlockExecutorFactory<
         Transaction = TxTy<Self::Primitives>,
         Receipt = ReceiptTy<Self::Primitives>,
-        EvmTypes: evm2::EvmTypes<Tx: From<TxTy<Self::Primitives>>>,
+        EvmTypes: evm2::EvmTypes<Tx: From<TxTy<Self::Primitives>> + Transaction + Clone>,
     >;
 
     /// Configured block assembler.

--- a/examples/custom-evm/src/factory.rs
+++ b/examples/custom-evm/src/factory.rs
@@ -3,7 +3,7 @@
 use crate::{
     config::{custom_version, CustomConfigSelector, CustomTypes},
     opcode,
-    tx::{custom_registry, CustomEnvelope},
+    tx::custom_registry,
 };
 use alloy_primitives::{address, Address, Bytes};
 use evm2::{
@@ -91,7 +91,7 @@ impl EvmFactory for NodeEvmFactory {
 #[derive(Clone, Copy, Debug, Default)]
 pub struct CustomEvmFactory;
 
-impl EvmFactory<CustomEnvelope> for CustomEvmFactory {
+impl EvmFactory for CustomEvmFactory {
     type Types = CustomTypes;
     type SpecId = crate::config::CustomSpecId;
 


### PR DESCRIPTION
Makes `EthBlockExecutor` and its factory derive consensus transaction and receipt types from `ReceiptBuilder`, and the runtime transaction type from `EvmFactory::Types`, matching alloy-evm’s ownership model. Exposes the executor constructor with the same `(evm, context, chain spec, receipt builder)` shape used by downstream wrappers such as Tempo, while keeping Ethereum-specific defaults internal. Hashed-state streaming is now derived directly from whether an executor state hook is installed, removing the obsolete mode field.

Validated with workspace all-feature checks, no-default-feature checks for the affected crate, focused all-target Clippy, and 35 focused tests.