### PR TITLE
perf(trie): skip unnecessary historical trie changesets

### DIFF
--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -4,7 +4,7 @@ use crate::{
     ProviderError, RocksDBProviderFactory, StateProvider, StateRootProvider,
 };
 use alloy_eips::merge::EPOCH_SLOTS;
-use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
+use alloy_primitives::{keccak256, Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     table::Table,
@@ -258,8 +258,8 @@ where
                 .map(Some),
             HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
                 if self.provider.cached_storage_settings().use_hashed_state() {
-                    let hashed_address = alloy_primitives::keccak256(address);
-                    let hashed_slot = alloy_primitives::keccak256(lookup_key);
+                    let hashed_address = keccak256(address);
+                    let hashed_slot = keccak256(lookup_key);
                     Ok(self
                         .tx()
                         .cursor_dup_read::<tables::HashedStorages>()?
@@ -377,7 +377,7 @@ where
             }
             HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
                 if self.provider.cached_storage_settings().use_hashed_state() {
-                    let hashed_address = alloy_primitives::keccak256(address);
+                    let hashed_address = keccak256(address);
                     Ok(self.tx().get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)?)
                 } else {
                     Ok(self.tx().get_by_encoded_key::<tables::PlainAccountState>(address)?)
@@ -482,17 +482,14 @@ where
         reth_trie_db::with_adapter!(self.provider, |A| {
             let input = self.build_overlay(
                 TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(
-                        alloy_primitives::keccak256(address),
-                        hashed_storage,
-                    ),
+                    HashedPostState::from_hashed_storage(keccak256(address), hashed_storage),
                 )),
                 false,
             )?;
             let hashed_storage = input
                 .state
                 .account_storages()
-                .get(&alloy_primitives::keccak256(address))
+                .get(&keccak256(address))
                 .cloned()
                 .unwrap_or_default()
                 .into();
@@ -510,17 +507,14 @@ where
         reth_trie_db::with_adapter!(self.provider, |A| {
             let input = self.build_overlay(
                 TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(
-                        alloy_primitives::keccak256(address),
-                        hashed_storage,
-                    ),
+                    HashedPostState::from_hashed_storage(keccak256(address), hashed_storage),
                 )),
                 false,
             )?;
             let hashed_storage = input
                 .state
                 .account_storages()
-                .get(&alloy_primitives::keccak256(address))
+                .get(&keccak256(address))
                 .cloned()
                 .unwrap_or_default()
                 .into();
@@ -543,17 +537,14 @@ where
         reth_trie_db::with_adapter!(self.provider, |A| {
             let input = self.build_overlay(
                 TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(
-                        alloy_primitives::keccak256(address),
-                        hashed_storage,
-                    ),
+                    HashedPostState::from_hashed_storage(keccak256(address), hashed_storage),
                 )),
                 false,
             )?;
             let hashed_storage = input
                 .state
                 .account_storages()
-                .get(&alloy_primitives::keccak256(address))
+                .get(&keccak256(address))
                 .cloned()
                 .unwrap_or_default()
                 .into();

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -1,4 +1,4 @@
-use super::overlay::{Overlay, OverlayBuilder, OverlaySource};
+use super::overlay::OverlayBuilder;
 use crate::{
     AccountReader, BlockHashReader, ChangeSetReader, EitherReader, HashedPostStateProvider,
     ProviderError, RocksDBProviderFactory, StateProvider, StateRootProvider,
@@ -287,7 +287,11 @@ where
         Ok(tip.saturating_sub(self.block_number) > limit)
     }
 
-    fn build_overlay(&self, input: TrieInputSorted) -> ProviderResult<TrieInputSorted>
+    fn build_overlay(
+        &self,
+        mut input: TrieInputSorted,
+        trie_changesets_required: bool,
+    ) -> ProviderResult<TrieInputSorted>
     where
         Provider:
             BlockHashReader + PruneCheckpointReader + StageCheckpointReader + StorageSettingsCache,
@@ -308,13 +312,13 @@ where
             .block_hash(target_block)?
             .ok_or_else(|| ProviderError::HeaderNotFound(target_block.into()))?;
 
-        let TrieInputSorted { nodes, state, prefix_sets } = input;
-        let overlay_builder = OverlayBuilder::<N>::new(anchor_hash, self.changeset_cache.clone())
-            .with_overlay_source(Some(OverlaySource::Immediate { trie: nodes, state }));
-        let Overlay { trie_updates, hashed_post_state } =
-            overlay_builder.build_overlay(self.provider)?;
+        OverlayBuilder::<N>::new(anchor_hash, self.changeset_cache.clone()).build_overlay(
+            self.provider,
+            &mut input,
+            trie_changesets_required,
+        )?;
 
-        Ok(TrieInputSorted::new(trie_updates, hashed_post_state, prefix_sets))
+        Ok(input)
     }
 
     /// Set the lowest block number at which the account history is available.
@@ -418,16 +422,17 @@ where
 {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider, |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(hashed_state),
-            ))?;
+            let input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
+                false,
+            )?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.tx(), input)?)
         })
     }
 
     fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider, |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.tx(), input)?)
         })
     }
