### PR TITLE
fix(trie): start partial proofs below known parent

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -461,7 +461,7 @@ fn process_connection<RpcMiddleware, HttpMiddleware>(
     >,
     <<HttpMiddleware as Layer<TowerServiceNoHttp<RpcMiddleware>>>::Service as Service<String>>::Future:
     Send + Unpin,
- {
+{
     let ProcessConnection {
         http_middleware,
         rpc_middleware,

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -924,8 +924,10 @@ where
         // If the trie cursor is seeked to a branch whose leaves have already been processed
         // then we can't use it, instead we seek forward and try again.
         if trie_cursor_path < uncalculated_lower_bound {
-            *trie_cursor_state =
-                TrieCursorState::seeked(self.trie_cursor_seek(*uncalculated_lower_bound)?);
+            *trie_cursor_state = TrieCursorState::seeked(
+                *uncalculated_lower_bound,
+                self.trie_cursor_seek(*uncalculated_lower_bound)?,
+            );
 
             // Having just seeked forward we need to check if the cursor is now exhausted,
             // extracting the new path at the same time.
@@ -1248,7 +1250,8 @@ where
             // trie cursor to the next cached node at-or-after `child_path`.
             if trie_cursor_state.path().is_some_and(|path| path < &child_path) {
                 trace!(target: TRACE_TARGET, ?child_path, "Seeking trie cursor to child path");
-                *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(child_path)?);
+                *trie_cursor_state =
+                    TrieCursorState::seeked(child_path, self.trie_cursor_seek(child_path)?);
             }
 
             // If the next cached branch node is a child of `child_path` then we can assume it is
@@ -1344,8 +1347,10 @@ where
         // first unconsumed entry. Exhaustion is similarly stable across forward-only ranges.
         if trie_cursor_state.needs_seek_to(&traversal_lower_bound) {
             trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
-            *trie_cursor_state =
-                TrieCursorState::seeked(self.trie_cursor_seek(traversal_lower_bound)?);
+            *trie_cursor_state = TrieCursorState::seeked(
+                traversal_lower_bound,
+                self.trie_cursor_seek(traversal_lower_bound)?,
+            );
         }
 
         // `uncalculated_lower_bound` tracks the lower bound of node paths which have yet to be
@@ -1548,17 +1553,28 @@ where
             if previous_traversal_bounds.is_some_and(|(_, previous_upper_bound)| {
                 previous_upper_bound.is_none_or(|upper_bound| upper_bound > traversal_lower_bound)
             }) {
-                trace!(
-                    target: TRACE_TARGET,
-                    ?previous_traversal_bounds,
-                    ?traversal_lower_bound,
-                    ?traversal_upper_bound,
-                    "Resetting cursors before overlapping or backward traversal range",
-                );
-                self.trie_cursor.reset();
-                trie_cursor_state = TrieCursorState::unseeked();
-                self.hashed_cursor.reset();
-                hashed_cursor_state = HashedCursorState::unseeked();
+                if trie_cursor_state.needs_reset_before_seek(&traversal_lower_bound) {
+                    trace!(
+                        target: TRACE_TARGET,
+                        ?previous_traversal_bounds,
+                        ?traversal_lower_bound,
+                        ?traversal_upper_bound,
+                        "Resetting trie cursor before overlapping or backward traversal range",
+                    );
+                    self.trie_cursor.reset();
+                    trie_cursor_state = TrieCursorState::unseeked();
+                }
+                if hashed_cursor_state.needs_reset_before_seek(&traversal_lower_bound) {
+                    trace!(
+                        target: TRACE_TARGET,
+                        ?previous_traversal_bounds,
+                        ?traversal_lower_bound,
+                        ?traversal_upper_bound,
+                        "Resetting hashed cursor before overlapping or backward traversal range",
+                    );
+                    self.hashed_cursor.reset();
+                    hashed_cursor_state = HashedCursorState::unseeked();
+                }
             }
 
             if let Err(err) = self.proof_subtrie(
@@ -1822,8 +1838,8 @@ enum TrieCursorState {
     Available(Nibbles, BranchNodeCompact),
     /// Cursor is seeked to this path, but the node has been used.
     Taken(Nibbles),
-    /// Cursor has been exhausted.
-    Exhausted,
+    /// Cursor has been exhausted after seeking from the given lower bound.
+    Exhausted(Nibbles),
 }
 
 impl TrieCursorState {
@@ -1833,8 +1849,8 @@ impl TrieCursorState {
     }
 
     /// Creates a [`Self`] based on an entry returned from the cursor itself.
-    fn seeked(entry: Option<(Nibbles, BranchNodeCompact)>) -> Self {
-        entry.map_or(Self::Exhausted, |(path, node)| Self::Available(path, node))
+    fn seeked(key: Nibbles, entry: Option<(Nibbles, BranchNodeCompact)>) -> Self {
+        entry.map_or(Self::Exhausted(key), |(path, node)| Self::Available(path, node))
     }
 
     /// Returns the path the cursor is seeked to, or None if it's exhausted.
@@ -1846,7 +1862,7 @@ impl TrieCursorState {
         match self {
             Self::Unseeked => panic!("cursor is unseeked"),
             Self::Available(path, _) | Self::Taken(path) => Some(path),
-            Self::Exhausted => None,
+            Self::Exhausted(_) => None,
         }
     }
 
@@ -1855,7 +1871,16 @@ impl TrieCursorState {
         match self {
             Self::Unseeked | Self::Taken(_) => true,
             Self::Available(current_path, _) => current_path < path,
-            Self::Exhausted => false,
+            Self::Exhausted(_) => false,
+        }
+    }
+
+    /// Returns true if seeking to `path` requires resetting the forward-only cursor.
+    fn needs_reset_before_seek(&self, path: &Nibbles) -> bool {
+        match self {
+            Self::Unseeked => false,
+            Self::Available(current_path, _) | Self::Taken(current_path) => current_path > path,
+            Self::Exhausted(exhausted_at) => exhausted_at > path,
         }
     }
 
@@ -1908,6 +1933,15 @@ impl<V> HashedCursorState<V> {
         match self {
             Self::Unseeked => true,
             Self::Available(path, _) => path < key,
+            Self::Exhausted(exhausted_at) => exhausted_at > key,
+        }
+    }
+
+    /// Returns true if seeking to `key` requires resetting the forward-only cursor.
+    fn needs_reset_before_seek(&self, key: &Nibbles) -> bool {
+        match self {
+            Self::Unseeked => false,
+            Self::Available(path, _) => path > key,
             Self::Exhausted(exhausted_at) => exhausted_at > key,
         }
     }
@@ -2015,13 +2049,14 @@ mod tests {
     }
 
     fn proof_inner_reset_counts(
+        trie_nodes: impl IntoIterator<Item = (Nibbles, BranchNodeCompact)>,
         values: impl IntoIterator<Item = (B256, U256)>,
         targets: &mut [ProofV2Target],
     ) -> (usize, usize) {
         let trie_resets = Rc::new(Cell::new(0));
         let hashed_resets = Rc::new(Cell::new(0));
         let trie_cursor = ResetCountingCursor::new(
-            MockTrieCursor::new(Arc::default(), Arc::default()),
+            MockTrieCursor::new(Arc::new(trie_nodes.into_iter().collect()), Arc::default()),
             Rc::clone(&trie_resets),
         );
         let hashed_cursor = ResetCountingCursor::new(
@@ -2564,7 +2599,7 @@ mod tests {
         let mut targets = [key_40, key_20]
             .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
 
-        let (trie_resets, hashed_resets) = proof_inner_reset_counts(values, &mut targets);
+        let (trie_resets, hashed_resets) = proof_inner_reset_counts([], values, &mut targets);
 
         assert_eq!(trie_resets, 0);
         assert_eq!(hashed_resets, 0);
@@ -2683,7 +2718,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_range_within_sibling_span_resets_cursors() {
+    fn test_nested_range_within_sibling_span_resets_only_advanced_cursor() {
         let key_20 = B256::right_padding_from(&[0x20, 0x10]);
         let key_30 = B256::right_padding_from(&[0x30, 0x10]);
         let key_40 = B256::right_padding_from(&[0x40, 0x10]);
@@ -2694,10 +2729,31 @@ mod tests {
             ProofV2Target::new(key_30).with_parent(ProofV2TargetParent::new(1)),
         ];
 
-        let (trie_resets, hashed_resets) = proof_inner_reset_counts(values, &mut targets);
+        let (trie_resets, hashed_resets) = proof_inner_reset_counts([], values, &mut targets);
+
+        assert_eq!(trie_resets, 0);
+        assert_eq!(hashed_resets, 1);
+    }
+
+    #[test]
+    fn test_nested_range_resets_advanced_trie_cursor_independently() {
+        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
+        let key_30 = B256::right_padding_from(&[0x30, 0x10]);
+        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
+        let mut targets = [
+            ProofV2Target::new(key_20).with_parent(ProofV2TargetParent::new(0)),
+            ProofV2Target::new(key_40).with_parent(ProofV2TargetParent::new(0)),
+            ProofV2Target::new(key_30).with_parent(ProofV2TargetParent::new(1)),
+        ];
+
+        let (trie_resets, hashed_resets) = proof_inner_reset_counts(
+            [(Nibbles::from_nibbles([0x6]), BranchNodeCompact::default())],
+            [(key_20, U256::from(1))],
+            &mut targets,
+        );
 
         assert_eq!(trie_resets, 1);
-        assert_eq!(hashed_resets, 1);
+        assert_eq!(hashed_resets, 0);
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1622,7 +1622,8 @@ where
         let mut hashed_cursor_state = HashedCursorState::unseeked();
 
         static EMPTY_TARGETS: [ProofV2Target; 0] = [];
-        let sub_trie_targets = SubTrieTargets { parent_prefix: None, targets: &EMPTY_TARGETS };
+        let sub_trie_targets =
+            SubTrieTargets { prefix: Nibbles::new(), parent_prefix: None, targets: &EMPTY_TARGETS };
 
         if let Err(err) = self.proof_subtrie(
             value_encoder,
@@ -2412,6 +2413,67 @@ mod tests {
             [ProofV2Target::new(other_child_target).with_parent(ProofV2TargetParent::new(3))];
         let (proof, _) = harness.proof_v2(&mut other_child);
         assert!(proof.is_empty(), "a different direct child is unrelated to the target");
+    }
+
+    #[test]
+    fn test_known_parent_targets_are_chunked_by_direct_child() {
+        let stored_slot_a = B256::right_padding_from(&[0xea, 0x53]);
+        let stored_slot_b = B256::right_padding_from(&[0xeb, 0x53]);
+        let target_a = B256::right_padding_from(&[0xea, 0x1f]);
+        let target_b = B256::right_padding_from(&[0xeb, 0x1f]);
+        let harness = ProofTestHarness::new(BTreeMap::from([
+            (stored_slot_a, U256::from(1)),
+            (stored_slot_b, U256::from(2)),
+        ]));
+        let mut targets = [target_a, target_b]
+            .map(|target| ProofV2Target::new(target).with_parent(ProofV2TargetParent::new(1)));
+
+        let (proof, root) = harness.proof_v2(&mut targets);
+
+        assert!(root.is_none());
+        assert_eq!(proof.len(), 2);
+        assert_eq!(proof[0].path, Nibbles::from_nibbles([0xe, 0xa]));
+        assert_eq!(proof[1].path, Nibbles::from_nibbles([0xe, 0xb]));
+    }
+
+    #[test]
+    fn test_known_parent_does_not_use_stale_parent_mask() {
+        let stored_slot_a = B256::right_padding_from(&[0xea, 0x53]);
+        let stored_slot = B256::right_padding_from(&[0xeb, 0x53]);
+        let stored_slot_c = B256::right_padding_from(&[0xec, 0x53]);
+        let target = B256::right_padding_from(&[0xeb, 0x1f]);
+        let stored_slot_nibbles = Nibbles::unpack(stored_slot);
+
+        // The known parent at `e` is supplied by the sparse trie and may be stale in the database
+        // when partial persistence masks that path. In particular, its state mask can omit the
+        // live `eb` child while hashed state already contains that child's leaf.
+        let stale_parent_mask = TrieMask::new((1 << 0xa) | (1 << 0xc));
+        let stale_parent = BranchNodeCompact::new(
+            stale_parent_mask,
+            TrieMask::new(0),
+            TrieMask::new(0),
+            Vec::new(),
+            None,
+        );
+        let storage_nodes = BTreeMap::from([(Nibbles::from_nibbles([0xe]), stale_parent)]);
+
+        let mut harness = TrieTestHarness::new(BTreeMap::from([
+            (stored_slot_a, U256::from(1)),
+            (stored_slot, U256::from(2)),
+            (stored_slot_c, U256::from(3)),
+        ]));
+        harness.set_trie_nodes(storage_nodes);
+
+        let mut targets = [ProofV2Target::new(target).with_parent(ProofV2TargetParent::new(1))];
+        let (proof, root) = harness.proof_v2(&mut targets);
+
+        assert!(root.is_none());
+        assert_eq!(proof.len(), 1);
+        assert_eq!(proof[0].path, stored_slot_nibbles.slice(0..2));
+        let TrieNodeV2::Leaf(leaf) = &proof[0].node else {
+            panic!("live direct child should be reconstructed as a leaf")
+        };
+        assert_eq!(leaf.key, stored_slot_nibbles.slice(2..));
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1970,121 +1970,19 @@ enum PopCachedBranchOutcome {
 mod tests {
     use super::*;
     use crate::{
-        hashed_cursor::{
-            mock::{MockHashedCursor, MockHashedCursorFactory},
-            HashedCursorFactory,
-        },
-        mock::{KeyVisit, KeyVisitType},
+        hashed_cursor::{mock::MockHashedCursorFactory, HashedCursorFactory},
         proof::StorageProof as LegacyStorageProof,
         test_utils::TrieTestHarness,
-        trie_cursor::{depth_first, mock::MockTrieCursor, TrieCursorFactory},
+        trie_cursor::{depth_first, TrieCursorFactory},
     };
     use alloy_primitives::map::B256Set;
     use alloy_rlp::Decodable;
     use alloy_trie::proof::AddedRemovedKeys;
     use itertools::Itertools;
-    use reth_storage_errors::db::DatabaseError;
     use reth_trie_common::{
         prefix_set::PrefixSetMut, ProofTrieNode, ProofV2TargetParent, TrieNode, EMPTY_ROOT_HASH,
     };
-    use std::{cell::Cell, collections::BTreeMap, rc::Rc, sync::Arc};
-
-    /// Cursor wrapper which counts explicit resets while forwarding all other operations.
-    #[derive(Debug)]
-    struct ResetCountingCursor<C> {
-        inner: C,
-        resets: Rc<Cell<usize>>,
-    }
-
-    impl<C> ResetCountingCursor<C> {
-        fn new(inner: C, resets: Rc<Cell<usize>>) -> Self {
-            Self { inner, resets }
-        }
-    }
-
-    impl<C: TrieCursor> TrieCursor for ResetCountingCursor<C> {
-        fn seek_exact(
-            &mut self,
-            key: Nibbles,
-        ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-            self.inner.seek_exact(key)
-        }
-
-        fn seek(
-            &mut self,
-            key: Nibbles,
-        ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-            self.inner.seek(key)
-        }
-
-        fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-            self.inner.next()
-        }
-
-        fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-            self.inner.current()
-        }
-
-        fn reset(&mut self) {
-            self.resets.set(self.resets.get() + 1);
-            self.inner.reset();
-        }
-    }
-
-    impl<C: HashedCursor> HashedCursor for ResetCountingCursor<C> {
-        type Value = C::Value;
-
-        fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-            self.inner.seek(key)
-        }
-
-        fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
-            self.inner.next()
-        }
-
-        fn reset(&mut self) {
-            self.resets.set(self.resets.get() + 1);
-            self.inner.reset();
-        }
-    }
-
-    fn proof_inner_reset_counts(
-        trie_nodes: impl IntoIterator<Item = (Nibbles, BranchNodeCompact)>,
-        values: impl IntoIterator<Item = (B256, U256)>,
-        targets: &mut [ProofV2Target],
-    ) -> (usize, usize) {
-        let trie_resets = Rc::new(Cell::new(0));
-        let hashed_resets = Rc::new(Cell::new(0));
-        let trie_cursor = ResetCountingCursor::new(
-            MockTrieCursor::new(Arc::new(trie_nodes.into_iter().collect()), Arc::default()),
-            Rc::clone(&trie_resets),
-        );
-        let hashed_cursor = ResetCountingCursor::new(
-            MockHashedCursor::new(Arc::new(values.into_iter().collect()), Arc::default()),
-            Rc::clone(&hashed_resets),
-        );
-        let mut calculator =
-            ProofCalculator::<_, _, StorageValueEncoder>::new(trie_cursor, hashed_cursor);
-
-        calculator.proof_inner(&mut StorageValueEncoder, targets).unwrap();
-        (trie_resets.get(), hashed_resets.get())
-    }
-
-    fn proof_inner_trie_visits(
-        trie_nodes: BTreeMap<Nibbles, BranchNodeCompact>,
-        values: impl IntoIterator<Item = (B256, U256)>,
-        targets: &mut [ProofV2Target],
-    ) -> Vec<KeyVisit<Nibbles>> {
-        let visited_keys = Arc::default();
-        let trie_cursor = MockTrieCursor::new(Arc::new(trie_nodes), Arc::clone(&visited_keys));
-        let hashed_cursor =
-            MockHashedCursor::new(Arc::new(values.into_iter().collect()), Arc::default());
-        let mut calculator =
-            ProofCalculator::<_, _, StorageValueEncoder>::new(trie_cursor, hashed_cursor);
-
-        calculator.proof_inner(&mut StorageValueEncoder, targets).unwrap();
-        visited_keys.lock().clone()
-    }
+    use std::collections::BTreeMap;
 
     /// Converts legacy proofs to V2 proofs by combining extension nodes with their child branch
     /// nodes.
@@ -2568,149 +2466,23 @@ mod tests {
     }
 
     #[test]
-    fn test_known_parent_sibling_span_retains_each_target_child() {
+    fn test_known_parent_sibling_span_retains_only_target_children() {
         let stored_slot_a = B256::right_padding_from(&[0xea, 0x53]);
         let stored_slot_b = B256::right_padding_from(&[0xeb, 0x53]);
+        let stored_slot_c = B256::right_padding_from(&[0xec, 0x53]);
         let target_a = B256::right_padding_from(&[0xea, 0x1f]);
-        let target_b = B256::right_padding_from(&[0xeb, 0x1f]);
+        let target_c = B256::right_padding_from(&[0xec, 0x1f]);
         let harness = ProofTestHarness::new(BTreeMap::from([
             (stored_slot_a, U256::from(1)),
             (stored_slot_b, U256::from(2)),
+            (stored_slot_c, U256::from(3)),
         ]));
-        let mut targets = [target_a, target_b]
+        let mut targets = [target_a, target_c]
             .map(|target| ProofV2Target::new(target).with_parent(ProofV2TargetParent::new(1)));
 
         let (proof, root) = harness.proof_v2(&mut targets);
 
         assert!(root.is_none());
-        assert_eq!(proof.len(), 2);
-        assert_eq!(proof[0].path, Nibbles::from_nibbles([0xe, 0xa]));
-        assert_eq!(proof[1].path, Nibbles::from_nibbles([0xe, 0xb]));
-    }
-
-    #[test]
-    fn test_disjoint_ranges_reuse_cursors() {
-        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
-        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
-        let values = [key_20, key_40]
-            .into_iter()
-            .enumerate()
-            .map(|(index, key)| (key, U256::from(index + 1)));
-        let mut targets = [key_40, key_20]
-            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
-
-        let (trie_resets, hashed_resets) = proof_inner_reset_counts([], values, &mut targets);
-
-        assert_eq!(trie_resets, 0);
-        assert_eq!(hashed_resets, 0);
-    }
-
-    #[test]
-    fn test_disjoint_ranges_reuse_available_trie_entry() {
-        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
-        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
-        let values = [(key_20, U256::from(1)), (key_40, U256::from(2))];
-        let mut targets = [key_20, key_40]
-            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
-        let buffered_path = Nibbles::from_nibbles([0x6]);
-
-        let visits = proof_inner_trie_visits(
-            BTreeMap::from([(buffered_path, BranchNodeCompact::default())]),
-            values,
-            &mut targets,
-        );
-
-        assert_eq!(
-            visits,
-            [KeyVisit {
-                visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x2, 0x0])),
-                visited_key: Some(buffered_path),
-            }]
-        );
-    }
-
-    #[test]
-    fn test_disjoint_ranges_reuse_exhausted_trie_cursor() {
-        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
-        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
-        let values = [(key_20, U256::from(1)), (key_40, U256::from(2))];
-        let mut targets = [key_20, key_40]
-            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
-
-        let visits = proof_inner_trie_visits(BTreeMap::new(), values, &mut targets);
-
-        assert_eq!(
-            visits,
-            [KeyVisit {
-                visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x2, 0x0])),
-                visited_key: None,
-            }]
-        );
-    }
-
-    #[test]
-    fn test_disjoint_ranges_seek_past_available_trie_entry() {
-        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
-        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
-        let values = [(key_20, U256::from(1)), (key_40, U256::from(2))];
-        let mut targets = [key_20, key_40]
-            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
-        let gap_path = Nibbles::from_nibbles([0x3]);
-        let buffered_path = Nibbles::from_nibbles([0x6]);
-
-        let visits = proof_inner_trie_visits(
-            BTreeMap::from([
-                (gap_path, BranchNodeCompact::default()),
-                (buffered_path, BranchNodeCompact::default()),
-            ]),
-            values,
-            &mut targets,
-        );
-
-        assert_eq!(
-            visits,
-            [
-                KeyVisit {
-                    visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x2, 0x0])),
-                    visited_key: Some(gap_path),
-                },
-                KeyVisit {
-                    visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x4, 0x0])),
-                    visited_key: Some(buffered_path),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn test_known_parent_sibling_span_uses_single_hashed_seek() {
-        let key_ea = B256::right_padding_from(&[0xea, 0x10]);
-        let key_eb = B256::right_padding_from(&[0xeb, 0x10]);
-        let key_ec = B256::right_padding_from(&[0xec, 0x10]);
-        let values = Arc::new(BTreeMap::from([
-            (key_ea, U256::from(1)),
-            (key_eb, U256::from(2)),
-            (key_ec, U256::from(3)),
-        ]));
-        let visited_keys = Arc::default();
-        let trie_cursor = MockTrieCursor::new(Arc::default(), Arc::default());
-        let hashed_cursor = MockHashedCursor::new(values, Arc::clone(&visited_keys));
-        let mut calculator =
-            ProofCalculator::<_, _, StorageValueEncoder>::new(trie_cursor, hashed_cursor);
-        let mut targets = [key_ea, key_ec]
-            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
-
-        let proof = calculator.proof_inner(&mut StorageValueEncoder, &mut targets).unwrap();
-
-        let seek_keys = visited_keys
-            .lock()
-            .iter()
-            .filter_map(|visit| match &visit.visit_type {
-                KeyVisitType::SeekNonExact(key) => Some(*key),
-                KeyVisitType::SeekExact(_) | KeyVisitType::Next => None,
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(seek_keys, [B256::right_padding_from(&[0xea])]);
         assert_eq!(
             proof.iter().map(|node| node.path).collect::<Vec<_>>(),
             [Nibbles::from_nibbles([0xe, 0xa]), Nibbles::from_nibbles([0xe, 0xc])]
@@ -2718,56 +2490,16 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_range_within_sibling_span_resets_only_advanced_cursor() {
-        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
-        let key_30 = B256::right_padding_from(&[0x30, 0x10]);
-        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
-        let values = [(key_20, U256::from(1)), (key_30, U256::from(2)), (key_40, U256::from(3))];
-        let mut targets = [
-            ProofV2Target::new(key_20).with_parent(ProofV2TargetParent::new(0)),
-            ProofV2Target::new(key_40).with_parent(ProofV2TargetParent::new(0)),
-            ProofV2Target::new(key_30).with_parent(ProofV2TargetParent::new(1)),
-        ];
-
-        let (trie_resets, hashed_resets) = proof_inner_reset_counts([], values, &mut targets);
-
-        assert_eq!(trie_resets, 0);
-        assert_eq!(hashed_resets, 1);
-    }
-
-    #[test]
-    fn test_nested_range_resets_advanced_trie_cursor_independently() {
-        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
-        let key_30 = B256::right_padding_from(&[0x30, 0x10]);
-        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
-        let mut targets = [
-            ProofV2Target::new(key_20).with_parent(ProofV2TargetParent::new(0)),
-            ProofV2Target::new(key_40).with_parent(ProofV2TargetParent::new(0)),
-            ProofV2Target::new(key_30).with_parent(ProofV2TargetParent::new(1)),
-        ];
-
-        let (trie_resets, hashed_resets) = proof_inner_reset_counts(
-            [(Nibbles::from_nibbles([0x6]), BranchNodeCompact::default())],
-            [(key_20, U256::from(1))],
-            &mut targets,
-        );
-
-        assert_eq!(trie_resets, 1);
-        assert_eq!(hashed_resets, 0);
-    }
-
-    #[test]
     fn test_known_parent_does_not_use_stale_parent_mask() {
         let stored_slot_a = B256::right_padding_from(&[0xea, 0x53]);
-        let stored_slot_b = B256::right_padding_from(&[0xeb, 0x53]);
+        let stored_slot = B256::right_padding_from(&[0xeb, 0x53]);
         let stored_slot_c = B256::right_padding_from(&[0xec, 0x53]);
-        let stored_slot_d = B256::right_padding_from(&[0xed, 0x53]);
-        let target_b = B256::right_padding_from(&[0xeb, 0x1f]);
-        let target_d = B256::right_padding_from(&[0xed, 0x1f]);
+        let target = B256::right_padding_from(&[0xeb, 0x1f]);
+        let stored_slot_nibbles = Nibbles::unpack(stored_slot);
 
         // The known parent at `e` is supplied by the sparse trie and may be stale in the database
         // when partial persistence masks that path. In particular, its state mask can omit the
-        // live `eb` and `ed` children while hashed state already contains their leaves.
+        // live `eb` child while hashed state already contains that child's leaf.
         let stale_parent_mask = TrieMask::new((1 << 0xa) | (1 << 0xc));
         let stale_parent = BranchNodeCompact::new(
             stale_parent_mask,
@@ -2780,32 +2512,21 @@ mod tests {
 
         let mut harness = TrieTestHarness::new(BTreeMap::from([
             (stored_slot_a, U256::from(1)),
-            (stored_slot_b, U256::from(2)),
+            (stored_slot, U256::from(2)),
             (stored_slot_c, U256::from(3)),
-            (stored_slot_d, U256::from(4)),
         ]));
         harness.set_trie_nodes(storage_nodes);
-        let trie_cursor_factory = harness.trie_cursor_factory();
 
-        let mut targets = [target_b, target_d]
-            .map(|target| ProofV2Target::new(target).with_parent(ProofV2TargetParent::new(1)));
+        let mut targets = [ProofV2Target::new(target).with_parent(ProofV2TargetParent::new(1))];
         let (proof, root) = harness.proof_v2(&mut targets);
 
         assert!(root.is_none());
-        assert_eq!(
-            proof.iter().map(|node| node.path).collect::<Vec<_>>(),
-            [Nibbles::from_nibbles([0xe, 0xb]), Nibbles::from_nibbles([0xe, 0xd])]
-        );
-
-        let visited_keys = trie_cursor_factory.visited_storage_keys(harness.hashed_address());
-        assert!(matches!(
-            visited_keys.first().map(|visit| &visit.visit_type),
-            Some(KeyVisitType::SeekNonExact(path))
-                if path == &Nibbles::from_nibbles([0xe, 0xb])
-        ));
-        assert!(visited_keys
-            .iter()
-            .all(|visit| visit.visited_key != Some(Nibbles::from_nibbles([0xe]))));
+        assert_eq!(proof.len(), 1);
+        assert_eq!(proof[0].path, stored_slot_nibbles.slice(0..2));
+        let TrieNodeV2::Leaf(leaf) = &proof[0].node else {
+            panic!("live direct child should be reconstructed as a leaf")
+        };
+        assert_eq!(leaf.key, stored_slot_nibbles.slice(2..));
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1343,15 +1343,13 @@ where
 
         // `next_uncached_key_range`, which will be called in the loop below, expects the trie
         // cursor to have already been positioned. Cursor resets for overlapping sub-tries are
-        // handled by `proof_inner`, so a buffered entry at-or-after this disjoint range remains the
-        // first unconsumed entry. Exhaustion is similarly stable across forward-only ranges.
-        if trie_cursor_state.needs_seek_to(&traversal_lower_bound) {
-            trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
-            *trie_cursor_state = TrieCursorState::seeked(
-                traversal_lower_bound,
-                self.trie_cursor_seek(traversal_lower_bound)?,
-            );
-        }
+        // handled by `proof_inner`; disjoint sub-tries can seek forward from the existing cursor
+        // frontier.
+        trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
+        *trie_cursor_state = TrieCursorState::seeked(
+            traversal_lower_bound,
+            self.trie_cursor_seek(traversal_lower_bound)?,
+        );
 
         // `uncalculated_lower_bound` tracks the lower bound of node paths which have yet to be
         // visited, either via the hashed key cursor (`calculate_key_range`) or trie cursor
@@ -1863,15 +1861,6 @@ impl TrieCursorState {
             Self::Unseeked => panic!("cursor is unseeked"),
             Self::Available(path, _) | Self::Taken(path) => Some(path),
             Self::Exhausted(_) => None,
-        }
-    }
-
-    /// Returns true if the cursor must seek to be usable for a range starting at `path`.
-    fn needs_seek_to(&self, path: &Nibbles) -> bool {
-        match self {
-            Self::Unseeked | Self::Taken(_) => true,
-            Self::Available(current_path, _) => current_path < path,
-            Self::Exhausted(_) => false,
         }
     }
 

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1342,21 +1342,10 @@ where
         // cursor to have already been positioned. Cursor resets for overlapping sub-tries are
         // handled by `proof_inner`, so a buffered entry at-or-after this disjoint range remains the
         // first unconsumed entry. Exhaustion is similarly stable across forward-only ranges.
-        let needs_seek = match trie_cursor_state {
-            TrieCursorState::Unseeked | TrieCursorState::Taken(_) => true,
-            TrieCursorState::Available(path, _) => *path < traversal_lower_bound,
-            TrieCursorState::Exhausted => false,
-        };
-        if needs_seek {
+        if trie_cursor_state.needs_seek_to(&traversal_lower_bound) {
             trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
             *trie_cursor_state =
                 TrieCursorState::seeked(self.trie_cursor_seek(traversal_lower_bound)?);
-        } else {
-            trace!(
-                target: TRACE_TARGET,
-                current=?trie_cursor_state.path(),
-                "Reusing trie cursor position",
-            );
         }
 
         // `uncalculated_lower_bound` tracks the lower bound of node paths which have yet to be
@@ -1858,6 +1847,15 @@ impl TrieCursorState {
             Self::Unseeked => panic!("cursor is unseeked"),
             Self::Available(path, _) | Self::Taken(path) => Some(path),
             Self::Exhausted => None,
+        }
+    }
+
+    /// Returns true if the cursor must seek to be usable for a range starting at `path`.
+    fn needs_seek_to(&self, path: &Nibbles) -> bool {
+        match self {
+            Self::Unseeked | Self::Taken(_) => true,
+            Self::Available(current_path, _) => current_path < path,
+            Self::Exhausted => false,
         }
     }
 

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1343,13 +1343,15 @@ where
 
         // `next_uncached_key_range`, which will be called in the loop below, expects the trie
         // cursor to have already been positioned. Cursor resets for overlapping sub-tries are
-        // handled by `proof_inner`; disjoint sub-tries can seek forward from the existing cursor
-        // frontier.
-        trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
-        *trie_cursor_state = TrieCursorState::seeked(
-            traversal_lower_bound,
-            self.trie_cursor_seek(traversal_lower_bound)?,
-        );
+        // handled by `proof_inner`, so a buffered entry at-or-after this disjoint range remains the
+        // first unconsumed entry. Exhaustion is similarly stable across forward-only ranges.
+        if trie_cursor_state.needs_seek_to(&traversal_lower_bound) {
+            trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
+            *trie_cursor_state = TrieCursorState::seeked(
+                traversal_lower_bound,
+                self.trie_cursor_seek(traversal_lower_bound)?,
+            );
+        }
 
         // `uncalculated_lower_bound` tracks the lower bound of node paths which have yet to be
         // visited, either via the hashed key cursor (`calculate_key_range`) or trie cursor
@@ -1861,6 +1863,15 @@ impl TrieCursorState {
             Self::Unseeked => panic!("cursor is unseeked"),
             Self::Available(path, _) | Self::Taken(path) => Some(path),
             Self::Exhausted(_) => None,
+        }
+    }
+
+    /// Returns true if the cursor must seek to be usable for a range starting at `path`.
+    fn needs_seek_to(&self, path: &Nibbles) -> bool {
+        match self {
+            Self::Unseeked | Self::Taken(_) => true,
+            Self::Available(current_path, _) => current_path < path,
+            Self::Exhausted(_) => false,
         }
     }
 

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -924,10 +924,8 @@ where
         // If the trie cursor is seeked to a branch whose leaves have already been processed
         // then we can't use it, instead we seek forward and try again.
         if trie_cursor_path < uncalculated_lower_bound {
-            *trie_cursor_state = TrieCursorState::seeked(
-                *uncalculated_lower_bound,
-                self.trie_cursor_seek(*uncalculated_lower_bound)?,
-            );
+            *trie_cursor_state =
+                TrieCursorState::seeked(self.trie_cursor_seek(*uncalculated_lower_bound)?);
 
             // Having just seeked forward we need to check if the cursor is now exhausted,
             // extracting the new path at the same time.
@@ -1243,8 +1241,7 @@ where
             // trie cursor to the next cached node at-or-after `child_path`.
             if trie_cursor_state.path().is_some_and(|path| path < &child_path) {
                 trace!(target: TRACE_TARGET, ?child_path, "Seeking trie cursor to child path");
-                *trie_cursor_state =
-                    TrieCursorState::seeked(child_path, self.trie_cursor_seek(child_path)?);
+                *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(child_path)?);
             }
 
             // If the next cached branch node is a child of `child_path` then we can assume it is
@@ -1331,23 +1328,11 @@ where
         debug_assert!(self.child_stack.is_empty());
 
         // `next_uncached_key_range`, which will be called in the loop below, expects the trie
-        // cursor to have already been seeked. The trie cursor is forward-only, but exact sub-trie
-        // chunks can overlap previous chunks, so reset it if this seek needs to move backwards.
-        if trie_cursor_state.needs_reset_before_seek(&sub_trie_prefix) {
-            trace!(target: TRACE_TARGET, "Resetting trie cursor before sub-trie");
-            self.trie_cursor.reset();
-            *trie_cursor_state = TrieCursorState::unseeked();
-        }
-
+        // cursor to have already been seeked. Cursor resets for overlapping sub-tries are handled
+        // by `proof_inner`; disjoint sub-tries can safely continue from the existing cursor
+        // frontier.
         trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
-        *trie_cursor_state =
-            TrieCursorState::seeked(sub_trie_prefix, self.trie_cursor_seek(sub_trie_prefix)?);
-
-        if hashed_cursor_state.needs_reset_before_seek(&sub_trie_prefix) {
-            trace!(target: TRACE_TARGET, "Resetting hashed cursor before sub-trie");
-            self.hashed_cursor.reset();
-            *hashed_cursor_state = HashedCursorState::unseeked();
-        }
+        *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(sub_trie_prefix)?);
 
         // `uncalculated_lower_bound` tracks the lower bound of node paths which have yet to be
         // visited, either via the hashed key cursor (`calculate_key_range`) or trie cursor
@@ -1538,10 +1523,27 @@ where
         // cursors are unseeked.
         let mut trie_cursor_state = TrieCursorState::unseeked();
         let mut hashed_cursor_state = HashedCursorState::unseeked();
+        let mut previous_sub_trie_prefix = None;
 
         // Divide targets into chunks, each chunk corresponding to a different sub-trie within the
         // overall trie, and handle all proofs within that sub-trie.
         for sub_trie_targets in iter_sub_trie_targets(targets) {
+            let sub_trie_prefix = sub_trie_targets.prefix();
+            if previous_sub_trie_prefix
+                .is_some_and(|previous| ordered_sub_tries_overlap(&previous, &sub_trie_prefix))
+            {
+                trace!(
+                    target: TRACE_TARGET,
+                    ?previous_sub_trie_prefix,
+                    ?sub_trie_prefix,
+                    "Resetting cursors before overlapping sub-trie",
+                );
+                self.trie_cursor.reset();
+                trie_cursor_state = TrieCursorState::unseeked();
+                self.hashed_cursor.reset();
+                hashed_cursor_state = HashedCursorState::unseeked();
+            }
+
             if let Err(err) = self.proof_subtrie(
                 value_encoder,
                 &mut trie_cursor_state,
@@ -1551,6 +1553,8 @@ where
                 self.clear_computation_state();
                 return Err(err);
             }
+
+            previous_sub_trie_prefix = Some(sub_trie_prefix);
         }
 
         trace!(
@@ -1797,8 +1801,8 @@ enum TrieCursorState {
     Available(Nibbles, BranchNodeCompact),
     /// Cursor is seeked to this path, but the node has been used.
     Taken(Nibbles),
-    /// Cursor has been exhausted after seeking from the given lower bound.
-    Exhausted(Nibbles),
+    /// Cursor has been exhausted.
+    Exhausted,
 }
 
 impl TrieCursorState {
@@ -1808,8 +1812,8 @@ impl TrieCursorState {
     }
 
     /// Creates a [`Self`] based on an entry returned from the cursor itself.
-    fn seeked(key: Nibbles, entry: Option<(Nibbles, BranchNodeCompact)>) -> Self {
-        entry.map_or(Self::Exhausted(key), |(path, node)| Self::Available(path, node))
+    fn seeked(entry: Option<(Nibbles, BranchNodeCompact)>) -> Self {
+        entry.map_or(Self::Exhausted, |(path, node)| Self::Available(path, node))
     }
 
     /// Returns the path the cursor is seeked to, or None if it's exhausted.
@@ -1821,16 +1825,7 @@ impl TrieCursorState {
         match self {
             Self::Unseeked => panic!("cursor is unseeked"),
             Self::Available(path, _) | Self::Taken(path) => Some(path),
-            Self::Exhausted(_) => None,
-        }
-    }
-
-    /// Returns true if seeking to `key` requires resetting the forward-only cursor.
-    fn needs_reset_before_seek(&self, key: &Nibbles) -> bool {
-        match self {
-            Self::Unseeked => false,
-            Self::Available(path, _) | Self::Taken(path) => path > key,
-            Self::Exhausted(exhausted_at) => exhausted_at > key,
+            Self::Exhausted => None,
         }
     }
 
@@ -1887,15 +1882,6 @@ impl<V> HashedCursorState<V> {
         }
     }
 
-    /// Returns true if seeking to `key` requires resetting the forward-only cursor.
-    fn needs_reset_before_seek(&self, key: &Nibbles) -> bool {
-        match self {
-            Self::Unseeked => false,
-            Self::Available(path, _) => path > key,
-            Self::Exhausted(exhausted_at) => exhausted_at > key,
-        }
-    }
-
     /// Takes the path and value from a [`Self::Available`]. Panics if not [`Self::Available`].
     fn take(&mut self) -> (Nibbles, V) {
         match core::mem::replace(self, Self::Unseeked) {
@@ -1920,19 +1906,103 @@ enum PopCachedBranchOutcome {
 mod tests {
     use super::*;
     use crate::{
-        hashed_cursor::{mock::MockHashedCursorFactory, HashedCursorFactory},
+        hashed_cursor::{
+            mock::{MockHashedCursor, MockHashedCursorFactory},
+            HashedCursorFactory,
+        },
         proof::StorageProof as LegacyStorageProof,
         test_utils::TrieTestHarness,
-        trie_cursor::{depth_first, TrieCursorFactory},
+        trie_cursor::{depth_first, mock::MockTrieCursor, TrieCursorFactory},
     };
     use alloy_primitives::map::B256Set;
     use alloy_rlp::Decodable;
     use alloy_trie::proof::AddedRemovedKeys;
     use itertools::Itertools;
+    use reth_storage_errors::db::DatabaseError;
     use reth_trie_common::{
         prefix_set::PrefixSetMut, ProofTrieNode, ProofV2TargetParent, TrieNode, EMPTY_ROOT_HASH,
     };
-    use std::collections::BTreeMap;
+    use std::{cell::Cell, collections::BTreeMap, rc::Rc, sync::Arc};
+
+    /// Cursor wrapper which counts explicit resets while forwarding all other operations.
+    #[derive(Debug)]
+    struct ResetCountingCursor<C> {
+        inner: C,
+        resets: Rc<Cell<usize>>,
+    }
+
+    impl<C> ResetCountingCursor<C> {
+        fn new(inner: C, resets: Rc<Cell<usize>>) -> Self {
+            Self { inner, resets }
+        }
+    }
+
+    impl<C: TrieCursor> TrieCursor for ResetCountingCursor<C> {
+        fn seek_exact(
+            &mut self,
+            key: Nibbles,
+        ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+            self.inner.seek_exact(key)
+        }
+
+        fn seek(
+            &mut self,
+            key: Nibbles,
+        ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+            self.inner.seek(key)
+        }
+
+        fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+            self.inner.next()
+        }
+
+        fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
+            self.inner.current()
+        }
+
+        fn reset(&mut self) {
+            self.resets.set(self.resets.get() + 1);
+            self.inner.reset();
+        }
+    }
+
+    impl<C: HashedCursor> HashedCursor for ResetCountingCursor<C> {
+        type Value = C::Value;
+
+        fn seek(&mut self, key: B256) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+            self.inner.seek(key)
+        }
+
+        fn next(&mut self) -> Result<Option<(B256, Self::Value)>, DatabaseError> {
+            self.inner.next()
+        }
+
+        fn reset(&mut self) {
+            self.resets.set(self.resets.get() + 1);
+            self.inner.reset();
+        }
+    }
+
+    fn proof_inner_reset_counts(
+        values: impl IntoIterator<Item = (B256, U256)>,
+        targets: &mut [ProofV2Target],
+    ) -> (usize, usize) {
+        let trie_resets = Rc::new(Cell::new(0));
+        let hashed_resets = Rc::new(Cell::new(0));
+        let trie_cursor = ResetCountingCursor::new(
+            MockTrieCursor::new(Arc::default(), Arc::default()),
+            Rc::clone(&trie_resets),
+        );
+        let hashed_cursor = ResetCountingCursor::new(
+            MockHashedCursor::new(Arc::new(values.into_iter().collect()), Arc::default()),
+            Rc::clone(&hashed_resets),
+        );
+        let mut calculator =
+            ProofCalculator::<_, _, StorageValueEncoder>::new(trie_cursor, hashed_cursor);
+
+        calculator.proof_inner(&mut StorageValueEncoder, targets).unwrap();
+        (trie_resets.get(), hashed_resets.get())
+    }
 
     /// Converts legacy proofs to V2 proofs by combining extension nodes with their child branch
     /// nodes.
@@ -2434,6 +2504,44 @@ mod tests {
         assert_eq!(proof.len(), 2);
         assert_eq!(proof[0].path, Nibbles::from_nibbles([0xe, 0xa]));
         assert_eq!(proof[1].path, Nibbles::from_nibbles([0xe, 0xb]));
+    }
+
+    #[test]
+    fn test_disjoint_sub_tries_reuse_cursors() {
+        let key_ea = B256::right_padding_from(&[0xea, 0x10]);
+        let key_eb = B256::right_padding_from(&[0xeb, 0x10]);
+        let key_ec = B256::right_padding_from(&[0xec, 0x10]);
+        let key_ed = B256::right_padding_from(&[0xed, 0x10]);
+        let values = [key_ea, key_eb, key_ec, key_ed]
+            .into_iter()
+            .enumerate()
+            .map(|(index, key)| (key, U256::from(index + 1)));
+        let mut targets = [key_ed, key_ea, key_eb]
+            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
+
+        let (trie_resets, hashed_resets) = proof_inner_reset_counts(values, &mut targets);
+
+        assert_eq!(trie_resets, 0);
+        assert_eq!(hashed_resets, 0);
+    }
+
+    #[test]
+    fn test_nested_sub_trie_resets_cursors() {
+        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
+        let key_21 = B256::right_padding_from(&[0x21, 0x10]);
+        let key_2f = B256::right_padding_from(&[0x2f, 0x10]);
+        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
+        let values = [(key_2f, U256::from(1)), (key_40, U256::from(2))];
+        let mut targets = [
+            ProofV2Target::new(key_2f).with_parent(ProofV2TargetParent::new(0)),
+            ProofV2Target::new(key_20).with_parent(ProofV2TargetParent::new(1)),
+            ProofV2Target::new(key_21).with_parent(ProofV2TargetParent::new(1)),
+        ];
+
+        let (trie_resets, hashed_resets) = proof_inner_reset_counts(values, &mut targets);
+
+        assert_eq!(trie_resets, 1);
+        assert_eq!(hashed_resets, 1);
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -897,7 +897,7 @@ where
     fn try_pop_cached_branch(
         &mut self,
         trie_cursor_state: &mut TrieCursorState,
-        sub_trie_prefix: &Nibbles,
+        traversal_upper_bound: Option<&Nibbles>,
         uncalculated_lower_bound: &Option<Nibbles>,
     ) -> Result<PopCachedBranchOutcome, StateProofError> {
         // If the `uncalculated_lower_bound` is None it indicates that there can be no more
@@ -936,8 +936,9 @@ where
             };
         }
 
-        // If the trie cursor has exceeded the sub-trie then we consider it to be exhausted.
-        if !trie_cursor_path.starts_with(sub_trie_prefix) {
+        // If the trie cursor has reached the end of the traversal range then we consider cached
+        // data to be exhausted. The cursor itself remains positioned for reuse by a later range.
+        if traversal_upper_bound.is_some_and(|upper_bound| trie_cursor_path >= upper_bound) {
             return Ok(PopCachedBranchOutcome::Exhausted)
         }
 
@@ -1009,11 +1010,17 @@ where
         &mut self,
         targets: &mut Option<TargetsCursor<'a>>,
         trie_cursor_state: &mut TrieCursorState,
-        sub_trie_prefix: &Nibbles,
-        sub_trie_upper_bound: Option<&Nibbles>,
+        traversal_upper_bound: Option<&Nibbles>,
         mut uncalculated_lower_bound: Option<Nibbles>,
     ) -> Result<Option<(Nibbles, Option<Nibbles>)>, StateProofError> {
         loop {
+            if let (Some(lower_bound), Some(upper_bound)) =
+                (uncalculated_lower_bound.as_ref(), traversal_upper_bound) &&
+                lower_bound >= upper_bound
+            {
+                return Ok(None)
+            }
+
             // Pop the currently cached branch node.
             //
             // NOTE we pop off the `cached_branch_stack` because cloning the `BranchNodeCompact`
@@ -1021,7 +1028,7 @@ where
             // push the cached branch back onto the stack once done.
             let (cached_path, cached_branch) = match self.try_pop_cached_branch(
                 trie_cursor_state,
-                sub_trie_prefix,
+                traversal_upper_bound,
                 &uncalculated_lower_bound,
             )? {
                 PopCachedBranchOutcome::Popped(cached) => cached,
@@ -1032,7 +1039,7 @@ where
                     trace!(target: TRACE_TARGET, ?uncalculated_lower_bound, "Exhausted cached trie nodes");
                     if let Some(lower) = uncalculated_lower_bound {
                         self.commit_branches(targets, &lower)?;
-                        return Ok(Some((lower, sub_trie_upper_bound.copied())));
+                        return Ok(Some((lower, traversal_upper_bound.copied())));
                     }
                     return Ok(None)
                 }
@@ -1300,7 +1307,11 @@ where
         target = TRACE_TARGET,
         level = "trace",
         skip_all,
-        fields(parent_prefix=?sub_trie_targets.parent_prefix),
+        fields(
+            parent_prefix=?sub_trie_targets.parent_prefix,
+            lower_bound=?sub_trie_targets.range.lower_bound(),
+            upper_bound=?sub_trie_targets.range.upper_bound(),
+        ),
     )]
     fn proof_subtrie<'a>(
         &mut self,
@@ -1309,8 +1320,9 @@ where
         hashed_cursor_state: &mut HashedCursorState<VE::DeferredEncoder>,
         sub_trie_targets: SubTrieTargets<'a>,
     ) -> Result<(), StateProofError> {
-        let sub_trie_prefix = sub_trie_targets.prefix();
-        let sub_trie_upper_bound = sub_trie_targets.upper_bound();
+        let traversal_range = sub_trie_targets.range();
+        let traversal_lower_bound = traversal_range.lower_bound();
+        let traversal_upper_bound = traversal_range.upper_bound();
 
         // Wrap targets into a `TargetsCursor`.  targets can be empty if we only want to calculate
         // the root, in which case we don't need a cursor.
@@ -1332,13 +1344,13 @@ where
         // by `proof_inner`; disjoint sub-tries can safely continue from the existing cursor
         // frontier.
         trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
-        *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(sub_trie_prefix)?);
+        *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(traversal_lower_bound)?);
 
         // `uncalculated_lower_bound` tracks the lower bound of node paths which have yet to be
         // visited, either via the hashed key cursor (`calculate_key_range`) or trie cursor
         // (`next_uncached_key_range`). If/when this becomes None then there are no further nodes
         // which could exist.
-        let mut uncalculated_lower_bound = Some(sub_trie_prefix);
+        let mut uncalculated_lower_bound = Some(traversal_lower_bound);
 
         trace!(target: TRACE_TARGET, "Starting loop");
         loop {
@@ -1349,8 +1361,7 @@ where
             let Some((calc_lower_bound, calc_upper_bound)) = self.next_uncached_key_range(
                 &mut targets,
                 trie_cursor_state,
-                &sub_trie_prefix,
-                sub_trie_upper_bound.as_ref(),
+                traversal_upper_bound.as_ref(),
                 prev_uncalculated_lower_bound,
             )?
             else {
@@ -1370,8 +1381,8 @@ where
             {
                 let msg = format!(
                     "next_uncached_key_range went backwards: calc_lower={calc_lower_bound:?} < \
-                     prev_lower={prev_lower:?}, calc_upper={calc_upper_bound:?}, prefix={:?}",
-                    sub_trie_prefix,
+                     prev_lower={prev_lower:?}, calc_upper={calc_upper_bound:?}, range={:?}",
+                    traversal_range,
                 );
                 error!(target: TRACE_TARGET, "{msg}");
                 return Err(StateProofError::TrieInconsistency(msg));
@@ -1389,10 +1400,11 @@ where
             // Once outside `calculate_key_range`, `hashed_cursor_state` will be at the first key
             // after the range, or exhausted.
             //
-            // If the hashed cursor is exhausted, or not within the range of the
-            // sub-trie, then there are no more keys at all, meaning the trie couldn't possibly have
-            // more data and we should complete computation.
-            if hashed_cursor_state.path().is_none_or(|key| !key.starts_with(&sub_trie_prefix)) {
+            // If the hashed cursor is exhausted, or has reached the end of the traversal range,
+            // then there are no more keys which can contribute to these target children.
+            if hashed_cursor_state.path().is_none_or(|key| {
+                traversal_upper_bound.is_some_and(|upper_bound| key >= &upper_bound)
+            }) {
                 break;
             }
 
@@ -1523,20 +1535,20 @@ where
         // cursors are unseeked.
         let mut trie_cursor_state = TrieCursorState::unseeked();
         let mut hashed_cursor_state = HashedCursorState::unseeked();
-        let mut previous_sub_trie_prefix = None;
+        let mut previous_traversal_range: Option<SubTrieRange> = None;
 
-        // Divide targets into chunks, each chunk corresponding to a different sub-trie within the
-        // overall trie, and handle all proofs within that sub-trie.
+        // Divide targets into bounded ranges, each corresponding to the direct children of one
+        // already-revealed parent, and handle all proofs within that range.
         for sub_trie_targets in iter_sub_trie_targets(targets) {
-            let sub_trie_prefix = sub_trie_targets.prefix();
-            if previous_sub_trie_prefix
-                .is_some_and(|previous| ordered_sub_tries_overlap(&previous, &sub_trie_prefix))
+            let traversal_range = sub_trie_targets.range();
+            if previous_traversal_range
+                .is_some_and(|previous| !previous.is_strictly_before(&traversal_range))
             {
                 trace!(
                     target: TRACE_TARGET,
-                    ?previous_sub_trie_prefix,
-                    ?sub_trie_prefix,
-                    "Resetting cursors before overlapping sub-trie",
+                    ?previous_traversal_range,
+                    ?traversal_range,
+                    "Resetting cursors before overlapping or backward traversal range",
                 );
                 self.trie_cursor.reset();
                 trie_cursor_state = TrieCursorState::unseeked();
@@ -1554,7 +1566,7 @@ where
                 return Err(err);
             }
 
-            previous_sub_trie_prefix = Some(sub_trie_prefix);
+            previous_traversal_range = Some(traversal_range);
         }
 
         trace!(
@@ -1626,8 +1638,11 @@ where
         let mut hashed_cursor_state = HashedCursorState::unseeked();
 
         static EMPTY_TARGETS: [ProofV2Target; 0] = [];
-        let sub_trie_targets =
-            SubTrieTargets { prefix: Nibbles::new(), parent_prefix: None, targets: &EMPTY_TARGETS };
+        let sub_trie_targets = SubTrieTargets {
+            range: SubTrieRange::new(Nibbles::new(), None),
+            parent_prefix: None,
+            targets: &EMPTY_TARGETS,
+        };
 
         if let Err(err) = self.proof_subtrie(
             value_encoder,
@@ -1910,6 +1925,7 @@ mod tests {
             mock::{MockHashedCursor, MockHashedCursorFactory},
             HashedCursorFactory,
         },
+        mock::KeyVisitType,
         proof::StorageProof as LegacyStorageProof,
         test_utils::TrieTestHarness,
         trie_cursor::{depth_first, mock::MockTrieCursor, TrieCursorFactory},
@@ -2486,7 +2502,7 @@ mod tests {
     }
 
     #[test]
-    fn test_known_parent_targets_are_chunked_by_direct_child() {
+    fn test_known_parent_sibling_span_retains_each_target_child() {
         let stored_slot_a = B256::right_padding_from(&[0xea, 0x53]);
         let stored_slot_b = B256::right_padding_from(&[0xeb, 0x53]);
         let target_a = B256::right_padding_from(&[0xea, 0x1f]);
@@ -2507,16 +2523,14 @@ mod tests {
     }
 
     #[test]
-    fn test_disjoint_sub_tries_reuse_cursors() {
-        let key_ea = B256::right_padding_from(&[0xea, 0x10]);
-        let key_eb = B256::right_padding_from(&[0xeb, 0x10]);
-        let key_ec = B256::right_padding_from(&[0xec, 0x10]);
-        let key_ed = B256::right_padding_from(&[0xed, 0x10]);
-        let values = [key_ea, key_eb, key_ec, key_ed]
+    fn test_disjoint_ranges_reuse_cursors() {
+        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
+        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
+        let values = [key_20, key_40]
             .into_iter()
             .enumerate()
             .map(|(index, key)| (key, U256::from(index + 1)));
-        let mut targets = [key_ed, key_ea, key_eb]
+        let mut targets = [key_40, key_20]
             .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
 
         let (trie_resets, hashed_resets) = proof_inner_reset_counts(values, &mut targets);
@@ -2526,16 +2540,50 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_sub_trie_resets_cursors() {
+    fn test_known_parent_sibling_span_uses_single_hashed_seek() {
+        let key_ea = B256::right_padding_from(&[0xea, 0x10]);
+        let key_eb = B256::right_padding_from(&[0xeb, 0x10]);
+        let key_ec = B256::right_padding_from(&[0xec, 0x10]);
+        let values = Arc::new(BTreeMap::from([
+            (key_ea, U256::from(1)),
+            (key_eb, U256::from(2)),
+            (key_ec, U256::from(3)),
+        ]));
+        let visited_keys = Arc::default();
+        let trie_cursor = MockTrieCursor::new(Arc::default(), Arc::default());
+        let hashed_cursor = MockHashedCursor::new(values, Arc::clone(&visited_keys));
+        let mut calculator =
+            ProofCalculator::<_, _, StorageValueEncoder>::new(trie_cursor, hashed_cursor);
+        let mut targets = [key_ea, key_ec]
+            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
+
+        let proof = calculator.proof_inner(&mut StorageValueEncoder, &mut targets).unwrap();
+
+        let seek_keys = visited_keys
+            .lock()
+            .iter()
+            .filter_map(|visit| match &visit.visit_type {
+                KeyVisitType::SeekNonExact(key) => Some(*key),
+                KeyVisitType::SeekExact(_) | KeyVisitType::Next => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(seek_keys, [B256::right_padding_from(&[0xea])]);
+        assert_eq!(
+            proof.iter().map(|node| node.path).collect::<Vec<_>>(),
+            [Nibbles::from_nibbles([0xe, 0xa]), Nibbles::from_nibbles([0xe, 0xc])]
+        );
+    }
+
+    #[test]
+    fn test_nested_range_within_sibling_span_resets_cursors() {
         let key_20 = B256::right_padding_from(&[0x20, 0x10]);
-        let key_21 = B256::right_padding_from(&[0x21, 0x10]);
-        let key_2f = B256::right_padding_from(&[0x2f, 0x10]);
+        let key_30 = B256::right_padding_from(&[0x30, 0x10]);
         let key_40 = B256::right_padding_from(&[0x40, 0x10]);
-        let values = [(key_2f, U256::from(1)), (key_40, U256::from(2))];
+        let values = [(key_20, U256::from(1)), (key_30, U256::from(2)), (key_40, U256::from(3))];
         let mut targets = [
-            ProofV2Target::new(key_2f).with_parent(ProofV2TargetParent::new(0)),
-            ProofV2Target::new(key_20).with_parent(ProofV2TargetParent::new(1)),
-            ProofV2Target::new(key_21).with_parent(ProofV2TargetParent::new(1)),
+            ProofV2Target::new(key_20).with_parent(ProofV2TargetParent::new(0)),
+            ProofV2Target::new(key_40).with_parent(ProofV2TargetParent::new(0)),
+            ProofV2Target::new(key_30).with_parent(ProofV2TargetParent::new(1)),
         ];
 
         let (trie_resets, hashed_resets) = proof_inner_reset_counts(values, &mut targets);
@@ -2547,14 +2595,15 @@ mod tests {
     #[test]
     fn test_known_parent_does_not_use_stale_parent_mask() {
         let stored_slot_a = B256::right_padding_from(&[0xea, 0x53]);
-        let stored_slot = B256::right_padding_from(&[0xeb, 0x53]);
+        let stored_slot_b = B256::right_padding_from(&[0xeb, 0x53]);
         let stored_slot_c = B256::right_padding_from(&[0xec, 0x53]);
-        let target = B256::right_padding_from(&[0xeb, 0x1f]);
-        let stored_slot_nibbles = Nibbles::unpack(stored_slot);
+        let stored_slot_d = B256::right_padding_from(&[0xed, 0x53]);
+        let target_b = B256::right_padding_from(&[0xeb, 0x1f]);
+        let target_d = B256::right_padding_from(&[0xed, 0x1f]);
 
         // The known parent at `e` is supplied by the sparse trie and may be stale in the database
         // when partial persistence masks that path. In particular, its state mask can omit the
-        // live `eb` child while hashed state already contains that child's leaf.
+        // live `eb` and `ed` children while hashed state already contains their leaves.
         let stale_parent_mask = TrieMask::new((1 << 0xa) | (1 << 0xc));
         let stale_parent = BranchNodeCompact::new(
             stale_parent_mask,
@@ -2567,21 +2616,32 @@ mod tests {
 
         let mut harness = TrieTestHarness::new(BTreeMap::from([
             (stored_slot_a, U256::from(1)),
-            (stored_slot, U256::from(2)),
+            (stored_slot_b, U256::from(2)),
             (stored_slot_c, U256::from(3)),
+            (stored_slot_d, U256::from(4)),
         ]));
         harness.set_trie_nodes(storage_nodes);
+        let trie_cursor_factory = harness.trie_cursor_factory();
 
-        let mut targets = [ProofV2Target::new(target).with_parent(ProofV2TargetParent::new(1))];
+        let mut targets = [target_b, target_d]
+            .map(|target| ProofV2Target::new(target).with_parent(ProofV2TargetParent::new(1)));
         let (proof, root) = harness.proof_v2(&mut targets);
 
         assert!(root.is_none());
-        assert_eq!(proof.len(), 1);
-        assert_eq!(proof[0].path, stored_slot_nibbles.slice(0..2));
-        let TrieNodeV2::Leaf(leaf) = &proof[0].node else {
-            panic!("live direct child should be reconstructed as a leaf")
-        };
-        assert_eq!(leaf.key, stored_slot_nibbles.slice(2..));
+        assert_eq!(
+            proof.iter().map(|node| node.path).collect::<Vec<_>>(),
+            [Nibbles::from_nibbles([0xe, 0xb]), Nibbles::from_nibbles([0xe, 0xd])]
+        );
+
+        let visited_keys = trie_cursor_factory.visited_storage_keys(harness.hashed_address());
+        assert!(matches!(
+            visited_keys.first().map(|visit| &visit.visit_type),
+            Some(KeyVisitType::SeekNonExact(path))
+                if path == &Nibbles::from_nibbles([0xe, 0xb])
+        ));
+        assert!(visited_keys
+            .iter()
+            .all(|visit| visit.visited_key != Some(Nibbles::from_nibbles([0xe]))));
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1340,11 +1340,25 @@ where
         debug_assert!(self.child_stack.is_empty());
 
         // `next_uncached_key_range`, which will be called in the loop below, expects the trie
-        // cursor to have already been seeked. Cursor resets for overlapping sub-tries are handled
-        // by `proof_inner`; disjoint sub-tries can safely continue from the existing cursor
-        // frontier.
-        trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
-        *trie_cursor_state = TrieCursorState::seeked(self.trie_cursor_seek(traversal_lower_bound)?);
+        // cursor to have already been positioned. Cursor resets for overlapping sub-tries are
+        // handled by `proof_inner`, so a buffered entry at-or-after this disjoint range remains the
+        // first unconsumed entry. Exhaustion is similarly stable across forward-only ranges.
+        let needs_seek = match trie_cursor_state {
+            TrieCursorState::Unseeked | TrieCursorState::Taken(_) => true,
+            TrieCursorState::Available(path, _) => *path < traversal_lower_bound,
+            TrieCursorState::Exhausted => false,
+        };
+        if needs_seek {
+            trace!(target: TRACE_TARGET, "Doing initial seek of trie cursor");
+            *trie_cursor_state =
+                TrieCursorState::seeked(self.trie_cursor_seek(traversal_lower_bound)?);
+        } else {
+            trace!(
+                target: TRACE_TARGET,
+                current=?trie_cursor_state.path(),
+                "Reusing trie cursor position",
+            );
+        }
 
         // `uncalculated_lower_bound` tracks the lower bound of node paths which have yet to be
         // visited, either via the hashed key cursor (`calculate_key_range`) or trie cursor
@@ -1925,7 +1939,7 @@ mod tests {
             mock::{MockHashedCursor, MockHashedCursorFactory},
             HashedCursorFactory,
         },
-        mock::KeyVisitType,
+        mock::{KeyVisit, KeyVisitType},
         proof::StorageProof as LegacyStorageProof,
         test_utils::TrieTestHarness,
         trie_cursor::{depth_first, mock::MockTrieCursor, TrieCursorFactory},
@@ -2018,6 +2032,22 @@ mod tests {
 
         calculator.proof_inner(&mut StorageValueEncoder, targets).unwrap();
         (trie_resets.get(), hashed_resets.get())
+    }
+
+    fn proof_inner_trie_visits(
+        trie_nodes: BTreeMap<Nibbles, BranchNodeCompact>,
+        values: impl IntoIterator<Item = (B256, U256)>,
+        targets: &mut [ProofV2Target],
+    ) -> Vec<KeyVisit<Nibbles>> {
+        let visited_keys = Arc::default();
+        let trie_cursor = MockTrieCursor::new(Arc::new(trie_nodes), Arc::clone(&visited_keys));
+        let hashed_cursor =
+            MockHashedCursor::new(Arc::new(values.into_iter().collect()), Arc::default());
+        let mut calculator =
+            ProofCalculator::<_, _, StorageValueEncoder>::new(trie_cursor, hashed_cursor);
+
+        calculator.proof_inner(&mut StorageValueEncoder, targets).unwrap();
+        visited_keys.lock().clone()
     }
 
     /// Converts legacy proofs to V2 proofs by combining extension nodes with their child branch
@@ -2537,6 +2567,83 @@ mod tests {
 
         assert_eq!(trie_resets, 0);
         assert_eq!(hashed_resets, 0);
+    }
+
+    #[test]
+    fn test_disjoint_ranges_reuse_available_trie_entry() {
+        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
+        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
+        let values = [(key_20, U256::from(1)), (key_40, U256::from(2))];
+        let mut targets = [key_20, key_40]
+            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
+        let buffered_path = Nibbles::from_nibbles([0x6]);
+
+        let visits = proof_inner_trie_visits(
+            BTreeMap::from([(buffered_path, BranchNodeCompact::default())]),
+            values,
+            &mut targets,
+        );
+
+        assert_eq!(
+            visits,
+            [KeyVisit {
+                visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x2, 0x0])),
+                visited_key: Some(buffered_path),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_disjoint_ranges_reuse_exhausted_trie_cursor() {
+        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
+        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
+        let values = [(key_20, U256::from(1)), (key_40, U256::from(2))];
+        let mut targets = [key_20, key_40]
+            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
+
+        let visits = proof_inner_trie_visits(BTreeMap::new(), values, &mut targets);
+
+        assert_eq!(
+            visits,
+            [KeyVisit {
+                visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x2, 0x0])),
+                visited_key: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_disjoint_ranges_seek_past_available_trie_entry() {
+        let key_20 = B256::right_padding_from(&[0x20, 0x10]);
+        let key_40 = B256::right_padding_from(&[0x40, 0x10]);
+        let values = [(key_20, U256::from(1)), (key_40, U256::from(2))];
+        let mut targets = [key_20, key_40]
+            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
+        let gap_path = Nibbles::from_nibbles([0x3]);
+        let buffered_path = Nibbles::from_nibbles([0x6]);
+
+        let visits = proof_inner_trie_visits(
+            BTreeMap::from([
+                (gap_path, BranchNodeCompact::default()),
+                (buffered_path, BranchNodeCompact::default()),
+            ]),
+            values,
+            &mut targets,
+        );
+
+        assert_eq!(
+            visits,
+            [
+                KeyVisit {
+                    visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x2, 0x0])),
+                    visited_key: Some(gap_path),
+                },
+                KeyVisit {
+                    visit_type: KeyVisitType::SeekNonExact(Nibbles::from_nibbles([0x4, 0x0])),
+                    visited_key: Some(buffered_path),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1309,8 +1309,8 @@ where
         skip_all,
         fields(
             parent_prefix=?sub_trie_targets.parent_prefix,
-            lower_bound=?sub_trie_targets.range.lower_bound(),
-            upper_bound=?sub_trie_targets.range.upper_bound(),
+            lower_bound=?sub_trie_targets.lower_bound,
+            upper_bound=?sub_trie_targets.upper_bound,
         ),
     )]
     fn proof_subtrie<'a>(
@@ -1320,9 +1320,8 @@ where
         hashed_cursor_state: &mut HashedCursorState<VE::DeferredEncoder>,
         sub_trie_targets: SubTrieTargets<'a>,
     ) -> Result<(), StateProofError> {
-        let traversal_range = sub_trie_targets.range();
-        let traversal_lower_bound = traversal_range.lower_bound();
-        let traversal_upper_bound = traversal_range.upper_bound();
+        let traversal_lower_bound = sub_trie_targets.lower_bound;
+        let traversal_upper_bound = sub_trie_targets.upper_bound;
 
         // Wrap targets into a `TargetsCursor`.  targets can be empty if we only want to calculate
         // the root, in which case we don't need a cursor.
@@ -1395,8 +1394,9 @@ where
             {
                 let msg = format!(
                     "next_uncached_key_range went backwards: calc_lower={calc_lower_bound:?} < \
-                     prev_lower={prev_lower:?}, calc_upper={calc_upper_bound:?}, range={:?}",
-                    traversal_range,
+                     prev_lower={prev_lower:?}, calc_upper={calc_upper_bound:?}, \
+                     lower_bound={traversal_lower_bound:?}, \
+                     upper_bound={traversal_upper_bound:?}",
                 );
                 error!(target: TRACE_TARGET, "{msg}");
                 return Err(StateProofError::TrieInconsistency(msg));
@@ -1549,19 +1549,21 @@ where
         // cursors are unseeked.
         let mut trie_cursor_state = TrieCursorState::unseeked();
         let mut hashed_cursor_state = HashedCursorState::unseeked();
-        let mut previous_traversal_range: Option<SubTrieRange> = None;
+        let mut previous_traversal_bounds: Option<(Nibbles, Option<Nibbles>)> = None;
 
         // Divide targets into bounded ranges, each corresponding to the direct children of one
         // already-revealed parent, and handle all proofs within that range.
         for sub_trie_targets in iter_sub_trie_targets(targets) {
-            let traversal_range = sub_trie_targets.range();
-            if previous_traversal_range
-                .is_some_and(|previous| !previous.is_strictly_before(&traversal_range))
-            {
+            let traversal_lower_bound = sub_trie_targets.lower_bound;
+            let traversal_upper_bound = sub_trie_targets.upper_bound;
+            if previous_traversal_bounds.is_some_and(|(_, previous_upper_bound)| {
+                previous_upper_bound.is_none_or(|upper_bound| upper_bound > traversal_lower_bound)
+            }) {
                 trace!(
                     target: TRACE_TARGET,
-                    ?previous_traversal_range,
-                    ?traversal_range,
+                    ?previous_traversal_bounds,
+                    ?traversal_lower_bound,
+                    ?traversal_upper_bound,
                     "Resetting cursors before overlapping or backward traversal range",
                 );
                 self.trie_cursor.reset();
@@ -1580,7 +1582,7 @@ where
                 return Err(err);
             }
 
-            previous_traversal_range = Some(traversal_range);
+            previous_traversal_bounds = Some((traversal_lower_bound, traversal_upper_bound));
         }
 
         trace!(
@@ -1653,7 +1655,8 @@ where
 
         static EMPTY_TARGETS: [ProofV2Target; 0] = [];
         let sub_trie_targets = SubTrieTargets {
-            range: SubTrieRange::new(Nibbles::new(), None),
+            lower_bound: Nibbles::new(),
+            upper_bound: None,
             parent_prefix: None,
             targets: &EMPTY_TARGETS,
         };

--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -1875,12 +1875,12 @@ impl TrieCursorState {
         }
     }
 
-    /// Returns true if seeking to `path` requires resetting the forward-only cursor.
-    fn needs_reset_before_seek(&self, path: &Nibbles) -> bool {
+    /// Returns true if seeking to `key` requires resetting the forward-only cursor.
+    fn needs_reset_before_seek(&self, key: &Nibbles) -> bool {
         match self {
             Self::Unseeked => false,
-            Self::Available(current_path, _) | Self::Taken(current_path) => current_path > path,
-            Self::Exhausted(exhausted_at) => exhausted_at > path,
+            Self::Available(path, _) | Self::Taken(path) => path > key,
+            Self::Exhausted(exhausted_at) => exhausted_at > key,
         }
     }
 

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -8,6 +8,16 @@ pub(crate) fn known_parent_prefix(target: &ProofV2Target) -> Option<Nibbles> {
     target.parent.path(target.key_nibbles)
 }
 
+// Returns the concrete prefix to traverse for a target. If the parent is already known then the
+// traversal starts at its direct child; otherwise it starts at the trie root.
+#[inline]
+fn sub_trie_prefix(target: &ProofV2Target) -> Nibbles {
+    target
+        .parent
+        .path_len()
+        .map_or_else(Nibbles::new, |parent_len| target.key_nibbles.slice(0..parent_len + 1))
+}
+
 // A helper function which returns the first path following a sub-trie in lexicographical order.
 #[inline]
 fn sub_trie_upper_bound(sub_trie_prefix: &Nibbles) -> Option<Nibbles> {
@@ -17,6 +27,8 @@ fn sub_trie_upper_bound(sub_trie_prefix: &Nibbles) -> Option<Nibbles> {
 /// Describes a set of targets which all apply to a single sub-trie, ie a section of the overall
 /// trie whose nodes all share a prefix.
 pub(crate) struct SubTrieTargets<'a> {
+    /// The concrete prefix used to traverse this sub-trie.
+    pub(crate) prefix: Nibbles,
     /// The path of the already-revealed parent branch. `None` means the actual trie root is
     /// requested, while `Some(Nibbles::new())` means the root branch is already revealed.
     pub(crate) parent_prefix: Option<Nibbles>,
@@ -28,8 +40,8 @@ pub(crate) struct SubTrieTargets<'a> {
 impl<'a> SubTrieTargets<'a> {
     /// Returns the concrete prefix used to traverse this sub-trie.
     #[inline]
-    pub(crate) fn prefix(&self) -> Nibbles {
-        self.parent_prefix.unwrap_or_default()
+    pub(crate) const fn prefix(&self) -> Nibbles {
+        self.prefix
     }
 
     // A helper function which returns the first path following a sub-trie in lexicographical order.
@@ -44,24 +56,24 @@ impl<'a> SubTrieTargets<'a> {
 pub(crate) fn iter_sub_trie_targets(
     targets: &mut [ProofV2Target],
 ) -> impl Iterator<Item = SubTrieTargets<'_>> {
-    // Sort globally by parent context, then target key. `None` and `Some(Nibbles::new())` remain
-    // distinct despite both traversing from the root. This also leaves each resulting chunk
-    // ordered for the `ProofCalculator`.
+    // Sort globally by concrete sub-trie, then target key. `None` and a known root parent remain
+    // distinct: the former traverses from the root, while the latter traverses from one of the
+    // root's direct children. This also leaves each resulting chunk ordered for the
+    // `ProofCalculator`.
     targets.sort_unstable_by(|a, b| {
-        known_parent_prefix(a)
-            .cmp(&known_parent_prefix(b))
-            .then_with(|| a.key_nibbles.cmp(&b.key_nibbles))
+        sub_trie_prefix(a).cmp(&sub_trie_prefix(b)).then_with(|| a.key_nibbles.cmp(&b.key_nibbles))
     });
 
-    // Chunk targets by exact known-parent prefix. Prefixes nested below a previous prefix are still
-    // processed as their own sub-trie.
-    let target_chunks = targets
-        .chunk_by_mut(|current, next| known_parent_prefix(current) == known_parent_prefix(next));
+    // Chunk targets by exact concrete prefixes. Different children of the same known parent must
+    // be processed independently so traversal never consults the parent node.
+    let target_chunks =
+        targets.chunk_by_mut(|current, next| sub_trie_prefix(current) == sub_trie_prefix(next));
 
     // Map the chunks to the return type.
     target_chunks.map(move |targets| {
+        let prefix = sub_trie_prefix(&targets[0]);
         let parent_prefix = known_parent_prefix(&targets[0]);
-        SubTrieTargets { parent_prefix, targets }
+        SubTrieTargets { prefix, parent_prefix, targets }
     })
 }
 
@@ -82,7 +94,8 @@ mod tests {
         };
 
         // Test cases: (input_targets, expected_output)
-        // Expected output format: Vec<(known_parent_prefix_hex, Vec<key_hex>)>
+        // Expected output format:
+        // Vec<(known_parent_prefix_hex, sub_trie_prefix_hex, Vec<key_hex>)>
         let test_cases = vec![
             // Case 1: Empty targets
             (vec![], vec![]),
@@ -91,6 +104,7 @@ mod tests {
                 vec![ProofV2Target::new(B256::repeat_byte(0x20))],
                 vec![(
                     None,
+                    "",
                     vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                 )],
             ),
@@ -102,6 +116,7 @@ mod tests {
                 ],
                 vec![(
                     None,
+                    "",
                     vec![
                         "2020202020202020202020202020202020202020202020202020202020202020",
                         "2121212121212121212121212121212121212121212121212121212121212121",
@@ -119,15 +134,17 @@ mod tests {
                 vec![
                     (
                         Some("2"),
+                        "20",
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some("4"),
+                        "40",
                         vec!["4040404040404040404040404040404040404040404040404040404040404040"],
                     ),
                 ],
             ),
-            // Case 5: Three targets, two in same sub-trie, one separate
+            // Case 5: Targets below different children of the same parent are separate
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -140,13 +157,17 @@ mod tests {
                 vec![
                     (
                         Some("2"),
-                        vec![
-                            "2020202020202020202020202020202020202020202020202020202020202020",
-                            "2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f",
-                        ],
+                        "20",
+                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
+                    ),
+                    (
+                        Some("2"),
+                        "2f",
+                        vec!["2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f"],
                     ),
                     (
                         Some("4"),
+                        "40",
                         vec!["4040404040404040404040404040404040404040404040404040404040404040"],
                     ),
                 ],
@@ -162,10 +183,12 @@ mod tests {
                 vec![
                     (
                         Some("2"),
+                        "20",
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some("2f"),
+                        "2f2",
                         vec!["2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f"],
                     ),
                 ],
@@ -187,27 +210,32 @@ mod tests {
                 vec![
                     (
                         Some("2"),
+                        "20",
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some("2f2"),
+                        "2f2f",
                         vec!["2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f"],
                     ),
                     (
                         Some("4c"),
+                        "4c4",
                         vec!["4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"],
                     ),
                     (
                         Some("4c4"),
+                        "4c4c",
                         vec!["4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"],
                     ),
                     (
                         Some("4e"),
+                        "4e4",
                         vec!["4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e"],
                     ),
                 ],
             ),
-            // Case 8: A root parent should result in a zero-length sub-trie prefix
+            // Case 8: A known root parent splits targets by the root's direct children
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -215,15 +243,20 @@ mod tests {
                     ProofV2Target::new(B256::repeat_byte(0x40))
                         .with_parent(ProofV2TargetParent::new(0)),
                 ],
-                vec![(
-                    Some(""),
-                    vec![
-                        "2020202020202020202020202020202020202020202020202020202020202020",
-                        "4040404040404040404040404040404040404040404040404040404040404040",
-                    ],
-                )],
+                vec![
+                    (
+                        Some(""),
+                        "2",
+                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
+                    ),
+                    (
+                        Some(""),
+                        "4",
+                        vec!["4040404040404040404040404040404040404040404040404040404040404040"],
+                    ),
+                ],
             ),
-            // Case 9: Second target's sub-trie prefix is root
+            // Case 9: Concrete sub-trie prefixes determine chunk order
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -233,12 +266,14 @@ mod tests {
                 ],
                 vec![
                     (
-                        Some(""),
-                        vec!["4040404040404040404040404040404040404040404040404040404040404040"],
+                        Some("2"),
+                        "20",
+                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
-                        Some("2"),
-                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
+                        Some(""),
+                        "4",
+                        vec!["4040404040404040404040404040404040404040404040404040404040404040"],
                     ),
                 ],
             ),
@@ -252,10 +287,12 @@ mod tests {
                 vec![
                     (
                         None,
+                        "",
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some(""),
+                        "4",
                         vec!["4040404040404040404040404040404040404040404040404040404040404040"],
                     ),
                 ],
@@ -275,11 +312,11 @@ mod tests {
                 sub_tries.len()
             );
 
-            for (j, (sub_trie, (exp_parent_prefix_hex, exp_keys))) in
+            for (j, (sub_trie, (exp_parent_prefix_hex, exp_prefix_hex, exp_keys))) in
                 sub_tries.iter().zip(expected.iter()).enumerate()
             {
                 let exp_parent_prefix = exp_parent_prefix_hex.map(nibbles);
-                let exp_prefix = exp_parent_prefix.unwrap_or_default();
+                let exp_prefix = nibbles(exp_prefix_hex);
 
                 assert_eq!(
                     sub_trie.parent_prefix, exp_parent_prefix,
@@ -329,5 +366,23 @@ mod tests {
         assert_eq!(sub_tries.len(), 1);
         assert_eq!(sub_tries[0].targets[0].key(), B256::repeat_byte(0x20));
         assert_eq!(sub_tries[0].parent_prefix, None);
+    }
+
+    #[test]
+    fn test_iter_sub_trie_targets_groups_same_parent_child() {
+        let key_a = B256::right_padding_from(&[0x20, 0x10]);
+        let key_b = B256::right_padding_from(&[0x20, 0x00]);
+        let mut targets = [key_a, key_b]
+            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
+
+        let sub_tries = iter_sub_trie_targets(&mut targets).collect::<Vec<_>>();
+
+        assert_eq!(sub_tries.len(), 1);
+        assert_eq!(sub_tries[0].parent_prefix, Some(Nibbles::from_nibbles([0x2])));
+        assert_eq!(sub_tries[0].prefix(), Nibbles::from_nibbles([0x2, 0x0]));
+        assert_eq!(
+            sub_tries[0].targets.iter().map(ProofV2Target::key).collect::<Vec<_>>(),
+            [key_b, key_a]
+        );
     }
 }

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -80,23 +80,13 @@ mod tests {
         // Expected output format:
         // Vec<(known_parent_prefix_hex, lower_bound_hex, upper_bound_hex, Vec<key_hex>)>
         let test_cases = vec![
-            // Case 1: Empty targets
+            // Empty targets.
             (vec![], vec![]),
-            // Case 2: Single target without a known parent
-            (
-                vec![ProofV2Target::new(B256::repeat_byte(0x20))],
-                vec![(
-                    None,
-                    "",
-                    None,
-                    vec!["2020202020202020202020202020202020202020202020202020202020202020"],
-                )],
-            ),
-            // Case 3: Multiple targets in same sub-trie without known parents
+            // A root traversal stays unbounded and sorts its targets.
             (
                 vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20)),
                     ProofV2Target::new(B256::repeat_byte(0x21)),
+                    ProofV2Target::new(B256::repeat_byte(0x20)),
                 ],
                 vec![(
                     None,
@@ -108,30 +98,7 @@ mod tests {
                     ],
                 )],
             ),
-            // Case 4: Multiple targets in different sub-tries
-            (
-                vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20))
-                        .with_parent(ProofV2TargetParent::new(1)),
-                    ProofV2Target::new(B256::repeat_byte(0x40))
-                        .with_parent(ProofV2TargetParent::new(1)),
-                ],
-                vec![
-                    (
-                        Some("2"),
-                        "20",
-                        Some("21"),
-                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
-                    ),
-                    (
-                        Some("4"),
-                        "40",
-                        Some("41"),
-                        vec!["4040404040404040404040404040404040404040404040404040404040404040"],
-                    ),
-                ],
-            ),
-            // Case 5: Targets below children 0 and f of parent 2 span [20, 3)
+            // Targets below children 0 and f of parent 2 span [20, 3).
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -159,7 +126,7 @@ mod tests {
                     ),
                 ],
             ),
-            // Case 6: Targets with different parent paths in different sub-tries
+            // Nested parent paths remain separate groups.
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -182,72 +149,25 @@ mod tests {
                     ),
                 ],
             ),
-            // Case 7: More complex chunking with nested sub-trie prefixes
-            (
-                vec![
-                    ProofV2Target::new(B256::repeat_byte(0x20))
-                        .with_parent(ProofV2TargetParent::new(1)),
-                    ProofV2Target::new(B256::repeat_byte(0x2f))
-                        .with_parent(ProofV2TargetParent::new(3)),
-                    ProofV2Target::new(B256::repeat_byte(0x4c))
-                        .with_parent(ProofV2TargetParent::new(2)),
-                    ProofV2Target::new(B256::repeat_byte(0x4c))
-                        .with_parent(ProofV2TargetParent::new(3)),
-                    ProofV2Target::new(B256::repeat_byte(0x4e))
-                        .with_parent(ProofV2TargetParent::new(2)),
-                ],
-                vec![
-                    (
-                        Some("2"),
-                        "20",
-                        Some("21"),
-                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
-                    ),
-                    (
-                        Some("2f2"),
-                        "2f2f",
-                        Some("2f3"),
-                        vec!["2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f"],
-                    ),
-                    (
-                        Some("4c"),
-                        "4c4",
-                        Some("4c5"),
-                        vec!["4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"],
-                    ),
-                    (
-                        Some("4c4"),
-                        "4c4c",
-                        Some("4c4d"),
-                        vec!["4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"],
-                    ),
-                    (
-                        Some("4e"),
-                        "4e4",
-                        Some("4e5"),
-                        vec!["4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e"],
-                    ),
-                ],
-            ),
-            // Case 8: Known-root children 2 and 4 span [2, 5)
+            // A known-root span ending in child f is unbounded.
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
                         .with_parent(ProofV2TargetParent::new(0)),
-                    ProofV2Target::new(B256::repeat_byte(0x40))
+                    ProofV2Target::new(B256::repeat_byte(0xf0))
                         .with_parent(ProofV2TargetParent::new(0)),
                 ],
                 vec![(
                     Some(""),
                     "2",
-                    Some("5"),
+                    None,
                     vec![
                         "2020202020202020202020202020202020202020202020202020202020202020",
-                        "4040404040404040404040404040404040404040404040404040404040404040",
+                        "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
                     ],
                 )],
             ),
-            // Case 9: Parent ordering can make traversal ranges move backwards (4 then 20)
+            // Parent ordering can make traversal ranges move backwards (4 then 20).
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -270,7 +190,7 @@ mod tests {
                     ),
                 ],
             ),
-            // Case 10: Root and root-parent targets are distinct despite sharing a prefix
+            // Root and root-parent targets are distinct despite sharing a prefix.
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20)),
@@ -295,125 +215,33 @@ mod tests {
         ];
 
         for (i, (mut input_targets, expected)) in test_cases.into_iter().enumerate() {
-            let test_case = i + 1;
-            let sub_tries: Vec<_> = iter_sub_trie_targets(&mut input_targets).collect();
+            let actual = iter_sub_trie_targets(&mut input_targets)
+                .map(|sub_trie| {
+                    (
+                        sub_trie.parent_prefix,
+                        sub_trie.lower_bound,
+                        sub_trie.upper_bound,
+                        sub_trie
+                            .targets
+                            .iter()
+                            .map(|target| target.key_nibbles)
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let expected = expected
+                .into_iter()
+                .map(|(parent_prefix, lower_bound, upper_bound, keys)| {
+                    (
+                        parent_prefix.map(nibbles),
+                        nibbles(lower_bound),
+                        upper_bound.map(nibbles),
+                        keys.into_iter().map(nibbles).collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>();
 
-            assert_eq!(
-                sub_tries.len(),
-                expected.len(),
-                "Test case {} failed: expected {} sub-tries, got {}",
-                test_case,
-                expected.len(),
-                sub_tries.len()
-            );
-
-            for (
-                j,
-                (
-                    sub_trie,
-                    (exp_parent_prefix_hex, exp_lower_bound_hex, exp_upper_bound_hex, exp_keys),
-                ),
-            ) in sub_tries.iter().zip(expected.iter()).enumerate()
-            {
-                let exp_parent_prefix = exp_parent_prefix_hex.map(nibbles);
-                let exp_lower_bound = nibbles(exp_lower_bound_hex);
-                let exp_upper_bound = exp_upper_bound_hex.map(nibbles);
-
-                assert_eq!(
-                    sub_trie.parent_prefix, exp_parent_prefix,
-                    "Test case {} sub-trie {}: parent prefix mismatch",
-                    test_case, j
-                );
-                assert_eq!(
-                    sub_trie.lower_bound, exp_lower_bound,
-                    "Test case {} sub-trie {}: lower bound mismatch",
-                    test_case, j
-                );
-                assert_eq!(
-                    sub_trie.upper_bound, exp_upper_bound,
-                    "Test case {} sub-trie {}: upper bound mismatch",
-                    test_case, j
-                );
-                assert_eq!(
-                    sub_trie.targets.len(),
-                    exp_keys.len(),
-                    "Test case {} sub-trie {}: expected {} targets, got {}",
-                    test_case,
-                    j,
-                    exp_keys.len(),
-                    sub_trie.targets.len()
-                );
-
-                for (k, (target, exp_key_hex)) in
-                    sub_trie.targets.iter().zip(exp_keys.iter()).enumerate()
-                {
-                    let exp_key = nibbles(exp_key_hex);
-                    assert_eq!(
-                        target.key_nibbles, exp_key,
-                        "Test case {} sub-trie {} target {}: key mismatch",
-                        test_case, j, k
-                    );
-                }
-            }
+            assert_eq!(actual, expected, "test case {}", i + 1);
         }
-    }
-
-    #[test]
-    fn test_iter_sub_trie_targets_key_order_after_sort() {
-        let mut targets = [
-            ProofV2Target::new(B256::repeat_byte(0x40)),
-            ProofV2Target::new(B256::repeat_byte(0x20)),
-        ];
-
-        let sub_tries = iter_sub_trie_targets(&mut targets).collect::<Vec<_>>();
-
-        assert_eq!(sub_tries.len(), 1);
-        assert_eq!(sub_tries[0].targets[0].key(), B256::repeat_byte(0x20));
-        assert_eq!(sub_tries[0].parent_prefix, None);
-    }
-
-    #[test]
-    fn test_iter_sub_trie_targets_groups_same_parent_child() {
-        let key_a = B256::right_padding_from(&[0x20, 0x10]);
-        let key_b = B256::right_padding_from(&[0x20, 0x00]);
-        let mut targets = [key_a, key_b]
-            .map(|key| ProofV2Target::new(key).with_parent(ProofV2TargetParent::new(1)));
-
-        let sub_tries = iter_sub_trie_targets(&mut targets).collect::<Vec<_>>();
-
-        assert_eq!(sub_tries.len(), 1);
-        assert_eq!(sub_tries[0].parent_prefix, Some(Nibbles::from_nibbles([0x2])));
-        assert_eq!(
-            (sub_tries[0].lower_bound, sub_tries[0].upper_bound),
-            (Nibbles::from_nibbles([0x2, 0x0]), Some(Nibbles::from_nibbles([0x2, 0x1])),)
-        );
-        assert_eq!(
-            sub_tries[0].targets.iter().map(ProofV2Target::key).collect::<Vec<_>>(),
-            [key_b, key_a]
-        );
-    }
-
-    #[test]
-    fn test_child_f_upper_bounds() {
-        let root_child_f = B256::repeat_byte(0xf0);
-        let non_root_child_f = B256::repeat_byte(0x2f);
-        let mut targets = [
-            ProofV2Target::new(non_root_child_f).with_parent(ProofV2TargetParent::new(1)),
-            ProofV2Target::new(root_child_f).with_parent(ProofV2TargetParent::new(0)),
-        ];
-
-        let sub_tries = iter_sub_trie_targets(&mut targets).collect::<Vec<_>>();
-
-        assert_eq!(sub_tries.len(), 2);
-        assert_eq!(sub_tries[0].parent_prefix, Some(Nibbles::new()));
-        assert_eq!(
-            (sub_tries[0].lower_bound, sub_tries[0].upper_bound),
-            (Nibbles::from_nibbles([0xf]), None)
-        );
-        assert_eq!(sub_tries[1].parent_prefix, Some(Nibbles::from_nibbles([0x2])));
-        assert_eq!(
-            (sub_tries[1].lower_bound, sub_tries[1].upper_bound),
-            (Nibbles::from_nibbles([0x2, 0xf]), Some(Nibbles::from_nibbles([0x3])),)
-        );
     }
 }

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -8,37 +8,57 @@ pub(crate) fn known_parent_prefix(target: &ProofV2Target) -> Option<Nibbles> {
     target.parent.path(target.key_nibbles)
 }
 
-// Returns the concrete prefix to traverse for a target. If the parent is already known then the
-// traversal starts at its direct child; otherwise it starts at the trie root.
+// Returns the direct child of the known parent which contains the target. If there is no known
+// parent then the target requires the full trie.
 #[inline]
-fn sub_trie_prefix(target: &ProofV2Target) -> Nibbles {
+fn target_child_prefix(target: &ProofV2Target) -> Nibbles {
     target
         .parent
         .path_len()
         .map_or_else(Nibbles::new, |parent_len| target.key_nibbles.slice(0..parent_len + 1))
 }
 
-// A helper function which returns the first path following a sub-trie in lexicographical order.
-#[inline]
-fn sub_trie_upper_bound(sub_trie_prefix: &Nibbles) -> Option<Nibbles> {
-    sub_trie_prefix.next_without_prefix()
+/// A half-open range of trie paths traversed for a group of proof targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SubTrieRange {
+    /// The first path in the range.
+    lower_bound: Nibbles,
+    /// The first path after the range, or `None` if the range extends through the end of the trie.
+    upper_bound: Option<Nibbles>,
 }
 
-/// Returns whether two lexicographically ordered sub-trie prefixes overlap.
-///
-/// Sub-trie ranges are either disjoint or nested, so ordered ranges overlap exactly when the next
-/// prefix is a descendant of the previous prefix. Equal prefixes are grouped before this check.
-#[inline]
-pub(crate) fn ordered_sub_tries_overlap(previous: &Nibbles, next: &Nibbles) -> bool {
-    debug_assert!(previous < next, "sub-trie prefixes must be strictly ordered");
-    next.starts_with(previous)
+impl SubTrieRange {
+    /// Creates a new traversal range.
+    #[inline]
+    pub(crate) const fn new(lower_bound: Nibbles, upper_bound: Option<Nibbles>) -> Self {
+        Self { lower_bound, upper_bound }
+    }
+
+    /// Returns the first path in the range.
+    #[inline]
+    pub(crate) const fn lower_bound(&self) -> Nibbles {
+        self.lower_bound
+    }
+
+    /// Returns the first path after the range.
+    #[inline]
+    pub(crate) const fn upper_bound(&self) -> Option<Nibbles> {
+        self.upper_bound
+    }
+
+    /// Returns whether `next` starts at or after this range ends, so forward-only cursors can be
+    /// reused without resetting.
+    #[inline]
+    pub(crate) fn is_strictly_before(&self, next: &Self) -> bool {
+        self.upper_bound.is_some_and(|upper_bound| upper_bound <= next.lower_bound)
+    }
 }
 
-/// Describes a set of targets which all apply to a single sub-trie, ie a section of the overall
-/// trie whose nodes all share a prefix.
+/// Describes targets with the same already-revealed parent and the bounded range traversed to
+/// calculate their direct children.
 pub(crate) struct SubTrieTargets<'a> {
-    /// The concrete prefix used to traverse this sub-trie.
-    pub(crate) prefix: Nibbles,
+    /// The range traversed for these targets.
+    pub(crate) range: SubTrieRange,
     /// The path of the already-revealed parent branch. `None` means the actual trie root is
     /// requested, while `Some(Nibbles::new())` means the root branch is already revealed.
     pub(crate) parent_prefix: Option<Nibbles>,
@@ -48,43 +68,41 @@ pub(crate) struct SubTrieTargets<'a> {
 }
 
 impl<'a> SubTrieTargets<'a> {
-    /// Returns the concrete prefix used to traverse this sub-trie.
+    /// Returns the range traversed for these targets.
     #[inline]
-    pub(crate) const fn prefix(&self) -> Nibbles {
-        self.prefix
-    }
-
-    // A helper function which returns the first path following a sub-trie in lexicographical order.
-    #[inline]
-    pub(crate) fn upper_bound(&self) -> Option<Nibbles> {
-        sub_trie_upper_bound(&self.prefix())
+    pub(crate) const fn range(&self) -> SubTrieRange {
+        self.range
     }
 }
 
 /// Given a set of [`ProofV2Target`]s, returns an iterator over those same [`ProofV2Target`]s
-/// chunked by the sub-tries they apply to within the overall trie.
+/// grouped by their already-revealed parent. Each group traverses the bounded span from its first
+/// targeted direct child through its last targeted direct child.
 pub(crate) fn iter_sub_trie_targets(
     targets: &mut [ProofV2Target],
 ) -> impl Iterator<Item = SubTrieTargets<'_>> {
-    // Sort globally by concrete sub-trie, then target key. `None` and a known root parent remain
-    // distinct: the former traverses from the root, while the latter traverses from one of the
-    // root's direct children. This also leaves each resulting chunk ordered for the
-    // `ProofCalculator`.
+    // Sort by parent context first so equal parents are contiguous, then by target key so the
+    // first and last targets determine the traversal bounds for the group. `None` and a known root
+    // parent remain distinct.
     targets.sort_unstable_by(|a, b| {
-        sub_trie_prefix(a).cmp(&sub_trie_prefix(b)).then_with(|| a.key_nibbles.cmp(&b.key_nibbles))
+        known_parent_prefix(a)
+            .cmp(&known_parent_prefix(b))
+            .then_with(|| a.key_nibbles.cmp(&b.key_nibbles))
     });
 
-    // Chunk targets by exact concrete prefixes. Different children of the same known parent must
-    // be processed independently so traversal never consults the parent node.
-    let target_chunks =
-        targets.chunk_by_mut(|current, next| sub_trie_prefix(current) == sub_trie_prefix(next));
-
-    // Map the chunks to the return type.
-    target_chunks.map(move |targets| {
-        let prefix = sub_trie_prefix(&targets[0]);
-        let parent_prefix = known_parent_prefix(&targets[0]);
-        SubTrieTargets { prefix, parent_prefix, targets }
-    })
+    targets
+        .chunk_by_mut(|current, next| known_parent_prefix(current) == known_parent_prefix(next))
+        .map(|targets| {
+            let parent_prefix = known_parent_prefix(&targets[0]);
+            let lower_bound = target_child_prefix(&targets[0]);
+            let upper_bound = target_child_prefix(targets.last().expect("chunk is non-empty"))
+                .next_without_prefix();
+            SubTrieTargets {
+                range: SubTrieRange::new(lower_bound, upper_bound),
+                parent_prefix,
+                targets,
+            }
+        })
 }
 
 #[cfg(test)]
@@ -105,7 +123,7 @@ mod tests {
 
         // Test cases: (input_targets, expected_output)
         // Expected output format:
-        // Vec<(known_parent_prefix_hex, sub_trie_prefix_hex, Vec<key_hex>)>
+        // Vec<(known_parent_prefix_hex, lower_bound_hex, upper_bound_hex, Vec<key_hex>)>
         let test_cases = vec![
             // Case 1: Empty targets
             (vec![], vec![]),
@@ -115,6 +133,7 @@ mod tests {
                 vec![(
                     None,
                     "",
+                    None,
                     vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                 )],
             ),
@@ -127,6 +146,7 @@ mod tests {
                 vec![(
                     None,
                     "",
+                    None,
                     vec![
                         "2020202020202020202020202020202020202020202020202020202020202020",
                         "2121212121212121212121212121212121212121212121212121212121212121",
@@ -145,16 +165,18 @@ mod tests {
                     (
                         Some("2"),
                         "20",
+                        Some("21"),
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some("4"),
                         "40",
+                        Some("41"),
                         vec!["4040404040404040404040404040404040404040404040404040404040404040"],
                     ),
                 ],
             ),
-            // Case 5: Targets below different children of the same parent are separate
+            // Case 5: Targets below children 0 and f of parent 2 span [20, 3)
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -168,16 +190,16 @@ mod tests {
                     (
                         Some("2"),
                         "20",
-                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
-                    ),
-                    (
-                        Some("2"),
-                        "2f",
-                        vec!["2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f"],
+                        Some("3"),
+                        vec![
+                            "2020202020202020202020202020202020202020202020202020202020202020",
+                            "2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f",
+                        ],
                     ),
                     (
                         Some("4"),
                         "40",
+                        Some("41"),
                         vec!["4040404040404040404040404040404040404040404040404040404040404040"],
                     ),
                 ],
@@ -194,11 +216,13 @@ mod tests {
                     (
                         Some("2"),
                         "20",
+                        Some("21"),
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some("2f"),
                         "2f2",
+                        Some("2f3"),
                         vec!["2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f"],
                     ),
                 ],
@@ -221,31 +245,36 @@ mod tests {
                     (
                         Some("2"),
                         "20",
+                        Some("21"),
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some("2f2"),
                         "2f2f",
+                        Some("2f3"),
                         vec!["2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f"],
                     ),
                     (
                         Some("4c"),
                         "4c4",
+                        Some("4c5"),
                         vec!["4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"],
                     ),
                     (
                         Some("4c4"),
                         "4c4c",
+                        Some("4c4d"),
                         vec!["4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c"],
                     ),
                     (
                         Some("4e"),
                         "4e4",
+                        Some("4e5"),
                         vec!["4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e"],
                     ),
                 ],
             ),
-            // Case 8: A known root parent splits targets by the root's direct children
+            // Case 8: Known-root children 2 and 4 span [2, 5)
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -253,20 +282,17 @@ mod tests {
                     ProofV2Target::new(B256::repeat_byte(0x40))
                         .with_parent(ProofV2TargetParent::new(0)),
                 ],
-                vec![
-                    (
-                        Some(""),
-                        "2",
-                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
-                    ),
-                    (
-                        Some(""),
-                        "4",
-                        vec!["4040404040404040404040404040404040404040404040404040404040404040"],
-                    ),
-                ],
+                vec![(
+                    Some(""),
+                    "2",
+                    Some("5"),
+                    vec![
+                        "2020202020202020202020202020202020202020202020202020202020202020",
+                        "4040404040404040404040404040404040404040404040404040404040404040",
+                    ],
+                )],
             ),
-            // Case 9: Concrete sub-trie prefixes determine chunk order
+            // Case 9: Parent ordering can make traversal ranges move backwards (4 then 20)
             (
                 vec![
                     ProofV2Target::new(B256::repeat_byte(0x20))
@@ -276,14 +302,16 @@ mod tests {
                 ],
                 vec![
                     (
-                        Some("2"),
-                        "20",
-                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
-                    ),
-                    (
                         Some(""),
                         "4",
+                        Some("5"),
                         vec!["4040404040404040404040404040404040404040404040404040404040404040"],
+                    ),
+                    (
+                        Some("2"),
+                        "20",
+                        Some("21"),
+                        vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                 ],
             ),
@@ -298,11 +326,13 @@ mod tests {
                     (
                         None,
                         "",
+                        None,
                         vec!["2020202020202020202020202020202020202020202020202020202020202020"],
                     ),
                     (
                         Some(""),
                         "4",
+                        Some("5"),
                         vec!["4040404040404040404040404040404040404040404040404040404040404040"],
                     ),
                 ],
@@ -322,11 +352,17 @@ mod tests {
                 sub_tries.len()
             );
 
-            for (j, (sub_trie, (exp_parent_prefix_hex, exp_prefix_hex, exp_keys))) in
-                sub_tries.iter().zip(expected.iter()).enumerate()
+            for (
+                j,
+                (
+                    sub_trie,
+                    (exp_parent_prefix_hex, exp_lower_bound_hex, exp_upper_bound_hex, exp_keys),
+                ),
+            ) in sub_tries.iter().zip(expected.iter()).enumerate()
             {
                 let exp_parent_prefix = exp_parent_prefix_hex.map(nibbles);
-                let exp_prefix = nibbles(exp_prefix_hex);
+                let exp_lower_bound = nibbles(exp_lower_bound_hex);
+                let exp_upper_bound = exp_upper_bound_hex.map(nibbles);
 
                 assert_eq!(
                     sub_trie.parent_prefix, exp_parent_prefix,
@@ -334,9 +370,16 @@ mod tests {
                     test_case, j
                 );
                 assert_eq!(
-                    sub_trie.prefix(),
-                    exp_prefix,
-                    "Test case {} sub-trie {}: traversal prefix mismatch",
+                    sub_trie.range().lower_bound(),
+                    exp_lower_bound,
+                    "Test case {} sub-trie {}: lower bound mismatch",
+                    test_case,
+                    j
+                );
+                assert_eq!(
+                    sub_trie.range().upper_bound(),
+                    exp_upper_bound,
+                    "Test case {} sub-trie {}: upper bound mismatch",
                     test_case,
                     j
                 );
@@ -365,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_sub_trie_targets_key_order_after_global_sort() {
+    fn test_iter_sub_trie_targets_key_order_after_sort() {
         let mut targets = [
             ProofV2Target::new(B256::repeat_byte(0x40)),
             ProofV2Target::new(B256::repeat_byte(0x20)),
@@ -389,10 +432,40 @@ mod tests {
 
         assert_eq!(sub_tries.len(), 1);
         assert_eq!(sub_tries[0].parent_prefix, Some(Nibbles::from_nibbles([0x2])));
-        assert_eq!(sub_tries[0].prefix(), Nibbles::from_nibbles([0x2, 0x0]));
+        assert_eq!(
+            sub_tries[0].range(),
+            SubTrieRange::new(
+                Nibbles::from_nibbles([0x2, 0x0]),
+                Some(Nibbles::from_nibbles([0x2, 0x1])),
+            )
+        );
         assert_eq!(
             sub_tries[0].targets.iter().map(ProofV2Target::key).collect::<Vec<_>>(),
             [key_b, key_a]
+        );
+    }
+
+    #[test]
+    fn test_child_f_upper_bounds() {
+        let root_child_f = B256::repeat_byte(0xf0);
+        let non_root_child_f = B256::repeat_byte(0x2f);
+        let mut targets = [
+            ProofV2Target::new(non_root_child_f).with_parent(ProofV2TargetParent::new(1)),
+            ProofV2Target::new(root_child_f).with_parent(ProofV2TargetParent::new(0)),
+        ];
+
+        let sub_tries = iter_sub_trie_targets(&mut targets).collect::<Vec<_>>();
+
+        assert_eq!(sub_tries.len(), 2);
+        assert_eq!(sub_tries[0].parent_prefix, Some(Nibbles::new()));
+        assert_eq!(sub_tries[0].range(), SubTrieRange::new(Nibbles::from_nibbles([0xf]), None));
+        assert_eq!(sub_tries[1].parent_prefix, Some(Nibbles::from_nibbles([0x2])));
+        assert_eq!(
+            sub_tries[1].range(),
+            SubTrieRange::new(
+                Nibbles::from_nibbles([0x2, 0xf]),
+                Some(Nibbles::from_nibbles([0x3])),
+            )
         );
     }
 }

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -18,61 +18,20 @@ fn target_child_prefix(target: &ProofV2Target) -> Nibbles {
         .map_or_else(Nibbles::new, |parent_len| target.key_nibbles.slice(0..parent_len + 1))
 }
 
-/// A half-open range of trie paths traversed for a group of proof targets.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct SubTrieRange {
-    /// The first path in the range.
-    lower_bound: Nibbles,
-    /// The first path after the range, or `None` if the range extends through the end of the trie.
-    upper_bound: Option<Nibbles>,
-}
-
-impl SubTrieRange {
-    /// Creates a new traversal range.
-    #[inline]
-    pub(crate) const fn new(lower_bound: Nibbles, upper_bound: Option<Nibbles>) -> Self {
-        Self { lower_bound, upper_bound }
-    }
-
-    /// Returns the first path in the range.
-    #[inline]
-    pub(crate) const fn lower_bound(&self) -> Nibbles {
-        self.lower_bound
-    }
-
-    /// Returns the first path after the range.
-    #[inline]
-    pub(crate) const fn upper_bound(&self) -> Option<Nibbles> {
-        self.upper_bound
-    }
-
-    /// Returns whether `next` starts at or after this range ends, so forward-only cursors can be
-    /// reused without resetting.
-    #[inline]
-    pub(crate) fn is_strictly_before(&self, next: &Self) -> bool {
-        self.upper_bound.is_some_and(|upper_bound| upper_bound <= next.lower_bound)
-    }
-}
-
 /// Describes targets with the same already-revealed parent and the bounded range traversed to
 /// calculate their direct children.
 pub(crate) struct SubTrieTargets<'a> {
-    /// The range traversed for these targets.
-    pub(crate) range: SubTrieRange,
+    /// The first path traversed for these targets.
+    pub(crate) lower_bound: Nibbles,
+    /// The first path after the traversal range, or `None` if it extends through the end of the
+    /// trie.
+    pub(crate) upper_bound: Option<Nibbles>,
     /// The path of the already-revealed parent branch. `None` means the actual trie root is
     /// requested, while `Some(Nibbles::new())` means the root branch is already revealed.
     pub(crate) parent_prefix: Option<Nibbles>,
     /// The targets belonging to this sub-trie. These will be sorted by their `key` field,
     /// lexicographically.
     pub(crate) targets: &'a [ProofV2Target],
-}
-
-impl<'a> SubTrieTargets<'a> {
-    /// Returns the range traversed for these targets.
-    #[inline]
-    pub(crate) const fn range(&self) -> SubTrieRange {
-        self.range
-    }
 }
 
 /// Given a set of [`ProofV2Target`]s, returns an iterator over those same [`ProofV2Target`]s
@@ -97,11 +56,7 @@ pub(crate) fn iter_sub_trie_targets(
             let lower_bound = target_child_prefix(&targets[0]);
             let upper_bound = target_child_prefix(targets.last().expect("chunk is non-empty"))
                 .next_without_prefix();
-            SubTrieTargets {
-                range: SubTrieRange::new(lower_bound, upper_bound),
-                parent_prefix,
-                targets,
-            }
+            SubTrieTargets { lower_bound, upper_bound, parent_prefix, targets }
         })
 }
 
@@ -370,18 +325,14 @@ mod tests {
                     test_case, j
                 );
                 assert_eq!(
-                    sub_trie.range().lower_bound(),
-                    exp_lower_bound,
+                    sub_trie.lower_bound, exp_lower_bound,
                     "Test case {} sub-trie {}: lower bound mismatch",
-                    test_case,
-                    j
+                    test_case, j
                 );
                 assert_eq!(
-                    sub_trie.range().upper_bound(),
-                    exp_upper_bound,
+                    sub_trie.upper_bound, exp_upper_bound,
                     "Test case {} sub-trie {}: upper bound mismatch",
-                    test_case,
-                    j
+                    test_case, j
                 );
                 assert_eq!(
                     sub_trie.targets.len(),
@@ -433,11 +384,8 @@ mod tests {
         assert_eq!(sub_tries.len(), 1);
         assert_eq!(sub_tries[0].parent_prefix, Some(Nibbles::from_nibbles([0x2])));
         assert_eq!(
-            sub_tries[0].range(),
-            SubTrieRange::new(
-                Nibbles::from_nibbles([0x2, 0x0]),
-                Some(Nibbles::from_nibbles([0x2, 0x1])),
-            )
+            (sub_tries[0].lower_bound, sub_tries[0].upper_bound),
+            (Nibbles::from_nibbles([0x2, 0x0]), Some(Nibbles::from_nibbles([0x2, 0x1])),)
         );
         assert_eq!(
             sub_tries[0].targets.iter().map(ProofV2Target::key).collect::<Vec<_>>(),
@@ -458,14 +406,14 @@ mod tests {
 
         assert_eq!(sub_tries.len(), 2);
         assert_eq!(sub_tries[0].parent_prefix, Some(Nibbles::new()));
-        assert_eq!(sub_tries[0].range(), SubTrieRange::new(Nibbles::from_nibbles([0xf]), None));
+        assert_eq!(
+            (sub_tries[0].lower_bound, sub_tries[0].upper_bound),
+            (Nibbles::from_nibbles([0xf]), None)
+        );
         assert_eq!(sub_tries[1].parent_prefix, Some(Nibbles::from_nibbles([0x2])));
         assert_eq!(
-            sub_tries[1].range(),
-            SubTrieRange::new(
-                Nibbles::from_nibbles([0x2, 0xf]),
-                Some(Nibbles::from_nibbles([0x3])),
-            )
+            (sub_tries[1].lower_bound, sub_tries[1].upper_bound),
+            (Nibbles::from_nibbles([0x2, 0xf]), Some(Nibbles::from_nibbles([0x3])),)
         );
     }
 }

--- a/crates/trie/trie/src/proof_v2/target.rs
+++ b/crates/trie/trie/src/proof_v2/target.rs
@@ -24,6 +24,16 @@ fn sub_trie_upper_bound(sub_trie_prefix: &Nibbles) -> Option<Nibbles> {
     sub_trie_prefix.next_without_prefix()
 }
 
+/// Returns whether two lexicographically ordered sub-trie prefixes overlap.
+///
+/// Sub-trie ranges are either disjoint or nested, so ordered ranges overlap exactly when the next
+/// prefix is a descendant of the previous prefix. Equal prefixes are grouped before this check.
+#[inline]
+pub(crate) fn ordered_sub_tries_overlap(previous: &Nibbles, next: &Nibbles) -> bool {
+    debug_assert!(previous < next, "sub-trie prefixes must be strictly ordered");
+    next.starts_with(previous)
+}
+
 /// Describes a set of targets which all apply to a single sub-trie, ie a section of the overall
 /// trie whose nodes all share a prefix.
 pub(crate) struct SubTrieTargets<'a> {


### PR DESCRIPTION
Start known-parent proofs at direct children and batch targets sharing a parent into one bounded traversal. This prevents a stale masked parent node (due to partial persistence) from suppressing live child ranges without splitting sibling targets into independent cursor traversals (which is bad for perf).

For targets `aed2` and `aed4` under known parent `aed`:

**Before (`origin/main`)**
- Seek `aed` and traverse `[aed, aee)`, putting the parent and all 16 child ranges in scope.
- The database parent can be consulted even though the sparse trie already supplied the current parent.

**After**
- Seek the first targeted child, `aed2`, and traverse the bounded sibling span `[aed2, aed5)` once. The parent is never read by the trie traversal, while outer siblings `aed0`–`aed1` and `aed5`–`aedf` are excluded from calculation.
- Targeted children `aed2` and `aed4` are calculated and retained independently.
- Untargeted `aed3` stays inside the traversal span but is not retained. Usable cached trie data skips its leaves; if it is uncached, the hashed cursor advances through it sequentially instead of performing another seek at `aed4`.

This narrows the work from the whole parent range while preserving efficient sequential traversal between targeted siblings.

## Testing

Ran 1k big blocks, 20k mainnet blocks, and 10k mainnet blocks with reorgs with no issues.