### PR TITLE
feat(trie): add sparse trie pruning duration metric

### DIFF
--- a/.github/config/bench-metrics-targets.json
+++ b/.github/config/bench-metrics-targets.json
@@ -87,6 +87,12 @@
       "min_value_pct_total_latency": 15.0
     },
     {
+      "query": "reth_tree_root_sparse_trie_prune_duration_histogram",
+      "target": "decrease",
+      "floor_pct": 5.0,
+      "min_value_pct_total_latency": 0.0
+    },
+    {
       "query": "reth_tree_root_hashing_task_idle_time_seconds",
       "target": "increase",
       "floor_pct": 5.0,

--- a/.github/config/bench-metrics-targets.json
+++ b/.github/config/bench-metrics-targets.json
@@ -66,7 +66,8 @@
       "query": "reth_sync_block_validation_state_root_histogram",
       "target": "decrease",
       "floor_pct": 5.0,
-      "min_value_pct_total_latency": 5.0
+      "min_value_pct_total_latency": 5.0,
+      "unit": "seconds"
     },
     {
       "query": "reth_trie_proof_task_account_worker_idle_time_seconds",
@@ -90,7 +91,8 @@
       "query": "reth_tree_root_sparse_trie_prune_duration_histogram",
       "target": "decrease",
       "floor_pct": 5.0,
-      "min_value_pct_total_latency": 0.0
+      "min_value_pct_total_latency": 0.0,
+      "unit": "seconds"
     },
     {
       "query": "reth_tree_root_hashing_task_idle_time_seconds",
@@ -114,13 +116,15 @@
       "query": "reth_storage_providers_database_save_blocks_commit_mdbx",
       "target": "decrease",
       "floor_pct": 5.0,
-      "min_value_pct_total_latency": 13.6
+      "min_value_pct_total_latency": 13.6,
+      "unit": "seconds"
     },
     {
       "query": "reth_storage_providers_database_save_blocks_commit_rocksdb",
       "target": "decrease",
       "floor_pct": 2.5,
-      "min_value_pct_total_latency": 0.8
+      "min_value_pct_total_latency": 0.8,
+      "unit": "seconds"
     },
     {
       "query": "reth_storage_providers_database_save_blocks_mdbx",
@@ -133,19 +137,22 @@
       "query": "reth_storage_providers_database_save_blocks_rocksdb",
       "target": "decrease",
       "floor_pct": 2.5,
-      "min_value_pct_total_latency": 14.2
+      "min_value_pct_total_latency": 14.2,
+      "unit": "seconds"
     },
     {
       "query": "reth_storage_providers_database_save_blocks_sf",
       "target": "decrease",
       "floor_pct": 2.5,
-      "min_value_pct_total_latency": 5.4
+      "min_value_pct_total_latency": 5.4,
+      "unit": "seconds"
     },
     {
       "query": "reth_sync_block_validation_deferred_trie_compute_duration",
       "target": "decrease",
       "floor_pct": 2.5,
-      "min_value_pct_total_latency": 1.4
+      "min_value_pct_total_latency": 1.4,
+      "unit": "seconds"
     },
     {
       "query": "reth_executor_named_worker_queue_wait_duration_seconds",

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -700,9 +700,13 @@ impl DefaultStateRootStrategy {
                 let start = Instant::now();
                 let (mut trie, deferred) = task.into_trie_for_reuse();
                 if let Some(prune_blocks) = pending_sparse_trie_prune_blocks {
+                    let prune_start = Instant::now();
                     let retained_paths =
                         sparse_trie_retained_paths(prune_blocks, result.hashed_state.as_ref());
                     trie.prune(retained_paths);
+                    trie_metrics
+                        .sparse_trie_prune_duration_histogram
+                        .record(prune_start.elapsed().as_secs_f64());
                 }
                 trie_metrics
                     .into_trie_for_reuse_duration_histogram

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -978,6 +978,8 @@ pub(super) struct SparseTrieTaskMetrics {
     pub(super) sparse_trie_total_duration_histogram: Histogram,
     /// Time spent preparing the sparse trie for reuse after state root computation.
     pub(super) into_trie_for_reuse_duration_histogram: Histogram,
+    /// Time spent building the retention set and pruning the sparse trie.
+    pub(super) sparse_trie_prune_duration_histogram: Histogram,
     /// Time spent waiting for preserved sparse trie cache to become available.
     pub(super) sparse_trie_cache_wait_duration_histogram: Histogram,
     /// Histogram for sparse trie task idle time in seconds (waiting for updates or proof


### PR DESCRIPTION
Records sparse trie pruning duration across retention-set construction and trie pruning. Adds the histogram to Derek bench targets so pruning regressions are surfaced in benchmark comparisons.