@@ -437,9 +442,10 @@ where
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider, |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(hashed_state),
-            ))?;
+            let input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
+                true,
+            )?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(self.tx(), input)?)
         })
     }
@@ -449,7 +455,7 @@ where
         input: TrieInput,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider, |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input), true)?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(self.tx(), input)?)
         })
     }
@@ -474,12 +480,15 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider, |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
+            let input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(
+                    HashedPostState::from_hashed_storage(
+                        alloy_primitives::keccak256(address),
+                        hashed_storage,
+                    ),
                 )),
-            ))?;
+                false,
+            )?;
             let hashed_storage = input
                 .state
                 .account_storages()
@@ -499,12 +508,15 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<reth_trie::StorageProof> {
         reth_trie_db::with_adapter!(self.provider, |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
+            let input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(
+                    HashedPostState::from_hashed_storage(
+                        alloy_primitives::keccak256(address),
+                        hashed_storage,
+                    ),
                 )),
-            ))?;
+                false,
+            )?;
             let hashed_storage = input
                 .state
                 .account_storages()
@@ -529,12 +541,15 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
         reth_trie_db::with_adapter!(self.provider, |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
+            let input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(
+                    HashedPostState::from_hashed_storage(
+                        alloy_primitives::keccak256(address),
+                        hashed_storage,
+                    ),
                 )),
-            ))?;
+                false,
+            )?;
             let hashed_storage = input
                 .state
                 .account_storages()
@@ -575,7 +590,7 @@ where
     ) -> ProviderResult<AccountProof> {
         reth_trie_db::with_adapter!(self.provider, |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -593,7 +608,7 @@ where
     ) -> ProviderResult<MultiProof> {
         reth_trie_db::with_adapter!(self.provider, |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -612,7 +627,7 @@ where
     ) -> ProviderResult<Vec<Bytes>> {
         reth_trie_db::with_adapter!(self.provider, |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             let witness = TrieWitness::new(
                 InMemoryTrieCursorFactory::new(
                     reth_trie_db::DatabaseTrieCursorFactory::<_, A>::new(self.tx()),

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -20,7 +20,7 @@ use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
     updates::TrieUpdatesSorted,
-    HashedPostStateSorted,
+    HashedPostStateSorted, TrieInputSorted,
 };
 use reth_trie_db::{
     ChangesetCache, DatabaseAccountTrieCursor, DatabaseHashedCursorFactory,
@@ -50,27 +50,11 @@ pub(crate) struct OverlayStateProviderMetrics {
     hashed_state_size: Histogram,
     /// Overall duration of the [`OverlayStateProviderFactory::database_provider_ro`] call
     database_provider_ro_duration: Histogram,
-    /// Number of cache misses when fetching [`Overlay`]s from the overlay cache.
+    /// Number of cache misses when fetching [`TrieInputSorted`]s from the overlay cache.
     overlay_cache_misses: Counter,
     /// Number of managed overlay creations skipped because the reused sparse trie already covers
     /// the DB tip to parent range.
     sparse_trie_overlay_skips: Counter,
-}
-
-/// Contains all fields required to initialize an [`OverlayStateProvider`].
-#[derive(Debug, Clone)]
-pub(super) struct Overlay {
-    pub(super) trie_updates: Arc<TrieUpdatesSorted>,
-    pub(super) hashed_post_state: Arc<HashedPostStateSorted>,
-}
-
-impl Overlay {
-    fn empty() -> Self {
-        Self {
-            trie_updates: Arc::new(TrieUpdatesSorted::default()),
-            hashed_post_state: Arc::new(HashedPostStateSorted::default()),
-        }
-    }
 }
 
 /// Source of overlay data for [`OverlayStateProviderFactory`].
@@ -125,14 +109,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             reused_sparse_trie_anchor_hash: None,
             metrics: OverlayStateProviderMetrics::default(),
         }
-    }
-
-    /// Set the overlay source.
-    ///
-    /// This overlay will be applied on top of any reverts.
-    pub(super) fn with_overlay_source(mut self, source: Option<OverlaySource<N>>) -> Self {
-        self.overlay_source = source;
-        self
     }
 
     /// Skips managed overlay construction when the sparse trie was reused and the DB tip is
@@ -335,7 +311,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         Ok(Some(anchor_number + 1..=db_tip_block.number))
     }
 
-    /// Calculates a new [`Overlay`] given a transaction and the current db tip.
+    /// Calculates a new [`TrieInputSorted`] given a transaction and the current db tip.
     #[instrument(
         level = "debug",
         target = "providers::state::overlay",
@@ -346,7 +322,8 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         &self,
         provider: &Provider,
         db_tip_block: BlockNumHash,
-    ) -> ProviderResult<Overlay>
+        trie_changesets_required: bool,
+    ) -> ProviderResult<TrieInputSorted>
     where
         Provider: ChangeSetReader
             + StorageChangeSetReader
@@ -383,14 +360,10 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         let (trie_updates, hashed_post_state) = if let Some(revert_blocks) =
             self.reverts_required(provider, db_tip_block, anchor_hash)?
         {
-            debug!(
-                target: "providers::state::overlay",
-                ?revert_blocks,
-                "Collecting trie reverts for overlay state provider"
-            );
+            debug!(target: "providers::state::overlay", ?revert_blocks, "Collecting reverts");
 
-            // Collect trie reverts using changeset cache
-            let trie_reverts = {
+            // Collect trie reverts using changeset cache when intermediate nodes are required.
+            let trie_reverts = if trie_changesets_required {
                 let _guard =
                     debug_span!(target: "providers::state::overlay", "retrieving_trie_reverts")
                         .entered();
@@ -404,6 +377,9 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
                 retrieve_trie_reverts_duration = start.elapsed();
                 accumulated_reverts
+            } else {
+                retrieve_trie_reverts_duration = Duration::ZERO;
+                Arc::new(TrieUpdatesSorted::default())
             };
 
             // Collect state reverts
@@ -463,7 +439,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
                 self.metrics.sparse_trie_overlay_skips.increment(1);
 
-                return Ok(Overlay::empty())
+                return Ok(TrieInputSorted::default())
             }
 
             let (trie_updates, hashed_post_state) = self.resolve_overlays(db_tip_block.hash)?;
@@ -486,12 +462,23 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         self.metrics.trie_updates_size.record(trie_updates_total_len as f64);
         self.metrics.hashed_state_size.record(hashed_state_updates_total_len as f64);
 
-        Ok(Overlay { trie_updates, hashed_post_state })
+        let prefix_sets = if trie_changesets_required {
+            Default::default()
+        } else {
+            hashed_post_state.construct_prefix_sets()
+        };
+
+        Ok(TrieInputSorted::new(trie_updates, hashed_post_state, prefix_sets))
     }
 
-    /// Builds the effective overlay for the given provider.
+    /// Builds the effective overlay for the given provider and prepends it to `input`.
     #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
-    pub(super) fn build_overlay<Provider>(&self, provider: &Provider) -> ProviderResult<Overlay>
+    pub(super) fn build_overlay<Provider>(
+        &self,
+        provider: &Provider,
+        input: &mut TrieInputSorted,
+        trie_changesets_required: bool,
+    ) -> ProviderResult<()>
     where
         Provider: StageCheckpointReader
             + PruneCheckpointReader
@@ -502,7 +489,23 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             + StorageSettingsCache,
     {
         let db_tip_block = self.get_db_tip_block(provider)?;
-        self.calculate_overlay(provider, db_tip_block)
+        let mut overlay =
+            self.calculate_overlay(provider, db_tip_block, trie_changesets_required)?;
+
+        if overlay.nodes.is_empty() {
+            overlay.nodes = std::mem::take(&mut input.nodes);
+        } else if !input.nodes.is_empty() {
+            Arc::make_mut(&mut overlay.nodes).extend_ref_and_sort(&input.nodes);
+        }
+        if overlay.state.is_empty() {
+            overlay.state = std::mem::take(&mut input.state);
+        } else if !input.state.is_empty() {
+            Arc::make_mut(&mut overlay.state).extend_ref_and_sort(&input.state);
+        }
+        overlay.prefix_sets.extend(std::mem::take(&mut input.prefix_sets));
+        *input = overlay;
+
+        Ok(())
     }
 }
 
@@ -516,9 +519,10 @@ pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
     factory: F,
     /// Overlay builder containing the configuration and overlay calculation logic.
     overlay_builder: OverlayBuilder<N>,
-    /// A cache which maps `db_tip -> Overlay`. If the db tip changes during usage of the factory
-    /// then a new entry will get added to this, but in most cases only one entry is present.
-    overlay_cache: Arc<DashMap<BlockHash, Overlay>>,
+    /// A cache which maps `db_tip -> TrieInputSorted`. If the db tip changes during usage of the
+    /// factory then a new entry will get added to this, but in most cases only one entry is
+    /// present.
+    overlay_cache: Arc<DashMap<BlockHash, TrieInputSorted>>,
 }
 
 impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
@@ -553,10 +557,10 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
         self
     }
 
-    /// Fetches an [`Overlay`] from the cache based on the current db tip block. If there is no
-    /// cached value then this calculates the [`Overlay`] and populates the cache.
+    /// Fetches a [`TrieInputSorted`] from the cache based on the current db tip block. If there is
+    /// no cached value then this calculates the input and populates the cache.
     #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
-    fn get_overlay<Provider>(&self, provider: &Provider) -> ProviderResult<Overlay>
+    fn get_overlay<Provider>(&self, provider: &Provider) -> ProviderResult<TrieInputSorted>
     where
         Provider: StageCheckpointReader
             + PruneCheckpointReader
@@ -572,7 +576,8 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
             dashmap::Entry::Occupied(entry) => entry.get().clone(),
             dashmap::Entry::Vacant(entry) => {
                 self.overlay_builder.metrics.overlay_cache_misses.increment(1);
-                let overlay = self.overlay_builder.build_overlay(provider)?;
+                let mut overlay = TrieInputSorted::default();
+                self.overlay_builder.build_overlay(provider, &mut overlay, true)?;
                 entry.insert(overlay.clone());
                 overlay
             }
@@ -609,11 +614,11 @@ where
             res
         };
 
-        let Overlay { trie_updates, hashed_post_state } = self.get_overlay(&provider)?;
+        let TrieInputSorted { nodes, state, .. } = self.get_overlay(&provider)?;
 
         let is_v2 = provider.cached_storage_settings().is_v2();
         self.overlay_builder.metrics.database_provider_ro_duration.record(overall_start.elapsed());
-        Ok(OverlayStateProvider::new(provider, trie_updates, hashed_post_state, is_v2))
+        Ok(OverlayStateProvider::new(provider, nodes, state, is_v2))
     }
 }
 
@@ -738,6 +743,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::NoopProvider;
     use reth_primitives_traits::Account;
     use reth_trie::HashedPostState;
 
@@ -796,5 +802,27 @@ mod tests {
             .into_sorted();
         let builder = builder.with_extended_hashed_state_overlay(hashed_state);
         assert!(!builder.should_skip_overlay_for_reused_sparse_trie(parent_hash));
+    }
+
+    #[test]
+    fn calculate_overlay_uses_prefix_sets_without_trie_changesets() {
+        let parent_hash = B256::with_last_byte(1);
+        let hashed_state = HashedPostState::default()
+            .with_accounts([(B256::with_last_byte(2), Some(Account::default()))])
+            .into_sorted();
+        let provider = NoopProvider::default();
+        let db_tip_block = BlockNumHash::new(0, parent_hash);
+
+        let input = OverlayBuilder::<EthPrimitives>::new(parent_hash, ChangesetCache::default())
+            .with_hashed_state_overlay(Some(Arc::new(hashed_state.clone())))
+            .calculate_overlay(&provider, db_tip_block, false)
+            .unwrap();
+        assert_eq!(input.prefix_sets, hashed_state.construct_prefix_sets());
+
+        let input = OverlayBuilder::<EthPrimitives>::new(parent_hash, ChangesetCache::default())
+            .with_hashed_state_overlay(Some(Arc::new(hashed_state)))
+            .calculate_overlay(&provider, db_tip_block, true)
+            .unwrap();
+        assert!(input.prefix_sets.is_empty());
     }
 }


### PR DESCRIPTION
Replaces the overlay result type with TrieInputSorted and makes OverlayBuilder extend an existing trie input. Historical root, proof, and witness paths now derive prefix sets from hashed state without requesting trie changesets, while update-returning methods and OverlayStateProvider retain trie changesets.