### PR TITLE
feat(trie): prune sparse trie cache by epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8336,7 +8336,6 @@ dependencies = [
  "eyre",
  "futures",
  "indexmap 2.14.0",
- "itertools 0.14.0",
  "metrics",
  "metrics-util",
  "moka",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -60,7 +60,6 @@ reth-metrics = { workspace = true, features = ["common"] }
 
 # misc
 indexmap.workspace = true
-itertools.workspace = true
 schnellru.workspace = true
 rayon.workspace = true
 tracing.workspace = true

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -194,7 +194,7 @@ impl<N: NodePrimitives> EngineApiTreeState<N> {
     ///
     /// `None` means no prune request is pending. `Some(Vec::new())` means a prune was requested,
     /// but no in-memory parent-chain blocks were found for the parent hash; the sparse trie task
-    /// should still prune using the current block's hashed post state.
+    /// should still prune nodes cached before the current block's epoch.
     pub fn take_sparse_trie_prune_blocks(
         &mut self,
         parent_hash: B256,

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -593,6 +593,7 @@ where
                 &self.runtime,
                 &self.state_trie_overlays,
                 &env,
+                &parent_block,
                 provider_builder.clone(),
                 overlay_factory,
                 &self.config,

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -662,20 +662,22 @@ impl DefaultStateRootStrategy {
                 prune_older_than,
                 chunk_size,
             );
+            let published_anchor_hash = published_sparse_trie_anchor_hash(
+                sparse_trie_anchor_hash,
+                reused_preserved_sparse_trie,
+                pending_sparse_trie_prune_blocks.as_deref(),
+            );
+            // The cutoff and anchor are the only data needed during hashing; release the block
+            // outputs before the potentially long-running trie task.
+            drop(pending_sparse_trie_prune_blocks);
 
             let result = task.run();
-            let task_result = result.as_ref().ok().cloned();
 
             // Publish a handle before sending the result so the next block can inspect the
             // state root immediately while the trie is finalized for reuse below.
-            let pending_trie = if let Some(result) = &task_result {
-                let preserved_anchor_hash = published_sparse_trie_anchor_hash(
-                    sparse_trie_anchor_hash,
-                    reused_preserved_sparse_trie,
-                    pending_sparse_trie_prune_blocks.as_deref(),
-                );
+            let pending_trie = if let Ok(result) = &result {
                 let (preserved, completer) =
-                    PreservedSparseTrie::pending(result.state_root, preserved_anchor_hash);
+                    PreservedSparseTrie::pending(result.state_root, published_anchor_hash);
                 state_trie_overlays.store_sparse_trie(preserved);
                 Some(completer)
             } else {
@@ -703,14 +705,8 @@ impl DefaultStateRootStrategy {
             let _enter =
                 debug_span!(target: "engine::tree::payload_processor", "preserve").entered();
             let mut trie_to_drop = None;
-            let deferred = if task_result.is_some() {
-                let pending_trie =
-                    pending_trie.expect("pending trie is created for successful task result");
-                let start = Instant::now();
+            let deferred = if let Some(pending_trie) = pending_trie {
                 let (trie, deferred) = task.into_trie_for_reuse();
-                trie_metrics
-                    .into_trie_for_reuse_duration_histogram
-                    .record(start.elapsed().as_secs_f64());
                 trie_metrics
                     .sparse_trie_retained_storage_tries
                     .set(trie.retained_storage_tries_count() as f64);
@@ -1072,7 +1068,6 @@ where
         let StateRootComputeOutcome {
             state_root,
             trie_updates,
-            hashed_state: _hashed_state,
             #[cfg(feature = "trie-debug")]
             debug_recorders,
         } = outcome;
@@ -1314,17 +1309,10 @@ mod tests {
     use revm::state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot, TransactionId};
 
     #[test]
-    fn sparse_trie_prune_older_than_is_none_without_request() {
+    fn sparse_trie_prune_older_than_uses_requested_range() {
         assert_eq!(sparse_trie_prune_older_than::<EthPrimitives>(None, 10), None);
-    }
-
-    #[test]
-    fn sparse_trie_prune_older_than_uses_current_epoch_for_empty_range() {
         assert_eq!(sparse_trie_prune_older_than::<EthPrimitives>(Some(&[]), 10), Some(10));
-    }
 
-    #[test]
-    fn sparse_trie_prune_older_than_uses_oldest_block() {
         let mut blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(7..10).collect();
         blocks.reverse();
 

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -60,7 +60,7 @@ use reth_chain_state::{ExecutedBlock, PreservedSparseTrie, StateTrieOverlayManag
 use reth_errors::ProviderResult;
 use reth_evm::{ConfigureEvm, OnStateHook};
 use reth_primitives_traits::{
-    AlloyBlockHeader, FastInstant as Instant, NodePrimitives, RecoveredBlock,
+    AlloyBlockHeader, FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedHeader,
 };
 use reth_provider::{
     providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockReader,
@@ -87,7 +87,6 @@ pub use reth_trie_parallel::{
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 use reth_trie_sparse::{ArenaParallelSparseTrie, RevealableSparseTrie, SparseStateTrie};
-use revm::context::Block as _;
 use std::{
     fmt,
     sync::{
@@ -246,6 +245,7 @@ where
     executor: &'a reth_tasks::Runtime,
     state_trie_overlays: &'a StateTrieOverlayManager<N>,
     env: &'a ExecutionEnv<Evm>,
+    parent_header: &'a SealedHeader<N::BlockHeader>,
     provider_builder: StateProviderBuilder<N, P>,
     overlay_factory: OverlayStateProviderFactory<P, N>,
     config: &'a TreeConfig,
@@ -277,6 +277,7 @@ where
         executor: &'a reth_tasks::Runtime,
         state_trie_overlays: &'a StateTrieOverlayManager<N>,
         env: &'a ExecutionEnv<Evm>,
+        parent_header: &'a SealedHeader<N::BlockHeader>,
         provider_builder: StateProviderBuilder<N, P>,
         overlay_factory: OverlayStateProviderFactory<P, N>,
         config: &'a TreeConfig,
@@ -287,6 +288,7 @@ where
             executor,
             state_trie_overlays,
             env,
+            parent_header,
             provider_builder,
             overlay_factory,
             config,
@@ -298,6 +300,11 @@ where
     /// Returns the execution environment for the block.
     pub const fn env(&self) -> &ExecutionEnv<Evm> {
         self.env
+    }
+
+    /// Returns the sealed parent block header.
+    pub const fn parent_header(&self) -> &SealedHeader<N::BlockHeader> {
+        self.parent_header
     }
 
     /// Returns the task runtime used by state-root work.
@@ -518,9 +525,7 @@ impl DefaultStateRootStrategy {
             + 'static,
     {
         let StateRootTaskOptions {
-            parent_hash,
-            parent_state_root,
-            epoch,
+            parent_header,
             preserved_sparse_trie,
             transaction_count,
             config,
@@ -538,6 +543,7 @@ impl DefaultStateRootStrategy {
 
         let (state_root_tx, state_root_rx) = mpsc::channel();
         let (hashed_state_tx, hashed_state_rx) = mpsc::channel();
+        let parent_state_root = parent_header.state_root();
 
         self.spawn_sparse_trie_task(
             executor,
@@ -548,9 +554,7 @@ impl DefaultStateRootStrategy {
             from_multi_proof,
             cancel_rx,
             SparseTrieTaskOptions {
-                parent_hash,
-                parent_state_root,
-                epoch,
+                parent_header,
                 preserved_sparse_trie,
                 chunk_size: config.multiproof_chunk_size(),
                 pending_sparse_trie_prune_blocks: if config.disable_sparse_trie_cache_pruning() {
@@ -584,9 +588,7 @@ impl DefaultStateRootStrategy {
         options: SparseTrieTaskOptions<N>,
     ) {
         let SparseTrieTaskOptions {
-            parent_hash,
-            parent_state_root,
-            epoch,
+            parent_header,
             preserved_sparse_trie,
             chunk_size,
             pending_sparse_trie_prune_blocks,
@@ -598,6 +600,10 @@ impl DefaultStateRootStrategy {
         let parent_span = Span::current();
         executor.clone().spawn_blocking_named("sparse-trie", move || {
             reth_tasks::once!(increase_thread_priority);
+
+            let parent_hash = parent_header.hash();
+            let parent_state_root = parent_header.state_root();
+            let epoch = parent_header.number().saturating_add(1);
 
             let _enter = debug_span!(
                 target: "engine::tree::payload_processor",
@@ -737,9 +743,7 @@ impl DefaultStateRootStrategy {
 }
 
 struct SparseTrieTaskOptions<N: NodePrimitives> {
-    parent_hash: B256,
-    parent_state_root: B256,
-    epoch: u64,
+    parent_header: SealedHeader<N::BlockHeader>,
     preserved_sparse_trie: Option<PreservedSparseTrie>,
     chunk_size: usize,
     /// `None` disables pruning. `Some(Vec::new())` prunes using only the current block's paths.
@@ -747,9 +751,7 @@ struct SparseTrieTaskOptions<N: NodePrimitives> {
 }
 
 struct StateRootTaskOptions<'a, N: NodePrimitives> {
-    parent_hash: B256,
-    parent_state_root: B256,
-    epoch: u64,
+    parent_header: SealedHeader<N::BlockHeader>,
     preserved_sparse_trie: Option<PreservedSparseTrie>,
     transaction_count: Option<usize>,
     config: &'a TreeConfig,
@@ -908,6 +910,7 @@ where
             executor,
             state_trie_overlays,
             env,
+            parent_header,
             provider_builder,
             overlay_factory,
             config,
@@ -931,9 +934,7 @@ where
             state_trie_overlays,
             overlay_factory.clone(),
             StateRootTaskOptions {
-                parent_hash: env.parent_hash,
-                parent_state_root: env.parent_state_root,
-                epoch: env.evm_env.block_env.number().saturating_to(),
+                parent_header: parent_header.clone(),
                 preserved_sparse_trie,
                 transaction_count: Some(env.transaction_count),
                 config,
@@ -992,6 +993,7 @@ where
 
         let pending_sparse_trie_prune_blocks = ctx.take_sparse_trie_prune_blocks();
         let parent_state_root = ctx.parent_state_root();
+        let parent_header = SealedHeader::new(ctx.parent_header().clone(), ctx.parent_hash());
         let preserved_sparse_trie = ctx.state_trie_overlays.take_sparse_trie();
         let overlay_factory = if let Some(anchor_hash) = preserved_sparse_trie
             .as_ref()
@@ -1008,9 +1010,7 @@ where
                 ctx.state_trie_overlays,
                 overlay_factory,
                 StateRootTaskOptions {
-                    parent_hash: ctx.parent_hash(),
-                    parent_state_root,
-                    epoch: ctx.parent_header().number().saturating_add(1),
+                    parent_header,
                     preserved_sparse_trie,
                     // Tx count unknown at FCU time (block built incrementally): full proof workers.
                     transaction_count: None,
@@ -1663,9 +1663,7 @@ mod tests {
                 OverlayBuilder::<EthPrimitives>::new(genesis_hash, ChangesetCache::new()),
             ),
             StateRootTaskOptions {
-                parent_hash: genesis_hash,
-                parent_state_root: env.parent_state_root,
-                epoch: 0,
+                parent_header: SealedHeader::new(Default::default(), genesis_hash),
                 preserved_sparse_trie: None,
                 transaction_count: Some(env.transaction_count),
                 config: &TreeConfig::default(),

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -667,9 +667,6 @@ impl DefaultStateRootStrategy {
                 reused_preserved_sparse_trie,
                 pending_sparse_trie_prune_blocks.as_deref(),
             );
-            // The cutoff and anchor are the only data needed during hashing; release the block
-            // outputs before the potentially long-running trie task.
-            drop(pending_sparse_trie_prune_blocks);
 
             let result = task.run();
 

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -87,6 +87,7 @@ pub use reth_trie_parallel::{
 #[cfg(feature = "trie-debug")]
 use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 use reth_trie_sparse::{ArenaParallelSparseTrie, RevealableSparseTrie, SparseStateTrie};
+use revm::context::Block as _;
 use std::{
     fmt,
     sync::{
@@ -519,6 +520,7 @@ impl DefaultStateRootStrategy {
         let StateRootTaskOptions {
             parent_hash,
             parent_state_root,
+            epoch,
             preserved_sparse_trie,
             transaction_count,
             config,
@@ -548,6 +550,7 @@ impl DefaultStateRootStrategy {
             SparseTrieTaskOptions {
                 parent_hash,
                 parent_state_root,
+                epoch,
                 preserved_sparse_trie,
                 chunk_size: config.multiproof_chunk_size(),
                 pending_sparse_trie_prune_blocks: if config.disable_sparse_trie_cache_pruning() {
@@ -583,6 +586,7 @@ impl DefaultStateRootStrategy {
         let SparseTrieTaskOptions {
             parent_hash,
             parent_state_root,
+            epoch,
             preserved_sparse_trie,
             chunk_size,
             pending_sparse_trie_prune_blocks,
@@ -651,6 +655,7 @@ impl DefaultStateRootStrategy {
                 trie_metrics.clone(),
                 sparse_state_trie,
                 parent_state_root,
+                epoch,
                 chunk_size,
             );
 
@@ -734,6 +739,7 @@ impl DefaultStateRootStrategy {
 struct SparseTrieTaskOptions<N: NodePrimitives> {
     parent_hash: B256,
     parent_state_root: B256,
+    epoch: u64,
     preserved_sparse_trie: Option<PreservedSparseTrie>,
     chunk_size: usize,
     /// `None` disables pruning. `Some(Vec::new())` prunes using only the current block's paths.
@@ -743,6 +749,7 @@ struct SparseTrieTaskOptions<N: NodePrimitives> {
 struct StateRootTaskOptions<'a, N: NodePrimitives> {
     parent_hash: B256,
     parent_state_root: B256,
+    epoch: u64,
     preserved_sparse_trie: Option<PreservedSparseTrie>,
     transaction_count: Option<usize>,
     config: &'a TreeConfig,
@@ -926,6 +933,7 @@ where
             StateRootTaskOptions {
                 parent_hash: env.parent_hash,
                 parent_state_root: env.parent_state_root,
+                epoch: env.evm_env.block_env.number().saturating_to(),
                 preserved_sparse_trie,
                 transaction_count: Some(env.transaction_count),
                 config,
@@ -1002,6 +1010,7 @@ where
                 StateRootTaskOptions {
                     parent_hash: ctx.parent_hash(),
                     parent_state_root,
+                    epoch: ctx.parent_header().number().saturating_add(1),
                     preserved_sparse_trie,
                     // Tx count unknown at FCU time (block built incrementally): full proof workers.
                     transaction_count: None,
@@ -1656,6 +1665,7 @@ mod tests {
             StateRootTaskOptions {
                 parent_hash: genesis_hash,
                 parent_state_root: env.parent_state_root,
+                epoch: 0,
                 preserved_sparse_trie: None,
                 transaction_count: Some(env.transaction_count),
                 config: &TreeConfig::default(),

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -43,7 +43,7 @@
 //!
 //! Returning empty trie updates in the outcome means the trie tables are no longer maintained:
 //! `eth_getProof` and anything else that reads the stored trie will not work for new blocks.
-//! Sparse-trie cache pruning derives retained paths from each block's hashed post state.
+//! Sparse-trie cache pruning uses node epochs to retain the in-memory block range.
 
 mod sparse_trie;
 
@@ -52,10 +52,8 @@ use crate::tree::{
     metrics::BlockValidationMetrics, EngineApiTreeState, ExecutionEnv, StateProviderBuilder,
     TreeConfig,
 };
-use alloy_primitives::{map::B256Map, B256, U256};
+use alloy_primitives::B256;
 use crossbeam_channel::Receiver as CrossbeamReceiver;
-use itertools::Itertools;
-use rayon::{join, prelude::*};
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie, StateTrieOverlayManager};
 use reth_errors::ProviderResult;
 use reth_evm::{ConfigureEvm, OnStateHook};
@@ -69,10 +67,7 @@ use reth_provider::{
 };
 use reth_tasks::utils::increase_thread_priority;
 use reth_trie::{
-    hashed_cursor::HashedCursorFactory,
-    prefix_set::{PrefixSet, TriePrefixSets},
-    trie_cursor::TrieCursorFactory,
-    updates::TrieUpdates,
+    hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
     HashedPostState,
 };
 use reth_trie_parallel::proof_task::{ProofTaskCtx, ProofWorkerHandle};
@@ -604,6 +599,8 @@ impl DefaultStateRootStrategy {
             let parent_hash = parent_header.hash();
             let parent_state_root = parent_header.state_root();
             let epoch = parent_header.number().saturating_add(1);
+            let prune_older_than =
+                sparse_trie_prune_older_than(pending_sparse_trie_prune_blocks.as_deref(), epoch);
 
             let _enter = debug_span!(
                 target: "engine::tree::payload_processor",
@@ -662,6 +659,7 @@ impl DefaultStateRootStrategy {
                 sparse_state_trie,
                 parent_state_root,
                 epoch,
+                prune_older_than,
                 chunk_size,
             );
 
@@ -705,16 +703,11 @@ impl DefaultStateRootStrategy {
             let _enter =
                 debug_span!(target: "engine::tree::payload_processor", "preserve").entered();
             let mut trie_to_drop = None;
-            let deferred = if let Some(result) = task_result {
+            let deferred = if task_result.is_some() {
                 let pending_trie =
                     pending_trie.expect("pending trie is created for successful task result");
                 let start = Instant::now();
-                let (mut trie, deferred) = task.into_trie_for_reuse();
-                if let Some(prune_blocks) = pending_sparse_trie_prune_blocks {
-                    let retained_paths =
-                        sparse_trie_retained_paths(prune_blocks, result.hashed_state.as_ref());
-                    trie.prune(retained_paths);
-                }
+                let (trie, deferred) = task.into_trie_for_reuse();
                 trie_metrics
                     .into_trie_for_reuse_duration_histogram
                     .record(start.elapsed().as_secs_f64());
@@ -746,7 +739,7 @@ struct SparseTrieTaskOptions<N: NodePrimitives> {
     parent_header: SealedHeader<N::BlockHeader>,
     preserved_sparse_trie: Option<PreservedSparseTrie>,
     chunk_size: usize,
-    /// `None` disables pruning. `Some(Vec::new())` prunes using only the current block's paths.
+    /// `None` disables pruning. `Some(Vec::new())` prunes nodes older than the current block.
     pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<N>>>,
 }
 
@@ -758,94 +751,14 @@ struct StateRootTaskOptions<'a, N: NodePrimitives> {
     pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<N>>>,
 }
 
-fn sparse_trie_retained_paths<N: NodePrimitives>(
-    prune_blocks: Vec<ExecutedBlock<N>>,
-    current_hashed_state: &HashedPostState,
-) -> TriePrefixSets {
-    struct StorageAcc<'a> {
-        wiped: bool,
-        first: Option<&'a [(B256, U256)]>,
-        rest: Vec<&'a [(B256, U256)]>,
-    }
-
-    let current_hashed_state = current_hashed_state.clone_into_sorted();
-    let mut account_slices = Vec::with_capacity(prune_blocks.len() + 1);
-    let mut storage_acc = B256Map::<StorageAcc<'_>>::default();
-
-    for state in prune_blocks
-        .iter()
-        .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-        .chain(core::iter::once(&current_hashed_state))
-    {
-        account_slices.push(state.accounts.as_slice());
-
-        for (address, storage) in &state.storages {
-            let entry = storage_acc.entry(*address).or_insert_with(|| StorageAcc {
-                wiped: false,
-                first: None,
-                rest: Vec::new(),
-            });
-            if entry.wiped {
-                continue
-            }
-            if storage.wiped {
-                entry.wiped = true;
-                entry.first = None;
-                entry.rest.clear();
-            } else if entry.first.is_some() {
-                entry.rest.push(storage.storage_slots.as_slice());
-            } else {
-                entry.first = Some(storage.storage_slots.as_slice());
-            }
-        }
-    }
-
-    let mut storage_addresses = storage_acc.keys().copied().collect::<Vec<_>>();
-    storage_addresses.sort_unstable();
-
-    let (account_prefix_set, storage_prefix_sets) = join(
-        || {
-            PrefixSet::from(
-                account_slices
-                    .into_iter()
-                    .map(|slice| slice.iter().map(|(address, _)| address))
-                    .kmerge()
-                    .dedup()
-                    .copied()
-                    .merge(storage_addresses)
-                    .dedup(),
-            )
-        },
-        || {
-            storage_acc
-                .par_iter()
-                .map(|(address, entry)| {
-                    let prefix_set = if entry.wiped {
-                        PrefixSet::all_paths()
-                    } else {
-                        PrefixSet::from(
-                            entry
-                                .first
-                                .iter()
-                                .copied()
-                                .chain(entry.rest.iter().copied())
-                                .map(|slice| slice.iter().map(|(slot, _)| slot))
-                                .kmerge()
-                                .dedup()
-                                .copied(),
-                        )
-                    };
-                    (*address, prefix_set)
-                })
-                .collect()
-        },
-    );
-
-    TriePrefixSets {
-        account_prefix_set,
-        storage_prefix_sets,
-        destroyed_accounts: Default::default(),
-    }
+fn sparse_trie_prune_older_than<N: NodePrimitives>(
+    pending_sparse_trie_prune_blocks: Option<&[ExecutedBlock<N>]>,
+    epoch: u64,
+) -> Option<u64> {
+    // The parent chain is ordered newest to oldest. An empty chain means the block being
+    // calculated is the only in-memory block whose trie nodes need to be retained.
+    pending_sparse_trie_prune_blocks
+        .map(|blocks| blocks.last().map_or(epoch, |block| block.recovered_block().number()))
 }
 
 fn published_sparse_trie_anchor_hash<N: NodePrimitives>(
@@ -1396,128 +1309,26 @@ mod tests {
         HashingWriter,
     };
     use reth_testing_utils::generators;
-    use reth_trie::{
-        test_utils::state_root, HashedPostState, HashedStorage, LazyTrieData, Nibbles,
-    };
+    use reth_trie::test_utils::state_root;
     use reth_trie_db::ChangesetCache;
     use revm::state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot, TransactionId};
 
-    fn with_hashed_state(
-        block: ExecutedBlock<EthPrimitives>,
-        hashed_state: HashedPostState,
-    ) -> ExecutedBlock<EthPrimitives> {
-        let mut trie_data = block.trie_data();
-        trie_data.sorted.hashed_state = Arc::new(hashed_state.into_sorted());
-        ExecutedBlock::with_deferred_trie_data(
-            block.recovered_block,
-            block.execution_output,
-            LazyTrieData::ready(trie_data),
-        )
-    }
-
-    fn trie_hashed_state(account_path: u8, storage_path: u8) -> HashedPostState {
-        HashedPostState::default()
-            .with_accounts([(B256::with_last_byte(account_path), Some(Account::default()))])
-            .with_storages([(
-                B256::with_last_byte(account_path),
-                HashedStorage::from_iter(false, [(B256::with_last_byte(storage_path), U256::ONE)]),
-            )])
+    #[test]
+    fn sparse_trie_prune_older_than_is_none_without_request() {
+        assert_eq!(sparse_trie_prune_older_than::<EthPrimitives>(None, 10), None);
     }
 
     #[test]
-    fn sparse_trie_retained_paths_merges_prune_blocks_with_current_block() {
-        let blocks: Vec<_> = TestBlockBuilder::eth()
-            .get_executed_blocks(1..3)
-            .zip([trie_hashed_state(0x01, 0x02), trie_hashed_state(0x03, 0x04)])
-            .map(|(block, hashed_state)| with_hashed_state(block, hashed_state))
-            .collect();
-        let current_hashed_state = trie_hashed_state(0x05, 0x06);
-
-        let retained_paths = sparse_trie_retained_paths(blocks, &current_hashed_state);
-
-        assert_eq!(retained_paths.account_prefix_set.len(), 3);
-        assert_eq!(retained_paths.storage_prefix_sets.len(), 3);
+    fn sparse_trie_prune_older_than_uses_current_epoch_for_empty_range() {
+        assert_eq!(sparse_trie_prune_older_than::<EthPrimitives>(Some(&[]), 10), Some(10));
     }
 
     #[test]
-    fn sparse_trie_retained_paths_uses_hashed_state() {
-        let blocks: Vec<_> = TestBlockBuilder::eth()
-            .get_executed_blocks(1..2)
-            .map(|block| with_hashed_state(block, trie_hashed_state(0x01, 0x02)))
-            .collect();
-        let current_hashed_state = trie_hashed_state(0x03, 0x04);
+    fn sparse_trie_prune_older_than_uses_oldest_block() {
+        let mut blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(7..10).collect();
+        blocks.reverse();
 
-        let retained_paths = sparse_trie_retained_paths(blocks, &current_hashed_state);
-
-        assert_eq!(retained_paths.account_prefix_set.len(), 2);
-        assert_eq!(retained_paths.storage_prefix_sets.len(), 2);
-    }
-
-    #[test]
-    fn sparse_trie_retained_paths_merges_sorted_paths_directly() {
-        let account = B256::with_last_byte(1);
-        let destroyed = B256::with_last_byte(2);
-        let storage_only = B256::with_last_byte(3);
-        let wiped_storage = B256::with_last_byte(4);
-        let account_slot = B256::with_last_byte(10);
-        let first_slot = B256::with_last_byte(11);
-        let second_slot = B256::with_last_byte(12);
-        let third_slot = B256::with_last_byte(13);
-
-        let first = HashedPostState::default()
-            .with_accounts([(account, Some(Account::default())), (destroyed, None)])
-            .with_storages([
-                (account, HashedStorage::from_iter(false, [(account_slot, U256::from(1))])),
-                (
-                    storage_only,
-                    HashedStorage::from_iter(
-                        false,
-                        [(first_slot, U256::from(1)), (third_slot, U256::from(3))],
-                    ),
-                ),
-                (wiped_storage, HashedStorage::from_iter(false, [(first_slot, U256::from(1))])),
-            ]);
-        let second = HashedPostState::default().with_accounts([(account, None)]).with_storages([
-            (
-                storage_only,
-                HashedStorage::from_iter(
-                    false,
-                    [(second_slot, U256::from(2)), (third_slot, U256::from(30))],
-                ),
-            ),
-            (wiped_storage, HashedStorage::from_iter(true, [])),
-        ]);
-        let blocks = TestBlockBuilder::eth()
-            .get_executed_blocks(1..3)
-            .zip([first, second])
-            .map(|(block, hashed_state)| with_hashed_state(block, hashed_state))
-            .collect();
-
-        let retained_paths = sparse_trie_retained_paths(blocks, &HashedPostState::default());
-
-        assert_eq!(
-            retained_paths.account_prefix_set.slice(),
-            &[
-                Nibbles::unpack(account),
-                Nibbles::unpack(destroyed),
-                Nibbles::unpack(storage_only),
-                Nibbles::unpack(wiped_storage),
-            ]
-        );
-        assert_eq!(
-            retained_paths.storage_prefix_sets[&storage_only].slice(),
-            &[
-                Nibbles::unpack(first_slot),
-                Nibbles::unpack(second_slot),
-                Nibbles::unpack(third_slot),
-            ]
-        );
-        assert_eq!(
-            retained_paths.storage_prefix_sets[&account].slice(),
-            &[Nibbles::unpack(account_slot)]
-        );
-        assert!(retained_paths.storage_prefix_sets[&wiped_storage].all());
-        assert!(retained_paths.destroyed_accounts.is_empty());
+        assert_eq!(sparse_trie_prune_older_than(Some(&blocks), 10), Some(7));
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -50,6 +50,8 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     trie: SparseStateTrie<A, S>,
     /// The parent block's state root.
     parent_state_root: B256,
+    /// The epoch associated with nodes cached by this task.
+    epoch: u64,
     /// Handle to the proof worker pools (storage and account).
     proof_worker_handle: ProofWorkerHandle,
 
@@ -137,6 +139,7 @@ where
         metrics: SparseTrieTaskMetrics,
         trie: SparseStateTrie<A, S>,
         parent_state_root: B256,
+        epoch: u64,
         chunk_size: usize,
     ) -> Self {
         let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
@@ -158,6 +161,7 @@ where
             final_hashed_state_tx: Some(final_hashed_state_tx),
             trie,
             parent_state_root,
+            epoch,
             chunk_size,
             max_targets_for_chunking: DEFAULT_MAX_TARGETS_FOR_CHUNKING,
             account_updates: Default::default(),
@@ -333,7 +337,7 @@ where
         debug!(target: "engine::root", "All proofs processed, ending calculation");
 
         let start = Instant::now();
-        let (state_root, trie_updates) = match self.trie.root_with_updates() {
+        let (state_root, trie_updates) = match self.trie.root_with_updates(self.epoch) {
             Ok(result) => result,
             Err(err)
                 if matches!(
@@ -429,7 +433,7 @@ where
             // If there's still no pending updates spend some time pre-computing the account
             // trie upper hashes
             if self.proof_result_rx.is_empty() {
-                self.trie.calculate_subtries();
+                self.trie.calculate_subtries(self.epoch);
             }
         } else if !updates_queued {
             // If we don't have any pending updates, apply them to the trie,
@@ -738,6 +742,7 @@ where
 
         let parent_span =
             debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
+        let epoch = self.epoch;
         tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
             let span = if tracing::enabled!(tracing::Level::TRACE) {
                 debug_span!(
@@ -760,7 +765,9 @@ where
             // - we do not insert/remove entries between pointer collection and use, so pointers
             //   stay valid and map reallocation cannot occur;
             // - each pointer is consumed by at most one rayon task, so no aliasing mutable access.
-            unsafe { (*trie).root().expect("updates are drained, trie should be revealed by now") };
+            unsafe {
+                (*trie).root(epoch).expect("updates are drained, trie should be revealed by now")
+            };
         });
     }
 
@@ -792,7 +799,7 @@ where
                         // If account has pending storage updates, it is still pending.
                         return true;
                     } else if let Some(account) = account.take() {
-                        let storage_root = self.trie.storage_root(addr).expect("updates are drained, storage trie should be revealed by now");
+                        let storage_root = self.trie.storage_root(addr, self.epoch).expect("updates are drained, storage trie should be revealed by now");
                         let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
                         self.account_updates.insert(*addr, LeafUpdate::Changed(encoded));
                         num_promoted += 1;
@@ -821,7 +828,7 @@ where
 
                     (account, storage_root)
                 } else {
-                    (trie_account.map(Into::into), self.trie.storage_root(addr).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
+                    (trie_account.map(Into::into), self.trie.storage_root(addr, self.epoch).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
                 };
 
                 let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
@@ -1222,6 +1229,7 @@ mod tests {
             SparseTrieTaskMetrics::default(),
             trie,
             parent_state_root,
+            0,
             1,
         );
 
@@ -1267,6 +1275,7 @@ mod tests {
             SparseTrieTaskMetrics::default(),
             trie,
             B256::from([0x55; 32]),
+            0,
             1,
         );
 
@@ -1346,6 +1355,7 @@ mod tests {
             SparseTrieTaskMetrics::default(),
             trie,
             B256::from([0x55; 32]),
+            0,
             1,
         );
 
@@ -1391,6 +1401,7 @@ mod tests {
             SparseTrieTaskMetrics::default(),
             trie,
             B256::from([0x55; 32]),
+            0,
             1,
         );
 

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -111,9 +111,9 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     pending_targets: PendingTargets,
     /// Proof batches dispatched to workers and not yet received.
     in_flight_proof_batches: usize,
-    /// Whether execution/prewarming updates have been received but not yet passed to
+    /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
-    updates_pending: bool,
+    pending_updates: usize,
     /// Combined final hashed state.
     ///
     /// Sparse trie task observes and hashes all state updates, allowing it to cheaply construct a
@@ -183,7 +183,7 @@ where
             storage_cache_misses: 0,
             pending_targets: Default::default(),
             in_flight_proof_batches: 0,
-            updates_pending: false,
+            pending_updates: Default::default(),
             final_hashed_state: Default::default(),
             metrics,
         }
@@ -284,6 +284,7 @@ where
                         "updates channel disconnected before state root calculation".to_string(),
                     ))?;
                     self.on_message(update);
+                    self.pending_updates += 1;
                 }
                 recv(self.proof_result_rx) -> message => {
                     let wake = Instant::now();
@@ -447,11 +448,9 @@ where
         match message {
             SparseTrieTaskMessage::PrefetchProofs(targets) => {
                 self.on_prewarm_targets(targets);
-                self.updates_pending = true;
             }
             SparseTrieTaskMessage::HashedState(hashed_state) => {
                 self.on_hashed_state_update(hashed_state);
-                self.updates_pending = true;
             }
             SparseTrieTaskMessage::FinishedStateUpdates => {
                 let hashed_state = Arc::new(core::mem::take(&mut self.final_hashed_state));
@@ -559,12 +558,12 @@ where
     }
 
     fn process_new_updates(&mut self) -> SparseTrieResult<()> {
-        if !self.updates_pending {
+        if self.pending_updates == 0 {
             return Ok(());
         }
 
         let _span = debug_span!("process_new_updates").entered();
-        self.updates_pending = false;
+        self.pending_updates = 0;
 
         // Firstly apply all new storage and account updates to the tries.
         self.process_leaf_updates(true)?;
@@ -910,7 +909,7 @@ where
     fn ensure_not_stalled(&self, updates_queued: bool) -> Result<(), StateRootTaskError> {
         if self.finished_state_updates &&
             !updates_queued &&
-            !self.updates_pending &&
+            self.pending_updates == 0 &&
             self.pending_targets.is_empty() &&
             self.in_flight_proof_batches == 0 &&
             self.proof_result_rx.is_empty() &&

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -111,9 +111,9 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     pending_targets: PendingTargets,
     /// Proof batches dispatched to workers and not yet received.
     in_flight_proof_batches: usize,
-    /// Number of pending execution/prewarming updates received but not yet passed to
+    /// Whether execution/prewarming updates have been received but not yet passed to
     /// `update_leaves`.
-    pending_updates: usize,
+    updates_pending: bool,
     /// Combined final hashed state.
     ///
     /// Sparse trie task observes and hashes all state updates, allowing it to cheaply construct a
@@ -183,7 +183,7 @@ where
             storage_cache_misses: 0,
             pending_targets: Default::default(),
             in_flight_proof_batches: 0,
-            pending_updates: Default::default(),
+            updates_pending: false,
             final_hashed_state: Default::default(),
             metrics,
         }
@@ -266,7 +266,6 @@ where
         let mut total_idle_time = std::time::Duration::ZERO;
         let mut idle_start = Instant::now();
         let mut done = false;
-        let mut finalized_hashed_state = None;
 
         // Streaming phase: updates are still arriving. Ends when the finish marker is
         // processed. Only producers hold update senders, so the channel closing before the
@@ -284,10 +283,7 @@ where
                     let update = message.map_err(|_| StateRootTaskError::Other(
                         "updates channel disconnected before state root calculation".to_string(),
                     ))?;
-                    if let Some(hashed_state) = self.on_message(update) {
-                        finalized_hashed_state = Some(hashed_state);
-                    }
-                    self.pending_updates += 1;
+                    self.on_message(update);
                 }
                 recv(self.proof_result_rx) -> message => {
                     let wake = Instant::now();
@@ -366,9 +362,6 @@ where
         let debug_recorders = self.trie.take_debug_recorders();
 
         let end = Instant::now();
-        if self.prune_older_than.is_some() {
-            self.metrics.sparse_trie_prune_duration_histogram.record(end.duration_since(start));
-        }
         self.metrics.sparse_trie_final_update_duration_histogram.record(end.duration_since(start));
         self.metrics.sparse_trie_total_duration_histogram.record(end.duration_since(now));
 
@@ -376,16 +369,9 @@ where
         self.metrics.sparse_trie_account_cache_misses.record(self.account_cache_misses as f64);
         self.metrics.sparse_trie_storage_cache_hits.record(self.storage_cache_hits as f64);
         self.metrics.sparse_trie_storage_cache_misses.record(self.storage_cache_misses as f64);
-        self.account_cache_hits = 0;
-        self.account_cache_misses = 0;
-        self.storage_cache_hits = 0;
-        self.storage_cache_misses = 0;
-
         Ok(StateRootComputeOutcome {
             state_root,
             trie_updates: Arc::new(trie_updates),
-            hashed_state: finalized_hashed_state
-                .expect("finished state updates publish the hashed post state"),
             #[cfg(feature = "trie-debug")]
             debug_recorders,
         })
@@ -457,21 +443,20 @@ where
     }
 
     /// Processes a [`SparseTrieTaskMessage`] from the hashing task.
-    fn on_message(&mut self, message: SparseTrieTaskMessage) -> Option<Arc<HashedPostState>> {
+    fn on_message(&mut self, message: SparseTrieTaskMessage) {
         match message {
             SparseTrieTaskMessage::PrefetchProofs(targets) => {
                 self.on_prewarm_targets(targets);
-                None
+                self.updates_pending = true;
             }
             SparseTrieTaskMessage::HashedState(hashed_state) => {
                 self.on_hashed_state_update(hashed_state);
-                None
+                self.updates_pending = true;
             }
             SparseTrieTaskMessage::FinishedStateUpdates => {
                 let hashed_state = Arc::new(core::mem::take(&mut self.final_hashed_state));
-                let _ = self.final_hashed_state_tx.take().unwrap().send(Arc::clone(&hashed_state));
+                let _ = self.final_hashed_state_tx.take().unwrap().send(hashed_state);
                 self.finished_state_updates = true;
-                Some(hashed_state)
             }
         }
     }
@@ -574,12 +559,12 @@ where
     }
 
     fn process_new_updates(&mut self) -> SparseTrieResult<()> {
-        if self.pending_updates == 0 {
+        if !self.updates_pending {
             return Ok(());
         }
 
         let _span = debug_span!("process_new_updates").entered();
-        self.pending_updates = 0;
+        self.updates_pending = false;
 
         // Firstly apply all new storage and account updates to the tries.
         self.process_leaf_updates(true)?;
@@ -809,7 +794,7 @@ where
                         // If account has pending storage updates, it is still pending.
                         return true;
                     } else if let Some(account) = account.take() {
-                        let storage_root = self.trie.storage_root(addr, self.epoch, None).expect("updates are drained, storage trie should be revealed by now");
+                        let storage_root = self.trie.storage_root(addr, self.epoch).expect("updates are drained, storage trie should be revealed by now");
                         let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
                         self.account_updates.insert(*addr, LeafUpdate::Changed(encoded));
                         num_promoted += 1;
@@ -838,7 +823,7 @@ where
 
                     (account, storage_root)
                 } else {
-                    (trie_account.map(Into::into), self.trie.storage_root(addr, self.epoch, None).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
+                    (trie_account.map(Into::into), self.trie.storage_root(addr, self.epoch).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
                 };
 
                 let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
@@ -925,7 +910,7 @@ where
     fn ensure_not_stalled(&self, updates_queued: bool) -> Result<(), StateRootTaskError> {
         if self.finished_state_updates &&
             !updates_queued &&
-            self.pending_updates == 0 &&
+            !self.updates_pending &&
             self.pending_targets.is_empty() &&
             self.in_flight_proof_batches == 0 &&
             self.proof_result_rx.is_empty() &&
@@ -993,10 +978,6 @@ pub(super) struct SparseTrieTaskMetrics {
     pub(super) sparse_trie_final_update_duration_histogram: Histogram,
     /// Histogram of sparse trie total durations.
     pub(super) sparse_trie_total_duration_histogram: Histogram,
-    /// Time spent preparing the sparse trie for reuse after state root computation.
-    pub(super) into_trie_for_reuse_duration_histogram: Histogram,
-    /// Time spent calculating and epoch-pruning the final sparse trie root.
-    pub(super) sparse_trie_prune_duration_histogram: Histogram,
     /// Time spent waiting for preserved sparse trie cache to become available.
     pub(super) sparse_trie_cache_wait_duration_histogram: Histogram,
     /// Histogram for sparse trie task idle time in seconds (waiting for updates or proof

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -52,6 +52,8 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     parent_state_root: B256,
     /// The epoch associated with nodes cached by this task.
     epoch: u64,
+    /// Prunes cached nodes older than this epoch during final root calculation.
+    prune_older_than: Option<u64>,
     /// Handle to the proof worker pools (storage and account).
     proof_worker_handle: ProofWorkerHandle,
 
@@ -140,6 +142,7 @@ where
         trie: SparseStateTrie<A, S>,
         parent_state_root: B256,
         epoch: u64,
+        prune_older_than: Option<u64>,
         chunk_size: usize,
     ) -> Self {
         let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
@@ -162,6 +165,7 @@ where
             trie,
             parent_state_root,
             epoch,
+            prune_older_than,
             chunk_size,
             max_targets_for_chunking: DEFAULT_MAX_TARGETS_FOR_CHUNKING,
             account_updates: Default::default(),
@@ -337,25 +341,26 @@ where
         debug!(target: "engine::root", "All proofs processed, ending calculation");
 
         let start = Instant::now();
-        let (state_root, trie_updates) = match self.trie.root_with_updates(self.epoch) {
-            Ok(result) => result,
-            Err(err)
-                if matches!(
-                    err.kind(),
-                    SparseStateTrieErrorKind::Sparse(SparseTrieErrorKind::Blind)
-                ) =>
-            {
-                // A still-blind account trie means this block never changed state, so preserve
-                // the cached parent root instead of fetching and revealing
-                // the unchanged root node.
-                (self.parent_state_root, TrieUpdates::default())
-            }
-            Err(err) => {
-                return Err(StateRootTaskError::Other(format!(
-                    "could not calculate state root: {err:?}"
-                )))
-            }
-        };
+        let (state_root, trie_updates) =
+            match self.trie.root_with_updates(self.epoch, self.prune_older_than) {
+                Ok(result) => result,
+                Err(err)
+                    if matches!(
+                        err.kind(),
+                        SparseStateTrieErrorKind::Sparse(SparseTrieErrorKind::Blind)
+                    ) =>
+                {
+                    // A still-blind account trie means this block never changed state, so preserve
+                    // the cached parent root instead of fetching and revealing
+                    // the unchanged root node.
+                    (self.parent_state_root, TrieUpdates::default())
+                }
+                Err(err) => {
+                    return Err(StateRootTaskError::Other(format!(
+                        "could not calculate state root: {err:?}"
+                    )))
+                }
+            };
 
         #[cfg(feature = "trie-debug")]
         let debug_recorders = self.trie.take_debug_recorders();
@@ -766,7 +771,9 @@ where
             //   stay valid and map reallocation cannot occur;
             // - each pointer is consumed by at most one rayon task, so no aliasing mutable access.
             unsafe {
-                (*trie).root(epoch).expect("updates are drained, trie should be revealed by now")
+                (*trie)
+                    .root(epoch, None)
+                    .expect("updates are drained, trie should be revealed by now")
             };
         });
     }
@@ -799,7 +806,7 @@ where
                         // If account has pending storage updates, it is still pending.
                         return true;
                     } else if let Some(account) = account.take() {
-                        let storage_root = self.trie.storage_root(addr, self.epoch).expect("updates are drained, storage trie should be revealed by now");
+                        let storage_root = self.trie.storage_root(addr, self.epoch, None).expect("updates are drained, storage trie should be revealed by now");
                         let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
                         self.account_updates.insert(*addr, LeafUpdate::Changed(encoded));
                         num_promoted += 1;
@@ -828,7 +835,7 @@ where
 
                     (account, storage_root)
                 } else {
-                    (trie_account.map(Into::into), self.trie.storage_root(addr, self.epoch).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
+                    (trie_account.map(Into::into), self.trie.storage_root(addr, self.epoch, None).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
                 };
 
                 let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
@@ -1230,6 +1237,7 @@ mod tests {
             trie,
             parent_state_root,
             0,
+            None,
             1,
         );
 
@@ -1276,6 +1284,7 @@ mod tests {
             trie,
             B256::from([0x55; 32]),
             0,
+            None,
             1,
         );
 
@@ -1356,6 +1365,7 @@ mod tests {
             trie,
             B256::from([0x55; 32]),
             0,
+            None,
             1,
         );
 
@@ -1402,6 +1412,7 @@ mod tests {
             trie,
             B256::from([0x55; 32]),
             0,
+            None,
             1,
         );
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -611,20 +611,6 @@ fn on_new_persisted_block_queues_sparse_trie_prune_request() {
 }
 
 #[test]
-fn on_new_persisted_block_queues_sparse_trie_prune_with_in_memory_blocks() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
-    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
-    test_harness
-        .tree
-        .persistence_state
-        .finish(blocks[0].recovered_block().hash(), blocks[0].recovered_block().number);
-
-    test_harness.tree.on_new_persisted_block().unwrap();
-
-    assert!(test_harness.tree.state.pending_sparse_trie_prune());
-}
-
-#[test]
 fn on_new_persisted_block_skips_sparse_trie_prune_when_state_root_task_disabled() {
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
     let configs = [

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -41,8 +41,6 @@ pub struct StateRootComputeOutcome {
     pub state_root: B256,
     /// The trie updates.
     pub trie_updates: Arc<TrieUpdates>,
-    /// Hashed post state produced while computing the state root.
-    pub hashed_state: Arc<HashedPostState>,
     /// Debug recorders taken from the sparse tries, keyed by `None` for account trie
     /// and `Some(address)` for storage tries.
     #[cfg(feature = "trie-debug")]
@@ -686,7 +684,6 @@ mod tests {
             .send(Ok(StateRootComputeOutcome {
                 state_root: B256::repeat_byte(0x42),
                 trie_updates: Arc::new(TrieUpdates::default()),
-                hashed_state: Arc::new(HashedPostState::default()),
                 #[cfg(feature = "trie-debug")]
                 debug_recorders: Vec::new(),
             }))

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -137,7 +137,7 @@ impl ArenaCursor {
                 _ => None,
             });
             let child_is_empty_subtrie = arena.get(entry.index).is_some_and(|node| {
-                matches!(node, ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot))
+                matches!(node, ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot { .. }))
             });
             let child_is_dirty =
                 child_is_empty_subtrie || matches!(child_state, Some(ArenaSparseNodeState::Dirty));
@@ -317,7 +317,7 @@ impl ArenaCursor {
             let head_idx = head.index;
 
             let head_branch = match &arena[head_idx] {
-                ArenaSparseNode::EmptyRoot => {
+                ArenaSparseNode::EmptyRoot { .. } => {
                     return SeekResult::EmptyRoot;
                 }
                 ArenaSparseNode::Leaf { key, .. } => {

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -130,18 +130,25 @@ impl ArenaCursor {
         }
 
         if let Some(parent) = self.stack.last() {
-            let child_is_dirty = arena.get(entry.index).is_some_and(|node| match node {
-                ArenaSparseNode::Branch(b) => matches!(b.state, ArenaSparseNodeState::Dirty),
-                ArenaSparseNode::Leaf { state, .. } => matches!(state, ArenaSparseNodeState::Dirty),
-                ArenaSparseNode::Subtrie(s) => {
-                    let root = &s.arena[s.root];
-                    matches!(root, ArenaSparseNode::EmptyRoot) ||
-                        matches!(root.state_ref(), Some(ArenaSparseNodeState::Dirty))
-                }
-                _ => false,
+            let child_state = arena.get(entry.index).and_then(|node| match node {
+                ArenaSparseNode::Branch(b) => Some(&b.state),
+                ArenaSparseNode::Leaf { state, .. } => Some(state),
+                ArenaSparseNode::Subtrie(s) => s.arena[s.root].state_ref(),
+                _ => None,
             });
+            let child_is_empty_subtrie = arena.get(entry.index).is_some_and(|node| {
+                matches!(node, ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot))
+            });
+            let child_is_dirty =
+                child_is_empty_subtrie || matches!(child_state, Some(ArenaSparseNodeState::Dirty));
+            let child_is_revealed = matches!(child_state, Some(ArenaSparseNodeState::Revealed));
             if child_is_dirty {
                 *arena[parent.index].state_mut() = ArenaSparseNodeState::Dirty;
+            } else if child_is_revealed {
+                let parent_state = arena[parent.index].state_mut();
+                if !matches!(parent_state, ArenaSparseNodeState::Dirty) {
+                    *parent_state = ArenaSparseNodeState::Revealed;
+                }
             }
         }
 

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -130,17 +130,8 @@ impl ArenaCursor {
         }
 
         if let Some(parent) = self.stack.last() {
-            let child_state = arena.get(entry.index).and_then(|node| match node {
-                ArenaSparseNode::Branch(b) => Some(&b.state),
-                ArenaSparseNode::Leaf { state, .. } => Some(state),
-                ArenaSparseNode::Subtrie(s) => s.arena[s.root].state_ref(),
-                _ => None,
-            });
-            let child_is_empty_subtrie = arena.get(entry.index).is_some_and(|node| {
-                matches!(node, ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot { .. }))
-            });
-            let child_is_dirty =
-                child_is_empty_subtrie || matches!(child_state, Some(ArenaSparseNodeState::Dirty));
+            let child_state = arena.get(entry.index).and_then(ArenaSparseNode::state_ref);
+            let child_is_dirty = matches!(child_state, Some(ArenaSparseNodeState::Dirty));
             let child_is_revealed = matches!(child_state, Some(ArenaSparseNodeState::Revealed));
             if child_is_dirty {
                 *arena[parent.index].state_mut() = ArenaSparseNodeState::Dirty;

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -119,6 +119,13 @@ struct ArenaTrieBuffers {
     rlp_node_buf: Vec<RlpNode>,
 }
 
+/// Result of hashing an arena and optionally pruning its cached nodes.
+struct CachedRlpResult {
+    rlp_node: RlpNode,
+    pruned_leaves: u64,
+    root_prunable: bool,
+}
+
 impl ArenaTrieBuffers {
     fn clear(&mut self) {
         if let Some(updates) = self.updates.as_mut() {
@@ -150,6 +157,8 @@ struct ArenaSparseSubtrie {
     num_leaves: u64,
     /// Number of dirty (modified since last hash) leaves in this subtrie.
     num_dirty_leaves: u64,
+    /// Whether the last root calculation found that the entire subtrie was old enough to prune.
+    root_prunable: bool,
 }
 
 impl ArenaSparseSubtrie {
@@ -171,6 +180,7 @@ impl ArenaSparseSubtrie {
             required_proofs: Vec::new(),
             num_leaves: 0,
             num_dirty_leaves: 0,
+            root_prunable: false,
         })
     }
 
@@ -376,6 +386,7 @@ impl ArenaSparseSubtrie {
         if sorted_updates.is_empty() {
             return;
         }
+        self.root_prunable = false;
         trace!(target: TRACE_TARGET, "Subtrie update_leaves");
 
         debug_assert!(
@@ -450,6 +461,7 @@ impl ArenaSparseSubtrie {
         if nodes.is_empty() {
             return Ok(());
         }
+        self.root_prunable = false;
         trace!(target: TRACE_TARGET, path = ?self.path, num_nodes = nodes.len(), "Subtrie reveal_nodes");
 
         debug_assert!(
@@ -486,15 +498,18 @@ impl ArenaSparseSubtrie {
     /// After this call every node reachable from `self.root` will be in `Cached` state.
     ///
     /// Trie updates are written directly to `self.buffers.updates` (if `Some`).
-    fn update_cached_rlp(&mut self, epoch: u64) {
-        ArenaParallelSparseTrie::update_cached_rlp(
+    fn update_cached_rlp(&mut self, epoch: u64, prune_older_than: Option<u64>) {
+        let result = ArenaParallelSparseTrie::update_cached_rlp(
             &mut self.arena,
             self.root,
             self.path,
             &mut self.buffers,
             epoch,
+            prune_older_than,
         );
+        self.num_leaves -= result.pruned_leaves;
         self.num_dirty_leaves = 0;
+        self.root_prunable = result.root_prunable;
         #[cfg(debug_assertions)]
         self.debug_assert_counters();
     }
@@ -635,6 +650,9 @@ impl Default for ArenaParallelismThresholds {
 /// Pruned nodes are replaced with `ArenaSparseNodeBranchChild::Blinded` entries using their
 /// cached RLP. Subtries are pruned in parallel when their leaf count exceeds
 /// [`ArenaParallelismThresholds::min_leaves_for_prune`].
+///
+/// [`SparseTrie::root`] can also prune nodes below a strict epoch cutoff in place after hashing,
+/// without cloning or compacting either arena.
 #[derive(Debug, Clone)]
 pub struct ArenaParallelSparseTrie {
     /// The arena allocating nodes in the upper trie.
@@ -645,6 +663,8 @@ pub struct ArenaParallelSparseTrie {
     buffers: ArenaTrieBuffers,
     /// Thresholds controlling when parallelism is enabled for different operations.
     parallelism_thresholds: ArenaParallelismThresholds,
+    /// Whether the last root calculation found that the entire trie was old enough to prune.
+    root_prunable: bool,
     /// Debug recorder for tracking mutating operations.
     #[cfg(feature = "trie-debug")]
     debug_recorder: TrieDebugRecorder,
@@ -1135,6 +1155,23 @@ impl ArenaParallelSparseTrie {
         masks
     }
 
+    /// Computes and caches the arena RLP, then optionally prunes cached nodes older than the
+    /// provided epoch without compacting the arena.
+    fn update_cached_rlp(
+        arena: &mut NodeArena,
+        root: Index,
+        base_path: Nibbles,
+        buffers: &mut ArenaTrieBuffers,
+        epoch: u64,
+        prune_older_than: Option<u64>,
+    ) -> CachedRlpResult {
+        let rlp_node = Self::calculate_cached_rlp(arena, root, base_path, buffers, epoch);
+        let (root_prunable, pruned_leaves) = prune_older_than
+            .map(|threshold| Self::prune_cached_nodes(arena, root, threshold))
+            .unwrap_or_default();
+        CachedRlpResult { rlp_node, pruned_leaves, root_prunable }
+    }
+
     /// Computes and caches `RlpNode` for all uncached nodes reachable from `root` in `arena`.
     ///
     /// Uses the cursor's stack to walk uncached branches depth-first. For each branch,
@@ -1148,7 +1185,7 @@ impl ArenaParallelSparseTrie {
     /// via `BranchNodeRef` using the last N entries on `rlp_node_buf`, then replaced with a
     /// single result `RlpNode`.
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all, fields(base_path = ?base_path), ret)]
-    fn update_cached_rlp(
+    fn calculate_cached_rlp(
         arena: &mut NodeArena,
         root: Index,
         base_path: Nibbles,
@@ -1344,6 +1381,94 @@ impl ArenaParallelSparseTrie {
             panic!("root must be cached after update_cached_rlp");
         };
         rlp_node.clone()
+    }
+
+    /// Prunes cached descendants in place, returning whether `idx` can itself be pruned by its
+    /// parent and the number of leaves removed from this arena.
+    ///
+    /// The trie has already been hashed, so replacing a revealed child with its cached RLP does
+    /// not change the logical trie or its root. A branch is pruneable only after all of its
+    /// revealed children have been pruned. The caller always retains the arena root.
+    fn prune_cached_nodes(arena: &mut NodeArena, idx: Index, prune_older_than: u64) -> (bool, u64) {
+        match &arena[idx] {
+            ArenaSparseNode::EmptyRoot => return (false, 0),
+            ArenaSparseNode::Leaf { state, .. } => {
+                let epoch = state.cached_epoch().expect("leaf must be cached before pruning");
+                return (epoch < prune_older_than, 0)
+            }
+            ArenaSparseNode::Branch(branch) => {
+                let epoch =
+                    branch.state.cached_epoch().expect("branch must be cached before pruning");
+                if epoch >= prune_older_than {
+                    return (false, 0)
+                }
+            }
+            ArenaSparseNode::Subtrie(subtrie) => return (subtrie.root_prunable, 0),
+            ArenaSparseNode::TakenSubtrie => {
+                unreachable!("taken subtrie must be restored before pruning")
+            }
+        }
+
+        let revealed_children: SmallVec<[(usize, Index); 16]> = arena[idx]
+            .branch_ref()
+            .children
+            .iter()
+            .enumerate()
+            .filter_map(|(child_pos, child)| match child {
+                ArenaSparseNodeBranchChild::Revealed(child_idx) => Some((child_pos, *child_idx)),
+                ArenaSparseNodeBranchChild::Blinded(_) => None,
+            })
+            .collect();
+        let mut children_to_prune: SmallVec<[(usize, Index, RlpNode); 16]> = SmallVec::new();
+        let mut pruned_leaves = 0;
+
+        for (child_pos, child_idx) in revealed_children {
+            let child_is_leaf = matches!(arena[child_idx], ArenaSparseNode::Leaf { .. });
+            let (child_is_prunable, child_pruned_leaves) =
+                Self::prune_cached_nodes(arena, child_idx, prune_older_than);
+            pruned_leaves += child_pruned_leaves;
+
+            if child_is_prunable {
+                let rlp_node = arena[child_idx]
+                    .state_ref()
+                    .and_then(ArenaSparseNodeState::cached_rlp_node)
+                    .cloned()
+                    .expect("pruned child must have a cached RLP");
+                children_to_prune.push((child_pos, child_idx, rlp_node));
+                pruned_leaves += u64::from(child_is_leaf);
+            }
+        }
+
+        for (child_pos, child_idx, rlp_node) in children_to_prune {
+            arena[idx].branch_mut().children[child_pos] =
+                ArenaSparseNodeBranchChild::Blinded(rlp_node);
+            arena.remove(child_idx).expect("pruned child must exist");
+        }
+
+        let oldest_retained_epoch = arena[idx]
+            .branch_ref()
+            .children
+            .iter()
+            .filter_map(|child| match child {
+                ArenaSparseNodeBranchChild::Revealed(child_idx) => {
+                    arena[*child_idx].state_ref().and_then(ArenaSparseNodeState::cached_epoch)
+                }
+                ArenaSparseNodeBranchChild::Blinded(_) => None,
+            })
+            .min();
+
+        if let Some(oldest_retained_epoch) = oldest_retained_epoch {
+            let ArenaSparseNodeState::Cached { epoch, .. } = &mut arena[idx].branch_mut().state
+            else {
+                unreachable!("branch must remain cached while pruning")
+            };
+            *epoch = oldest_retained_epoch;
+            (false, pruned_leaves)
+        } else {
+            // Preserve the old branch epoch until the result reaches the arena-root caller or a
+            // parent replaces this node with a blinded child.
+            (true, pruned_leaves)
+        }
     }
 
     /// Immutable traversal to find a leaf value at `full_path` starting from `root` in `arena`.
@@ -2260,6 +2385,7 @@ impl Default for ArenaParallelSparseTrie {
             root,
             buffers: ArenaTrieBuffers::default(),
             parallelism_thresholds: ArenaParallelismThresholds::default(),
+            root_prunable: false,
             #[cfg(feature = "trie-debug")]
             debug_recorder: Default::default(),
         }
@@ -2268,16 +2394,121 @@ impl Default for ArenaParallelSparseTrie {
 
 impl ArenaParallelSparseTrie {
     /// Hashes a subtrie at `head_idx` and collects its update actions.
-    fn update_upper_subtrie(&mut self, head_idx: Index, epoch: u64) {
+    fn update_upper_subtrie(&mut self, head_idx: Index, epoch: u64, prune_older_than: Option<u64>) {
         let ArenaSparseNode::Subtrie(subtrie) = &mut self.upper_arena[head_idx] else {
             unreachable!()
         };
 
         if !subtrie.arena[subtrie.root].is_cached() {
-            subtrie.update_cached_rlp(epoch);
+            subtrie.update_cached_rlp(epoch, prune_older_than);
         }
 
         Self::merge_subtrie_updates(&mut self.buffers.updates, &mut subtrie.buffers.updates);
+    }
+
+    /// Updates lower-subtrie hashes and optionally prunes them using a strict epoch cutoff.
+    #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
+    fn update_subtrie_hashes_with_pruning(&mut self, epoch: u64, prune_older_than: Option<u64>) {
+        #[cfg(feature = "trie-debug")]
+        self.debug_recorder.record(RecordedOp::UpdateSubtrieHashes { epoch, prune_older_than });
+
+        trace!(target: TRACE_TARGET, "Updating subtrie hashes");
+
+        // Only descend if the root is a branch; otherwise there are no subtries.
+        if !matches!(&self.upper_arena[self.root], ArenaSparseNode::Branch(_)) {
+            return;
+        }
+
+        // Count the work across all subtries to make one global parallelism decision. Hashing is
+        // proportional to dirty leaves, while pruning must inspect every revealed leaf.
+        let mut total_work_leaves: u64 = 0;
+        let mut taken: Vec<(Index, Box<ArenaSparseSubtrie>)> = Vec::new();
+        for (idx, node) in &mut self.upper_arena {
+            let ArenaSparseNode::Subtrie(s) = node else { continue };
+            if prune_older_than.is_none() && s.num_dirty_leaves == 0 && s.arena[s.root].is_cached()
+            {
+                continue;
+            }
+            total_work_leaves +=
+                if prune_older_than.is_some() { s.num_leaves } else { s.num_dirty_leaves };
+            let ArenaSparseNode::Subtrie(subtrie) =
+                mem::replace(node, ArenaSparseNode::TakenSubtrie)
+            else {
+                unreachable!()
+            };
+            taken.push((idx, subtrie));
+        }
+
+        // Hash and prune taken subtries in parallel when their total work meets the threshold.
+        if !taken.is_empty() {
+            let parallelism_threshold = if prune_older_than.is_some() {
+                self.parallelism_thresholds.min_leaves_for_prune
+            } else {
+                self.parallelism_thresholds.min_dirty_leaves
+            };
+            if taken.len() == 1 || total_work_leaves < parallelism_threshold {
+                for (_, subtrie) in &mut taken {
+                    subtrie.update_cached_rlp(epoch, prune_older_than);
+                }
+            } else {
+                use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+                let parent_span = tracing::Span::current();
+                taken = taken
+                    .into_par_iter()
+                    .map(|(idx, mut subtrie)| {
+                        let _guard = parent_span.enter();
+                        subtrie.update_cached_rlp(epoch, prune_older_than);
+                        (idx, subtrie)
+                    })
+                    .collect();
+            }
+        }
+
+        // If the root branch is already cached and nothing was taken for parallel
+        // hashing, there are no dirty subtries to process.
+        if taken.is_empty() && self.upper_arena[self.root].is_cached() {
+            return;
+        }
+
+        // Walk the upper trie depth-first, restoring hashed subtries and inline-hashing
+        // any remaining dirty subtries. Only descend into dirty branches; clean subtrees
+        // cannot contain dirty subtries since dirty state propagates upward.
+        taken.sort_unstable_by_key(|(_, b)| Reverse(b.path));
+
+        self.buffers.cursor.reset(&self.upper_arena, self.root, Nibbles::default());
+
+        loop {
+            let result = self.buffers.cursor.next(&mut self.upper_arena, |_, child| match child {
+                ArenaSparseNode::Branch(_) => prune_older_than.is_some() || !child.is_cached(),
+                ArenaSparseNode::Subtrie(_) => !child.is_cached(),
+                ArenaSparseNode::TakenSubtrie => true,
+                _ => false,
+            });
+
+            match result {
+                NextResult::Done => break,
+                NextResult::Branch => continue,
+                NextResult::NonBranch => {}
+            }
+
+            // Head is a subtrie or taken-subtrie — process it.
+            let head_idx = self.buffers.cursor.head().expect("cursor is non-empty").index;
+
+            if matches!(&self.upper_arena[head_idx], ArenaSparseNode::TakenSubtrie) {
+                let (_, subtrie) = taken.pop().expect("taken subtries must not be exhausted");
+                debug_assert_eq!(
+                    subtrie.path,
+                    self.buffers.cursor.head().expect("cursor is non-empty").path,
+                    "taken subtrie path mismatch",
+                );
+                self.upper_arena[head_idx] = ArenaSparseNode::Subtrie(subtrie);
+            }
+
+            self.update_upper_subtrie(head_idx, epoch, prune_older_than);
+        }
+
+        debug_assert!(taken.is_empty(), "all taken subtries must be restored");
     }
 }
 
@@ -2289,6 +2520,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         masks: Option<BranchNodeMasks>,
         retain_updates: bool,
     ) -> SparseTrieResult<()> {
+        self.root_prunable = false;
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::SetRoot {
             node: ProofTrieNodeRecord::from_proof_trie_node_v2(&ProofTrieNodeV2 {
@@ -2354,6 +2586,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         if nodes.is_empty() {
             return Ok(());
         }
+        self.root_prunable = false;
 
         #[cfg(feature = "trie-debug")]
         self.debug_recorder.record(RecordedOp::RevealNodes {
@@ -2502,119 +2735,35 @@ impl SparseTrie for ArenaParallelSparseTrie {
     }
 
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all, ret)]
-    fn root(&mut self, epoch: u64) -> B256 {
+    fn root(&mut self, epoch: u64, prune_older_than: Option<u64>) -> B256 {
         #[cfg(feature = "trie-debug")]
-        self.debug_recorder.record(RecordedOp::Root { epoch });
+        self.debug_recorder.record(RecordedOp::Root { epoch, prune_older_than });
 
-        self.update_subtrie_hashes(epoch);
+        self.update_subtrie_hashes_with_pruning(epoch, prune_older_than);
 
-        let rlp_node = Self::update_cached_rlp(
+        let result = Self::update_cached_rlp(
             &mut self.upper_arena,
             self.root,
             Nibbles::default(),
             &mut self.buffers,
             epoch,
+            prune_older_than,
         );
+        self.root_prunable = result.root_prunable;
 
-        rlp_node.as_hash().expect("root RlpNode must be a hash")
+        result.rlp_node.as_hash().expect("root RlpNode must be a hash")
     }
 
     fn is_root_cached(&self) -> bool {
         self.upper_arena[self.root].is_cached()
     }
 
-    #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
+    fn root_is_prunable(&self) -> bool {
+        self.root_prunable
+    }
+
     fn update_subtrie_hashes(&mut self, epoch: u64) {
-        #[cfg(feature = "trie-debug")]
-        self.debug_recorder.record(RecordedOp::UpdateSubtrieHashes { epoch });
-
-        trace!(target: TRACE_TARGET, "Updating subtrie hashes");
-
-        // Only descend if the root is a branch; otherwise there are no subtries.
-        if !matches!(&self.upper_arena[self.root], ArenaSparseNode::Branch(_)) {
-            return;
-        }
-
-        // Count total dirty leaves across all subtries to make one global parallelism decision.
-        let mut total_dirty_leaves: u64 = 0;
-        let mut taken: Vec<(Index, Box<ArenaSparseSubtrie>)> = Vec::new();
-        for (idx, node) in &mut self.upper_arena {
-            let ArenaSparseNode::Subtrie(s) = node else { continue };
-            if s.num_dirty_leaves == 0 && s.arena[s.root].is_cached() {
-                continue;
-            }
-            total_dirty_leaves += s.num_dirty_leaves;
-            let ArenaSparseNode::Subtrie(subtrie) =
-                mem::replace(node, ArenaSparseNode::TakenSubtrie)
-            else {
-                unreachable!()
-            };
-            taken.push((idx, subtrie));
-        }
-
-        // Hash taken subtries in parallel if total dirty leaves meet the threshold.
-        if !taken.is_empty() {
-            if taken.len() == 1 || total_dirty_leaves < self.parallelism_thresholds.min_dirty_leaves
-            {
-                for (_, subtrie) in &mut taken {
-                    subtrie.update_cached_rlp(epoch);
-                }
-            } else {
-                use rayon::iter::{IntoParallelIterator, ParallelIterator};
-
-                let parent_span = tracing::Span::current();
-                taken = taken
-                    .into_par_iter()
-                    .map(|(idx, mut subtrie)| {
-                        let _guard = parent_span.enter();
-                        subtrie.update_cached_rlp(epoch);
-                        (idx, subtrie)
-                    })
-                    .collect();
-            }
-        }
-
-        // If the root branch is already cached and nothing was taken for parallel
-        // hashing, there are no dirty subtries to process.
-        if taken.is_empty() && self.upper_arena[self.root].is_cached() {
-            return;
-        }
-
-        // Walk the upper trie depth-first, restoring hashed subtries and inline-hashing
-        // any remaining dirty subtries. Only descend into dirty branches; clean subtrees
-        // cannot contain dirty subtries since dirty state propagates upward.
-        taken.sort_unstable_by_key(|(_, b)| Reverse(b.path));
-
-        self.buffers.cursor.reset(&self.upper_arena, self.root, Nibbles::default());
-
-        loop {
-            let result = self.buffers.cursor.next(&mut self.upper_arena, |_, child| match child {
-                ArenaSparseNode::Branch(_) | ArenaSparseNode::Subtrie(_) => !child.is_cached(),
-                ArenaSparseNode::TakenSubtrie => true,
-                _ => false,
-            });
-
-            match result {
-                NextResult::Done => break,
-                NextResult::Branch => continue,
-                NextResult::NonBranch => {}
-            }
-
-            // Head is a subtrie or taken-subtrie — process it.
-            let head_idx = self.buffers.cursor.head().expect("cursor is non-empty").index;
-
-            if matches!(&self.upper_arena[head_idx], ArenaSparseNode::TakenSubtrie) {
-                let (_, subtrie) = taken.pop().expect("taken subtries must not be exhausted");
-                debug_assert_eq!(
-                    subtrie.path,
-                    self.buffers.cursor.head().expect("cursor is non-empty").path,
-                    "taken subtrie path mismatch",
-                );
-                self.upper_arena[head_idx] = ArenaSparseNode::Subtrie(subtrie);
-            }
-
-            self.update_upper_subtrie(head_idx, epoch);
-        }
+        self.update_subtrie_hashes_with_pruning(epoch, None);
     }
 
     fn get_leaf_value(&self, full_path: &Nibbles) -> Option<&Vec<u8>> {
@@ -2663,6 +2812,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
         self.upper_arena = SlotMap::new();
         self.root = self.upper_arena.insert(ArenaSparseNode::EmptyRoot);
+        self.root_prunable = false;
         self.buffers.clear();
     }
 
@@ -2684,6 +2834,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         fields(num_retained_leaves = retained_leaves.len()),
     )]
     fn prune(&mut self, retained_leaves: &[Nibbles]) -> usize {
+        self.root_prunable = false;
         // Only descend if the root is a branch; otherwise there are no subtries.
         if !matches!(&self.upper_arena[self.root], ArenaSparseNode::Branch(_)) {
             return 0;
@@ -2860,6 +3011,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         if updates.is_empty() {
             return Ok(());
         }
+        self.root_prunable = false;
 
         #[cfg(feature = "trie-debug")]
         let recorded_updates: Vec<_> =
@@ -3179,7 +3331,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
 mod tests {
     use super::{
         ArenaSparseNode, ArenaSparseNodeBranch, ArenaSparseNodeBranchChild, ArenaSparseNodeState,
-        TRACE_TARGET,
+        ArenaSparseSubtrie, TRACE_TARGET,
     };
     use crate::{ArenaParallelSparseTrie, ArenaParallelismThresholds, LeafUpdate, SparseTrie};
     use alloy_primitives::{map::B256Map, B256, U256};
@@ -3204,19 +3356,32 @@ mod tests {
         node.state_ref().and_then(ArenaSparseNodeState::cached_epoch).expect("node must be cached")
     }
 
+    fn update_leaves(
+        trie: &mut ArenaParallelSparseTrie,
+        updates: impl IntoIterator<Item = (B256, Vec<u8>)>,
+    ) {
+        trie.update_leaves(
+            &mut B256Map::from_iter(
+                updates.into_iter().map(|(key, value)| (key, LeafUpdate::Changed(value))),
+            ),
+            |_, _| panic!("fully revealed trie must not request proofs"),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn leaf_epoch_changes_only_when_recached() {
         let mut trie = ArenaParallelSparseTrie::default();
         trie.upper_arena[trie.root] = revealed_leaf(1);
 
-        trie.root(10);
+        trie.root(10, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
 
-        trie.root(11);
+        trie.root(11, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
 
         *trie.upper_arena[trie.root].state_mut() = ArenaSparseNodeState::Dirty;
-        trie.root(12);
+        trie.root(12, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 12);
     }
 
@@ -3246,20 +3411,215 @@ mod tests {
                 (third_leaf, LeafUpdate::Changed(vec![3; 32])),
             ],
         );
-        trie.root(10);
+        trie.root(10, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
 
         update(&mut trie, vec![(first_leaf, LeafUpdate::Changed(vec![4; 32]))]);
-        trie.root(20);
+        trie.root(20, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
 
         update(&mut trie, vec![(second_leaf, LeafUpdate::Changed(vec![5; 32]))]);
-        trie.root(30);
+        trie.root(30, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
 
         update(&mut trie, vec![(third_leaf, LeafUpdate::Changed(vec![6; 32]))]);
-        trie.root(40);
+        trie.root(40, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 20);
+    }
+
+    #[test]
+    fn root_prunes_cached_leaves_strictly_without_compacting() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        let keys = [0x00, 0x10, 0x20].map(|first_byte| {
+            let mut key = [0; 32];
+            key[0] = first_byte;
+            B256::from(key)
+        });
+        update_leaves(
+            &mut trie,
+            keys.into_iter().enumerate().map(|(i, key)| (key, vec![i as u8 + 1; 32])),
+        );
+
+        let expected_root = trie.root(10, None);
+        let root_idx = trie.root;
+        let child_indices: Vec<_> = trie.upper_arena[root_idx]
+            .branch_ref()
+            .children
+            .iter()
+            .map(|child| match child {
+                ArenaSparseNodeBranchChild::Revealed(idx) => *idx,
+                ArenaSparseNodeBranchChild::Blinded(_) => panic!("all leaves must be revealed"),
+            })
+            .collect();
+        let capacity = trie.upper_arena.capacity();
+
+        assert_eq!(trie.root(20, Some(10)), expected_root);
+        assert_eq!(trie.upper_arena.len(), 4, "the threshold is exclusive");
+
+        assert_eq!(trie.root(20, Some(11)), expected_root);
+        assert_eq!(trie.root, root_idx);
+        assert_eq!(trie.upper_arena.len(), 1);
+        assert_eq!(trie.upper_arena.capacity(), capacity);
+        assert!(child_indices.into_iter().all(|idx| !trie.upper_arena.contains_key(idx)));
+        assert!(trie.upper_arena[root_idx]
+            .branch_ref()
+            .children
+            .iter()
+            .all(ArenaSparseNodeBranchChild::is_blinded));
+        // The root retains the oldest pruned child epoch so repeated prune calls can still evict
+        // an independently-owned trie.
+        assert_eq!(cached_epoch(&trie.upper_arena[root_idx]), 10);
+        assert!(trie.root_is_prunable());
+        assert_eq!(trie.root(21, Some(12)), expected_root);
+        assert!(trie.root_is_prunable());
+        trie.clear();
+        assert!(!trie.root_is_prunable());
+    }
+
+    #[test]
+    fn root_prunes_only_old_children_and_preserves_hash_and_updates() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        trie.set_updates(true);
+        let keys = [0x00, 0x10, 0x20].map(|first_byte| {
+            let mut key = [0; 32];
+            key[0] = first_byte;
+            B256::from(key)
+        });
+        update_leaves(
+            &mut trie,
+            keys.into_iter().enumerate().map(|(i, key)| (key, vec![i as u8 + 1; 32])),
+        );
+        trie.root(10, None);
+
+        update_leaves(&mut trie, [(keys[2], vec![4; 32])]);
+        trie.root(20, None);
+
+        let root_idx = trie.root;
+        let child_indices: Vec<_> = trie.upper_arena[root_idx]
+            .branch_ref()
+            .children
+            .iter()
+            .map(|child| match child {
+                ArenaSparseNodeBranchChild::Revealed(idx) => *idx,
+                ArenaSparseNodeBranchChild::Blinded(_) => panic!("all leaves must be revealed"),
+            })
+            .collect();
+        let capacity = trie.upper_arena.capacity();
+        let mut unpruned = trie.clone();
+
+        let expected_root = unpruned.root(21, None);
+        let actual_root = trie.root(21, Some(15));
+
+        assert_eq!(actual_root, expected_root);
+        assert_eq!(trie.updates_ref(), unpruned.updates_ref());
+        assert_eq!(trie.root, root_idx);
+        assert_eq!(trie.upper_arena.capacity(), capacity);
+        assert!(!trie.upper_arena.contains_key(child_indices[0]));
+        assert!(!trie.upper_arena.contains_key(child_indices[1]));
+        assert!(trie.upper_arena.contains_key(child_indices[2]));
+        assert!(matches!(
+            trie.upper_arena[root_idx].branch_ref().children.as_slice(),
+            [
+                ArenaSparseNodeBranchChild::Blinded(_),
+                ArenaSparseNodeBranchChild::Blinded(_),
+                ArenaSparseNodeBranchChild::Revealed(idx),
+            ] if *idx == child_indices[2]
+        ));
+        assert_eq!(cached_epoch(&trie.upper_arena[root_idx]), 20);
+    }
+
+    #[test]
+    fn root_prunes_old_branch_after_its_children() {
+        let mut trie = ArenaParallelSparseTrie::default().with_parallelism_thresholds(
+            ArenaParallelismThresholds {
+                min_leaves_for_prune: 0,
+                ..ArenaParallelismThresholds::default()
+            },
+        );
+        let keys = [0x00, 0x01, 0x10].map(|first_byte| {
+            let mut key = [0; 32];
+            key[0] = first_byte;
+            B256::from(key)
+        });
+        update_leaves(
+            &mut trie,
+            keys.into_iter().enumerate().map(|(i, key)| (key, vec![i as u8 + 1; 32])),
+        );
+        trie.root(10, None);
+
+        update_leaves(&mut trie, [(keys[2], vec![4; 32])]);
+        let expected_root = trie.root(20, None);
+        let root_idx = trie.root;
+        let old_branch_idx = match trie.upper_arena[root_idx].branch_ref().children[0] {
+            ArenaSparseNodeBranchChild::Revealed(idx) => idx,
+            ArenaSparseNodeBranchChild::Blinded(_) => panic!("old branch must be revealed"),
+        };
+        assert!(matches!(trie.upper_arena[old_branch_idx], ArenaSparseNode::Branch(_)));
+        assert_eq!(
+            trie.upper_arena[old_branch_idx]
+                .branch_ref()
+                .children
+                .iter()
+                .filter(|child| matches!(
+                    child,
+                    ArenaSparseNodeBranchChild::Revealed(idx)
+                        if matches!(trie.upper_arena[*idx], ArenaSparseNode::Subtrie(_))
+                ))
+                .count(),
+            2,
+        );
+
+        assert_eq!(trie.root(21, Some(15)), expected_root);
+        assert!(!trie.upper_arena.contains_key(old_branch_idx));
+        assert!(matches!(
+            trie.upper_arena[root_idx].branch_ref().children[0],
+            ArenaSparseNodeBranchChild::Blinded(_)
+        ));
+        assert!(matches!(
+            trie.upper_arena[root_idx].branch_ref().children[1],
+            ArenaSparseNodeBranchChild::Revealed(_)
+        ));
+        assert_eq!(cached_epoch(&trie.upper_arena[root_idx]), 20);
+        assert!(!trie
+            .upper_arena
+            .values()
+            .any(|node| matches!(node, ArenaSparseNode::TakenSubtrie)));
+    }
+
+    #[test]
+    fn subtrie_pruning_updates_leaf_counters() {
+        let mut subtrie = ArenaSparseSubtrie::new(false);
+        let first_leaf = subtrie.arena.insert(revealed_leaf(1));
+        let second_leaf = subtrie.arena.insert(revealed_leaf(2));
+        let mut state_mask = TrieMask::default();
+        state_mask.set_bit(0);
+        state_mask.set_bit(1);
+        subtrie.arena[subtrie.root] = ArenaSparseNode::Branch(ArenaSparseNodeBranch {
+            state: ArenaSparseNodeState::Revealed,
+            children: [
+                ArenaSparseNodeBranchChild::Revealed(first_leaf),
+                ArenaSparseNodeBranchChild::Revealed(second_leaf),
+            ]
+            .into_iter()
+            .collect(),
+            state_mask,
+            short_key: Nibbles::default(),
+            branch_masks: BranchNodeMasks::default(),
+        });
+        subtrie.num_leaves = 2;
+
+        subtrie.update_cached_rlp(10, None);
+        subtrie.update_cached_rlp(20, Some(11));
+
+        assert_eq!(subtrie.num_leaves, 0);
+        assert_eq!(subtrie.num_dirty_leaves, 0);
+        assert!(subtrie.root_prunable);
+        assert_eq!(subtrie.arena.len(), 1);
+        assert!(subtrie.arena[subtrie.root]
+            .branch_ref()
+            .children
+            .iter()
+            .all(ArenaSparseNodeBranchChild::is_blinded));
     }
 
     #[test]
@@ -3282,11 +3642,11 @@ mod tests {
             branch_masks: BranchNodeMasks::default(),
         });
 
-        trie.root(10);
+        trie.root(10, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
 
         *trie.upper_arena[trie.root].state_mut() = ArenaSparseNodeState::Revealed;
-        trie.root(5);
+        trie.root(5, None);
         assert_eq!(cached_epoch(&trie.upper_arena[leaf]), 10);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
     }
@@ -3309,7 +3669,7 @@ mod tests {
             short_key: Nibbles::default(),
             branch_masks: BranchNodeMasks::default(),
         });
-        trie.root(10);
+        trie.root(10, None);
 
         trie.reveal_nodes(&mut [ProofTrieNodeV2 {
             path: Nibbles::from_nibbles([0]),
@@ -3325,7 +3685,7 @@ mod tests {
         };
         assert!(matches!(trie.upper_arena[leaf].state_ref(), Some(ArenaSparseNodeState::Revealed)));
 
-        trie.root(20);
+        trie.root(20, None);
         assert_eq!(cached_epoch(&trie.upper_arena[leaf]), 20);
     }
 
@@ -3406,7 +3766,7 @@ mod tests {
             }
 
             // Compute root and take updates from the APST.
-            let actual_root = apst.root(0);
+            let actual_root = apst.root(0, None);
             let mut actual_updates = apst.take_updates();
 
             // Minimize sparse updates inline (can't use TrieTestHarness::minimize_sparse_updates

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -12,7 +12,7 @@ use crate::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdat
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
 use alloy_primitives::{keccak256, map::B256Map, B256};
 use alloy_trie::TrieMask;
-use core::{cmp::Reverse, mem};
+use core::mem;
 use reth_execution_errors::SparseTrieResult;
 use reth_trie_common::{
     BranchNodeMasks, BranchNodeRef, ExtensionNodeRef, LeafNodeRef, Nibbles, ProofTrieNodeV2,
@@ -387,7 +387,6 @@ impl ArenaSparseSubtrie {
         if sorted_updates.is_empty() {
             return;
         }
-        self.root_prunable = false;
         trace!(target: TRACE_TARGET, "Subtrie update_leaves");
 
         debug_assert!(
@@ -462,7 +461,6 @@ impl ArenaSparseSubtrie {
         if nodes.is_empty() {
             return Ok(());
         }
-        self.root_prunable = false;
         trace!(target: TRACE_TARGET, path = ?self.path, num_nodes = nodes.len(), "Subtrie reveal_nodes");
 
         debug_assert!(
@@ -682,12 +680,12 @@ impl ArenaParallelSparseTrie {
     }
 
     /// Resets the debug recorder and records the current trie state as `SetRoot` + `RevealNodes`
-    /// ops, representing the initial state at the beginning of a block (after pruning).
+    /// operations, representing the initial state for the next block.
     ///
     /// Walks the upper arena and all subtries depth-first using the cursor, converting each
     /// node into a [`crate::debug_recorder::ProofTrieNodeRecord`].
     #[cfg(feature = "trie-debug")]
-    fn record_initial_state(&mut self) {
+    fn record_initial_state(&mut self, pruned: bool) {
         use crate::debug_recorder::{NodeStateRecord, TrieNodeRecord};
         use alloy_primitives::hex;
         use alloy_trie::nodes::{BranchNode, TrieNode};
@@ -817,9 +815,11 @@ impl ArenaParallelSparseTrie {
             }
         }
 
-        // Reset the recorder and record that we pruned, then the initial state.
+        // Reset the recorder, then record the initial state.
         self.debug_recorder.reset();
-        self.debug_recorder.record(RecordedOp::Prune);
+        if pruned {
+            self.debug_recorder.record(RecordedOp::Prune);
+        }
 
         // First node is the root → SetRoot, remaining → RevealNodes.
         if let Some(root_record) = nodes.first() {
@@ -1204,16 +1204,13 @@ impl ArenaParallelSparseTrie {
         // Step 1: Handle trivial roots that don't need the stack-based walk. Empty roots and
         // leaves are encoded in place. Already-cached branches need no work. Only uncached
         // branches enter the main loop below.
-        if matches!(arena[root], ArenaSparseNode::EmptyRoot { .. }) {
-            let empty_root_rlp = RlpNode::word_rlp(&EMPTY_ROOT_HASH);
-            if let Some(rlp_node) =
-                arena[root].state_ref().and_then(ArenaSparseNodeState::cached_rlp_node)
-            {
-                debug_assert_eq!(rlp_node, &empty_root_rlp);
+        if let ArenaSparseNode::EmptyRoot { state } = &mut arena[root] {
+            if let ArenaSparseNodeState::Cached { rlp_node, .. } = state {
+                debug_assert_eq!(rlp_node, &RlpNode::word_rlp(&EMPTY_ROOT_HASH));
                 return rlp_node.clone()
             }
-            *arena[root].state_mut() =
-                ArenaSparseNodeState::Cached { rlp_node: empty_root_rlp.clone(), epoch };
+            let empty_root_rlp = RlpNode::word_rlp(&EMPTY_ROOT_HASH);
+            *state = ArenaSparseNodeState::Cached { rlp_node: empty_root_rlp.clone(), epoch };
             return empty_root_rlp
         }
 
@@ -1295,40 +1292,16 @@ impl ArenaParallelSparseTrie {
                                     .and_then(ArenaSparseNodeState::cached_epoch)
                                     .expect("child leaf must be cached after encoding")
                             }
-                            ArenaSparseNode::Branch(child_b) => {
+                            ArenaSparseNode::Branch(_) | ArenaSparseNode::Subtrie(_) => {
                                 let ArenaSparseNodeState::Cached { rlp_node, epoch: child_epoch } =
-                                    &child_b.state
+                                    arena[child_idx]
+                                        .state_ref()
+                                        .expect("branch or subtrie root must have state")
                                 else {
-                                    panic!("child branch must be cached after DFS");
+                                    panic!("child branch or subtrie root must be cached");
                                 };
-                                let rlp_node = rlp_node.clone();
-                                rlp_node_buf.push(rlp_node);
+                                rlp_node_buf.push(rlp_node.clone());
                                 *child_epoch
-                            }
-                            ArenaSparseNode::Subtrie(subtrie) => {
-                                let subtrie_root = &subtrie.arena[subtrie.root];
-                                match subtrie_root {
-                                    ArenaSparseNode::Branch(ArenaSparseNodeBranch {
-                                        state:
-                                            ArenaSparseNodeState::Cached {
-                                                rlp_node,
-                                                epoch: child_epoch,
-                                            },
-                                        ..
-                                    }) |
-                                    ArenaSparseNode::Leaf {
-                                        state:
-                                            ArenaSparseNodeState::Cached {
-                                                rlp_node,
-                                                epoch: child_epoch,
-                                            },
-                                        ..
-                                    } => {
-                                        rlp_node_buf.push(rlp_node.clone());
-                                        *child_epoch
-                                    }
-                                    _ => panic!("subtrie root must be a cached Branch or Leaf"),
-                                }
                             }
                             ArenaSparseNode::TakenSubtrie | ArenaSparseNode::EmptyRoot { .. } => {
                                 unreachable!("Unexpected child {:?}", arena[child_idx]);
@@ -1420,20 +1393,15 @@ impl ArenaParallelSparseTrie {
             }
         }
 
-        let revealed_children: SmallVec<[(usize, Index); 16]> = arena[idx]
-            .branch_ref()
-            .children
-            .iter()
-            .enumerate()
-            .filter_map(|(child_pos, child)| match child {
-                ArenaSparseNodeBranchChild::Revealed(child_idx) => Some((child_pos, *child_idx)),
-                ArenaSparseNodeBranchChild::Blinded(_) => None,
-            })
-            .collect();
-        let mut children_to_prune: SmallVec<[(usize, Index, RlpNode); 16]> = SmallVec::new();
+        let num_children = arena[idx].branch_ref().children.len();
+        let mut has_retained_child = false;
         let mut pruned_leaves = 0;
 
-        for (child_pos, child_idx) in revealed_children {
+        for child_pos in 0..num_children {
+            let child_idx = match &arena[idx].branch_ref().children[child_pos] {
+                ArenaSparseNodeBranchChild::Revealed(child_idx) => *child_idx,
+                ArenaSparseNodeBranchChild::Blinded(_) => continue,
+            };
             let child_is_leaf = matches!(arena[child_idx], ArenaSparseNode::Leaf { .. });
             let (child_is_prunable, child_pruned_leaves) =
                 Self::prune_cached_nodes(arena, child_idx, prune_older_than);
@@ -1445,44 +1413,21 @@ impl ArenaParallelSparseTrie {
                     .and_then(ArenaSparseNodeState::cached_rlp_node)
                     .cloned()
                     .expect("pruned child must have a cached RLP");
-                children_to_prune.push((child_pos, child_idx, rlp_node));
+                arena[idx].branch_mut().children[child_pos] =
+                    ArenaSparseNodeBranchChild::Blinded(rlp_node);
+                arena.remove(child_idx).expect("pruned child must exist");
                 pruned_leaves += u64::from(child_is_leaf);
+            } else {
+                has_retained_child = true;
             }
         }
 
-        for (child_pos, child_idx, rlp_node) in children_to_prune {
-            arena[idx].branch_mut().children[child_pos] =
-                ArenaSparseNodeBranchChild::Blinded(rlp_node);
-            arena.remove(child_idx).expect("pruned child must exist");
-        }
-
-        let newest_retained_epoch = arena[idx]
+        let epoch = arena[idx]
             .branch_ref()
-            .children
-            .iter()
-            .filter_map(|child| match child {
-                ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                    arena[*child_idx].state_ref().and_then(ArenaSparseNodeState::cached_epoch)
-                }
-                ArenaSparseNodeBranchChild::Blinded(_) => None,
-            })
-            .max();
-
-        if let Some(newest_retained_epoch) = newest_retained_epoch {
-            let ArenaSparseNodeState::Cached { epoch, .. } = &mut arena[idx].branch_mut().state
-            else {
-                unreachable!("branch must remain cached while pruning")
-            };
-            *epoch = (*epoch).max(newest_retained_epoch);
-            (false, pruned_leaves)
-        } else {
-            let epoch = arena[idx]
-                .branch_ref()
-                .state
-                .cached_epoch()
-                .expect("branch must remain cached while pruning");
-            (epoch < prune_older_than, pruned_leaves)
-        }
+            .state
+            .cached_epoch()
+            .expect("branch must remain cached while pruning");
+        (!has_retained_child && epoch < prune_older_than, pruned_leaves)
     }
 
     /// Immutable traversal to find a leaf value at `full_path` starting from `root` in `arena`.
@@ -2318,7 +2263,7 @@ impl ArenaParallelSparseTrie {
             .expect("Blinded result but child nibble not in state_mask");
 
         let cached_rlp = match &head_branch.children[dense_child_idx] {
-            ArenaSparseNodeBranchChild::Blinded(rlp) => rlp.clone(),
+            ArenaSparseNodeBranchChild::Blinded(rlp) => rlp,
             ArenaSparseNodeBranchChild::Revealed(_) => return None,
         };
 
@@ -2409,19 +2354,6 @@ impl Default for ArenaParallelSparseTrie {
 }
 
 impl ArenaParallelSparseTrie {
-    /// Hashes a subtrie at `head_idx` and collects its update actions.
-    fn update_upper_subtrie(&mut self, head_idx: Index, epoch: u64, prune_older_than: Option<u64>) {
-        let ArenaSparseNode::Subtrie(subtrie) = &mut self.upper_arena[head_idx] else {
-            unreachable!()
-        };
-
-        if !subtrie.arena[subtrie.root].is_cached() {
-            subtrie.update_cached_rlp(epoch, prune_older_than);
-        }
-
-        Self::merge_subtrie_updates(&mut self.buffers.updates, &mut subtrie.buffers.updates);
-    }
-
     /// Updates lower-subtrie hashes and optionally prunes them using a strict epoch cutoff.
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
     fn update_subtrie_hashes_with_pruning(&mut self, epoch: u64, prune_older_than: Option<u64>) {
@@ -2456,75 +2388,33 @@ impl ArenaParallelSparseTrie {
         }
 
         // Hash and prune taken subtries in parallel when their total work meets the threshold.
-        if !taken.is_empty() {
-            let parallelism_threshold = if prune_older_than.is_some() {
-                self.parallelism_thresholds.min_leaves_for_prune
-            } else {
-                self.parallelism_thresholds.min_dirty_leaves
-            };
-            if taken.len() == 1 || total_work_leaves < parallelism_threshold {
-                for (_, subtrie) in &mut taken {
-                    subtrie.update_cached_rlp(epoch, prune_older_than);
-                }
-            } else {
-                use rayon::iter::{IntoParallelIterator, ParallelIterator};
-
-                let parent_span = tracing::Span::current();
-                taken = taken
-                    .into_par_iter()
-                    .map(|(idx, mut subtrie)| {
-                        let _guard = parent_span.enter();
-                        subtrie.update_cached_rlp(epoch, prune_older_than);
-                        (idx, subtrie)
-                    })
-                    .collect();
-            }
-        }
-
-        // If the root branch is already cached and nothing was taken for parallel
-        // hashing, there are no dirty subtries to process.
-        if taken.is_empty() && self.upper_arena[self.root].is_cached() {
+        if taken.is_empty() {
             return;
         }
+        let parallelism_threshold = if prune_older_than.is_some() {
+            self.parallelism_thresholds.min_leaves_for_prune
+        } else {
+            self.parallelism_thresholds.min_dirty_leaves
+        };
+        if taken.len() == 1 || total_work_leaves < parallelism_threshold {
+            for (_, subtrie) in &mut taken {
+                subtrie.update_cached_rlp(epoch, prune_older_than);
+            }
+        } else {
+            use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
-        // Walk the upper trie depth-first, restoring hashed subtries and inline-hashing
-        // any remaining dirty subtries. Only descend into dirty branches; clean subtrees
-        // cannot contain dirty subtries since dirty state propagates upward.
-        taken.sort_unstable_by_key(|(_, b)| Reverse(b.path));
-
-        self.buffers.cursor.reset(&self.upper_arena, self.root, Nibbles::default());
-
-        loop {
-            let result = self.buffers.cursor.next(&mut self.upper_arena, |_, child| match child {
-                ArenaSparseNode::Branch(_) => prune_older_than.is_some() || !child.is_cached(),
-                ArenaSparseNode::Subtrie(_) => !child.is_cached(),
-                ArenaSparseNode::TakenSubtrie => true,
-                _ => false,
+            let parent_span = tracing::Span::current();
+            taken.par_iter_mut().for_each(|(_, subtrie)| {
+                let _guard = parent_span.enter();
+                subtrie.update_cached_rlp(epoch, prune_older_than);
             });
-
-            match result {
-                NextResult::Done => break,
-                NextResult::Branch => continue,
-                NextResult::NonBranch => {}
-            }
-
-            // Head is a subtrie or taken-subtrie — process it.
-            let head_idx = self.buffers.cursor.head().expect("cursor is non-empty").index;
-
-            if matches!(&self.upper_arena[head_idx], ArenaSparseNode::TakenSubtrie) {
-                let (_, subtrie) = taken.pop().expect("taken subtries must not be exhausted");
-                debug_assert_eq!(
-                    subtrie.path,
-                    self.buffers.cursor.head().expect("cursor is non-empty").path,
-                    "taken subtrie path mismatch",
-                );
-                self.upper_arena[head_idx] = ArenaSparseNode::Subtrie(subtrie);
-            }
-
-            self.update_upper_subtrie(head_idx, epoch, prune_older_than);
         }
 
-        debug_assert!(taken.is_empty(), "all taken subtries must be restored");
+        // Every subtrie that needed work was taken above, so they can be restored directly.
+        for (idx, mut subtrie) in taken {
+            Self::merge_subtrie_updates(&mut self.buffers.updates, &mut subtrie.buffers.updates);
+            self.upper_arena[idx] = ArenaSparseNode::Subtrie(subtrie);
+        }
     }
 }
 
@@ -3013,7 +2903,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         }
 
         #[cfg(feature = "trie-debug")]
-        self.record_initial_state();
+        self.record_initial_state(true);
 
         pruned
     }
@@ -3344,7 +3234,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
     #[cfg(feature = "trie-debug")]
     fn take_debug_recorder(&mut self) -> TrieDebugRecorder {
-        core::mem::take(&mut self.debug_recorder)
+        let recorder = core::mem::take(&mut self.debug_recorder);
+        self.record_initial_state(false);
+        recorder
     }
 }
 
@@ -3404,48 +3296,6 @@ mod tests {
         *trie.upper_arena[trie.root].state_mut() = ArenaSparseNodeState::Dirty;
         trie.root(12, None);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 12);
-    }
-
-    #[test]
-    fn branch_epoch_tracks_newest_dependency() {
-        let mut trie = ArenaParallelSparseTrie::default();
-        let key = |first_byte| {
-            let mut key = [0; 32];
-            key[0] = first_byte;
-            B256::from(key)
-        };
-        let first_leaf = key(0x00);
-        let second_leaf = key(0x01);
-        let third_leaf = key(0x10);
-        let update = |trie: &mut ArenaParallelSparseTrie, updates| {
-            trie.update_leaves(&mut B256Map::from_iter(updates), |_, _| {
-                panic!("fully revealed trie must not request proofs")
-            })
-            .unwrap();
-        };
-
-        update(
-            &mut trie,
-            vec![
-                (first_leaf, LeafUpdate::Changed(vec![1; 32])),
-                (second_leaf, LeafUpdate::Changed(vec![2; 32])),
-                (third_leaf, LeafUpdate::Changed(vec![3; 32])),
-            ],
-        );
-        trie.root(10, None);
-        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
-
-        update(&mut trie, vec![(first_leaf, LeafUpdate::Changed(vec![4; 32]))]);
-        trie.root(20, None);
-        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 20);
-
-        update(&mut trie, vec![(second_leaf, LeafUpdate::Changed(vec![5; 32]))]);
-        trie.root(30, None);
-        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 30);
-
-        update(&mut trie, vec![(third_leaf, LeafUpdate::Changed(vec![6; 32]))]);
-        trie.root(40, None);
-        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 40);
     }
 
     #[test]
@@ -3542,6 +3392,7 @@ mod tests {
             })
             .collect();
         let capacity = trie.upper_arena.capacity();
+        let spare_capacity = capacity - trie.upper_arena.len();
 
         assert_eq!(trie.root(20, Some(10)), expected_root);
         assert_eq!(trie.upper_arena.len(), 4, "the threshold is exclusive");
@@ -3560,6 +3411,20 @@ mod tests {
         // independently-owned trie.
         assert_eq!(cached_epoch(&trie.upper_arena[root_idx]), 10);
         assert!(trie.root_is_prunable());
+
+        // Fill more than the arena's pre-prune spare capacity. Capacity can remain unchanged only
+        // if inserts reuse at least one slot freed by epoch pruning.
+        let reused_slots: Vec<_> = (0..=spare_capacity)
+            .map(|_| {
+                trie.upper_arena
+                    .insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed })
+            })
+            .collect();
+        assert_eq!(trie.upper_arena.capacity(), capacity);
+        for idx in reused_slots {
+            trie.upper_arena.remove(idx);
+        }
+
         assert_eq!(trie.root(21, Some(12)), expected_root);
         assert!(trie.root_is_prunable());
         trie.clear();
@@ -3594,7 +3459,6 @@ mod tests {
                 ArenaSparseNodeBranchChild::Blinded(_) => panic!("all leaves must be revealed"),
             })
             .collect();
-        let capacity = trie.upper_arena.capacity();
         let mut unpruned = trie.clone();
 
         let expected_root = unpruned.root(21, None);
@@ -3603,7 +3467,6 @@ mod tests {
         assert_eq!(actual_root, expected_root);
         assert_eq!(trie.updates_ref(), unpruned.updates_ref());
         assert_eq!(trie.root, root_idx);
-        assert_eq!(trie.upper_arena.capacity(), capacity);
         assert!(!trie.upper_arena.contains_key(child_indices[0]));
         assert!(!trie.upper_arena.contains_key(child_indices[1]));
         assert!(trie.upper_arena.contains_key(child_indices[2]));
@@ -3782,6 +3645,23 @@ mod tests {
 
         trie.root(20, None);
         assert_eq!(cached_epoch(&trie.upper_arena[leaf]), 20);
+    }
+
+    #[cfg(feature = "trie-debug")]
+    #[test]
+    fn taking_debug_recorder_seeds_the_next_block() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        update_leaves(&mut trie, [(B256::with_last_byte(1), vec![1; 32])]);
+        trie.root(10, None);
+
+        let first_block = trie.take_debug_recorder();
+        assert!(!first_block.is_empty());
+
+        let next_block = trie.take_debug_recorder();
+        assert!(matches!(
+            next_block.ops().first(),
+            Some(crate::debug_recorder::RecordedOp::SetRoot { .. })
+        ));
     }
 
     /// Test harness for proptest-based arena sparse trie testing.

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1257,7 +1257,11 @@ impl ArenaParallelSparseTrie {
             );
 
             rlp_node_buf.clear();
-            let mut oldest_child_epoch = None;
+            let was_dirty =
+                matches!(arena[head_idx].branch_ref().state, ArenaSparseNodeState::Dirty);
+            // A deletion or reveal can make a branch uncached without giving any child the
+            // current epoch, so the branch's own transition participates in the maximum.
+            let mut newest_epoch = epoch;
             let state_mask = arena[head_idx].branch_ref().state_mask;
             for (child_idx, _nibble) in BranchChildIter::new(state_mask) {
                 let child_epoch = match &arena[head_idx].branch_ref().children[child_idx] {
@@ -1317,10 +1321,7 @@ impl ArenaParallelSparseTrie {
                     }
                 };
                 if let Some(child_epoch) = child_epoch {
-                    oldest_child_epoch = Some(
-                        oldest_child_epoch
-                            .map_or(child_epoch, |oldest: u64| oldest.min(child_epoch)),
-                    );
+                    newest_epoch = newest_epoch.max(child_epoch);
                 }
             }
 
@@ -1330,7 +1331,6 @@ impl ArenaParallelSparseTrie {
             let state_mask = b.state_mask;
             let prev_branch_masks = b.branch_masks;
             let new_branch_masks = Self::get_branch_masks(arena, b);
-            let was_dirty = matches!(b.state, ArenaSparseNodeState::Dirty);
 
             rlp_buf.clear();
             let rlp_node = BranchNodeRef::new(rlp_node_buf, state_mask).rlp(rlp_buf);
@@ -1352,10 +1352,8 @@ impl ArenaParallelSparseTrie {
             );
 
             let branch = arena[head_idx].branch_mut();
-            branch.state = ArenaSparseNodeState::Cached {
-                rlp_node: rlp_node.clone(),
-                epoch: oldest_child_epoch.unwrap_or(epoch),
-            };
+            branch.state =
+                ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone(), epoch: newest_epoch };
             branch.branch_masks = new_branch_masks;
 
             // Record trie updates for dirty branches only.
@@ -1396,13 +1394,7 @@ impl ArenaParallelSparseTrie {
                 let epoch = state.cached_epoch().expect("leaf must be cached before pruning");
                 return (epoch < prune_older_than, 0)
             }
-            ArenaSparseNode::Branch(branch) => {
-                let epoch =
-                    branch.state.cached_epoch().expect("branch must be cached before pruning");
-                if epoch >= prune_older_than {
-                    return (false, 0)
-                }
-            }
+            ArenaSparseNode::Branch(_) => {}
             ArenaSparseNode::Subtrie(subtrie) => return (subtrie.root_prunable, 0),
             ArenaSparseNode::TakenSubtrie => {
                 unreachable!("taken subtrie must be restored before pruning")
@@ -1445,7 +1437,7 @@ impl ArenaParallelSparseTrie {
             arena.remove(child_idx).expect("pruned child must exist");
         }
 
-        let oldest_retained_epoch = arena[idx]
+        let newest_retained_epoch = arena[idx]
             .branch_ref()
             .children
             .iter()
@@ -1455,19 +1447,22 @@ impl ArenaParallelSparseTrie {
                 }
                 ArenaSparseNodeBranchChild::Blinded(_) => None,
             })
-            .min();
+            .max();
 
-        if let Some(oldest_retained_epoch) = oldest_retained_epoch {
+        if let Some(newest_retained_epoch) = newest_retained_epoch {
             let ArenaSparseNodeState::Cached { epoch, .. } = &mut arena[idx].branch_mut().state
             else {
                 unreachable!("branch must remain cached while pruning")
             };
-            *epoch = oldest_retained_epoch;
+            *epoch = (*epoch).max(newest_retained_epoch);
             (false, pruned_leaves)
         } else {
-            // Preserve the old branch epoch until the result reaches the arena-root caller or a
-            // parent replaces this node with a blinded child.
-            (true, pruned_leaves)
+            let epoch = arena[idx]
+                .branch_ref()
+                .state
+                .cached_epoch()
+                .expect("branch must remain cached while pruning");
+            (epoch < prune_older_than, pruned_leaves)
         }
     }
 
@@ -3386,7 +3381,7 @@ mod tests {
     }
 
     #[test]
-    fn branch_epoch_tracks_oldest_child() {
+    fn branch_epoch_tracks_newest_dependency() {
         let mut trie = ArenaParallelSparseTrie::default();
         let key = |first_byte| {
             let mut key = [0; 32];
@@ -3416,15 +3411,84 @@ mod tests {
 
         update(&mut trie, vec![(first_leaf, LeafUpdate::Changed(vec![4; 32]))]);
         trie.root(20, None);
-        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 20);
 
         update(&mut trie, vec![(second_leaf, LeafUpdate::Changed(vec![5; 32]))]);
         trie.root(30, None);
-        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 30);
 
         update(&mut trie, vec![(third_leaf, LeafUpdate::Changed(vec![6; 32]))]);
         trie.root(40, None);
-        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 20);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 40);
+    }
+
+    #[test]
+    fn deletion_refreshes_branch_epoch_while_pruning_old_children() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        let keys = [0x00, 0x10, 0x20].map(|first_byte| {
+            let mut key = [0; 32];
+            key[0] = first_byte;
+            B256::from(key)
+        });
+        update_leaves(
+            &mut trie,
+            keys.into_iter().enumerate().map(|(i, key)| (key, vec![i as u8 + 1; 32])),
+        );
+        trie.root(10, None);
+
+        // The deletion modifies the branch without creating a young surviving leaf.
+        update_leaves(&mut trie, [(keys[2], Vec::new())]);
+
+        let mut unpruned = trie.clone();
+        let expected_root = unpruned.root(20, None);
+        let root_idx = trie.root;
+
+        assert_eq!(trie.root(20, Some(15)), expected_root);
+        assert_eq!(trie.root, root_idx);
+        assert_eq!(cached_epoch(&trie.upper_arena[root_idx]), 20);
+        assert!(!trie.root_is_prunable());
+
+        let branch = trie.upper_arena[root_idx].branch_ref();
+        assert_eq!(branch.children.len(), 2);
+        assert!(branch.children.iter().all(ArenaSparseNodeBranchChild::is_blinded));
+        assert_eq!(trie.upper_arena.len(), 1);
+
+        assert_eq!(trie.root(21, Some(21)), expected_root);
+        assert!(trie.root_is_prunable());
+    }
+
+    #[test]
+    fn deletion_in_subtrie_retains_structural_epoch() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        let key = |first_byte, second_byte| {
+            let mut key = [0; 32];
+            key[0] = first_byte;
+            key[1] = second_byte;
+            B256::from(key)
+        };
+        let old = [key(0x00, 0x00), key(0x00, 0x10), key(0x00, 0x20)];
+        let sibling = key(0x01, 0x00);
+        update_leaves(
+            &mut trie,
+            old.into_iter()
+                .chain([sibling])
+                .enumerate()
+                .map(|(i, key)| (key, vec![i as u8 + 1; 32])),
+        );
+        trie.root(10, None);
+        assert!(trie.upper_arena.values().any(|node| matches!(node, ArenaSparseNode::Subtrie(_))));
+        let mut unpruned = trie.clone();
+
+        update_leaves(&mut trie, [(old[2], Vec::new())]);
+        update_leaves(&mut unpruned, [(old[2], Vec::new())]);
+        assert_eq!(trie.root(20, Some(15)), unpruned.root(20, None));
+
+        // This path is known absent beneath the retained, structurally-modified branch. If that
+        // branch was blinded, applying the update would request a proof and panic in the helper.
+        let inserted = key(0x00, 0x30);
+        update_leaves(&mut trie, [(inserted, vec![5; 32])]);
+        update_leaves(&mut unpruned, [(inserted, vec![5; 32])]);
+        assert_eq!(trie.root(21, Some(15)), unpruned.root(21, None));
     }
 
     #[test]
@@ -3466,8 +3530,8 @@ mod tests {
             .children
             .iter()
             .all(ArenaSparseNodeBranchChild::is_blinded));
-        // The root retains the oldest pruned child epoch so repeated prune calls can still evict
-        // an independently-owned trie.
+        // The root retains its cached epoch so repeated prune calls can still evict an
+        // independently-owned trie.
         assert_eq!(cached_epoch(&trie.upper_arena[root_idx]), 10);
         assert!(trie.root_is_prunable());
         assert_eq!(trie.root(21, Some(12)), expected_root);
@@ -3649,6 +3713,11 @@ mod tests {
         trie.root(5, None);
         assert_eq!(cached_epoch(&trie.upper_arena[leaf]), 10);
         assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+
+        *trie.upper_arena[trie.root].state_mut() = ArenaSparseNodeState::Revealed;
+        trie.root(20, None);
+        assert_eq!(cached_epoch(&trie.upper_arena[leaf]), 10);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 20);
     }
 
     #[test]

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -486,12 +486,13 @@ impl ArenaSparseSubtrie {
     /// After this call every node reachable from `self.root` will be in `Cached` state.
     ///
     /// Trie updates are written directly to `self.buffers.updates` (if `Some`).
-    fn update_cached_rlp(&mut self) {
+    fn update_cached_rlp(&mut self, epoch: u64) {
         ArenaParallelSparseTrie::update_cached_rlp(
             &mut self.arena,
             self.root,
             self.path,
             &mut self.buffers,
+            epoch,
         );
         self.num_dirty_leaves = 0;
         #[cfg(debug_assertions)]
@@ -673,9 +674,10 @@ impl ArenaParallelSparseTrie {
         fn state_to_record(state: &ArenaSparseNodeState) -> NodeStateRecord {
             match state {
                 ArenaSparseNodeState::Revealed => NodeStateRecord::Revealed,
-                ArenaSparseNodeState::Cached { rlp_node, .. } => {
-                    NodeStateRecord::Cached { rlp_node: hex::encode(rlp_node.as_ref()) }
-                }
+                ArenaSparseNodeState::Cached { rlp_node, epoch } => NodeStateRecord::Cached {
+                    rlp_node: hex::encode(rlp_node.as_ref()),
+                    epoch: *epoch,
+                },
                 ArenaSparseNodeState::Dirty => NodeStateRecord::Dirty,
             }
         }
@@ -1133,15 +1135,15 @@ impl ArenaParallelSparseTrie {
         masks
     }
 
-    /// Computes and caches `RlpNode` for all dirty nodes reachable from `root` in `arena`.
+    /// Computes and caches `RlpNode` for all uncached nodes reachable from `root` in `arena`.
     ///
-    /// Uses the cursor's stack to walk dirty branches depth-first. For each branch,
+    /// Uses the cursor's stack to walk uncached branches depth-first. For each branch,
     /// children are iterated left-to-right:
     /// - Blinded, cached, leaf, and `EmptyRoot` children have their `RlpNode` pushed directly onto
     ///   `rlp_node_buf`.
-    /// - Dirty branch children are pushed onto `stack` and processed recursively first.
+    /// - Uncached branch children are pushed onto `stack` and processed recursively first.
     ///
-    /// When a dirty branch child finishes and is popped, the parent resumes iteration after
+    /// When an uncached branch child finishes and is popped, the parent resumes iteration after
     /// the child's nibble. Once all children of a branch are processed, the branch is encoded
     /// via `BranchNodeRef` using the last N entries on `rlp_node_buf`, then replaced with a
     /// single result `RlpNode`.
@@ -1151,6 +1153,7 @@ impl ArenaParallelSparseTrie {
         root: Index,
         base_path: Nibbles,
         buffers: &mut ArenaTrieBuffers,
+        epoch: u64,
     ) -> RlpNode {
         let cursor = &mut buffers.cursor;
         let rlp_buf = &mut buffers.rlp_buf;
@@ -1161,11 +1164,11 @@ impl ArenaParallelSparseTrie {
 
         // Step 1: Handle trivial roots that don't need the stack-based walk.
         // EmptyRoot has no state to update. Leaves are encoded in place. Already-cached
-        // branches need no work. Only dirty branches enter the main loop below.
+        // branches need no work. Only uncached branches enter the main loop below.
         match &arena[root] {
             ArenaSparseNode::EmptyRoot => return RlpNode::word_rlp(&EMPTY_ROOT_HASH),
             ArenaSparseNode::Leaf { .. } => {
-                Self::encode_leaf(arena, root, rlp_buf, rlp_node_buf);
+                Self::encode_leaf(arena, root, rlp_buf, rlp_node_buf, epoch);
                 return rlp_node_buf.pop().expect("encode_leaf must push an RlpNode");
             }
             ArenaSparseNode::Branch(b) => {
@@ -1181,21 +1184,22 @@ impl ArenaParallelSparseTrie {
 
         cursor.reset(arena, root, base_path);
 
-        // Step 2: Walk dirty branches depth-first using `cursor.next`. Only dirty branches
+        // Step 2: Walk uncached branches depth-first using `cursor.next`. Only uncached branches
         // are descended into; all other children (leaves, cached branches, blinded, subtries)
         // are encoded when their parent branch is popped.
         loop {
             let result = cursor.next(&mut *arena, |_, node| {
                 matches!(
                     node,
-                    ArenaSparseNode::Branch(b) if matches!(b.state, ArenaSparseNodeState::Dirty)
+                    ArenaSparseNode::Branch(b)
+                        if !matches!(b.state, ArenaSparseNodeState::Cached { .. })
                 )
             });
 
             match result {
                 NextResult::Done => break,
                 NextResult::NonBranch => {
-                    unreachable!("should_descend only returns true for dirty branches")
+                    unreachable!("should_descend only returns true for uncached branches")
                 }
                 NextResult::Branch => {}
             };
@@ -1204,7 +1208,7 @@ impl ArenaParallelSparseTrie {
             let head_idx = head.index;
             let head_path = head.path;
 
-            // The branch at `head_idx` is exhausted. All its dirty child branches
+            // The branch at `head_idx` is exhausted. All its uncached child branches
             // have already been encoded and cached. Collect all children's RLP nodes
             // and encode the branch.
             trace!(
@@ -1216,38 +1220,55 @@ impl ArenaParallelSparseTrie {
             );
 
             rlp_node_buf.clear();
+            let mut oldest_child_epoch = None;
             let state_mask = arena[head_idx].branch_ref().state_mask;
             for (child_idx, _nibble) in BranchChildIter::new(state_mask) {
-                match &arena[head_idx].branch_ref().children[child_idx] {
+                let child_epoch = match &arena[head_idx].branch_ref().children[child_idx] {
                     ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
                         rlp_node_buf.push(rlp_node.clone());
+                        None
                     }
                     ArenaSparseNodeBranchChild::Revealed(child_idx) => {
                         let child_idx = *child_idx;
-                        match &arena[child_idx] {
+                        Some(match &arena[child_idx] {
                             ArenaSparseNode::Leaf { .. } => {
-                                Self::encode_leaf(arena, child_idx, rlp_buf, rlp_node_buf);
+                                Self::encode_leaf(arena, child_idx, rlp_buf, rlp_node_buf, epoch);
+                                arena[child_idx]
+                                    .state_ref()
+                                    .and_then(ArenaSparseNodeState::cached_epoch)
+                                    .expect("child leaf must be cached after encoding")
                             }
                             ArenaSparseNode::Branch(child_b) => {
-                                let ArenaSparseNodeState::Cached { rlp_node, .. } = &child_b.state
+                                let ArenaSparseNodeState::Cached { rlp_node, epoch: child_epoch } =
+                                    &child_b.state
                                 else {
                                     panic!("child branch must be cached after DFS");
                                 };
                                 let rlp_node = rlp_node.clone();
                                 rlp_node_buf.push(rlp_node);
+                                *child_epoch
                             }
                             ArenaSparseNode::Subtrie(subtrie) => {
                                 let subtrie_root = &subtrie.arena[subtrie.root];
                                 match subtrie_root {
                                     ArenaSparseNode::Branch(ArenaSparseNodeBranch {
-                                        state: ArenaSparseNodeState::Cached { rlp_node, .. },
+                                        state:
+                                            ArenaSparseNodeState::Cached {
+                                                rlp_node,
+                                                epoch: child_epoch,
+                                            },
                                         ..
                                     }) |
                                     ArenaSparseNode::Leaf {
-                                        state: ArenaSparseNodeState::Cached { rlp_node, .. },
+                                        state:
+                                            ArenaSparseNodeState::Cached {
+                                                rlp_node,
+                                                epoch: child_epoch,
+                                            },
                                         ..
                                     } => {
                                         rlp_node_buf.push(rlp_node.clone());
+                                        *child_epoch
                                     }
                                     _ => panic!("subtrie root must be a cached Branch or Leaf"),
                                 }
@@ -1255,8 +1276,14 @@ impl ArenaParallelSparseTrie {
                             ArenaSparseNode::TakenSubtrie | ArenaSparseNode::EmptyRoot => {
                                 unreachable!("Unexpected child {:?}", arena[child_idx]);
                             }
-                        }
+                        })
                     }
+                };
+                if let Some(child_epoch) = child_epoch {
+                    oldest_child_epoch = Some(
+                        oldest_child_epoch
+                            .map_or(child_epoch, |oldest: u64| oldest.min(child_epoch)),
+                    );
                 }
             }
 
@@ -1288,7 +1315,10 @@ impl ArenaParallelSparseTrie {
             );
 
             let branch = arena[head_idx].branch_mut();
-            branch.state = ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone() };
+            branch.state = ArenaSparseNodeState::Cached {
+                rlp_node: rlp_node.clone(),
+                epoch: oldest_child_epoch.unwrap_or(epoch),
+            };
             branch.branch_masks = new_branch_masks;
 
             // Record trie updates for dirty branches only.
@@ -1446,6 +1476,7 @@ impl ArenaParallelSparseTrie {
         idx: Index,
         rlp_buf: &mut Vec<u8>,
         rlp_node_buf: &mut Vec<RlpNode>,
+        epoch: u64,
     ) {
         let (key, value, state) = match &arena[idx] {
             ArenaSparseNode::Leaf { key, value, state } => (key, value, state),
@@ -1460,7 +1491,8 @@ impl ArenaParallelSparseTrie {
         rlp_buf.clear();
         let rlp_node = LeafNodeRef { key, value }.rlp(rlp_buf);
 
-        *arena[idx].state_mut() = ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone() };
+        *arena[idx].state_mut() =
+            ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone(), epoch };
         rlp_node_buf.push(rlp_node);
     }
 
@@ -2110,9 +2142,9 @@ impl ArenaParallelSparseTrie {
     /// Reveals a single proof node using a pre-computed [`SeekResult`] from
     /// [`ArenaCursor::seek`].
     ///
-    /// If the result is `Blinded`, the blinded child is replaced with the proof node (converted to
-    /// an arena node with `Cached` state). All other cases (already revealed, no child, diverged,
-    /// leaf head) are no-ops — the proof node is skipped.
+    /// If the result is `Blinded`, the blinded child is replaced with the revealed proof node.
+    /// All other cases (already revealed, no child, diverged, leaf head) are no-ops — the proof
+    /// node is skipped.
     ///
     /// Returns the `Index` of the revealed node in the arena, if any was revealed.
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
@@ -2158,14 +2190,13 @@ impl ArenaParallelSparseTrie {
         );
 
         let proof_node = mem::replace(node, ProofTrieNodeV2::empty());
-        let mut arena_node = ArenaSparseNode::from_proof_node(proof_node);
-
-        let state = arena_node.state_mut();
-        *state = ArenaSparseNodeState::Cached { rlp_node: cached_rlp };
-
+        let arena_node = ArenaSparseNode::from_proof_node(proof_node);
         let child_idx = arena.insert(arena_node);
-        arena[head_idx].branch_mut().children[dense_child_idx] =
-            ArenaSparseNodeBranchChild::Revealed(child_idx);
+        let parent_branch = arena[head_idx].branch_mut();
+        parent_branch.children[dense_child_idx] = ArenaSparseNodeBranchChild::Revealed(child_idx);
+        if !matches!(parent_branch.state, ArenaSparseNodeState::Dirty) {
+            parent_branch.state = ArenaSparseNodeState::Revealed;
+        }
 
         Some(child_idx)
     }
@@ -2237,13 +2268,13 @@ impl Default for ArenaParallelSparseTrie {
 
 impl ArenaParallelSparseTrie {
     /// Hashes a subtrie at `head_idx` and collects its update actions.
-    fn update_upper_subtrie(&mut self, head_idx: Index) {
+    fn update_upper_subtrie(&mut self, head_idx: Index, epoch: u64) {
         let ArenaSparseNode::Subtrie(subtrie) = &mut self.upper_arena[head_idx] else {
             unreachable!()
         };
 
         if !subtrie.arena[subtrie.root].is_cached() {
-            subtrie.update_cached_rlp();
+            subtrie.update_cached_rlp(epoch);
         }
 
         Self::merge_subtrie_updates(&mut self.buffers.updates, &mut subtrie.buffers.updates);
@@ -2388,6 +2419,14 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     if num_subtrie_nodes >= threshold {
                         // Take subtrie for parallel reveal.
                         trace!(target: TRACE_TARGET, ?prefix, num_subtrie_nodes, "Taking subtrie for parallel reveal");
+                        let parent_idx = cursor
+                            .parent()
+                            .expect("subtrie at the boundary must have an upper parent")
+                            .index;
+                        let parent_state = self.upper_arena[parent_idx].state_mut();
+                        if !matches!(parent_state, ArenaSparseNodeState::Dirty) {
+                            *parent_state = ArenaSparseNodeState::Revealed;
+                        }
                         let ArenaSparseNode::Subtrie(subtrie) = mem::replace(
                             &mut self.upper_arena[child_idx],
                             ArenaSparseNode::TakenSubtrie,
@@ -2463,17 +2502,18 @@ impl SparseTrie for ArenaParallelSparseTrie {
     }
 
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all, ret)]
-    fn root(&mut self) -> B256 {
+    fn root(&mut self, epoch: u64) -> B256 {
         #[cfg(feature = "trie-debug")]
-        self.debug_recorder.record(RecordedOp::Root);
+        self.debug_recorder.record(RecordedOp::Root { epoch });
 
-        self.update_subtrie_hashes();
+        self.update_subtrie_hashes(epoch);
 
         let rlp_node = Self::update_cached_rlp(
             &mut self.upper_arena,
             self.root,
             Nibbles::default(),
             &mut self.buffers,
+            epoch,
         );
 
         rlp_node.as_hash().expect("root RlpNode must be a hash")
@@ -2484,9 +2524,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
     }
 
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
-    fn update_subtrie_hashes(&mut self) {
+    fn update_subtrie_hashes(&mut self, epoch: u64) {
         #[cfg(feature = "trie-debug")]
-        self.debug_recorder.record(RecordedOp::UpdateSubtrieHashes);
+        self.debug_recorder.record(RecordedOp::UpdateSubtrieHashes { epoch });
 
         trace!(target: TRACE_TARGET, "Updating subtrie hashes");
 
@@ -2500,7 +2540,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         let mut taken: Vec<(Index, Box<ArenaSparseSubtrie>)> = Vec::new();
         for (idx, node) in &mut self.upper_arena {
             let ArenaSparseNode::Subtrie(s) = node else { continue };
-            if s.num_dirty_leaves == 0 {
+            if s.num_dirty_leaves == 0 && s.arena[s.root].is_cached() {
                 continue;
             }
             total_dirty_leaves += s.num_dirty_leaves;
@@ -2517,7 +2557,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
             if taken.len() == 1 || total_dirty_leaves < self.parallelism_thresholds.min_dirty_leaves
             {
                 for (_, subtrie) in &mut taken {
-                    subtrie.update_cached_rlp();
+                    subtrie.update_cached_rlp(epoch);
                 }
             } else {
                 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -2527,7 +2567,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     .into_par_iter()
                     .map(|(idx, mut subtrie)| {
                         let _guard = parent_span.enter();
-                        subtrie.update_cached_rlp();
+                        subtrie.update_cached_rlp(epoch);
                         (idx, subtrie)
                     })
                     .collect();
@@ -2573,7 +2613,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 self.upper_arena[head_idx] = ArenaSparseNode::Subtrie(subtrie);
             }
 
-            self.update_upper_subtrie(head_idx);
+            self.update_upper_subtrie(head_idx, epoch);
         }
     }
 
@@ -3137,14 +3177,157 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
 #[cfg(test)]
 mod tests {
-    use super::TRACE_TARGET;
+    use super::{
+        ArenaSparseNode, ArenaSparseNodeBranch, ArenaSparseNodeBranchChild, ArenaSparseNodeState,
+        TRACE_TARGET,
+    };
     use crate::{ArenaParallelSparseTrie, ArenaParallelismThresholds, LeafUpdate, SparseTrie};
     use alloy_primitives::{map::B256Map, B256, U256};
+    use alloy_trie::TrieMask;
     use rand::{seq::SliceRandom, Rng, SeedableRng};
     use reth_trie::test_utils::TrieTestHarness;
-    use reth_trie_common::{Nibbles, ProofV2Target};
+    use reth_trie_common::{
+        BranchNodeMasks, LeafNode, Nibbles, ProofTrieNodeV2, ProofV2Target, RlpNode, TrieNodeV2,
+    };
     use std::collections::BTreeMap;
     use tracing::{info, trace};
+
+    fn revealed_leaf(value: u8) -> ArenaSparseNode {
+        ArenaSparseNode::Leaf {
+            state: ArenaSparseNodeState::Revealed,
+            value: vec![value; 32],
+            key: Nibbles::unpack(B256::with_last_byte(value)),
+        }
+    }
+
+    fn cached_epoch(node: &ArenaSparseNode) -> u64 {
+        node.state_ref().and_then(ArenaSparseNodeState::cached_epoch).expect("node must be cached")
+    }
+
+    #[test]
+    fn leaf_epoch_changes_only_when_recached() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        trie.upper_arena[trie.root] = revealed_leaf(1);
+
+        trie.root(10);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+
+        trie.root(11);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+
+        *trie.upper_arena[trie.root].state_mut() = ArenaSparseNodeState::Dirty;
+        trie.root(12);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 12);
+    }
+
+    #[test]
+    fn branch_epoch_tracks_oldest_child() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        let key = |first_byte| {
+            let mut key = [0; 32];
+            key[0] = first_byte;
+            B256::from(key)
+        };
+        let first_leaf = key(0x00);
+        let second_leaf = key(0x01);
+        let third_leaf = key(0x10);
+        let update = |trie: &mut ArenaParallelSparseTrie, updates| {
+            trie.update_leaves(&mut B256Map::from_iter(updates), |_, _| {
+                panic!("fully revealed trie must not request proofs")
+            })
+            .unwrap();
+        };
+
+        update(
+            &mut trie,
+            vec![
+                (first_leaf, LeafUpdate::Changed(vec![1; 32])),
+                (second_leaf, LeafUpdate::Changed(vec![2; 32])),
+                (third_leaf, LeafUpdate::Changed(vec![3; 32])),
+            ],
+        );
+        trie.root(10);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+
+        update(&mut trie, vec![(first_leaf, LeafUpdate::Changed(vec![4; 32]))]);
+        trie.root(20);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+
+        update(&mut trie, vec![(second_leaf, LeafUpdate::Changed(vec![5; 32]))]);
+        trie.root(30);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+
+        update(&mut trie, vec![(third_leaf, LeafUpdate::Changed(vec![6; 32]))]);
+        trie.root(40);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 20);
+    }
+
+    #[test]
+    fn blinded_child_does_not_lower_branch_epoch() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        let leaf = trie.upper_arena.insert(revealed_leaf(1));
+        let mut state_mask = TrieMask::default();
+        state_mask.set_bit(0);
+        state_mask.set_bit(1);
+        trie.upper_arena[trie.root] = ArenaSparseNode::Branch(ArenaSparseNodeBranch {
+            state: ArenaSparseNodeState::Revealed,
+            children: [
+                ArenaSparseNodeBranchChild::Revealed(leaf),
+                ArenaSparseNodeBranchChild::Blinded(RlpNode::word_rlp(&B256::with_last_byte(2))),
+            ]
+            .into_iter()
+            .collect(),
+            state_mask,
+            short_key: Nibbles::default(),
+            branch_masks: BranchNodeMasks::default(),
+        });
+
+        trie.root(10);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+
+        *trie.upper_arena[trie.root].state_mut() = ArenaSparseNodeState::Revealed;
+        trie.root(5);
+        assert_eq!(cached_epoch(&trie.upper_arena[leaf]), 10);
+        assert_eq!(cached_epoch(&trie.upper_arena[trie.root]), 10);
+    }
+
+    #[test]
+    fn revealed_proof_leaf_uses_next_root_epoch() {
+        let mut trie = ArenaParallelSparseTrie::default();
+        let mut state_mask = TrieMask::default();
+        state_mask.set_bit(0);
+        state_mask.set_bit(1);
+        trie.upper_arena[trie.root] = ArenaSparseNode::Branch(ArenaSparseNodeBranch {
+            state: ArenaSparseNodeState::Revealed,
+            children: [
+                ArenaSparseNodeBranchChild::Blinded(RlpNode::word_rlp(&B256::with_last_byte(1))),
+                ArenaSparseNodeBranchChild::Blinded(RlpNode::word_rlp(&B256::with_last_byte(2))),
+            ]
+            .into_iter()
+            .collect(),
+            state_mask,
+            short_key: Nibbles::default(),
+            branch_masks: BranchNodeMasks::default(),
+        });
+        trie.root(10);
+
+        trie.reveal_nodes(&mut [ProofTrieNodeV2 {
+            path: Nibbles::from_nibbles([0]),
+            node: TrieNodeV2::Leaf(LeafNode::new(Nibbles::from_nibbles([0; 63]), vec![1; 32])),
+            masks: None,
+        }])
+        .unwrap();
+
+        let ArenaSparseNodeBranchChild::Revealed(leaf) =
+            trie.upper_arena[trie.root].branch_ref().children[0]
+        else {
+            panic!("proof leaf must be revealed")
+        };
+        assert!(matches!(trie.upper_arena[leaf].state_ref(), Some(ArenaSparseNodeState::Revealed)));
+
+        trie.root(20);
+        assert_eq!(cached_epoch(&trie.upper_arena[leaf]), 20);
+    }
 
     /// Test harness for proptest-based arena sparse trie testing.
     ///
@@ -3223,7 +3406,7 @@ mod tests {
             }
 
             // Compute root and take updates from the APST.
-            let actual_root = apst.root();
+            let actual_root = apst.root(0);
             let mut actual_updates = apst.take_updates();
 
             // Minimize sparse updates inline (can't use TrieTestHarness::minimize_sparse_updates

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -167,7 +167,8 @@ impl ArenaSparseSubtrie {
     /// before use.
     fn new(record_updates: bool) -> Box<Self> {
         let mut arena = SlotMap::new();
-        let root = arena.insert(ArenaSparseNode::EmptyRoot);
+        let root =
+            arena.insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed });
         let buffers = ArenaTrieBuffers {
             updates: record_updates.then(SparseTrieUpdates::default),
             ..Default::default()
@@ -390,7 +391,7 @@ impl ArenaSparseSubtrie {
         trace!(target: TRACE_TARGET, "Subtrie update_leaves");
 
         debug_assert!(
-            !matches!(self.arena[self.root], ArenaSparseNode::EmptyRoot),
+            !matches!(self.arena[self.root], ArenaSparseNode::EmptyRoot { .. }),
             "subtrie root must not be EmptyRoot at start of update_leaves"
         );
 
@@ -465,7 +466,7 @@ impl ArenaSparseSubtrie {
         trace!(target: TRACE_TARGET, path = ?self.path, num_nodes = nodes.len(), "Subtrie reveal_nodes");
 
         debug_assert!(
-            !matches!(self.arena[self.root], ArenaSparseNode::EmptyRoot),
+            !matches!(self.arena[self.root], ArenaSparseNode::EmptyRoot { .. }),
             "subtrie root must not be EmptyRoot in reveal_nodes"
         );
 
@@ -711,12 +712,12 @@ impl ArenaParallelSparseTrie {
             path: Nibbles,
         ) -> Option<ProofTrieNodeRecord> {
             match &arena[idx] {
-                ArenaSparseNode::EmptyRoot => Some(ProofTrieNodeRecord {
+                ArenaSparseNode::EmptyRoot { state } => Some(ProofTrieNodeRecord {
                     path,
                     node: TrieNodeRecord(TrieNode::EmptyRoot),
                     masks: None,
                     short_key: None,
-                    state: None,
+                    state: Some(state_to_record(state)),
                 }),
                 ArenaSparseNode::Branch(b) => {
                     let stack = b
@@ -925,7 +926,7 @@ impl ArenaParallelSparseTrie {
             return;
         };
 
-        if !matches!(subtrie.arena[subtrie.root], ArenaSparseNode::EmptyRoot) {
+        if !matches!(subtrie.arena[subtrie.root], ArenaSparseNode::EmptyRoot { .. }) {
             return;
         }
 
@@ -1005,7 +1006,8 @@ impl ArenaParallelSparseTrie {
 
             if count == 0 {
                 if branch_idx == self.root {
-                    self.upper_arena[branch_idx] = ArenaSparseNode::EmptyRoot;
+                    self.upper_arena[branch_idx] =
+                        ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Dirty };
                     return;
                 }
                 // Remove the empty branch from its parent.
@@ -1047,7 +1049,7 @@ impl ArenaParallelSparseTrie {
             // Check if the remaining child is an empty subtrie that should also be removed.
             let is_empty_subtrie = matches!(
                 &self.upper_arena[child_idx],
-                ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot)
+                ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot { .. })
             );
 
             if is_empty_subtrie {
@@ -1199,11 +1201,23 @@ impl ArenaParallelSparseTrie {
 
         rlp_node_buf.clear();
 
-        // Step 1: Handle trivial roots that don't need the stack-based walk.
-        // EmptyRoot has no state to update. Leaves are encoded in place. Already-cached
-        // branches need no work. Only uncached branches enter the main loop below.
+        // Step 1: Handle trivial roots that don't need the stack-based walk. Empty roots and
+        // leaves are encoded in place. Already-cached branches need no work. Only uncached
+        // branches enter the main loop below.
+        if matches!(arena[root], ArenaSparseNode::EmptyRoot { .. }) {
+            let empty_root_rlp = RlpNode::word_rlp(&EMPTY_ROOT_HASH);
+            if let Some(rlp_node) =
+                arena[root].state_ref().and_then(ArenaSparseNodeState::cached_rlp_node)
+            {
+                debug_assert_eq!(rlp_node, &empty_root_rlp);
+                return rlp_node.clone()
+            }
+            *arena[root].state_mut() =
+                ArenaSparseNodeState::Cached { rlp_node: empty_root_rlp.clone(), epoch };
+            return empty_root_rlp
+        }
+
         match &arena[root] {
-            ArenaSparseNode::EmptyRoot => return RlpNode::word_rlp(&EMPTY_ROOT_HASH),
             ArenaSparseNode::Leaf { .. } => {
                 Self::encode_leaf(arena, root, rlp_buf, rlp_node_buf, epoch);
                 return rlp_node_buf.pop().expect("encode_leaf must push an RlpNode");
@@ -1214,7 +1228,9 @@ impl ArenaParallelSparseTrie {
                     return rlp_node;
                 }
             }
-            ArenaSparseNode::Subtrie(_) | ArenaSparseNode::TakenSubtrie => {
+            ArenaSparseNode::EmptyRoot { .. } |
+            ArenaSparseNode::Subtrie(_) |
+            ArenaSparseNode::TakenSubtrie => {
                 unreachable!("Subtrie/TakenSubtrie should not appear inside a subtrie's own arena");
             }
         }
@@ -1314,7 +1330,7 @@ impl ArenaParallelSparseTrie {
                                     _ => panic!("subtrie root must be a cached Branch or Leaf"),
                                 }
                             }
-                            ArenaSparseNode::TakenSubtrie | ArenaSparseNode::EmptyRoot => {
+                            ArenaSparseNode::TakenSubtrie | ArenaSparseNode::EmptyRoot { .. } => {
                                 unreachable!("Unexpected child {:?}", arena[child_idx]);
                             }
                         })
@@ -1389,7 +1405,10 @@ impl ArenaParallelSparseTrie {
     /// revealed children have been pruned. The caller always retains the arena root.
     fn prune_cached_nodes(arena: &mut NodeArena, idx: Index, prune_older_than: u64) -> (bool, u64) {
         match &arena[idx] {
-            ArenaSparseNode::EmptyRoot => return (false, 0),
+            ArenaSparseNode::EmptyRoot { state } => {
+                let epoch = state.cached_epoch().expect("empty root must be cached before pruning");
+                return (epoch < prune_older_than, 0)
+            }
             ArenaSparseNode::Leaf { state, .. } => {
                 let epoch = state.cached_epoch().expect("leaf must be cached before pruning");
                 return (epoch < prune_older_than, 0)
@@ -1476,7 +1495,7 @@ impl ArenaParallelSparseTrie {
     ) -> Option<&'a Vec<u8>> {
         loop {
             match &arena[current] {
-                ArenaSparseNode::EmptyRoot | ArenaSparseNode::TakenSubtrie => return None,
+                ArenaSparseNode::EmptyRoot { .. } | ArenaSparseNode::TakenSubtrie => return None,
                 ArenaSparseNode::Leaf { key, value, .. } => {
                     let remaining = full_path.slice(path_offset..);
                     return (remaining == *key).then_some(value);
@@ -1524,7 +1543,7 @@ impl ArenaParallelSparseTrie {
     ) -> Result<LeafLookup, LeafLookupError> {
         loop {
             match &arena[current] {
-                ArenaSparseNode::EmptyRoot | ArenaSparseNode::TakenSubtrie => {
+                ArenaSparseNode::EmptyRoot { .. } | ArenaSparseNode::TakenSubtrie => {
                     return Ok(LeafLookup::NonExistent);
                 }
                 ArenaSparseNode::Leaf { key, value, .. } => {
@@ -1903,7 +1922,8 @@ impl ArenaParallelSparseTrie {
                     // The leaf is the root — replace with EmptyRoot and reset the cursor
                     // so subsequent iterations can call seek normally.
                     arena.remove(head_idx);
-                    *root = arena.insert(ArenaSparseNode::EmptyRoot);
+                    *root = arena
+                        .insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Dirty });
                     cursor.reset(arena, *root, head_path);
                     return (
                         RemoveLeafResult::Removed,
@@ -2374,7 +2394,8 @@ impl Drop for ArenaParallelSparseTrie {
 impl Default for ArenaParallelSparseTrie {
     fn default() -> Self {
         let mut upper_arena = SlotMap::new();
-        let root = upper_arena.insert(ArenaSparseNode::EmptyRoot);
+        let root = upper_arena
+            .insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed });
         Self {
             upper_arena,
             root,
@@ -2526,7 +2547,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         });
 
         debug_assert!(
-            matches!(self.upper_arena[self.root], ArenaSparseNode::EmptyRoot),
+            matches!(self.upper_arena[self.root], ArenaSparseNode::EmptyRoot { .. }),
             "set_root called on a trie that already has revealed nodes"
         );
 
@@ -2535,6 +2556,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
         match root {
             TrieNodeV2::EmptyRoot => {
                 trace!(target: TRACE_TARGET, "Setting empty root");
+                self.upper_arena[self.root] =
+                    ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed };
             }
             TrieNodeV2::Leaf(leaf) => {
                 trace!(target: TRACE_TARGET, key = ?leaf.key, "Setting leaf root");
@@ -2588,7 +2611,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
             nodes: nodes.iter().map(ProofTrieNodeRecord::from_proof_trie_node_v2).collect(),
         });
 
-        if matches!(self.upper_arena[self.root], ArenaSparseNode::EmptyRoot) {
+        if matches!(self.upper_arena[self.root], ArenaSparseNode::EmptyRoot { .. }) {
             trace!(target: TRACE_TARGET, "Skipping reveal_nodes on empty root");
             return Ok(());
         }
@@ -2797,6 +2820,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
     fn wipe(&mut self) {
         trace!(target: TRACE_TARGET, "Wiping arena trie");
         self.clear();
+        *self.upper_arena[self.root].state_mut() = ArenaSparseNodeState::Dirty;
         self.buffers.updates = self.buffers.updates.is_some().then(SparseTrieUpdates::wiped);
     }
 
@@ -2806,7 +2830,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
         self.debug_recorder.reset();
 
         self.upper_arena = SlotMap::new();
-        self.root = self.upper_arena.insert(ArenaSparseNode::EmptyRoot);
+        self.root = self
+            .upper_arena
+            .insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed });
         self.root_prunable = false;
         self.buffers.clear();
     }
@@ -3280,7 +3306,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                                 let head_idx = cursor.head().expect("cursor is non-empty").index;
                                 !matches!(
                                     &self.upper_arena[head_idx],
-                                    ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot)
+                                    ArenaSparseNode::Subtrie(s) if matches!(s.arena[s.root], ArenaSparseNode::EmptyRoot { .. })
                                 )
                             },
                             "taken subtrie became EmptyRoot — should have been forced inline"

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -18,6 +18,9 @@ pub(super) enum ArenaSparseNodeState {
     Cached {
         /// The cached RLP-encoded representation of the node.
         rlp_node: RlpNode,
+        /// The epoch when a leaf was most recently cached, or the oldest cached child epoch for a
+        /// branch.
+        epoch: u64,
     },
     /// The node has been modified and its RLP encoding needs recomputation.
     Dirty,
@@ -33,6 +36,14 @@ impl ArenaSparseNodeState {
     pub(super) const fn cached_rlp_node(&self) -> Option<&RlpNode> {
         match self {
             Self::Cached { rlp_node, .. } => Some(rlp_node),
+            _ => None,
+        }
+    }
+
+    /// Returns the epoch cached on the state, if there is one.
+    pub(super) const fn cached_epoch(&self) -> Option<u64> {
+        match self {
+            Self::Cached { epoch, .. } => Some(*epoch),
             _ => None,
         }
     }

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -18,8 +18,8 @@ pub(super) enum ArenaSparseNodeState {
     Cached {
         /// The cached RLP-encoded representation of the node.
         rlp_node: RlpNode,
-        /// The epoch when a leaf was most recently cached, or the oldest cached child epoch for a
-        /// branch.
+        /// The epoch when a leaf was most recently cached, or the newest retained dependency for
+        /// a branch, including its own reveal or structural modification.
         epoch: u64,
     },
     /// The node has been modified and its RLP encoding needs recomputation.

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -18,8 +18,8 @@ pub(super) enum ArenaSparseNodeState {
     Cached {
         /// The cached RLP-encoded representation of the node.
         rlp_node: RlpNode,
-        /// The epoch when a leaf was most recently cached, or the newest retained dependency for
-        /// a branch, including its own reveal or structural modification.
+        /// The epoch when an empty root or leaf was most recently cached, or the newest retained
+        /// dependency for a branch, including its own reveal or structural modification.
         epoch: u64,
     },
     /// The node has been modified and its RLP encoding needs recomputation.
@@ -166,7 +166,10 @@ impl ArenaSparseNodeBranch {
 #[derive(Debug, Clone, AsRefStr)]
 pub(super) enum ArenaSparseNode {
     /// Indicates a trie with no nodes.
-    EmptyRoot,
+    EmptyRoot {
+        /// Cached or dirty state of this node. Its cached RLP is always the empty root hash.
+        state: ArenaSparseNodeState,
+    },
     /// A branch node with up to 16 children.
     Branch(ArenaSparseNodeBranch),
     /// A leaf node containing a value.
@@ -185,26 +188,27 @@ pub(super) enum ArenaSparseNode {
 }
 
 impl ArenaSparseNode {
-    /// Returns the state of a Branch, Leaf, or Subtrie root node, or `None` for other types.
+    /// Returns the state of an `EmptyRoot`, `Branch`, `Leaf`, or `Subtrie` root node, or `None` for
+    /// other types.
     pub(super) fn state_ref(&self) -> Option<&ArenaSparseNodeState> {
         match self {
+            Self::EmptyRoot { state } | Self::Leaf { state, .. } => Some(state),
             Self::Branch(b) => Some(&b.state),
-            Self::Leaf { state, .. } => Some(state),
             Self::Subtrie(s) => s.arena[s.root].state_ref(),
             _ => None,
         }
     }
 
-    /// Returns a mutable reference to the state of a Branch or Leaf node.
+    /// Returns a mutable reference to the state of an `EmptyRoot`, `Branch`, or `Leaf` node.
     ///
     /// # Panics
     ///
-    /// Panics if called on a non-Branch/Leaf node.
+    /// Panics if called on a non-EmptyRoot/Branch/Leaf node.
     pub(super) fn state_mut(&mut self) -> &mut ArenaSparseNodeState {
         match self {
+            Self::EmptyRoot { state } | Self::Leaf { state, .. } => state,
             Self::Branch(b) => &mut b.state,
-            Self::Leaf { state, .. } => state,
-            _ => panic!("state_mut called on non-Branch/Leaf node"),
+            _ => panic!("state_mut called on non-EmptyRoot/Branch/Leaf node"),
         }
     }
 
@@ -290,9 +294,11 @@ impl ArenaSparseNode {
     /// case where a branch's RLP is small enough to be embedded rather than hashed.
     pub(super) fn cached_hash(&self) -> B256 {
         let rlp_node = match self {
-            Self::Branch(ArenaSparseNodeBranch { state, .. }) | Self::Leaf { state, .. } => state
-                .cached_rlp_node()
-                .expect("cached_hash called on non-Cached branch or leaf: {self:?}"),
+            Self::EmptyRoot { state } |
+            Self::Branch(ArenaSparseNodeBranch { state, .. }) |
+            Self::Leaf { state, .. } => {
+                state.cached_rlp_node().expect("cached_hash called on non-Cached node: {self:?}")
+            }
             Self::Subtrie(s) => return s.arena[s.root].cached_hash(),
             _ => panic!("cached_hash called on {self:?}"),
         };
@@ -310,7 +316,7 @@ impl ArenaSparseNode {
     pub(super) fn from_proof_node(proof_node: ProofTrieNodeV2) -> Self {
         let ProofTrieNodeV2 { node, masks, .. } = proof_node;
         match node {
-            TrieNodeV2::EmptyRoot => Self::EmptyRoot,
+            TrieNodeV2::EmptyRoot => Self::EmptyRoot { state: ArenaSparseNodeState::Revealed },
             TrieNodeV2::Leaf(leaf) => Self::Leaf {
                 state: ArenaSparseNodeState::Revealed,
                 key: leaf.key,

--- a/crates/trie/sparse/src/debug_recorder.rs
+++ b/crates/trie/sparse/src/debug_recorder.rs
@@ -67,11 +67,15 @@ pub enum RecordedOp {
     UpdateSubtrieHashes {
         /// The epoch used to cache updated nodes.
         epoch: u64,
+        /// Nodes cached before this epoch are pruned, if provided.
+        prune_older_than: Option<u64>,
     },
     /// Records a `root()` call.
     Root {
         /// The epoch used to cache updated nodes.
         epoch: u64,
+        /// Nodes cached before this epoch are pruned, if provided.
+        prune_older_than: Option<u64>,
     },
     /// Records a `set_root` call with the root node that was set.
     SetRoot {

--- a/crates/trie/sparse/src/debug_recorder.rs
+++ b/crates/trie/sparse/src/debug_recorder.rs
@@ -64,9 +64,15 @@ pub enum RecordedOp {
         proof_targets: Vec<(B256, Option<usize>)>,
     },
     /// Records an `update_subtrie_hashes` call.
-    UpdateSubtrieHashes,
+    UpdateSubtrieHashes {
+        /// The epoch used to cache updated nodes.
+        epoch: u64,
+    },
     /// Records a `root()` call.
-    Root,
+    Root {
+        /// The epoch used to cache updated nodes.
+        epoch: u64,
+    },
     /// Records a `set_root` call with the root node that was set.
     SetRoot {
         /// The root trie node that was set.
@@ -105,6 +111,8 @@ pub enum NodeStateRecord {
     Cached {
         /// The cached RLP-encoded node, hex-encoded.
         rlp_node: String,
+        /// The epoch associated with this cached node.
+        epoch: u64,
     },
     /// The node has been modified and its RLP encoding needs recomputation.
     Dirty,

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -5,15 +5,10 @@ use alloc::vec::Vec;
 use alloy_primitives::{map::B256Map, B256};
 use either::Either;
 use reth_execution_errors::{SparseStateTrieResult, SparseTrieErrorKind};
-#[cfg(test)]
-use reth_trie_common::prefix_set::TriePrefixSetsMut;
 use reth_trie_common::{
-    prefix_set::{PrefixSet, TriePrefixSets},
     updates::{StorageTrieUpdates, TrieUpdates},
     DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2, EMPTY_ROOT_HASH,
 };
-#[cfg(feature = "std")]
-use tracing::debug;
 use tracing::instrument;
 
 /// Holds data that should be dropped after any locks are released.
@@ -485,62 +480,6 @@ where
     pub fn retained_storage_tries_count(&self) -> usize {
         self.storage.tries.len() + self.storage.cleared_tries.len()
     }
-
-    /// Prunes account/storage tries according to the provided retained paths. All other revealed
-    /// paths are pruned to hash stubs or fully evicted.
-    ///
-    /// # Preconditions
-    ///
-    /// All revealed account and storage tries must already have computed hashes via `root()`
-    /// / `storage_root()` for their current state. Pruning a dirty revealed trie is a hard
-    /// error and may panic.
-    #[cfg(feature = "std")]
-    #[instrument(
-        level = "debug",
-        name = "SparseStateTrie::prune",
-        target = "trie::sparse",
-        skip_all
-    )]
-    pub fn prune(&mut self, retained_paths: TriePrefixSets) {
-        let retained_accounts = retained_paths.account_prefix_set.len();
-        let retained_storage_tries = retained_paths.storage_prefix_sets.len();
-        let total_storage_tries_before = self.storage.tries.len();
-
-        let TriePrefixSets { account_prefix_set, storage_prefix_sets, .. } = retained_paths;
-
-        let parent_span = tracing::Span::current();
-        let account_parent_span = parent_span.clone();
-
-        // Prune account and storage tries in parallel using the same retained set.
-        let (account_nodes_pruned, storage_tries_evicted) = rayon::join(
-            || {
-                let hashed_address = Option::<B256>::None;
-                let _span = tracing::trace_span!(
-                    target: "trie::sparse",
-                    parent: &account_parent_span,
-                    "prune_trie",
-                    ?hashed_address,
-                )
-                .entered();
-
-                self.state
-                    .as_revealed_mut()
-                    .map(|trie| trie.prune(account_prefix_set.slice()))
-                    .unwrap_or(0)
-            },
-            || self.storage.prune_by_retained_slots(storage_prefix_sets, &parent_span),
-        );
-
-        debug!(
-            target: "trie::sparse",
-            retained_accounts,
-            retained_storage_tries,
-            account_nodes_pruned,
-            storage_tries_evicted,
-            storage_tries_after = total_storage_tries_before - storage_tries_evicted,
-            "SparseStateTrie::prune completed"
-        );
-    }
 }
 
 /// The fields of [`SparseStateTrie`] related to storage tries. This is kept separate from the rest
@@ -556,60 +495,6 @@ struct StorageTries<S = ArenaParallelSparseTrie> {
     /// Debug records taken from fully pruned tries before their allocations are recycled.
     #[cfg(feature = "trie-debug")]
     evicted_debug_recorders: Vec<(B256, TrieDebugRecorder)>,
-}
-
-#[cfg(feature = "std")]
-impl<S: SparseTrieTrait> StorageTries<S> {
-    /// Prunes storage tries using the provided retained slots.
-    ///
-    /// Tries without retained slots are evicted entirely. Tries with retained slots are pruned to
-    /// those slots.
-    fn prune_by_retained_slots(
-        &mut self,
-        retained_slots: B256Map<PrefixSet>,
-        parent_span: &tracing::Span,
-    ) -> usize {
-        // Parallel pass: prune retained tries and clear evicted ones in place.
-        {
-            use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
-            self.tries.par_iter_mut().for_each(|(address, trie)| {
-                let hashed_address = Some(*address);
-                let _span = tracing::trace_span!(
-                    target: "trie::sparse",
-                    parent: parent_span,
-                    "prune_trie",
-                    ?hashed_address,
-                )
-                .entered();
-
-                if let Some(slots) = retained_slots.get(address) {
-                    if let Some(t) = trie.as_revealed_mut() {
-                        t.prune(slots.slice());
-                    }
-                } else {
-                    trie.clear();
-                }
-            });
-        }
-
-        // Cheap sequential drain: move already-cleared tries into the reuse pool.
-        let addresses_to_evict: Vec<B256> = self
-            .tries
-            .keys()
-            .filter(|address| !retained_slots.contains_key(*address))
-            .copied()
-            .collect();
-
-        let evicted = addresses_to_evict.len();
-        self.cleared_tries.reserve(evicted);
-        for address in &addresses_to_evict {
-            if let Some(trie) = self.tries.remove(address) {
-                self.cleared_tries.push(trie);
-            }
-        }
-
-        evicted
-    }
 }
 
 impl<S: SparseTrieTrait> StorageTries<S> {
@@ -833,96 +718,6 @@ mod tests {
             .unwrap()
             .get_leaf_value(&full_path_0)
             .is_none());
-    }
-
-    #[test]
-    fn prune_keeps_retained_paths_overlay_account_and_storage() {
-        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
-
-        let account = B256::ZERO;
-        let hot_account =
-            b256!("0x1000000000000000000000000000000000000000000000000000000000000000");
-        let slot = B256::ZERO;
-        let account_path = leaf_key([0x0], 64);
-        let storage_path = leaf_key([0x0], 64);
-
-        let leaf_value = alloy_rlp::encode(TrieAccount::default());
-        let leaf_0 = alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
-            leaf_key([], 63),
-            leaf_value.clone(),
-        )));
-        let leaf_1 =
-            alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 63), leaf_value)));
-
-        let subtree = || {
-            ProofNodes::from_iter([
-                (
-                    Nibbles::default(),
-                    alloy_rlp::encode(TrieNodeV2::Branch(BranchNodeV2 {
-                        key: Nibbles::default(),
-                        stack: vec![RlpNode::from_rlp(&leaf_0), RlpNode::from_rlp(&leaf_1)],
-                        state_mask: TrieMask::new(0b11),
-                        branch_rlp_node: None,
-                    }))
-                    .into(),
-                ),
-                (Nibbles::from_nibbles([0x0]), leaf_0.clone().into()),
-                (Nibbles::from_nibbles([0x1]), leaf_1.clone().into()),
-            ])
-        };
-
-        let multiproof = MultiProof {
-            account_subtree: subtree(),
-            storages: HashMap::from_iter([
-                (
-                    account,
-                    StorageMultiProof {
-                        root: B256::ZERO,
-                        subtree: subtree(),
-                        branch_node_masks: Default::default(),
-                    },
-                ),
-                (
-                    hot_account,
-                    StorageMultiProof {
-                        root: B256::ZERO,
-                        subtree: subtree(),
-                        branch_node_masks: Default::default(),
-                    },
-                ),
-            ]),
-            ..Default::default()
-        };
-
-        sparse.reveal_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
-        let trie_account = TrieAccount {
-            storage_root: sparse.storage_root(&account, 0, None).unwrap(),
-            ..Default::default()
-        };
-        apply_account_update(
-            &mut sparse,
-            account,
-            LeafUpdate::Changed(alloy_rlp::encode(trie_account)),
-        );
-        sparse.root(0, None).unwrap();
-        let mut retained_paths = TriePrefixSetsMut::default();
-        retained_paths.account_prefix_set.insert(Nibbles::unpack(account));
-        retained_paths
-            .storage_prefix_sets
-            .entry(account)
-            .or_default()
-            .insert(Nibbles::unpack(slot));
-        sparse.prune(retained_paths.freeze());
-
-        assert!(matches!(
-            sparse.state_trie_ref().unwrap().find_leaf(&account_path, None),
-            Ok(LeafLookup::Exists)
-        ));
-        assert!(matches!(
-            sparse.storage_trie_ref(&account).unwrap().find_leaf(&storage_path, None),
-            Ok(LeafLookup::Exists)
-        ));
-        assert!(sparse.storage_trie_ref(&hot_account).is_none());
     }
 
     #[test]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -360,15 +360,9 @@ where
         }
     }
 
-    /// Returns a storage sparse trie root if the trie has been revealed, optionally pruning nodes
-    /// cached before the strict epoch cutoff.
-    pub fn storage_root(
-        &mut self,
-        account: &B256,
-        epoch: u64,
-        prune_older_than: Option<u64>,
-    ) -> Option<B256> {
-        self.storage.tries.get_mut(account).and_then(|trie| trie.root(epoch, prune_older_than))
+    /// Returns a storage sparse trie root if the trie has been revealed.
+    pub fn storage_root(&mut self, account: &B256, epoch: u64) -> Option<B256> {
+        self.storage.tries.get_mut(account).and_then(|trie| trie.root(epoch, None))
     }
 
     /// Returns mutable reference to the revealed account sparse trie.
@@ -501,36 +495,33 @@ impl<S: SparseTrieTrait> StorageTries<S> {
     /// Updates every revealed storage-trie root when pruning and returns the tries whose entire
     /// materialized roots can be evicted after their pending updates are collected.
     fn update_roots(&mut self, epoch: u64, prune_older_than: Option<u64>) -> Vec<B256> {
-        if prune_older_than.is_none() {
-            return Vec::new()
-        }
+        let Some(prune_older_than) = prune_older_than else { return Vec::new() };
 
         use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
         self.tries
             .par_iter_mut()
             .filter_map(|(address, trie)| {
-                trie.root(epoch, prune_older_than);
-                let root_is_prunable =
-                    trie.as_revealed_ref().is_some_and(SparseTrieTrait::root_is_prunable);
-                root_is_prunable.then_some(*address)
+                let trie = trie.as_revealed_mut()?;
+                trie.root(epoch, Some(prune_older_than));
+                trie.root_is_prunable().then_some(*address)
             })
             .collect()
     }
 
-    /// Evicts tries after their pending updates have been collected, retaining their allocations
-    /// in the reuse pool.
+    /// Evicts tries after their pending updates have been collected and places the cleared trie
+    /// objects in the reuse pool.
     fn evict_prunable(&mut self, addresses: Vec<B256>) {
         self.cleared_tries.reserve(addresses.len());
         for address in addresses {
-            if let Some(mut trie) = self.tries.remove(&address) {
-                #[cfg(feature = "trie-debug")]
-                if let Some(revealed) = trie.as_revealed_mut() {
-                    self.evicted_debug_recorders.push((address, revealed.take_debug_recorder()));
-                }
-                trie.clear();
-                self.cleared_tries.push(trie);
+            let mut trie =
+                self.tries.remove(&address).expect("prunable storage trie must still be present");
+            #[cfg(feature = "trie-debug")]
+            if let Some(revealed) = trie.as_revealed_mut() {
+                self.evicted_debug_recorders.push((address, revealed.take_debug_recorder()));
             }
+            trie.clear();
+            self.cleared_tries.push(trie);
         }
     }
 
@@ -879,8 +870,7 @@ mod tests {
                 |_, _| panic!("empty trie must not request proofs"),
             )
             .unwrap();
-        sparse.storage_root(&address, 10, None).unwrap();
-        sparse.storage_root(&address, 20, Some(11)).unwrap();
+        sparse.storage_root(&address, 10).unwrap();
 
         sparse.root_with_updates(21, Some(12)).unwrap();
 
@@ -892,36 +882,6 @@ mod tests {
             .take_debug_recorders()
             .into_iter()
             .any(|(recorded_address, _)| recorded_address == Some(address)));
-    }
-
-    #[test]
-    fn root_with_pruning_collects_empty_storage_updates_before_eviction() {
-        let address = B256::with_last_byte(1);
-        let slot = B256::with_last_byte(2);
-        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default()
-            .with_accounts_trie(RevealableSparseTrie::revealed_empty());
-        sparse.insert_storage_trie(address, RevealableSparseTrie::revealed_empty());
-        let storage_trie = sparse.storage_trie_mut(&address).unwrap();
-        storage_trie.set_updates(true);
-        storage_trie
-            .update_leaves(
-                &mut B256Map::from_iter([(slot, LeafUpdate::Changed(vec![1]))]),
-                |_, _| panic!("empty trie must not request proofs"),
-            )
-            .unwrap();
-        sparse.storage_root(&address, 10, None).unwrap();
-
-        sparse.wipe_storage(address).unwrap();
-        let (_, updates) = sparse.root_with_updates(20, Some(11)).unwrap();
-
-        assert!(updates.storage_tries[&address].is_deleted);
-        assert!(sparse.storage.tries.contains_key(&address));
-        assert!(sparse.storage.cleared_tries.is_empty());
-
-        sparse.root_with_updates(21, Some(21)).unwrap();
-
-        assert!(!sparse.storage.tries.contains_key(&address));
-        assert_eq!(sparse.storage.cleared_tries.len(), 1);
     }
 
     #[test]
@@ -939,7 +899,7 @@ mod tests {
                 |_, _| panic!("empty trie must not request proofs"),
             )
             .unwrap();
-        sparse.storage_root(&address, 10, None).unwrap();
+        sparse.storage_root(&address, 10).unwrap();
 
         let mut deletion = B256Map::from_iter([(old_slot, LeafUpdate::Changed(Vec::new()))]);
         sparse
@@ -953,7 +913,6 @@ mod tests {
 
         assert!(sparse.storage.tries.contains_key(&address));
         assert!(sparse.storage.cleared_tries.is_empty());
-        assert_eq!(sparse.storage_root(&address, 20, None), Some(EMPTY_ROOT_HASH));
 
         let mut insertion = B256Map::from_iter([(new_slot, LeafUpdate::Changed(vec![2]))]);
         sparse
@@ -981,7 +940,7 @@ mod tests {
                 |_, _| panic!("empty trie must not request proofs"),
             )
             .unwrap();
-        sparse.storage_root(&address, 10, None).unwrap();
+        sparse.storage_root(&address, 10).unwrap();
 
         sparse
             .storage_trie_mut(&address)
@@ -1110,7 +1069,7 @@ mod tests {
             .update_leaves(&mut updates, |_, _| {})
             .unwrap();
         assert!(updates.is_empty());
-        trie_account_1.storage_root = sparse.storage_root(&address_1, 0, None).unwrap();
+        trie_account_1.storage_root = sparse.storage_root(&address_1, 0).unwrap();
         apply_account_update(
             &mut sparse,
             address_1,
@@ -1118,7 +1077,7 @@ mod tests {
         );
 
         sparse.wipe_storage(address_2).unwrap();
-        trie_account_2.storage_root = sparse.storage_root(&address_2, 0, None).unwrap();
+        trie_account_2.storage_root = sparse.storage_root(&address_2, 0).unwrap();
         apply_account_update(
             &mut sparse,
             address_2,

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -353,15 +353,15 @@ where
     ///
     /// If the trie has not been revealed, this function does nothing.
     #[instrument(level = "debug", target = "trie::sparse", skip_all)]
-    pub fn calculate_subtries(&mut self) {
+    pub fn calculate_subtries(&mut self, epoch: u64) {
         if let RevealableSparseTrie::Revealed(trie) = &mut self.state {
-            trie.update_subtrie_hashes();
+            trie.update_subtrie_hashes(epoch);
         }
     }
 
     /// Returns storage sparse trie root if the trie has been revealed.
-    pub fn storage_root(&mut self, account: &B256) -> Option<B256> {
-        self.storage.tries.get_mut(account).and_then(|trie| trie.root())
+    pub fn storage_root(&mut self, account: &B256, epoch: u64) -> Option<B256> {
+        self.storage.tries.get_mut(account).and_then(|trie| trie.root(epoch))
     }
 
     /// Returns mutable reference to the revealed account sparse trie.
@@ -370,19 +370,19 @@ where
     }
 
     /// Returns sparse trie root.
-    pub fn root(&mut self) -> SparseStateTrieResult<B256> {
+    pub fn root(&mut self, epoch: u64) -> SparseStateTrieResult<B256> {
         // record revealed node metrics
         #[cfg(feature = "metrics")]
         self.metrics.record();
 
-        Ok(self.revealed_trie_mut()?.root())
+        Ok(self.revealed_trie_mut()?.root(epoch))
     }
 
     /// Returns sparse trie root and trie updates.
     ///
     /// Returns an error if the account trie is still blind.
     #[instrument(level = "debug", target = "trie::sparse", skip_all)]
-    pub fn root_with_updates(&mut self) -> SparseStateTrieResult<(B256, TrieUpdates)> {
+    pub fn root_with_updates(&mut self, epoch: u64) -> SparseStateTrieResult<(B256, TrieUpdates)> {
         // record revealed node metrics
         #[cfg(feature = "metrics")]
         self.metrics.record();
@@ -390,7 +390,7 @@ where
         let storage_tries = self.storage_trie_updates();
         let revealed = self.revealed_trie_mut()?;
 
-        let (root, updates) = (revealed.root(), revealed.take_updates());
+        let (root, updates) = (revealed.root(epoch), revealed.take_updates());
         let updates = TrieUpdates {
             account_nodes: updates.updated_nodes,
             removed_nodes: updates.removed_nodes,
@@ -824,7 +824,7 @@ mod tests {
 
         sparse.reveal_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
         let trie_account = TrieAccount {
-            storage_root: sparse.storage_root(&account).unwrap(),
+            storage_root: sparse.storage_root(&account, 0).unwrap(),
             ..Default::default()
         };
         apply_account_update(
@@ -832,7 +832,7 @@ mod tests {
             account,
             LeafUpdate::Changed(alloy_rlp::encode(trie_account)),
         );
-        sparse.root().unwrap();
+        sparse.root(0).unwrap();
         let mut retained_paths = TriePrefixSetsMut::default();
         retained_paths.account_prefix_set.insert(Nibbles::unpack(account));
         retained_paths
@@ -975,7 +975,7 @@ mod tests {
     fn root_on_blind_trie_returns_blind_error() {
         let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
 
-        let err = sparse.root().unwrap_err();
+        let err = sparse.root(0).unwrap_err();
 
         assert!(matches!(err.kind(), SparseStateTrieErrorKind::Sparse(SparseTrieErrorKind::Blind)));
     }
@@ -1069,7 +1069,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(sparse.root().unwrap(), root);
+        assert_eq!(sparse.root(0).unwrap(), root);
 
         let address_3 = b256!("0x2000000000000000000000000000000000000000000000000000000000000000");
         let account_3 = Account { nonce: account_1.nonce + 1, ..account_1 };
@@ -1089,7 +1089,7 @@ mod tests {
             .update_leaves(&mut updates, |_, _| {})
             .unwrap();
         assert!(updates.is_empty());
-        trie_account_1.storage_root = sparse.storage_root(&address_1).unwrap();
+        trie_account_1.storage_root = sparse.storage_root(&address_1, 0).unwrap();
         apply_account_update(
             &mut sparse,
             address_1,
@@ -1097,14 +1097,14 @@ mod tests {
         );
 
         sparse.wipe_storage(address_2).unwrap();
-        trie_account_2.storage_root = sparse.storage_root(&address_2).unwrap();
+        trie_account_2.storage_root = sparse.storage_root(&address_2, 0).unwrap();
         apply_account_update(
             &mut sparse,
             address_2,
             LeafUpdate::Changed(alloy_rlp::encode(trie_account_2)),
         );
 
-        sparse.root().unwrap();
+        sparse.root(0).unwrap();
 
         let sparse_updates = sparse.take_trie_updates().unwrap();
         // TODO(alexey): assert against real state root calculation updates

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -7,7 +7,7 @@ use either::Either;
 use reth_execution_errors::{SparseStateTrieResult, SparseTrieErrorKind};
 use reth_trie_common::{
     updates::{StorageTrieUpdates, TrieUpdates},
-    DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2, EMPTY_ROOT_HASH,
+    DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2,
 };
 use tracing::instrument;
 
@@ -510,10 +510,10 @@ impl<S: SparseTrieTrait> StorageTries<S> {
         self.tries
             .par_iter_mut()
             .filter_map(|(address, trie)| {
-                let root = trie.root(epoch, prune_older_than);
+                trie.root(epoch, prune_older_than);
                 let root_is_prunable =
                     trie.as_revealed_ref().is_some_and(SparseTrieTrait::root_is_prunable);
-                (root == Some(EMPTY_ROOT_HASH) || root_is_prunable).then_some(*address)
+                root_is_prunable.then_some(*address)
             })
             .collect()
     }
@@ -895,7 +895,7 @@ mod tests {
     }
 
     #[test]
-    fn root_with_pruning_evicts_empty_storage_trie_after_collecting_updates() {
+    fn root_with_pruning_collects_empty_storage_updates_before_eviction() {
         let address = B256::with_last_byte(1);
         let slot = B256::with_last_byte(2);
         let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default()
@@ -915,6 +915,88 @@ mod tests {
         let (_, updates) = sparse.root_with_updates(20, Some(11)).unwrap();
 
         assert!(updates.storage_tries[&address].is_deleted);
+        assert!(sparse.storage.tries.contains_key(&address));
+        assert!(sparse.storage.cleared_tries.is_empty());
+
+        sparse.root_with_updates(21, Some(21)).unwrap();
+
+        assert!(!sparse.storage.tries.contains_key(&address));
+        assert_eq!(sparse.storage.cleared_tries.len(), 1);
+    }
+
+    #[test]
+    fn root_with_pruning_retains_recently_emptied_storage_trie() {
+        let address = B256::with_last_byte(1);
+        let old_slot = B256::with_last_byte(2);
+        let new_slot = B256::with_last_byte(3);
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default()
+            .with_accounts_trie(RevealableSparseTrie::revealed_empty());
+        sparse.insert_storage_trie(address, RevealableSparseTrie::revealed_empty());
+        let storage_trie = sparse.storage_trie_mut(&address).unwrap();
+        storage_trie
+            .update_leaves(
+                &mut B256Map::from_iter([(old_slot, LeafUpdate::Changed(vec![1]))]),
+                |_, _| panic!("empty trie must not request proofs"),
+            )
+            .unwrap();
+        sparse.storage_root(&address, 10, None).unwrap();
+
+        let mut deletion = B256Map::from_iter([(old_slot, LeafUpdate::Changed(Vec::new()))]);
+        sparse
+            .storage_trie_mut(&address)
+            .unwrap()
+            .update_leaves(&mut deletion, |_, _| panic!("revealed leaf must not request proofs"))
+            .unwrap();
+        assert!(deletion.is_empty());
+
+        sparse.root_with_updates(20, Some(20)).unwrap();
+
+        assert!(sparse.storage.tries.contains_key(&address));
+        assert!(sparse.storage.cleared_tries.is_empty());
+        assert_eq!(sparse.storage_root(&address, 20, None), Some(EMPTY_ROOT_HASH));
+
+        let mut insertion = B256Map::from_iter([(new_slot, LeafUpdate::Changed(vec![2]))]);
+        sparse
+            .storage_trie_mut(&address)
+            .unwrap()
+            .update_leaves(&mut insertion, |_, _| {
+                panic!("recently emptied trie must remain revealed")
+            })
+            .unwrap();
+        assert!(insertion.is_empty());
+    }
+
+    #[test]
+    fn root_with_pruning_evicts_old_empty_storage_trie() {
+        let address = B256::with_last_byte(1);
+        let slot = B256::with_last_byte(2);
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default()
+            .with_accounts_trie(RevealableSparseTrie::revealed_empty());
+        sparse.insert_storage_trie(address, RevealableSparseTrie::revealed_empty());
+        sparse
+            .storage_trie_mut(&address)
+            .unwrap()
+            .update_leaves(
+                &mut B256Map::from_iter([(slot, LeafUpdate::Changed(vec![1]))]),
+                |_, _| panic!("empty trie must not request proofs"),
+            )
+            .unwrap();
+        sparse.storage_root(&address, 10, None).unwrap();
+
+        sparse
+            .storage_trie_mut(&address)
+            .unwrap()
+            .update_leaves(
+                &mut B256Map::from_iter([(slot, LeafUpdate::Changed(Vec::new()))]),
+                |_, _| panic!("revealed leaf must not request proofs"),
+            )
+            .unwrap();
+
+        sparse.root_with_updates(20, Some(20)).unwrap();
+        assert!(sparse.storage.tries.contains_key(&address));
+
+        sparse.root_with_updates(21, Some(21)).unwrap();
+
         assert!(!sparse.storage.tries.contains_key(&address));
         assert_eq!(sparse.storage.cleared_tries.len(), 1);
     }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -10,7 +10,7 @@ use reth_trie_common::prefix_set::TriePrefixSetsMut;
 use reth_trie_common::{
     prefix_set::{PrefixSet, TriePrefixSets},
     updates::{StorageTrieUpdates, TrieUpdates},
-    DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2,
+    DecodedMultiProof, MultiProof, Nibbles, ProofTrieNodeV2, EMPTY_ROOT_HASH,
 };
 #[cfg(feature = "std")]
 use tracing::debug;
@@ -138,6 +138,12 @@ impl<A: SparseTrieTrait, S: SparseTrieTrait> SparseStateTrie<A, S> {
                 recorders.push((Some(*address), trie.take_debug_recorder()));
             }
         }
+        recorders.extend(
+            self.storage
+                .evicted_debug_recorders
+                .drain(..)
+                .map(|(address, recorder)| (Some(address), recorder)),
+        );
         recorders
     }
 }
@@ -359,9 +365,15 @@ where
         }
     }
 
-    /// Returns storage sparse trie root if the trie has been revealed.
-    pub fn storage_root(&mut self, account: &B256, epoch: u64) -> Option<B256> {
-        self.storage.tries.get_mut(account).and_then(|trie| trie.root(epoch))
+    /// Returns a storage sparse trie root if the trie has been revealed, optionally pruning nodes
+    /// cached before the strict epoch cutoff.
+    pub fn storage_root(
+        &mut self,
+        account: &B256,
+        epoch: u64,
+        prune_older_than: Option<u64>,
+    ) -> Option<B256> {
+        self.storage.tries.get_mut(account).and_then(|trie| trie.root(epoch, prune_older_than))
     }
 
     /// Returns mutable reference to the revealed account sparse trie.
@@ -369,28 +381,47 @@ where
         self.state.as_revealed_mut().ok_or_else(|| SparseTrieErrorKind::Blind.into())
     }
 
-    /// Returns sparse trie root.
-    pub fn root(&mut self, epoch: u64) -> SparseStateTrieResult<B256> {
+    /// Returns the account sparse trie root, optionally pruning the account trie. Storage tries
+    /// are not finalized by this method; use [`Self::root_with_updates`] for state-wide pruning.
+    pub fn root(
+        &mut self,
+        epoch: u64,
+        prune_older_than: Option<u64>,
+    ) -> SparseStateTrieResult<B256> {
         // record revealed node metrics
         #[cfg(feature = "metrics")]
         self.metrics.record();
 
-        Ok(self.revealed_trie_mut()?.root(epoch))
+        Ok(self.revealed_trie_mut()?.root(epoch, prune_older_than))
     }
 
     /// Returns sparse trie root and trie updates.
     ///
+    /// When pruning is requested, every revealed storage trie is finalized with the same epoch and
+    /// pruning threshold before its updates are collected.
+    ///
     /// Returns an error if the account trie is still blind.
     #[instrument(level = "debug", target = "trie::sparse", skip_all)]
-    pub fn root_with_updates(&mut self, epoch: u64) -> SparseStateTrieResult<(B256, TrieUpdates)> {
+    pub fn root_with_updates(
+        &mut self,
+        epoch: u64,
+        prune_older_than: Option<u64>,
+    ) -> SparseStateTrieResult<(B256, TrieUpdates)> {
         // record revealed node metrics
         #[cfg(feature = "metrics")]
         self.metrics.record();
 
+        // Validate before finalizing storage so a blind account trie error does not consume
+        // pending updates or evict cached storage tries.
+        self.revealed_trie_mut()?;
+
+        let prunable_storage_tries = self.storage.update_roots(epoch, prune_older_than);
+
         let storage_tries = self.storage_trie_updates();
+        self.storage.evict_prunable(prunable_storage_tries);
         let revealed = self.revealed_trie_mut()?;
 
-        let (root, updates) = (revealed.root(epoch), revealed.take_updates());
+        let (root, updates) = (revealed.root(epoch, prune_older_than), revealed.take_updates());
         let updates = TrieUpdates {
             account_nodes: updates.updated_nodes,
             removed_nodes: updates.removed_nodes,
@@ -522,6 +553,9 @@ struct StorageTries<S = ArenaParallelSparseTrie> {
     cleared_tries: Vec<RevealableSparseTrie<S>>,
     /// A default cleared trie instance, which will be cloned when creating new tries.
     default_trie: RevealableSparseTrie<S>,
+    /// Debug records taken from fully pruned tries before their allocations are recycled.
+    #[cfg(feature = "trie-debug")]
+    evicted_debug_recorders: Vec<(B256, TrieDebugRecorder)>,
 }
 
 #[cfg(feature = "std")]
@@ -579,9 +613,47 @@ impl<S: SparseTrieTrait> StorageTries<S> {
 }
 
 impl<S: SparseTrieTrait> StorageTries<S> {
+    /// Updates every revealed storage-trie root when pruning and returns the tries whose entire
+    /// materialized roots can be evicted after their pending updates are collected.
+    fn update_roots(&mut self, epoch: u64, prune_older_than: Option<u64>) -> Vec<B256> {
+        if prune_older_than.is_none() {
+            return Vec::new()
+        }
+
+        use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
+
+        self.tries
+            .par_iter_mut()
+            .filter_map(|(address, trie)| {
+                let root = trie.root(epoch, prune_older_than);
+                let root_is_prunable =
+                    trie.as_revealed_ref().is_some_and(SparseTrieTrait::root_is_prunable);
+                (root == Some(EMPTY_ROOT_HASH) || root_is_prunable).then_some(*address)
+            })
+            .collect()
+    }
+
+    /// Evicts tries after their pending updates have been collected, retaining their allocations
+    /// in the reuse pool.
+    fn evict_prunable(&mut self, addresses: Vec<B256>) {
+        self.cleared_tries.reserve(addresses.len());
+        for address in addresses {
+            if let Some(mut trie) = self.tries.remove(&address) {
+                #[cfg(feature = "trie-debug")]
+                if let Some(revealed) = trie.as_revealed_mut() {
+                    self.evicted_debug_recorders.push((address, revealed.take_debug_recorder()));
+                }
+                trie.clear();
+                self.cleared_tries.push(trie);
+            }
+        }
+    }
+
     /// Returns all fields to a cleared state, equivalent to the default state, keeping cleared
     /// collections for re-use later when possible.
     fn clear(&mut self) {
+        #[cfg(feature = "trie-debug")]
+        self.evicted_debug_recorders.clear();
         self.cleared_tries.extend(self.tries.drain().map(|(_, mut trie)| {
             trie.clear();
             trie
@@ -824,7 +896,7 @@ mod tests {
 
         sparse.reveal_decoded_multiproof(multiproof.try_into().unwrap()).unwrap();
         let trie_account = TrieAccount {
-            storage_root: sparse.storage_root(&account, 0).unwrap(),
+            storage_root: sparse.storage_root(&account, 0, None).unwrap(),
             ..Default::default()
         };
         apply_account_update(
@@ -832,7 +904,7 @@ mod tests {
             account,
             LeafUpdate::Changed(alloy_rlp::encode(trie_account)),
         );
-        sparse.root(0).unwrap();
+        sparse.root(0, None).unwrap();
         let mut retained_paths = TriePrefixSetsMut::default();
         retained_paths.account_prefix_set.insert(Nibbles::unpack(account));
         retained_paths
@@ -975,9 +1047,81 @@ mod tests {
     fn root_on_blind_trie_returns_blind_error() {
         let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
 
-        let err = sparse.root(0).unwrap_err();
+        let err = sparse.root(0, None).unwrap_err();
 
         assert!(matches!(err.kind(), SparseStateTrieErrorKind::Sparse(SparseTrieErrorKind::Blind)));
+    }
+
+    #[test]
+    fn root_with_updates_on_blind_trie_preserves_storage() {
+        let address = B256::with_last_byte(1);
+        let mut storage = RevealableSparseTrie::<ArenaParallelSparseTrie>::revealed_empty();
+        storage.as_revealed_mut().unwrap().set_updates(true);
+        storage.wipe().unwrap();
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
+        sparse.insert_storage_trie(address, storage);
+
+        let err = sparse.root_with_updates(10, Some(10)).unwrap_err();
+
+        assert!(matches!(err.kind(), SparseStateTrieErrorKind::Sparse(SparseTrieErrorKind::Blind)));
+        assert!(sparse.storage.tries.contains_key(&address));
+        assert!(sparse.storage_trie_ref(&address).unwrap().updates_ref().wiped);
+    }
+
+    #[test]
+    fn root_with_pruning_evicts_fully_old_storage_trie() {
+        let address = B256::with_last_byte(1);
+        let slot = B256::with_last_byte(2);
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default()
+            .with_accounts_trie(RevealableSparseTrie::revealed_empty());
+        sparse.insert_storage_trie(address, RevealableSparseTrie::revealed_empty());
+
+        sparse
+            .storage_trie_mut(&address)
+            .unwrap()
+            .update_leaves(
+                &mut B256Map::from_iter([(slot, LeafUpdate::Changed(vec![1]))]),
+                |_, _| panic!("empty trie must not request proofs"),
+            )
+            .unwrap();
+        sparse.storage_root(&address, 10, None).unwrap();
+        sparse.storage_root(&address, 20, Some(11)).unwrap();
+
+        sparse.root_with_updates(21, Some(12)).unwrap();
+
+        assert!(!sparse.storage.tries.contains_key(&address));
+        assert_eq!(sparse.storage.cleared_tries.len(), 1);
+        assert!(sparse.storage.cleared_tries[0].is_blind());
+        #[cfg(feature = "trie-debug")]
+        assert!(sparse
+            .take_debug_recorders()
+            .into_iter()
+            .any(|(recorded_address, _)| recorded_address == Some(address)));
+    }
+
+    #[test]
+    fn root_with_pruning_evicts_empty_storage_trie_after_collecting_updates() {
+        let address = B256::with_last_byte(1);
+        let slot = B256::with_last_byte(2);
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default()
+            .with_accounts_trie(RevealableSparseTrie::revealed_empty());
+        sparse.insert_storage_trie(address, RevealableSparseTrie::revealed_empty());
+        let storage_trie = sparse.storage_trie_mut(&address).unwrap();
+        storage_trie.set_updates(true);
+        storage_trie
+            .update_leaves(
+                &mut B256Map::from_iter([(slot, LeafUpdate::Changed(vec![1]))]),
+                |_, _| panic!("empty trie must not request proofs"),
+            )
+            .unwrap();
+        sparse.storage_root(&address, 10, None).unwrap();
+
+        sparse.wipe_storage(address).unwrap();
+        let (_, updates) = sparse.root_with_updates(20, Some(11)).unwrap();
+
+        assert!(updates.storage_tries[&address].is_deleted);
+        assert!(!sparse.storage.tries.contains_key(&address));
+        assert_eq!(sparse.storage.cleared_tries.len(), 1);
     }
 
     #[test]
@@ -1069,7 +1213,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(sparse.root(0).unwrap(), root);
+        assert_eq!(sparse.root(0, None).unwrap(), root);
 
         let address_3 = b256!("0x2000000000000000000000000000000000000000000000000000000000000000");
         let account_3 = Account { nonce: account_1.nonce + 1, ..account_1 };
@@ -1089,7 +1233,7 @@ mod tests {
             .update_leaves(&mut updates, |_, _| {})
             .unwrap();
         assert!(updates.is_empty());
-        trie_account_1.storage_root = sparse.storage_root(&address_1, 0).unwrap();
+        trie_account_1.storage_root = sparse.storage_root(&address_1, 0, None).unwrap();
         apply_account_update(
             &mut sparse,
             address_1,
@@ -1097,14 +1241,14 @@ mod tests {
         );
 
         sparse.wipe_storage(address_2).unwrap();
-        trie_account_2.storage_root = sparse.storage_root(&address_2, 0).unwrap();
+        trie_account_2.storage_root = sparse.storage_root(&address_2, 0, None).unwrap();
         apply_account_update(
             &mut sparse,
             address_2,
             LeafUpdate::Changed(alloy_rlp::encode(trie_account_2)),
         );
 
-        sparse.root(0).unwrap();
+        sparse.root(0, None).unwrap();
 
         let sparse_updates = sparse.take_trie_updates().unwrap();
         // TODO(alexey): assert against real state root calculation updates

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -98,15 +98,15 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// each node with [`TrieNodeV2::EmptyRoot`] to avoid cloning.
     fn reveal_nodes(&mut self, nodes: &mut [ProofTrieNodeV2]) -> SparseTrieResult<()>;
 
-    /// Calculates and returns the root hash of the trie.
+    /// Calculates and returns the root hash of the trie at the provided epoch.
     ///
-    /// This processes any dirty nodes by updating their RLP encodings
-    /// and returns the root hash.
+    /// This processes any dirty or revealed nodes by updating their RLP encodings and caching them
+    /// at `epoch`, then returns the root hash.
     ///
     /// # Returns
     ///
     /// The root hash of the trie.
-    fn root(&mut self) -> B256;
+    fn root(&mut self, epoch: u64) -> B256;
 
     /// Returns true if the root node is cached and does not need any recomputation.
     fn is_root_cached(&self) -> bool;
@@ -116,7 +116,7 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     ///
     /// The root node is considered to be at level 0. This method is useful for optimizing
     /// hash recalculations after localized changes to the trie structure.
-    fn update_subtrie_hashes(&mut self);
+    fn update_subtrie_hashes(&mut self, epoch: u64);
 
     /// Retrieves a reference to the leaf value at the specified path.
     ///

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -101,15 +101,23 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// Calculates and returns the root hash of the trie at the provided epoch.
     ///
     /// This processes any dirty or revealed nodes by updating their RLP encodings and caching them
-    /// at `epoch`, then returns the root hash.
+    /// at `epoch`, then returns the root hash. If `prune_older_than` is provided, leaves cached at
+    /// epochs strictly below it are pruned. A branch is pruned once all of its materialized
+    /// children are old enough to prune.
     ///
     /// # Returns
     ///
     /// The root hash of the trie.
-    fn root(&mut self, epoch: u64) -> B256;
+    fn root(&mut self, epoch: u64, prune_older_than: Option<u64>) -> B256;
 
     /// Returns true if the root node is cached and does not need any recomputation.
     fn is_root_cached(&self) -> bool;
+
+    /// Returns whether the most recent pruned root calculation found that the entire trie could
+    /// be evicted by its owner.
+    fn root_is_prunable(&self) -> bool {
+        false
+    }
 
     /// Recalculates and updates the RLP hashes of subtries deeper than a certain level. The level
     /// is defined in the implementation.

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -102,8 +102,8 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     ///
     /// This processes any dirty or revealed nodes by updating their RLP encodings and caching them
     /// at `epoch`, then returns the root hash. If `prune_older_than` is provided, leaves cached at
-    /// epochs strictly below it are pruned. A branch is pruned once all of its materialized
-    /// children are old enough to prune.
+    /// epochs strictly below it are pruned. A branch is pruned once its own cached transition and
+    /// all of its materialized children are old enough to prune.
     ///
     /// # Returns
     ///

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -101,9 +101,9 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// Calculates and returns the root hash of the trie at the provided epoch.
     ///
     /// This processes any dirty or revealed nodes by updating their RLP encodings and caching them
-    /// at `epoch`, then returns the root hash. If `prune_older_than` is provided, leaves cached at
-    /// epochs strictly below it are pruned. A branch is pruned once its own cached transition and
-    /// all of its materialized children are old enough to prune.
+    /// at `epoch`, then returns the root hash. If `prune_older_than` is provided, empty roots and
+    /// leaves cached at epochs strictly below it are prunable. A branch is pruned once its own
+    /// cached transition and all of its materialized children are old enough to prune.
     ///
     /// # Returns
     ///

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -193,17 +193,10 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// Note: All previously tracked changes to the trie are also removed.
     fn wipe(&mut self);
 
-    /// This clears all data structures in the sparse trie, keeping the backing data structures
-    /// allocated. An empty root node is inserted at the root.
-    ///
-    /// This is useful for reusing the trie without needing to reallocate memory.
+    /// Clears all data structures in the sparse trie and inserts an empty root node.
     fn clear(&mut self);
 
-    /// Returns a cheap O(1) size hint for the trie representing the count of revealed
-    /// (non-Hash) nodes.
-    ///
-    /// This is used as a heuristic for prioritizing which storage tries to keep
-    /// during pruning. Larger values indicate larger tries that are more valuable to preserve.
+    /// Returns a cheap O(1) count of revealed leaves.
     fn size_hint(&self) -> usize;
 
     /// Prunes all subtrees that do not contain retained leaves.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -178,8 +178,8 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     ///
     /// - `Some(B256)` with the calculated root hash if the trie is revealed.
     /// - `None` if the trie is still blind.
-    pub fn root(&mut self) -> Option<B256> {
-        Some(self.as_revealed_mut()?.root())
+    pub fn root(&mut self, epoch: u64) -> Option<B256> {
+        Some(self.as_revealed_mut()?.root(epoch))
     }
 
     /// Returns true if the root node is cached and does not need any recomputation.
@@ -199,9 +199,9 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     ///  - The trie root hash (`B256`).
     ///  - A [`SparseTrieUpdates`] structure containing information about updated nodes.
     ///  - `None` if the trie is still blind.
-    pub fn root_with_updates(&mut self) -> Option<(B256, SparseTrieUpdates)> {
+    pub fn root_with_updates(&mut self, epoch: u64) -> Option<(B256, SparseTrieUpdates)> {
         let revealed = self.as_revealed_mut()?;
-        Some((revealed.root(), revealed.take_updates()))
+        Some((revealed.root(epoch), revealed.take_updates()))
     }
 
     /// Clears this trie, setting it to a blind state.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -174,12 +174,15 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     /// "dirty" nodes are nodes that need their hashes to be recomputed because one or more of their
     /// children's hashes have changed.
     ///
+    /// If `prune_older_than` is provided, old leaves and branches whose materialized children are
+    /// all old are pruned after their hashes are calculated.
+    ///
     /// # Returns
     ///
     /// - `Some(B256)` with the calculated root hash if the trie is revealed.
     /// - `None` if the trie is still blind.
-    pub fn root(&mut self, epoch: u64) -> Option<B256> {
-        Some(self.as_revealed_mut()?.root(epoch))
+    pub fn root(&mut self, epoch: u64, prune_older_than: Option<u64>) -> Option<B256> {
+        Some(self.as_revealed_mut()?.root(epoch, prune_older_than))
     }
 
     /// Returns true if the root node is cached and does not need any recomputation.
@@ -192,6 +195,7 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     /// This is useful for when you need both the root hash and information about
     /// what nodes were modified, which can be used to efficiently update
     /// an external database.
+    /// `prune_older_than` applies the same strict epoch pruning as [`Self::root`].
     ///
     /// # Returns
     ///
@@ -199,9 +203,13 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
     ///  - The trie root hash (`B256`).
     ///  - A [`SparseTrieUpdates`] structure containing information about updated nodes.
     ///  - `None` if the trie is still blind.
-    pub fn root_with_updates(&mut self, epoch: u64) -> Option<(B256, SparseTrieUpdates)> {
+    pub fn root_with_updates(
+        &mut self,
+        epoch: u64,
+        prune_older_than: Option<u64>,
+    ) -> Option<(B256, SparseTrieUpdates)> {
         let revealed = self.as_revealed_mut()?;
-        Some((revealed.root(epoch), revealed.take_updates()))
+        Some((revealed.root(epoch, prune_older_than), revealed.take_updates()))
     }
 
     /// Clears this trie, setting it to a blind state.

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -23,7 +23,7 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Insert 1 new leaf under the same hashed prefix and modify 1 existing leaf.
     let mut new_key = B256::ZERO;
@@ -40,7 +40,7 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let hash1 = trie.root();
+    let hash1 = trie.root(0);
 
     // Verify hash1 matches the reference trie with updated values.
     let mut expected_storage = storage;
@@ -57,7 +57,7 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
     );
 
     // Taking updates should not affect the cached root.
-    let hash2 = trie.root();
+    let hash2 = trie.root(0);
     assert_eq!(hash1, hash2, "root should be unchanged after take_updates");
 }
 
@@ -82,7 +82,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // --- Round 1: Update leaves A (keys[0]) and B (keys[1]) ---
     let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
@@ -90,7 +90,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     changeset1.insert(keys[1], U256::from(200));
     let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
     harness.reveal_and_update(&mut trie, &mut leaf_updates1);
-    let root1 = trie.root();
+    let root1 = trie.root(0);
 
     // Verify root1 matches reference.
     harness.apply_changeset(changeset1);
@@ -104,7 +104,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     changeset2.insert(keys[3], U256::from(400));
     let mut leaf_updates2 = SuiteTestHarness::leaf_updates(&changeset2);
     harness.reveal_and_update(&mut trie, &mut leaf_updates2);
-    let root2 = trie.root();
+    let root2 = trie.root(0);
 
     // Verify root2 matches reference.
     harness.apply_changeset(changeset2);
@@ -122,7 +122,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     }
 
     // Root should still be correct after prune.
-    let root_after_prune = trie.root();
+    let root_after_prune = trie.root(0);
     assert_eq!(root_after_prune, harness.original_root(), "root should be unchanged after prune");
 
     // --- Round 3: Update leaf E (keys[4]) — needs re-reveal since it was pruned ---
@@ -130,7 +130,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     changeset3.insert(keys[4], U256::from(500));
     let mut leaf_updates3 = SuiteTestHarness::leaf_updates(&changeset3);
     harness.reveal_and_update(&mut trie, &mut leaf_updates3);
-    let root3 = trie.root();
+    let root3 = trie.root(0);
 
     // Verify root3 matches reference.
     harness.apply_changeset(changeset3);
@@ -167,7 +167,7 @@ pub(super) fn test_reveal_update_root_basic_lifecycle<T: SparseTrie>(new_trie: f
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root();
+    let root = trie.root(0);
 
     // Build reference trie with same mutations.
     let mut expected_storage = storage;
@@ -255,7 +255,7 @@ pub(super) fn test_incremental_reveal_and_update_with_retry<T: SparseTrie>(new_t
     expected_storage.insert(group_b_keys[1], U256::from(900));
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -322,9 +322,9 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     let mut acct_trie: T = acct_harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes for all tries.
-    let _ = a1_trie.root();
-    let _ = a2_trie.root();
-    let _ = acct_trie.root();
+    let _ = a1_trie.root(0);
+    let _ = a2_trie.root(0);
+    let _ = acct_trie.root(0);
 
     // --- Storage phase ---
     // A1: modify S1 (key 0x10), remove S2 (key 0x20), add S6 (key 0x60).
@@ -351,8 +351,8 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     a2_harness.reveal_and_update(&mut a2_trie, &mut a2_leaf_updates);
 
     // --- Storage root phase ---
-    let sr1 = a1_trie.root();
-    let sr2 = a2_trie.root();
+    let sr1 = a1_trie.root(0);
+    let sr2 = a2_trie.root(0);
 
     // Verify storage roots match references.
     a1_harness.apply_changeset(a1_changeset);
@@ -371,7 +371,7 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     acct_harness.reveal_and_update(&mut acct_trie, &mut acct_leaf_updates);
 
     // --- State root phase ---
-    let state_root = acct_trie.root();
+    let state_root = acct_trie.root(0);
 
     // Verify state root matches reference.
     acct_harness.apply_changeset(acct_changeset);
@@ -387,7 +387,7 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     acct_trie.prune(&retained);
 
     // Post-prune root should still be state_root.
-    let post_prune_root = acct_trie.root();
+    let post_prune_root = acct_trie.root(0);
     assert_eq!(post_prune_root, state_root, "root should be unchanged after prune");
 }
 
@@ -442,7 +442,7 @@ pub(super) fn test_touched_prewarm_then_changed_update<T: SparseTrie>(new_trie: 
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Step 3: Compute root and verify against reference.
-    let root = trie.root();
+    let root = trie.root(0);
 
     harness.apply_changeset(changeset);
     assert_eq!(
@@ -513,7 +513,7 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<T: Sp
     assert!(leaf_updates.is_empty(), "Changed key should be drained after reveal");
 
     // Step 5: Compute root and verify against reference.
-    let root = trie.root();
+    let root = trie.root(0);
 
     let mut changeset = BTreeMap::new();
     changeset.insert(target_key, new_value);
@@ -565,7 +565,7 @@ pub(super) fn test_get_leaf_value_for_storage_root_lookup<T: SparseTrie>(new_tri
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Step 5: Compute root and verify against reference.
-    let root = trie.root();
+    let root = trie.root(0);
 
     let mut changeset = BTreeMap::new();
     changeset.insert(key1, new_value);
@@ -620,7 +620,7 @@ pub(super) fn test_find_leaf_before_update_to_check_existence<T: SparseTrie>(new
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Step 4: Compute root and verify against reference.
-    let root = trie.root();
+    let root = trie.root(0);
 
     let mut changeset = BTreeMap::new();
     changeset.insert(key2, new_key2_value);
@@ -655,7 +655,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // --- Block 1: Update K1 (keys[0]), K2 (keys[1]), K3 (keys[2]) ---
     let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
@@ -664,7 +664,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset1.insert(keys[2], U256::from(300));
     let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
     harness.reveal_and_update(&mut trie, &mut leaf_updates1);
-    let root1 = trie.root();
+    let root1 = trie.root(0);
 
     harness.apply_changeset(changeset1);
     assert_eq!(root1, harness.original_root(), "block 1 root should match reference");
@@ -680,7 +680,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset_hot.insert(keys[0], U256::from(999));
     let mut leaf_updates_hot = SuiteTestHarness::leaf_updates(&changeset_hot);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_hot);
-    let root_hot = trie.root();
+    let root_hot = trie.root(0);
 
     harness.apply_changeset(changeset_hot);
     assert_eq!(
@@ -694,7 +694,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset_cold.insert(keys[4], U256::from(555));
     let mut leaf_updates_cold = SuiteTestHarness::leaf_updates(&changeset_cold);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_cold);
-    let root_cold = trie.root();
+    let root_cold = trie.root(0);
 
     harness.apply_changeset(changeset_cold);
     assert_eq!(

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -61,86 +61,6 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
     assert_eq!(hash1, hash2, "root should be unchanged after take_updates");
 }
 
-/// Multiple rounds of (update → root → `take_updates`), followed by a prune, simulating block
-/// processing.
-pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(new_trie: fn() -> T) {
-    // Build a trie with 10 primary leaves, each with a sibling under the same root child.
-    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
-    let mut keys = Vec::new();
-    for i in 0u8..10 {
-        let mut key = B256::ZERO;
-        key.0[0] = i << 4; // nibble prefixes: 0x0, 0x1, 0x2, ... 0x9
-        storage.insert(key, U256::from(i as u64 + 1));
-        keys.push(key);
-
-        let mut sibling = B256::ZERO;
-        sibling.0[0] = (i << 4) | 1;
-        storage.insert(sibling, U256::from(i as u64 + 100));
-    }
-
-    let mut harness = SuiteTestHarness::new(storage.clone());
-    let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-
-    // Cache initial hashes.
-    let _ = trie.root(0, None);
-
-    // --- Round 1: Update leaves A (keys[0]) and B (keys[1]) ---
-    let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
-    changeset1.insert(keys[0], U256::from(100));
-    changeset1.insert(keys[1], U256::from(200));
-    let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
-    harness.reveal_and_update(&mut trie, &mut leaf_updates1);
-    let root1 = trie.root(0, None);
-
-    // Verify root1 matches reference.
-    harness.apply_changeset(changeset1);
-    assert_eq!(root1, harness.original_root(), "round 1 root should match reference");
-
-    let _ = trie.take_updates();
-
-    // --- Round 2: Update leaves C (keys[2]) and D (keys[3]) ---
-    let mut changeset2: BTreeMap<B256, U256> = BTreeMap::new();
-    changeset2.insert(keys[2], U256::from(300));
-    changeset2.insert(keys[3], U256::from(400));
-    let mut leaf_updates2 = SuiteTestHarness::leaf_updates(&changeset2);
-    harness.reveal_and_update(&mut trie, &mut leaf_updates2);
-    let root2 = trie.root(0, None);
-
-    // Verify root2 matches reference.
-    harness.apply_changeset(changeset2);
-    assert_eq!(root2, harness.original_root(), "round 2 root should match reference");
-
-    let _ = trie.take_updates();
-
-    // --- Prune: retain only keys A,B,C,D ---
-    let retained: Vec<Nibbles> = keys[0..4].iter().map(|k| Nibbles::unpack(*k)).collect();
-    let pre_prune_size = trie.size_hint();
-    trie.prune(&retained);
-    let post_prune_size = trie.size_hint();
-    if pre_prune_size > 0 {
-        assert!(post_prune_size < pre_prune_size, "prune should reduce node count");
-    }
-
-    // Root should still be correct after prune.
-    let root_after_prune = trie.root(0, None);
-    assert_eq!(root_after_prune, harness.original_root(), "root should be unchanged after prune");
-
-    // --- Round 3: Update leaf E (keys[4]) — needs re-reveal since it was pruned ---
-    let mut changeset3: BTreeMap<B256, U256> = BTreeMap::new();
-    changeset3.insert(keys[4], U256::from(500));
-    let mut leaf_updates3 = SuiteTestHarness::leaf_updates(&changeset3);
-    harness.reveal_and_update(&mut trie, &mut leaf_updates3);
-    let root3 = trie.root(0, None);
-
-    // Verify root3 matches reference.
-    harness.apply_changeset(changeset3);
-    assert_eq!(
-        root3,
-        harness.original_root(),
-        "round 3 root should match reference after re-reveal"
-    );
-}
-
 /// Core production loop: reveal → update → root.
 ///
 /// Build a 5-leaf trie, reveal all proofs, apply 2 modifications + 1 removal,
@@ -266,8 +186,7 @@ pub(super) fn test_incremental_reveal_and_update_with_retry<T: SparseTrie>(new_t
 /// End-to-end block processing with storage + account coordination.
 ///
 /// Simulates a complete block processing cycle: receive state updates → apply to storage
-/// tries → compute storage roots → promote to account trie → compute state root → take
-/// updates → commit → prune for next block.
+/// tries → compute storage roots → promote to account trie → compute state root → take updates.
 pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn() -> T) {
     // --- Setup: Build account trie with 5 accounts ---
     // A1 storage: 5 slots, A2 storage: 3 slots, A3-A5: empty storage.
@@ -381,14 +300,6 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     let _ = acct_trie.take_updates();
     let _ = a1_trie.take_updates();
     let _ = a2_trie.take_updates();
-
-    // Prune account trie, retaining only A1 and A2 paths.
-    let retained: Vec<Nibbles> = acct_keys[0..2].iter().map(|k| Nibbles::unpack(*k)).collect();
-    acct_trie.prune(&retained);
-
-    // Post-prune root should still be state_root.
-    let post_prune_root = acct_trie.root(0, None);
-    assert_eq!(post_prune_root, state_root, "root should be unchanged after prune");
 }
 
 /// Prewarm via `Touched`, then mutate via `Changed`.
@@ -636,11 +547,11 @@ pub(super) fn test_find_leaf_before_update_to_check_existence<T: SparseTrie>(new
     );
 }
 
-/// After prune, hot leaves update immediately; cold leaves need re-reveal.
+/// After epoch pruning, hot leaves update immediately; cold leaves need re-reveal.
 ///
-/// Build 10-leaf trie, do Block 1 (update K1,K2,K3 → commit → prune retaining K1,K2),
-/// then Block 2: update K1 (hot, works immediately), update K5 (cold, needs re-reveal).
-pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn() -> T) {
+/// Build a 10-leaf trie at epoch 1, update K1,K2,K3 at epoch 2 while pruning epoch 1,
+/// then update K1 (hot) and K5 (cold, requiring re-reveal).
+pub(super) fn test_epoch_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn() -> T) {
     // Build a trie with 10 leaves.
     let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
     let mut keys = Vec::new();
@@ -655,7 +566,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root(0, None);
+    let _ = trie.root(1, None);
 
     // --- Block 1: Update K1 (keys[0]), K2 (keys[1]), K3 (keys[2]) ---
     let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
@@ -664,23 +575,19 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset1.insert(keys[2], U256::from(300));
     let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
     harness.reveal_and_update(&mut trie, &mut leaf_updates1);
-    let root1 = trie.root(0, None);
+    let root1 = trie.root(2, Some(2));
 
     harness.apply_changeset(changeset1);
     assert_eq!(root1, harness.original_root(), "block 1 root should match reference");
 
     let _ = trie.take_updates();
 
-    // --- Prune: retain only K1 and K2 as "hot" ---
-    let retained: Vec<Nibbles> = [keys[0], keys[1]].iter().map(|k| Nibbles::unpack(*k)).collect();
-    trie.prune(&retained);
-
     // --- Block 2 — hot path: Update K1 with a new value ---
     let mut changeset_hot: BTreeMap<B256, U256> = BTreeMap::new();
     changeset_hot.insert(keys[0], U256::from(999));
     let mut leaf_updates_hot = SuiteTestHarness::leaf_updates(&changeset_hot);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_hot);
-    let root_hot = trie.root(0, None);
+    let root_hot = trie.root(3, None);
 
     harness.apply_changeset(changeset_hot);
     assert_eq!(
@@ -694,7 +601,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset_cold.insert(keys[4], U256::from(555));
     let mut leaf_updates_cold = SuiteTestHarness::leaf_updates(&changeset_cold);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_cold);
-    let root_cold = trie.root(0, None);
+    let root_cold = trie.root(3, None);
 
     harness.apply_changeset(changeset_cold);
     assert_eq!(

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -23,7 +23,7 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Insert 1 new leaf under the same hashed prefix and modify 1 existing leaf.
     let mut new_key = B256::ZERO;
@@ -40,7 +40,7 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let hash1 = trie.root(0);
+    let hash1 = trie.root(0, None);
 
     // Verify hash1 matches the reference trie with updated values.
     let mut expected_storage = storage;
@@ -57,7 +57,7 @@ pub(super) fn test_full_lifecycle_update_root_take_updates<T: SparseTrie>(new_tr
     );
 
     // Taking updates should not affect the cached root.
-    let hash2 = trie.root(0);
+    let hash2 = trie.root(0, None);
     assert_eq!(hash1, hash2, "root should be unchanged after take_updates");
 }
 
@@ -82,7 +82,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // --- Round 1: Update leaves A (keys[0]) and B (keys[1]) ---
     let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
@@ -90,7 +90,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     changeset1.insert(keys[1], U256::from(200));
     let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
     harness.reveal_and_update(&mut trie, &mut leaf_updates1);
-    let root1 = trie.root(0);
+    let root1 = trie.root(0, None);
 
     // Verify root1 matches reference.
     harness.apply_changeset(changeset1);
@@ -104,7 +104,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     changeset2.insert(keys[3], U256::from(400));
     let mut leaf_updates2 = SuiteTestHarness::leaf_updates(&changeset2);
     harness.reveal_and_update(&mut trie, &mut leaf_updates2);
-    let root2 = trie.root(0);
+    let root2 = trie.root(0, None);
 
     // Verify root2 matches reference.
     harness.apply_changeset(changeset2);
@@ -122,7 +122,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     }
 
     // Root should still be correct after prune.
-    let root_after_prune = trie.root(0);
+    let root_after_prune = trie.root(0, None);
     assert_eq!(root_after_prune, harness.original_root(), "root should be unchanged after prune");
 
     // --- Round 3: Update leaf E (keys[4]) — needs re-reveal since it was pruned ---
@@ -130,7 +130,7 @@ pub(super) fn test_multi_round_update_take_updates_prune_cycle<T: SparseTrie>(ne
     changeset3.insert(keys[4], U256::from(500));
     let mut leaf_updates3 = SuiteTestHarness::leaf_updates(&changeset3);
     harness.reveal_and_update(&mut trie, &mut leaf_updates3);
-    let root3 = trie.root(0);
+    let root3 = trie.root(0, None);
 
     // Verify root3 matches reference.
     harness.apply_changeset(changeset3);
@@ -167,7 +167,7 @@ pub(super) fn test_reveal_update_root_basic_lifecycle<T: SparseTrie>(new_trie: f
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     // Build reference trie with same mutations.
     let mut expected_storage = storage;
@@ -255,7 +255,7 @@ pub(super) fn test_incremental_reveal_and_update_with_retry<T: SparseTrie>(new_t
     expected_storage.insert(group_b_keys[1], U256::from(900));
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -322,9 +322,9 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     let mut acct_trie: T = acct_harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes for all tries.
-    let _ = a1_trie.root(0);
-    let _ = a2_trie.root(0);
-    let _ = acct_trie.root(0);
+    let _ = a1_trie.root(0, None);
+    let _ = a2_trie.root(0, None);
+    let _ = acct_trie.root(0, None);
 
     // --- Storage phase ---
     // A1: modify S1 (key 0x10), remove S2 (key 0x20), add S6 (key 0x60).
@@ -351,8 +351,8 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     a2_harness.reveal_and_update(&mut a2_trie, &mut a2_leaf_updates);
 
     // --- Storage root phase ---
-    let sr1 = a1_trie.root(0);
-    let sr2 = a2_trie.root(0);
+    let sr1 = a1_trie.root(0, None);
+    let sr2 = a2_trie.root(0, None);
 
     // Verify storage roots match references.
     a1_harness.apply_changeset(a1_changeset);
@@ -371,7 +371,7 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     acct_harness.reveal_and_update(&mut acct_trie, &mut acct_leaf_updates);
 
     // --- State root phase ---
-    let state_root = acct_trie.root(0);
+    let state_root = acct_trie.root(0, None);
 
     // Verify state root matches reference.
     acct_harness.apply_changeset(acct_changeset);
@@ -387,7 +387,7 @@ pub(super) fn test_full_block_processing_lifecycle<T: SparseTrie>(new_trie: fn()
     acct_trie.prune(&retained);
 
     // Post-prune root should still be state_root.
-    let post_prune_root = acct_trie.root(0);
+    let post_prune_root = acct_trie.root(0, None);
     assert_eq!(post_prune_root, state_root, "root should be unchanged after prune");
 }
 
@@ -442,7 +442,7 @@ pub(super) fn test_touched_prewarm_then_changed_update<T: SparseTrie>(new_trie: 
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Step 3: Compute root and verify against reference.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     harness.apply_changeset(changeset);
     assert_eq!(
@@ -513,7 +513,7 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<T: Sp
     assert!(leaf_updates.is_empty(), "Changed key should be drained after reveal");
 
     // Step 5: Compute root and verify against reference.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     let mut changeset = BTreeMap::new();
     changeset.insert(target_key, new_value);
@@ -565,7 +565,7 @@ pub(super) fn test_get_leaf_value_for_storage_root_lookup<T: SparseTrie>(new_tri
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Step 5: Compute root and verify against reference.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     let mut changeset = BTreeMap::new();
     changeset.insert(key1, new_value);
@@ -620,7 +620,7 @@ pub(super) fn test_find_leaf_before_update_to_check_existence<T: SparseTrie>(new
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Step 4: Compute root and verify against reference.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     let mut changeset = BTreeMap::new();
     changeset.insert(key2, new_key2_value);
@@ -655,7 +655,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // --- Block 1: Update K1 (keys[0]), K2 (keys[1]), K3 (keys[2]) ---
     let mut changeset1: BTreeMap<B256, U256> = BTreeMap::new();
@@ -664,7 +664,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset1.insert(keys[2], U256::from(300));
     let mut leaf_updates1 = SuiteTestHarness::leaf_updates(&changeset1);
     harness.reveal_and_update(&mut trie, &mut leaf_updates1);
-    let root1 = trie.root(0);
+    let root1 = trie.root(0, None);
 
     harness.apply_changeset(changeset1);
     assert_eq!(root1, harness.original_root(), "block 1 root should match reference");
@@ -680,7 +680,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset_hot.insert(keys[0], U256::from(999));
     let mut leaf_updates_hot = SuiteTestHarness::leaf_updates(&changeset_hot);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_hot);
-    let root_hot = trie.root(0);
+    let root_hot = trie.root(0, None);
 
     harness.apply_changeset(changeset_hot);
     assert_eq!(
@@ -694,7 +694,7 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     changeset_cold.insert(keys[4], U256::from(555));
     let mut leaf_updates_cold = SuiteTestHarness::leaf_updates(&changeset_cold);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_cold);
-    let root_cold = trie.root(0);
+    let root_cold = trie.root(0, None);
 
     harness.apply_changeset(changeset_cold);
     assert_eq!(

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -272,7 +272,6 @@ sparse_trie_tests! {
     test_take_updates_no_duplicate_updated_and_removed_nodes,
     test_take_updates_cross_cancellation_across_root_calls,
 
-
     // prune
     test_prune_retains_specified_leaves,
     test_prune_keeps_upper_children_of_retained_branch,
@@ -312,7 +311,6 @@ sparse_trie_tests! {
 
     // lifecycle (integration tests)
     test_full_lifecycle_update_root_take_updates,
-    test_multi_round_update_take_updates_prune_cycle,
     test_reveal_update_root_basic_lifecycle,
     test_incremental_reveal_and_update_with_retry,
     test_full_block_processing_lifecycle,
@@ -320,5 +318,5 @@ sparse_trie_tests! {
     test_touched_on_blinded_triggers_proof_then_changed_succeeds,
     test_get_leaf_value_for_storage_root_lookup,
     test_find_leaf_before_update_to_check_existence,
-    test_prune_then_reuse_for_next_block,
+    test_epoch_prune_then_reuse_for_next_block,
 }

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -67,14 +67,14 @@ pub(super) fn test_prune_retains_specified_leaves<T: SparseTrie>(new_trie: fn() 
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root before prune.
-    let hash1 = trie.root();
+    let hash1 = trie.root(0);
 
     // Retain leaves A and B, prune the rest.
     let retained = [Nibbles::unpack(key_a), Nibbles::unpack(key_b)];
     trie.prune(&retained);
 
     // Root must be unchanged after prune.
-    let hash2 = trie.root();
+    let hash2 = trie.root(0);
     assert_eq!(hash1, hash2, "root hash should be unchanged after prune");
 
     // Retained leaves must still be accessible.
@@ -99,12 +99,12 @@ pub(super) fn test_prune_keeps_upper_children_of_retained_branch<T: SparseTrie>(
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
-    let root_before = trie.root();
+    let root_before = trie.root(0);
 
     let retained = [Nibbles::unpack(retained_key)];
     let pruned = trie.prune(&retained);
 
-    assert_eq!(trie.root(), root_before, "root must not change after prune");
+    assert_eq!(trie.root(0), root_before, "root must not change after prune");
     assert_eq!(pruned, 2, "protected branch children should be blinded, not removed");
     assert_update_requests_parent(&mut trie, protected_key_a, ProofV2TargetParent::new(1), 20);
 }
@@ -123,12 +123,12 @@ pub(super) fn test_prune_keeps_lower_children_of_retained_branch<T: SparseTrie>(
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
-    let root_before = trie.root();
+    let root_before = trie.root(0);
 
     let retained = [Nibbles::unpack(retained_key)];
     let pruned = trie.prune(&retained);
 
-    assert_eq!(trie.root(), root_before, "root must not change after prune");
+    assert_eq!(trie.root(0), root_before, "root must not change after prune");
     assert_eq!(pruned, 2, "protected lower branch children should be blinded, not removed");
     assert_update_requests_parent(&mut trie, protected_key_a, ProofV2TargetParent::new(3), 20);
 }
@@ -174,12 +174,12 @@ pub(super) fn test_prune_protects_children_by_parent_base_path<T: SparseTrie>(ne
     ])
     .expect("reveal_nodes should succeed");
 
-    let root_before = trie.root();
+    let root_before = trie.root(0);
     let retained = [Nibbles::from_nibbles([0x0, 0x0])];
     let pruned = trie.prune(&retained);
 
     assert_eq!(pruned, 0);
-    assert_eq!(trie.root(), root_before, "root must not change after prune");
+    assert_eq!(trie.root(0), root_before, "root must not change after prune");
 }
 
 /// Pruning should reduce the node count.
@@ -207,7 +207,7 @@ pub(super) fn test_prune_reduces_node_count<T: SparseTrie>(new_trie: fn() -> T) 
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root to cache hashes (required for pruning).
-    let _root = trie.root();
+    let _root = trie.root(0);
 
     let size_before = trie.size_hint();
 
@@ -241,14 +241,14 @@ pub(super) fn test_prune_empty_retained_set<T: SparseTrie>(new_trie: fn() -> T) 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let hash_before = trie.root();
+    let hash_before = trie.root(0);
 
     let size_before = trie.size_hint();
 
     // Prune with empty retained set — maximum pruning.
     let pruned_count = trie.prune(&[]);
 
-    let hash_after = trie.root();
+    let hash_after = trie.root(0);
     let size_after = trie.size_hint();
 
     assert_eq!(hash_before, hash_after, "root hash should be unchanged after prune");
@@ -286,7 +286,7 @@ pub(super) fn test_prune_requires_computed_hashes<T: SparseTrie>(new_trie: fn() 
     // Compare against pruning after root() is called (clean state).
     // With dirty nodes, pruning is limited because dirty subtrees lack cached hashes.
     let mut trie_clean: T = harness.init_trie_fully_revealed(false, new_trie);
-    trie_clean.root();
+    trie_clean.root(0);
     let clean_pruned = trie_clean.prune(&retained);
 
     assert!(
@@ -310,7 +310,7 @@ pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie>(new_trie:
     let harness = SuiteTestHarness::new(storage.clone());
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    trie.root();
+    trie.root(0);
 
     let retained = vec![Nibbles::unpack(keys[0]), Nibbles::unpack(keys[1])];
     trie.prune(&retained);
@@ -320,7 +320,7 @@ pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie>(new_trie:
     leaf_updates.insert(keys[0], LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root_after = trie.root();
+    let root_after = trie.root(0);
 
     let mut expected_storage = storage;
     expected_storage.insert(keys[0], new_value);
@@ -345,7 +345,7 @@ pub(super) fn test_prune_then_reveal_pruned_subtree<T: SparseTrie>(new_trie: fn(
     let harness = SuiteTestHarness::new(storage.clone());
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    trie.root();
+    trie.root(0);
 
     let retained = vec![Nibbles::unpack(keys[0])];
     trie.prune(&retained);
@@ -355,7 +355,7 @@ pub(super) fn test_prune_then_reveal_pruned_subtree<T: SparseTrie>(new_trie: fn(
     leaf_updates.insert(keys[2], LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root_after = trie.root();
+    let root_after = trie.root(0);
 
     let mut expected_storage = storage;
     expected_storage.insert(keys[2], new_value);
@@ -393,9 +393,9 @@ pub(super) fn test_prune_mixed_embedded_and_hashed_nodes<T: SparseTrie>(new_trie
     })
     .expect("update_leaves should succeed");
 
-    let root_before = trie.root();
+    let root_before = trie.root(0);
     trie.prune(&[]);
-    let root_after = trie.root();
+    let root_after = trie.root(0);
 
     assert_eq!(root_before, root_after, "root hash must be preserved after pruning mixed trie");
 }
@@ -416,12 +416,12 @@ pub(super) fn test_prune_then_update_no_panic<T: SparseTrie>(new_trie: fn() -> T
     let harness = SuiteTestHarness::new(storage.clone());
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before_prune = trie.root();
+    let root_before_prune = trie.root(0);
 
     // Prune everything.
     trie.prune(&[]);
 
-    let hash1 = trie.root();
+    let hash1 = trie.root(0);
     assert_eq!(hash1, root_before_prune, "root after prune must equal root before prune");
 
     // Insert a brand-new key not previously in the trie.
@@ -434,7 +434,7 @@ pub(super) fn test_prune_then_update_no_panic<T: SparseTrie>(new_trie: fn() -> T
     // The update will hit blinded nodes — the reveal_and_update loop supplies proofs.
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let hash2 = trie.root();
+    let hash2 = trie.root(0);
     assert_ne!(hash2, hash1, "root should change after inserting a new leaf");
 }
 
@@ -447,7 +447,7 @@ pub(super) fn test_prune_only_descends_into_branch_root<T: SparseTrie>(new_trie:
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let _root = trie.root();
+    let _root = trie.root(0);
     let pruned = trie.prune(&[]);
     assert_eq!(pruned, 0, "non-branch root should not prune any nodes");
 
@@ -480,7 +480,7 @@ pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie>(new_tri
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before = trie.root();
+    let root_before = trie.root(0);
     assert_eq!(root_before, harness.original_root());
 
     // Prune retaining only the small-subtrie leaf — the large subtrie should
@@ -488,6 +488,6 @@ pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie>(new_tri
     let retained = vec![Nibbles::unpack(small_key)];
     trie.prune(&retained);
 
-    let root_after = trie.root();
+    let root_after = trie.root(0);
     assert_eq!(root_after, root_before, "root must not change after prune");
 }

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -67,14 +67,14 @@ pub(super) fn test_prune_retains_specified_leaves<T: SparseTrie>(new_trie: fn() 
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root before prune.
-    let hash1 = trie.root(0);
+    let hash1 = trie.root(0, None);
 
     // Retain leaves A and B, prune the rest.
     let retained = [Nibbles::unpack(key_a), Nibbles::unpack(key_b)];
     trie.prune(&retained);
 
     // Root must be unchanged after prune.
-    let hash2 = trie.root(0);
+    let hash2 = trie.root(0, None);
     assert_eq!(hash1, hash2, "root hash should be unchanged after prune");
 
     // Retained leaves must still be accessible.
@@ -99,12 +99,12 @@ pub(super) fn test_prune_keeps_upper_children_of_retained_branch<T: SparseTrie>(
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
 
     let retained = [Nibbles::unpack(retained_key)];
     let pruned = trie.prune(&retained);
 
-    assert_eq!(trie.root(0), root_before, "root must not change after prune");
+    assert_eq!(trie.root(0, None), root_before, "root must not change after prune");
     assert_eq!(pruned, 2, "protected branch children should be blinded, not removed");
     assert_update_requests_parent(&mut trie, protected_key_a, ProofV2TargetParent::new(1), 20);
 }
@@ -123,12 +123,12 @@ pub(super) fn test_prune_keeps_lower_children_of_retained_branch<T: SparseTrie>(
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
 
     let retained = [Nibbles::unpack(retained_key)];
     let pruned = trie.prune(&retained);
 
-    assert_eq!(trie.root(0), root_before, "root must not change after prune");
+    assert_eq!(trie.root(0, None), root_before, "root must not change after prune");
     assert_eq!(pruned, 2, "protected lower branch children should be blinded, not removed");
     assert_update_requests_parent(&mut trie, protected_key_a, ProofV2TargetParent::new(3), 20);
 }
@@ -174,12 +174,12 @@ pub(super) fn test_prune_protects_children_by_parent_base_path<T: SparseTrie>(ne
     ])
     .expect("reveal_nodes should succeed");
 
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
     let retained = [Nibbles::from_nibbles([0x0, 0x0])];
     let pruned = trie.prune(&retained);
 
     assert_eq!(pruned, 0);
-    assert_eq!(trie.root(0), root_before, "root must not change after prune");
+    assert_eq!(trie.root(0, None), root_before, "root must not change after prune");
 }
 
 /// Pruning should reduce the node count.
@@ -207,7 +207,7 @@ pub(super) fn test_prune_reduces_node_count<T: SparseTrie>(new_trie: fn() -> T) 
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root to cache hashes (required for pruning).
-    let _root = trie.root(0);
+    let _root = trie.root(0, None);
 
     let size_before = trie.size_hint();
 
@@ -241,14 +241,14 @@ pub(super) fn test_prune_empty_retained_set<T: SparseTrie>(new_trie: fn() -> T) 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let hash_before = trie.root(0);
+    let hash_before = trie.root(0, None);
 
     let size_before = trie.size_hint();
 
     // Prune with empty retained set — maximum pruning.
     let pruned_count = trie.prune(&[]);
 
-    let hash_after = trie.root(0);
+    let hash_after = trie.root(0, None);
     let size_after = trie.size_hint();
 
     assert_eq!(hash_before, hash_after, "root hash should be unchanged after prune");
@@ -286,7 +286,7 @@ pub(super) fn test_prune_requires_computed_hashes<T: SparseTrie>(new_trie: fn() 
     // Compare against pruning after root() is called (clean state).
     // With dirty nodes, pruning is limited because dirty subtrees lack cached hashes.
     let mut trie_clean: T = harness.init_trie_fully_revealed(false, new_trie);
-    trie_clean.root(0);
+    trie_clean.root(0, None);
     let clean_pruned = trie_clean.prune(&retained);
 
     assert!(
@@ -310,7 +310,7 @@ pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie>(new_trie:
     let harness = SuiteTestHarness::new(storage.clone());
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    trie.root(0);
+    trie.root(0, None);
 
     let retained = vec![Nibbles::unpack(keys[0]), Nibbles::unpack(keys[1])];
     trie.prune(&retained);
@@ -320,7 +320,7 @@ pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie>(new_trie:
     leaf_updates.insert(keys[0], LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
 
     let mut expected_storage = storage;
     expected_storage.insert(keys[0], new_value);
@@ -345,7 +345,7 @@ pub(super) fn test_prune_then_reveal_pruned_subtree<T: SparseTrie>(new_trie: fn(
     let harness = SuiteTestHarness::new(storage.clone());
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    trie.root(0);
+    trie.root(0, None);
 
     let retained = vec![Nibbles::unpack(keys[0])];
     trie.prune(&retained);
@@ -355,7 +355,7 @@ pub(super) fn test_prune_then_reveal_pruned_subtree<T: SparseTrie>(new_trie: fn(
     leaf_updates.insert(keys[2], LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
 
     let mut expected_storage = storage;
     expected_storage.insert(keys[2], new_value);
@@ -393,9 +393,9 @@ pub(super) fn test_prune_mixed_embedded_and_hashed_nodes<T: SparseTrie>(new_trie
     })
     .expect("update_leaves should succeed");
 
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
     trie.prune(&[]);
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
 
     assert_eq!(root_before, root_after, "root hash must be preserved after pruning mixed trie");
 }
@@ -416,12 +416,12 @@ pub(super) fn test_prune_then_update_no_panic<T: SparseTrie>(new_trie: fn() -> T
     let harness = SuiteTestHarness::new(storage.clone());
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before_prune = trie.root(0);
+    let root_before_prune = trie.root(0, None);
 
     // Prune everything.
     trie.prune(&[]);
 
-    let hash1 = trie.root(0);
+    let hash1 = trie.root(0, None);
     assert_eq!(hash1, root_before_prune, "root after prune must equal root before prune");
 
     // Insert a brand-new key not previously in the trie.
@@ -434,7 +434,7 @@ pub(super) fn test_prune_then_update_no_panic<T: SparseTrie>(new_trie: fn() -> T
     // The update will hit blinded nodes — the reveal_and_update loop supplies proofs.
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let hash2 = trie.root(0);
+    let hash2 = trie.root(0, None);
     assert_ne!(hash2, hash1, "root should change after inserting a new leaf");
 }
 
@@ -447,7 +447,7 @@ pub(super) fn test_prune_only_descends_into_branch_root<T: SparseTrie>(new_trie:
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let _root = trie.root(0);
+    let _root = trie.root(0, None);
     let pruned = trie.prune(&[]);
     assert_eq!(pruned, 0, "non-branch root should not prune any nodes");
 
@@ -480,7 +480,7 @@ pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie>(new_tri
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
     assert_eq!(root_before, harness.original_root());
 
     // Prune retaining only the small-subtrie leaf — the large subtrie should
@@ -488,6 +488,6 @@ pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie>(new_tri
     let retained = vec![Nibbles::unpack(small_key)];
     trie.prune(&retained);
 
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
     assert_eq!(root_after, root_before, "root must not change after prune");
 }

--- a/crates/trie/sparse/tests/suite/reveal_nodes.rs
+++ b/crates/trie/sparse/tests/suite/reveal_nodes.rs
@@ -20,12 +20,12 @@ pub(super) fn test_reveal_nodes_empty_slice<T: SparseTrie>(new_trie: fn() -> T) 
     let mut trie = (new_trie)();
     trie.set_root(root_node.node, root_node.masks, true).expect("set_root should succeed");
 
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
 
     // Call reveal_nodes with an empty slice — should be a no-op.
     trie.reveal_nodes(&mut []).expect("reveal_nodes with empty slice should succeed");
 
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
     assert_eq!(root_before, root_after, "root should be unchanged after empty reveal_nodes");
 }
 
@@ -47,7 +47,7 @@ pub(super) fn test_reveal_nodes_single_leaf<T: SparseTrie>(new_trie: fn() -> T) 
 
     // Set root and reveal only one leaf's proof.
     let mut trie: T = harness.init_trie_with_targets(&[key_a], true, new_trie);
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, harness.original_root());
 }
 
@@ -69,7 +69,7 @@ pub(super) fn test_reveal_nodes_idempotent<T: SparseTrie>(new_trie: fn() -> T) {
 
     // First reveal: set root and reveal all proof nodes.
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-    let root_first = trie.root(0);
+    let root_first = trie.root(0, None);
     assert_eq!(root_first, harness.original_root());
 
     // Second reveal: reveal the same proof nodes again.
@@ -78,7 +78,7 @@ pub(super) fn test_reveal_nodes_idempotent<T: SparseTrie>(new_trie: fn() -> T) {
     let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
     trie.reveal_nodes(&mut proof_nodes).expect("second reveal_nodes should succeed");
 
-    let root_second = trie.root(0);
+    let root_second = trie.root(0, None);
     assert_eq!(root_first, root_second, "root should be unchanged after double reveal");
 }
 
@@ -104,7 +104,7 @@ pub(super) fn test_reveal_nodes_with_branch_masks<T: SparseTrie>(new_trie: fn() 
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to cache initial branch hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Add a new leaf under the same prefix so non-root branch nodes change.
     let mut new_key = B256::ZERO;
@@ -114,7 +114,7 @@ pub(super) fn test_reveal_nodes_with_branch_masks<T: SparseTrie>(new_trie: fn() 
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Updates should reflect which branch nodes were updated vs removed,
     // guided by the masks stored during reveal_nodes.
@@ -152,7 +152,7 @@ pub(super) fn test_reveal_nodes_skips_on_empty_root<T: SparseTrie>(new_trie: fn(
 
     // Trie should still be empty.
     assert_eq!(
-        trie.root(0),
+        trie.root(0, None),
         EMPTY_ROOT_HASH,
         "root should remain EMPTY_ROOT_HASH after reveal on empty root"
     );
@@ -204,7 +204,7 @@ pub(super) fn test_reveal_nodes_filters_unreachable_boundary_leaves<T: SparseTri
     trie.reveal_nodes(&mut proof_a).expect("reveal group A should succeed");
 
     // Verify root is correct with partial reveal.
-    let root_after_a = trie.root(0);
+    let root_after_a = trie.root(0, None);
     assert_eq!(root_after_a, harness.original_root(), "root after group A reveal should match");
 
     // Now generate proofs for group B keys and reveal them as extra nodes.
@@ -215,7 +215,7 @@ pub(super) fn test_reveal_nodes_filters_unreachable_boundary_leaves<T: SparseTri
     trie.reveal_nodes(&mut proof_b).expect("reveal extra group B nodes should succeed");
 
     // Root must still be correct — extra reveals should not corrupt state.
-    let root_after_b = trie.root(0);
+    let root_after_b = trie.root(0, None);
     assert_eq!(
         root_after_b,
         harness.original_root(),
@@ -228,7 +228,7 @@ pub(super) fn test_reveal_nodes_filters_unreachable_boundary_leaves<T: SparseTri
     let (mut proof_all, _) = harness.proof_v2(&mut targets_all);
     trie.reveal_nodes(&mut proof_all).expect("reveal all nodes should succeed");
 
-    let root_after_all = trie.root(0);
+    let root_after_all = trie.root(0, None);
     assert_eq!(
         root_after_all,
         harness.original_root(),
@@ -267,7 +267,7 @@ pub(super) fn test_reveal_insert_reveal_preserves_branch_state<T: SparseTrie>(ne
     trie.reveal_nodes(&mut proof_nodes).expect("reveal stale proof for key_c should succeed");
 
     // Root must match a reference trie with all 3 keys.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     let expected_storage =
         BTreeMap::from([(key_a, U256::from(1)), (key_b, insert_value), (key_c, U256::from(3))]);
     let expected_harness = SuiteTestHarness::new(expected_storage);
@@ -322,7 +322,7 @@ pub(super) fn test_remove_then_reveal_does_not_overwrite_collapsed_node<T: Spars
     trie.reveal_nodes(&mut stale_proof).expect("revealing stale proof should succeed");
 
     // Root must match a reference trie with only key_b and key_c.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     let expected_storage = BTreeMap::from([(key_b, U256::from(2)), (key_c, U256::from(3))]);
     let expected_harness = SuiteTestHarness::new(expected_storage);
     assert_eq!(
@@ -377,7 +377,7 @@ pub(super) fn test_insert_then_reveal_does_not_overwrite_branch<T: SparseTrie>(
     trie.reveal_nodes(&mut stale_proof).expect("revealing stale proof should succeed");
 
     // Root must match a reference trie with all 3 keys.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     let expected_storage =
         BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, insert_value)]);
     let expected_harness = SuiteTestHarness::new(expected_storage);

--- a/crates/trie/sparse/tests/suite/reveal_nodes.rs
+++ b/crates/trie/sparse/tests/suite/reveal_nodes.rs
@@ -20,12 +20,12 @@ pub(super) fn test_reveal_nodes_empty_slice<T: SparseTrie>(new_trie: fn() -> T) 
     let mut trie = (new_trie)();
     trie.set_root(root_node.node, root_node.masks, true).expect("set_root should succeed");
 
-    let root_before = trie.root();
+    let root_before = trie.root(0);
 
     // Call reveal_nodes with an empty slice — should be a no-op.
     trie.reveal_nodes(&mut []).expect("reveal_nodes with empty slice should succeed");
 
-    let root_after = trie.root();
+    let root_after = trie.root(0);
     assert_eq!(root_before, root_after, "root should be unchanged after empty reveal_nodes");
 }
 
@@ -47,7 +47,7 @@ pub(super) fn test_reveal_nodes_single_leaf<T: SparseTrie>(new_trie: fn() -> T) 
 
     // Set root and reveal only one leaf's proof.
     let mut trie: T = harness.init_trie_with_targets(&[key_a], true, new_trie);
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, harness.original_root());
 }
 
@@ -69,7 +69,7 @@ pub(super) fn test_reveal_nodes_idempotent<T: SparseTrie>(new_trie: fn() -> T) {
 
     // First reveal: set root and reveal all proof nodes.
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-    let root_first = trie.root();
+    let root_first = trie.root(0);
     assert_eq!(root_first, harness.original_root());
 
     // Second reveal: reveal the same proof nodes again.
@@ -78,7 +78,7 @@ pub(super) fn test_reveal_nodes_idempotent<T: SparseTrie>(new_trie: fn() -> T) {
     let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
     trie.reveal_nodes(&mut proof_nodes).expect("second reveal_nodes should succeed");
 
-    let root_second = trie.root();
+    let root_second = trie.root(0);
     assert_eq!(root_first, root_second, "root should be unchanged after double reveal");
 }
 
@@ -104,7 +104,7 @@ pub(super) fn test_reveal_nodes_with_branch_masks<T: SparseTrie>(new_trie: fn() 
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to cache initial branch hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Add a new leaf under the same prefix so non-root branch nodes change.
     let mut new_key = B256::ZERO;
@@ -114,7 +114,7 @@ pub(super) fn test_reveal_nodes_with_branch_masks<T: SparseTrie>(new_trie: fn() 
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Updates should reflect which branch nodes were updated vs removed,
     // guided by the masks stored during reveal_nodes.
@@ -152,7 +152,7 @@ pub(super) fn test_reveal_nodes_skips_on_empty_root<T: SparseTrie>(new_trie: fn(
 
     // Trie should still be empty.
     assert_eq!(
-        trie.root(),
+        trie.root(0),
         EMPTY_ROOT_HASH,
         "root should remain EMPTY_ROOT_HASH after reveal on empty root"
     );
@@ -204,7 +204,7 @@ pub(super) fn test_reveal_nodes_filters_unreachable_boundary_leaves<T: SparseTri
     trie.reveal_nodes(&mut proof_a).expect("reveal group A should succeed");
 
     // Verify root is correct with partial reveal.
-    let root_after_a = trie.root();
+    let root_after_a = trie.root(0);
     assert_eq!(root_after_a, harness.original_root(), "root after group A reveal should match");
 
     // Now generate proofs for group B keys and reveal them as extra nodes.
@@ -215,7 +215,7 @@ pub(super) fn test_reveal_nodes_filters_unreachable_boundary_leaves<T: SparseTri
     trie.reveal_nodes(&mut proof_b).expect("reveal extra group B nodes should succeed");
 
     // Root must still be correct — extra reveals should not corrupt state.
-    let root_after_b = trie.root();
+    let root_after_b = trie.root(0);
     assert_eq!(
         root_after_b,
         harness.original_root(),
@@ -228,7 +228,7 @@ pub(super) fn test_reveal_nodes_filters_unreachable_boundary_leaves<T: SparseTri
     let (mut proof_all, _) = harness.proof_v2(&mut targets_all);
     trie.reveal_nodes(&mut proof_all).expect("reveal all nodes should succeed");
 
-    let root_after_all = trie.root();
+    let root_after_all = trie.root(0);
     assert_eq!(
         root_after_all,
         harness.original_root(),
@@ -267,7 +267,7 @@ pub(super) fn test_reveal_insert_reveal_preserves_branch_state<T: SparseTrie>(ne
     trie.reveal_nodes(&mut proof_nodes).expect("reveal stale proof for key_c should succeed");
 
     // Root must match a reference trie with all 3 keys.
-    let root = trie.root();
+    let root = trie.root(0);
     let expected_storage =
         BTreeMap::from([(key_a, U256::from(1)), (key_b, insert_value), (key_c, U256::from(3))]);
     let expected_harness = SuiteTestHarness::new(expected_storage);
@@ -322,7 +322,7 @@ pub(super) fn test_remove_then_reveal_does_not_overwrite_collapsed_node<T: Spars
     trie.reveal_nodes(&mut stale_proof).expect("revealing stale proof should succeed");
 
     // Root must match a reference trie with only key_b and key_c.
-    let root = trie.root();
+    let root = trie.root(0);
     let expected_storage = BTreeMap::from([(key_b, U256::from(2)), (key_c, U256::from(3))]);
     let expected_harness = SuiteTestHarness::new(expected_storage);
     assert_eq!(
@@ -377,7 +377,7 @@ pub(super) fn test_insert_then_reveal_does_not_overwrite_branch<T: SparseTrie>(
     trie.reveal_nodes(&mut stale_proof).expect("revealing stale proof should succeed");
 
     // Root must match a reference trie with all 3 keys.
-    let root = trie.root();
+    let root = trie.root(0);
     let expected_storage =
         BTreeMap::from([(key_a, U256::from(1)), (key_b, U256::from(2)), (key_c, insert_value)]);
     let expected_harness = SuiteTestHarness::new(expected_storage);

--- a/crates/trie/sparse/tests/suite/root.rs
+++ b/crates/trie/sparse/tests/suite/root.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Calling `root()` on a fresh, empty trie returns `EMPTY_ROOT_HASH`.
 pub(super) fn test_root_empty_trie<T: SparseTrie>(new_trie: fn() -> T) {
     let mut trie = (new_trie)();
-    assert_eq!(trie.root(0), EMPTY_ROOT_HASH, "empty trie should return EMPTY_ROOT_HASH");
+    assert_eq!(trie.root(0, None), EMPTY_ROOT_HASH, "empty trie should return EMPTY_ROOT_HASH");
 }
 
 /// Second `root()` call returns cached hash without recomputation.
@@ -23,12 +23,12 @@ pub(super) fn test_root_cached_returns_without_recomputation<T: SparseTrie>(new_
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
-    let root1 = trie.root(0);
+    let root1 = trie.root(0, None);
     assert_eq!(root1, harness.original_root(), "first root should match reference");
 
     assert!(trie.is_root_cached(), "root should be cached after first computation");
 
-    let root2 = trie.root(0);
+    let root2 = trie.root(0, None);
     assert_eq!(root2, root1, "second root call should return the same cached hash");
 }
 
@@ -49,7 +49,7 @@ pub(super) fn test_root_after_single_leaf_update<T: SparseTrie>(new_trie: fn() -
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let original_root = trie.root(0);
+    let original_root = trie.root(0, None);
     assert_eq!(original_root, harness.original_root(), "initial root should match reference");
 
     // Modify key_b's value from 2 to 999.
@@ -57,7 +57,7 @@ pub(super) fn test_root_after_single_leaf_update<T: SparseTrie>(new_trie: fn() -
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changes);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let new_root = trie.root(0);
+    let new_root = trie.root(0, None);
     assert_ne!(new_root, original_root, "root should change after leaf update");
 
     // Build a reference trie with the updated value and verify.
@@ -105,7 +105,7 @@ pub(super) fn test_root_deterministic_across_update_orders<T: SparseTrie>(new_tr
                 SuiteTestHarness::leaf_updates(&BTreeMap::from([(*key, *value)]));
             trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
         }
-        trie.root(0)
+        trie.root(0, None)
     };
 
     // Build trie B: insert keys in order 5,3,1,4,2.
@@ -117,7 +117,7 @@ pub(super) fn test_root_deterministic_across_update_orders<T: SparseTrie>(new_tr
                 SuiteTestHarness::leaf_updates(&BTreeMap::from([(*key, *value)]));
             trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
         }
-        trie.root(0)
+        trie.root(0, None)
     };
 
     assert_eq!(root_a, root_b, "root hash should be deterministic regardless of insert order");
@@ -142,9 +142,9 @@ pub(super) fn test_root_handles_small_root_node_without_hash<T: SparseTrie>(new_
 
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root1 = trie.root(0);
+    let root1 = trie.root(0, None);
     assert_eq!(root1, harness.original_root(), "first root() should match reference trie");
 
-    let root2 = trie.root(0);
+    let root2 = trie.root(0, None);
     assert_eq!(root2, root1, "second root() should return cached result without panic");
 }

--- a/crates/trie/sparse/tests/suite/root.rs
+++ b/crates/trie/sparse/tests/suite/root.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Calling `root()` on a fresh, empty trie returns `EMPTY_ROOT_HASH`.
 pub(super) fn test_root_empty_trie<T: SparseTrie>(new_trie: fn() -> T) {
     let mut trie = (new_trie)();
-    assert_eq!(trie.root(), EMPTY_ROOT_HASH, "empty trie should return EMPTY_ROOT_HASH");
+    assert_eq!(trie.root(0), EMPTY_ROOT_HASH, "empty trie should return EMPTY_ROOT_HASH");
 }
 
 /// Second `root()` call returns cached hash without recomputation.
@@ -23,12 +23,12 @@ pub(super) fn test_root_cached_returns_without_recomputation<T: SparseTrie>(new_
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
-    let root1 = trie.root();
+    let root1 = trie.root(0);
     assert_eq!(root1, harness.original_root(), "first root should match reference");
 
     assert!(trie.is_root_cached(), "root should be cached after first computation");
 
-    let root2 = trie.root();
+    let root2 = trie.root(0);
     assert_eq!(root2, root1, "second root call should return the same cached hash");
 }
 
@@ -49,7 +49,7 @@ pub(super) fn test_root_after_single_leaf_update<T: SparseTrie>(new_trie: fn() -
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let original_root = trie.root();
+    let original_root = trie.root(0);
     assert_eq!(original_root, harness.original_root(), "initial root should match reference");
 
     // Modify key_b's value from 2 to 999.
@@ -57,7 +57,7 @@ pub(super) fn test_root_after_single_leaf_update<T: SparseTrie>(new_trie: fn() -
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changes);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let new_root = trie.root();
+    let new_root = trie.root(0);
     assert_ne!(new_root, original_root, "root should change after leaf update");
 
     // Build a reference trie with the updated value and verify.
@@ -105,7 +105,7 @@ pub(super) fn test_root_deterministic_across_update_orders<T: SparseTrie>(new_tr
                 SuiteTestHarness::leaf_updates(&BTreeMap::from([(*key, *value)]));
             trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
         }
-        trie.root()
+        trie.root(0)
     };
 
     // Build trie B: insert keys in order 5,3,1,4,2.
@@ -117,7 +117,7 @@ pub(super) fn test_root_deterministic_across_update_orders<T: SparseTrie>(new_tr
                 SuiteTestHarness::leaf_updates(&BTreeMap::from([(*key, *value)]));
             trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
         }
-        trie.root()
+        trie.root(0)
     };
 
     assert_eq!(root_a, root_b, "root hash should be deterministic regardless of insert order");
@@ -142,9 +142,9 @@ pub(super) fn test_root_handles_small_root_node_without_hash<T: SparseTrie>(new_
 
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root1 = trie.root();
+    let root1 = trie.root(0);
     assert_eq!(root1, harness.original_root(), "first root() should match reference trie");
 
-    let root2 = trie.root();
+    let root2 = trie.root(0);
     assert_eq!(root2, root1, "second root() should return cached result without panic");
 }

--- a/crates/trie/sparse/tests/suite/set_root.rs
+++ b/crates/trie/sparse/tests/suite/set_root.rs
@@ -15,7 +15,7 @@ pub(super) fn test_set_root_with_branch_node<T: SparseTrie>(new_trie: fn() -> T)
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, harness.original_root());
 }
 
@@ -30,7 +30,7 @@ pub(super) fn test_set_root_with_leaf_node<T: SparseTrie>(new_trie: fn() -> T) {
     let root_node = harness.root_node();
     let mut trie = (new_trie)();
     trie.set_root(root_node.node, root_node.masks, true).expect("set_root should succeed");
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, harness.original_root());
 }
 
@@ -50,7 +50,7 @@ pub(super) fn test_set_root_with_extension_node<T: SparseTrie>(new_trie: fn() ->
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, harness.original_root());
 }
 
@@ -74,7 +74,7 @@ pub(super) fn test_set_root_retains_updates_when_requested<T: SparseTrie>(new_tr
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root once so branch hashes are cached.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Add a new leaf under the same prefix so non-root branch nodes change.
     let mut new_key = B256::ZERO;
@@ -85,7 +85,7 @@ pub(super) fn test_set_root_retains_updates_when_requested<T: SparseTrie>(new_tr
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Compute root to finalize hashes and generate update actions.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // take_updates should return non-empty updates.
     let updates = trie.take_updates();
@@ -122,7 +122,7 @@ pub(super) fn test_set_root_does_not_retain_updates_when_not_requested<T: Sparse
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     let updates = trie.take_updates();
     assert!(
@@ -140,5 +140,5 @@ pub(super) fn test_set_root_does_not_retain_updates_when_not_requested<T: Sparse
 pub(super) fn test_set_root_with_empty_root<T: SparseTrie>(new_trie: fn() -> T) {
     let mut trie = (new_trie)();
     trie.set_root(TrieNodeV2::EmptyRoot, None, true).expect("set_root should succeed");
-    assert_eq!(trie.root(), EMPTY_ROOT_HASH);
+    assert_eq!(trie.root(0), EMPTY_ROOT_HASH);
 }

--- a/crates/trie/sparse/tests/suite/set_root.rs
+++ b/crates/trie/sparse/tests/suite/set_root.rs
@@ -141,4 +141,10 @@ pub(super) fn test_set_root_with_empty_root<T: SparseTrie>(new_trie: fn() -> T) 
     let mut trie = (new_trie)();
     trie.set_root(TrieNodeV2::EmptyRoot, None, true).expect("set_root should succeed");
     assert_eq!(trie.root(0, None), EMPTY_ROOT_HASH);
+    assert_eq!(trie.root(0, Some(1)), EMPTY_ROOT_HASH);
+    assert!(trie.root_is_prunable());
+
+    trie.set_root(TrieNodeV2::EmptyRoot, None, true).expect("set_root should reset cached state");
+    assert_eq!(trie.root(10, Some(10)), EMPTY_ROOT_HASH);
+    assert!(!trie.root_is_prunable());
 }

--- a/crates/trie/sparse/tests/suite/set_root.rs
+++ b/crates/trie/sparse/tests/suite/set_root.rs
@@ -15,7 +15,7 @@ pub(super) fn test_set_root_with_branch_node<T: SparseTrie>(new_trie: fn() -> T)
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, harness.original_root());
 }
 
@@ -30,7 +30,7 @@ pub(super) fn test_set_root_with_leaf_node<T: SparseTrie>(new_trie: fn() -> T) {
     let root_node = harness.root_node();
     let mut trie = (new_trie)();
     trie.set_root(root_node.node, root_node.masks, true).expect("set_root should succeed");
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, harness.original_root());
 }
 
@@ -50,7 +50,7 @@ pub(super) fn test_set_root_with_extension_node<T: SparseTrie>(new_trie: fn() ->
 
     let harness = SuiteTestHarness::new(storage);
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, harness.original_root());
 }
 
@@ -74,7 +74,7 @@ pub(super) fn test_set_root_retains_updates_when_requested<T: SparseTrie>(new_tr
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root once so branch hashes are cached.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Add a new leaf under the same prefix so non-root branch nodes change.
     let mut new_key = B256::ZERO;
@@ -85,7 +85,7 @@ pub(super) fn test_set_root_retains_updates_when_requested<T: SparseTrie>(new_tr
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Compute root to finalize hashes and generate update actions.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // take_updates should return non-empty updates.
     let updates = trie.take_updates();
@@ -122,7 +122,7 @@ pub(super) fn test_set_root_does_not_retain_updates_when_not_requested<T: Sparse
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     let updates = trie.take_updates();
     assert!(
@@ -140,5 +140,5 @@ pub(super) fn test_set_root_does_not_retain_updates_when_not_requested<T: Sparse
 pub(super) fn test_set_root_with_empty_root<T: SparseTrie>(new_trie: fn() -> T) {
     let mut trie = (new_trie)();
     trie.set_root(TrieNodeV2::EmptyRoot, None, true).expect("set_root should succeed");
-    assert_eq!(trie.root(0), EMPTY_ROOT_HASH);
+    assert_eq!(trie.root(0, None), EMPTY_ROOT_HASH);
 }

--- a/crates/trie/sparse/tests/suite/take_updates.rs
+++ b/crates/trie/sparse/tests/suite/take_updates.rs
@@ -35,7 +35,7 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie>(new_trie: fn() 
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial branch hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Round 1: add a new leaf A under the shared prefix, root, take.
     let mut key_a = B256::ZERO;
@@ -44,7 +44,7 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie>(new_trie: fn() 
     let changeset_a: BTreeMap<B256, U256> = BTreeMap::from([(key_a, U256::from(999))]);
     let mut leaf_updates_a = SuiteTestHarness::leaf_updates(&changeset_a);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_a);
-    let _ = trie.root();
+    let _ = trie.root(0);
     let updates1 = trie.take_updates();
 
     assert!(
@@ -67,7 +67,7 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie>(new_trie: fn() 
     let changeset_b: BTreeMap<B256, U256> = BTreeMap::from([(key_b, U256::from(888))]);
     let mut leaf_updates_b = SuiteTestHarness::leaf_updates(&changeset_b);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_b);
-    let _ = trie.root();
+    let _ = trie.root(0);
     let updates2 = trie.take_updates();
 
     assert!(
@@ -129,7 +129,7 @@ pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial branch hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Drain initial updates before the mutation under test.
     let _ = trie.take_updates();
@@ -155,7 +155,7 @@ pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let _ = trie.root();
+    let _ = trie.root(0);
     let updates = trie.take_updates();
 
     // updated_nodes should contain at least the branch at [1,0] (modified group).
@@ -235,14 +235,14 @@ pub(super) fn test_take_updates_cross_cancellation_across_root_calls<T: SparseTr
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial branch hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Changeset 1: insert key_new_a and key_new_b.
     let changeset1: BTreeMap<B256, U256> =
         [(key_new_a, val), (key_new_b, val)].into_iter().collect();
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset1);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Do NOT call take_updates() — updates accumulate across root() calls.
 
@@ -251,7 +251,7 @@ pub(super) fn test_take_updates_cross_cancellation_across_root_calls<T: SparseTr
         [(key_new_a, U256::ZERO), (key_new_b, U256::ZERO)].into_iter().collect();
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset2);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
-    let root_after_remove = trie.root();
+    let root_after_remove = trie.root(0);
 
     assert_eq!(
         harness.original_root(),
@@ -293,7 +293,7 @@ pub(super) fn test_take_updates_no_duplicate_updated_and_removed_nodes<T: Sparse
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root();
+    let _ = trie.root(0);
 
     // Step 1: Remove key_c — with only 3 keys under the root branch, removing one causes
     // structural changes (branch may collapse or lose a child).
@@ -312,7 +312,7 @@ pub(super) fn test_take_updates_no_duplicate_updated_and_removed_nodes<T: Sparse
     harness.reveal_and_update(&mut trie, &mut insert_updates);
 
     // Finalize and take updates.
-    let _ = trie.root();
+    let _ = trie.root(0);
     let updates = trie.take_updates();
 
     // The two sets must be mutually exclusive — no path in both.

--- a/crates/trie/sparse/tests/suite/take_updates.rs
+++ b/crates/trie/sparse/tests/suite/take_updates.rs
@@ -35,7 +35,7 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie>(new_trie: fn() 
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial branch hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Round 1: add a new leaf A under the shared prefix, root, take.
     let mut key_a = B256::ZERO;
@@ -44,7 +44,7 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie>(new_trie: fn() 
     let changeset_a: BTreeMap<B256, U256> = BTreeMap::from([(key_a, U256::from(999))]);
     let mut leaf_updates_a = SuiteTestHarness::leaf_updates(&changeset_a);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_a);
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
     let updates1 = trie.take_updates();
 
     assert!(
@@ -67,7 +67,7 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie>(new_trie: fn() 
     let changeset_b: BTreeMap<B256, U256> = BTreeMap::from([(key_b, U256::from(888))]);
     let mut leaf_updates_b = SuiteTestHarness::leaf_updates(&changeset_b);
     harness.reveal_and_update(&mut trie, &mut leaf_updates_b);
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
     let updates2 = trie.take_updates();
 
     assert!(
@@ -129,7 +129,7 @@ pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial branch hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Drain initial updates before the mutation under test.
     let _ = trie.take_updates();
@@ -155,7 +155,7 @@ pub(super) fn test_take_updates_contains_updated_and_removed_nodes<T: SparseTrie
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
     let updates = trie.take_updates();
 
     // updated_nodes should contain at least the branch at [1,0] (modified group).
@@ -235,14 +235,14 @@ pub(super) fn test_take_updates_cross_cancellation_across_root_calls<T: SparseTr
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial branch hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Changeset 1: insert key_new_a and key_new_b.
     let changeset1: BTreeMap<B256, U256> =
         [(key_new_a, val), (key_new_b, val)].into_iter().collect();
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset1);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Do NOT call take_updates() — updates accumulate across root() calls.
 
@@ -251,7 +251,7 @@ pub(super) fn test_take_updates_cross_cancellation_across_root_calls<T: SparseTr
         [(key_new_a, U256::ZERO), (key_new_b, U256::ZERO)].into_iter().collect();
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset2);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
-    let root_after_remove = trie.root(0);
+    let root_after_remove = trie.root(0, None);
 
     assert_eq!(
         harness.original_root(),
@@ -293,7 +293,7 @@ pub(super) fn test_take_updates_no_duplicate_updated_and_removed_nodes<T: Sparse
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Cache initial hashes.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
 
     // Step 1: Remove key_c — with only 3 keys under the root branch, removing one causes
     // structural changes (branch may collapse or lose a child).
@@ -312,7 +312,7 @@ pub(super) fn test_take_updates_no_duplicate_updated_and_removed_nodes<T: Sparse
     harness.reveal_and_update(&mut trie, &mut insert_updates);
 
     // Finalize and take updates.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
     let updates = trie.take_updates();
 
     // The two sets must be mutually exclusive — no path in both.

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -364,13 +364,22 @@ pub(super) fn test_remove_last_leaf_produces_empty_root<T: SparseTrie>(new_trie:
 
     let harness = SuiteTestHarness::new(base_storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
+    trie.root(10, None);
 
     // Remove the only leaf.
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root(0, None);
+    let root = trie.root(20, Some(20));
     assert_eq!(root, EMPTY_ROOT_HASH, "removing the only leaf should produce EMPTY_ROOT_HASH");
+    assert!(trie.is_root_cached());
+    assert!(!trie.root_is_prunable(), "the epoch cutoff is strict");
+
+    assert_eq!(trie.root(21, Some(20)), EMPTY_ROOT_HASH);
+    assert!(!trie.root_is_prunable(), "re-hashing must preserve the cached empty-root epoch");
+
+    assert_eq!(trie.root(21, Some(21)), EMPTY_ROOT_HASH);
+    assert!(trie.root_is_prunable());
 }
 
 /// Build 6 leaves then remove one-by-one, verifying root at each

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -27,7 +27,7 @@ pub(super) fn test_update_leaves_insert_new_leaf<T: SparseTrie>(new_trie: fn() -
     // The update map should be drained on success.
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful insert");
 
-    let root = trie.root();
+    let root = trie.root(0);
 
     // Compute expected root with all 4 leaves.
     let expected_storage = BTreeMap::from([
@@ -66,7 +66,7 @@ pub(super) fn test_update_leaves_modify_existing_leaf<T: SparseTrie>(new_trie: f
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful modify");
 
-    let root = trie.root();
+    let root = trie.root(0);
 
     // Compute expected root with the modified value.
     let expected_storage =
@@ -98,7 +98,7 @@ pub(super) fn test_insert_single_leaf_into_empty_trie<T: SparseTrie>(new_trie: f
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained");
 
-    let root = trie.root();
+    let root = trie.root(0);
 
     let expected_harness = SuiteTestHarness::new(BTreeMap::from([(key, value)]));
     assert_eq!(
@@ -136,7 +136,7 @@ pub(super) fn test_insert_multiple_leaves_into_empty_trie<T: SparseTrie>(new_tri
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained");
 
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, expected_harness.original_root(), "root should match reference 256-leaf trie");
 
     let updates = trie.take_updates();
@@ -174,7 +174,7 @@ pub(super) fn test_update_all_leaves_with_new_values<T: SparseTrie>(new_trie: fn
     })
     .expect("update_leaves should succeed");
 
-    let hash1 = trie.root();
+    let hash1 = trie.root(0);
     assert_eq!(hash1, expected_old.original_root(), "hash1 should match reference with old values");
 
     // Update all 256 keys with new values.
@@ -184,7 +184,7 @@ pub(super) fn test_update_all_leaves_with_new_values<T: SparseTrie>(new_trie: fn
     })
     .expect("update_leaves should succeed");
 
-    let hash2 = trie.root();
+    let hash2 = trie.root(0);
     assert_eq!(hash2, expected_new.original_root(), "hash2 should match reference with new values");
     assert_ne!(hash1, hash2, "roots should differ after updating all values");
 }
@@ -212,7 +212,7 @@ pub(super) fn test_two_leaves_at_adjacent_keys_root_correctness<T: SparseTrie>(
         panic!("no proof callback expected on empty trie");
     })
     .expect("update_leaves should succeed");
-    trie.root();
+    trie.root(0);
 
     // Insert second leaf and compute root.
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_51, value)]));
@@ -220,7 +220,7 @@ pub(super) fn test_two_leaves_at_adjacent_keys_root_correctness<T: SparseTrie>(
         panic!("no proof callback expected — all paths already revealed");
     })
     .expect("update_leaves should succeed");
-    let root = trie.root();
+    let root = trie.root(0);
 
     let expected = SuiteTestHarness::new(BTreeMap::from([(key_50, value), (key_51, value)]));
     assert_eq!(root, expected.original_root(), "root should match reference two-leaf trie");
@@ -253,7 +253,7 @@ pub(super) fn test_update_leaves_remove_leaf<T: SparseTrie>(new_trie: fn() -> T)
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful removal");
 
-    let root = trie.root();
+    let root = trie.root(0);
 
     // Expected: reference trie with only key1 and key3.
     let expected_storage = BTreeMap::from([(key1, U256::from(1)), (key3, U256::from(3))]);
@@ -299,7 +299,7 @@ pub(super) fn test_remove_leaf_branch_collapses_to_extension<T: SparseTrie>(new_
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_537, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root();
+    let root = trie.root(0);
 
     // Expected: reference trie with only the two remaining leaves.
     let expected_storage = BTreeMap::from([(key_50231, U256::from(1)), (key_50233, U256::from(2))]);
@@ -326,14 +326,14 @@ pub(super) fn test_remove_leaf_branch_collapses_to_leaf<T: SparseTrie>(new_trie:
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to cache hashes and drain initial updates.
-    let _ = trie.root();
+    let _ = trie.root(0);
     let _ = trie.take_updates();
 
     // Remove key_a → branch collapses to a single leaf (key_b).
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_a, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root();
+    let root = trie.root(0);
 
     // Expected: reference trie with only key_b.
     let expected_storage = BTreeMap::from([(key_b, U256::from(200))]);
@@ -369,7 +369,7 @@ pub(super) fn test_remove_last_leaf_produces_empty_root<T: SparseTrie>(new_trie:
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, EMPTY_ROOT_HASH, "removing the only leaf should produce EMPTY_ROOT_HASH");
 }
 
@@ -407,7 +407,7 @@ pub(super) fn test_insert_then_remove_sequence<T: SparseTrie>(new_trie: fn() -> 
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&base_storage);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root_after_insert = trie.root();
+    let root_after_insert = trie.root(0);
     assert_eq!(root_after_insert, harness.original_root(), "root after inserting all 6 leaves");
 
     // Remove leaves one at a time in the same order as the original test: k3, k1, k4, k6, k2, k5.
@@ -418,7 +418,7 @@ pub(super) fn test_insert_then_remove_sequence<T: SparseTrie>(new_trie: fn() -> 
         let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
         harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-        let root = trie.root();
+        let root = trie.root(0);
         assert_eq!(
             root,
             harness.original_root(),
@@ -429,7 +429,7 @@ pub(super) fn test_insert_then_remove_sequence<T: SparseTrie>(new_trie: fn() -> 
     }
 
     // After all removals, trie should be empty.
-    assert_eq!(trie.root(), EMPTY_ROOT_HASH, "final root should be EMPTY_ROOT_HASH");
+    assert_eq!(trie.root(0), EMPTY_ROOT_HASH, "final root should be EMPTY_ROOT_HASH");
 }
 
 /// Removing a nonexistent key should not invalidate cached hashes.
@@ -449,7 +449,7 @@ pub(super) fn test_remove_nonexistent_leaf_preserves_hashes<T: SparseTrie>(new_t
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root to cache hashes on all nodes.
-    let root_before = trie.root();
+    let root_before = trie.root(0);
     assert_eq!(root_before, harness.original_root());
 
     // Try to remove a key that doesn't exist in the trie.
@@ -459,7 +459,7 @@ pub(super) fn test_remove_nonexistent_leaf_preserves_hashes<T: SparseTrie>(new_t
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Root should be identical — cached hashes should be preserved.
-    let root_after = trie.root();
+    let root_after = trie.root(0);
     assert_eq!(
         root_before, root_after,
         "removing a nonexistent leaf should preserve cached hashes and return the same root"
@@ -578,7 +578,7 @@ pub(super) fn test_update_leaves_retry_after_reveal<T: SparseTrie>(new_trie: fn(
     expected_storage.insert(target_key, new_value);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -637,7 +637,7 @@ pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie>(ne
     expected_storage.remove(&revealed_key);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -833,7 +833,7 @@ pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie>(new_trie:
     let harness = SuiteTestHarness::new(base_storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before = trie.root();
+    let root_before = trie.root(0);
 
     // Call update_leaves with Touched for an existing key.
     let mut leaf_updates: B256Map<LeafUpdate> = once((key2, LeafUpdate::Touched)).collect();
@@ -849,7 +849,7 @@ pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie>(new_trie:
     // Key should be drained from the map.
     assert!(leaf_updates.is_empty(), "Touched key should be drained from updates map");
     // Root should be unchanged.
-    assert_eq!(trie.root(), root_before, "root should be unchanged after Touched no-op");
+    assert_eq!(trie.root(0), root_before, "root should be unchanged after Touched no-op");
 }
 
 /// `LeafUpdate::Touched` on a path with a blinded node should
@@ -880,7 +880,7 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie>(
     // Reveal only group_a keys, leaving group_b's subtrie blinded.
     let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false, new_trie);
 
-    let root_before = trie.root();
+    let root_before = trie.root(0);
 
     // Submit Touched for a key in group_b's blinded subtrie.
     let target_key = {
@@ -901,7 +901,7 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie>(
     // Key should remain in the updates map.
     assert!(!leaf_updates.is_empty(), "Touched key should remain in map when blinded");
     // Root should be unchanged (no mutation).
-    assert_eq!(trie.root(), root_before, "root should be unchanged after Touched on blinded path");
+    assert_eq!(trie.root(0), root_before, "root should be unchanged after Touched on blinded path");
 }
 
 /// Touched on a nonexistent key in an empty trie is drained silently.
@@ -945,7 +945,7 @@ pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: Sparse
     let harness = SuiteTestHarness::new(base_storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before = trie.root();
+    let root_before = trie.root(0);
 
     // Key 0x50 does not exist in the trie but its path is fully revealed (no blinded nodes).
     let nonexistent_key = B256::with_last_byte(0x50);
@@ -960,7 +960,7 @@ pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: Sparse
 
     assert!(leaf_updates.is_empty(), "Touched key should be drained from updates map");
     assert_eq!(callback_count, 0, "no callback should fire for Touched on revealed path");
-    assert_eq!(trie.root(), root_before, "root should be unchanged after Touched no-op");
+    assert_eq!(trie.root(0), root_before, "root should be unchanged after Touched no-op");
     assert_eq!(
         trie.get_leaf_value(&Nibbles::unpack(nonexistent_key)),
         None,
@@ -1023,7 +1023,7 @@ pub(super) fn test_update_leaves_multiple_mixed_updates<T: SparseTrie>(new_trie:
     // apply_changeset merged into existing storage — need a fresh harness for the expected state.
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -1075,7 +1075,7 @@ pub(super) fn test_remove_leaf_marks_ancestors_dirty_unconditionally<T: SparseTr
 
     // Call root() — all ancestors of the removed leaf must be marked dirty
     // even though no hashes were previously cached.
-    let root = trie.root();
+    let root = trie.root(0);
 
     // Build reference trie with same final state.
     let mut expected_storage = storage;
@@ -1145,7 +1145,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     // Insert all leaves.
     let mut insert_updates = SuiteTestHarness::leaf_updates(&initial_storage);
     harness.reveal_and_update(&mut trie, &mut insert_updates);
-    let root1 = trie.root();
+    let root1 = trie.root(0);
     assert_eq!(root1, harness.original_root(), "initial root should match");
 
     // Step 1: Remove key_c to collapse the branch at 0x10..
@@ -1153,7 +1153,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
-    let root2 = trie.root();
+    let root2 = trie.root(0);
     assert_eq!(root2, harness.original_root(), "root after removal should match");
 
     // Step 2: Re-insert key_c with a new value — this re-creates the branch.
@@ -1161,7 +1161,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     harness.apply_changeset(reinsert.clone());
     let mut reinsert_updates = SuiteTestHarness::leaf_updates(&reinsert);
     harness.reveal_and_update(&mut trie, &mut reinsert_updates);
-    let root3 = trie.root();
+    let root3 = trie.root(0);
     assert_eq!(root3, harness.original_root(), "root after re-insert should match");
 
     // Step 3: Update key_a — previously could be orphaned if branch collapse
@@ -1170,7 +1170,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     harness.apply_changeset(update.clone());
     let mut update_updates = SuiteTestHarness::leaf_updates(&update);
     harness.reveal_and_update(&mut trie, &mut update_updates);
-    let root4 = trie.root();
+    let root4 = trie.root(0);
     assert_eq!(root4, harness.original_root(), "root after updating key_a should match");
 
     // Verify the invariant: every key with a value must be findable via find_leaf.
@@ -1218,7 +1218,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
 
-    let root_after_removal = trie.root();
+    let root_after_removal = trie.root(0);
     assert_eq!(
         root_after_removal,
         harness.original_root(),
@@ -1240,7 +1240,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);
 
-    let root_after_update = trie.root();
+    let root_after_update = trie.root(0);
     assert_eq!(
         root_after_update,
         harness.original_root(),
@@ -1270,7 +1270,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute initial root and drain initial updates.
-    let _ = trie.root();
+    let _ = trie.root(0);
     let _ = trie.take_updates();
 
     // Prune: retain only keys[0] and keys[1] (nibbles 0x0 and 0x1).
@@ -1279,7 +1279,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     trie.prune(&retained);
 
     // Verify root is unchanged after prune.
-    let root_after_prune = trie.root();
+    let root_after_prune = trie.root(0);
     assert_eq!(root_after_prune, harness.original_root(), "root should be unchanged after prune");
 
     // Now remove keys[0] — this leaves keys[1] and all the blinded subtries.
@@ -1290,7 +1290,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
 
-    let root_after_removal = trie.root();
+    let root_after_removal = trie.root(0);
     assert_eq!(
         root_after_removal,
         harness.original_root(),
@@ -1313,7 +1313,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);
 
-    let root_after_mod = trie.root();
+    let root_after_mod = trie.root(0);
     assert_eq!(
         root_after_mod,
         harness.original_root(),
@@ -1396,7 +1396,7 @@ pub(super) fn test_branch_collapse_multi_empty_subtries_blinded_remaining<T: Spa
 
     // Root should match reference trie with only key_d8.
     let expected_harness = SuiteTestHarness::new(BTreeMap::from([(key_d8, U256::from(2))]));
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -1451,7 +1451,7 @@ pub(super) fn test_subtrie_collapse_touched_with_blinded_sibling<T: SparseTrie>(
     let mut trie: T = harness.init_trie_with_targets(&revealed_keys, false, new_trie);
 
     // Verify initial root matches.
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, harness.original_root(), "initial root mismatch");
 
     // Delete both 0xAB leaves + Touched on a third 0xAB key (not in the trie).
@@ -1473,7 +1473,7 @@ pub(super) fn test_subtrie_collapse_touched_with_blinded_sibling<T: SparseTrie>(
     expected_storage.remove(&key_ab2);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let actual_root = trie.root();
+    let actual_root = trie.root(0);
     assert_eq!(actual_root, expected_harness.original_root(), "post-delete root mismatch");
 }
 
@@ -1514,7 +1514,7 @@ pub(super) fn test_subtrie_emptied_by_deletes_with_touched<T: SparseTrie>(new_tr
     let mut trie: T = harness.init_trie_with_targets(&all_keys, false, new_trie);
 
     // Verify initial root matches.
-    let root = trie.root();
+    let root = trie.root(0);
     assert_eq!(root, harness.original_root(), "initial root mismatch");
 
     // Delete both 0xAB leaves + Touched on a third 0xAB key (not in the trie).
@@ -1535,6 +1535,6 @@ pub(super) fn test_subtrie_emptied_by_deletes_with_touched<T: SparseTrie>(new_tr
     expected_storage.remove(&key_ab2);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let actual_root = trie.root();
+    let actual_root = trie.root(0);
     assert_eq!(actual_root, expected_harness.original_root(), "post-delete root mismatch");
 }

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -654,11 +654,7 @@ pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie>(ne
     );
 }
 
-/// Atomic rollback — node structure and `prefix_set` unchanged after
-/// removal of a revealed leaf when the sibling is blinded.
-///
-/// Same scenario as the value-preservation test, but additionally checks that
-/// `size_hint` (node count) is unchanged and the update remains in the map.
+/// Atomic rollback after removal of a revealed leaf when the sibling is blinded.
 pub(super) fn test_update_leaves_removal_branch_collapse_blinded_sibling<T: SparseTrie>(
     new_trie: fn() -> T,
 ) {
@@ -687,7 +683,6 @@ pub(super) fn test_update_leaves_removal_branch_collapse_blinded_sibling<T: Spar
     let revealed_path = Nibbles::unpack(revealed_key);
     let original_value = trie.get_leaf_value(&revealed_path).cloned();
     assert!(original_value.is_some(), "revealed leaf should exist");
-    let node_count_before = trie.size_hint();
 
     // Attempt removal — branch collapse needs the blinded sibling, so it fails atomically.
     let mut leaf_updates =
@@ -704,9 +699,6 @@ pub(super) fn test_update_leaves_removal_branch_collapse_blinded_sibling<T: Spar
 
     // Update should remain in the map (not drained).
     assert!(!leaf_updates.is_empty(), "update should remain in map after blinded hit");
-
-    // Node count should be unchanged (no structural modification).
-    assert_eq!(trie.size_hint(), node_count_before, "node count should be unchanged");
 
     // Leaf value should be preserved (atomic rollback).
     let value_after = trie.get_leaf_value(&revealed_path);
@@ -1261,15 +1253,13 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
     );
 }
 
-/// Removal of a leaf should never corrupt blinded/pruned subtries.
+/// Removal of a leaf should never corrupt blinded subtries.
 ///
 /// When a branch collapses during leaf removal and the remaining child's value needs to be
 /// moved between subtries, the operation must not reveal (initialize) blind/unloaded subtries.
 /// Either the removal succeeds cleanly or it requests proofs for the blinded area.
 pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new_trie: fn() -> T) {
     // Create a trie with 10 leaves across different first-nibble subtries.
-    // We'll prune some subtries, then remove a leaf whose branch collapse
-    // involves a sibling in a pruned (blinded) subtrie.
     let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
     let mut keys = Vec::new();
     for i in 0u8..10 {
@@ -1280,22 +1270,13 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     }
 
     let mut harness = SuiteTestHarness::new(storage.clone());
-    let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
+    let mut trie: T = harness.init_trie_with_targets(&keys[..2], true, new_trie);
 
     // Compute initial root and drain initial updates.
     let _ = trie.root(0, None);
     let _ = trie.take_updates();
 
-    // Prune: retain only keys[0] and keys[1] (nibbles 0x0 and 0x1).
-    // All other subtries become blinded.
-    let retained: Vec<Nibbles> = [keys[0], keys[1]].iter().map(|k| Nibbles::unpack(*k)).collect();
-    trie.prune(&retained);
-
-    // Verify root is unchanged after prune.
-    let root_after_prune = trie.root(0, None);
-    assert_eq!(root_after_prune, harness.original_root(), "root should be unchanged after prune");
-
-    // Now remove keys[0] — this leaves keys[1] and all the blinded subtries.
+    // Remove keys[0] — this leaves keys[1] and all the blinded subtries.
     // The branch at the root still has multiple children (keys[1] + blinded children),
     // so this should not trigger a problematic branch collapse into blinded territory.
     let removal: BTreeMap<B256, U256> = once((keys[0], U256::ZERO)).collect();

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -27,7 +27,7 @@ pub(super) fn test_update_leaves_insert_new_leaf<T: SparseTrie>(new_trie: fn() -
     // The update map should be drained on success.
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful insert");
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     // Compute expected root with all 4 leaves.
     let expected_storage = BTreeMap::from([
@@ -66,7 +66,7 @@ pub(super) fn test_update_leaves_modify_existing_leaf<T: SparseTrie>(new_trie: f
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful modify");
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     // Compute expected root with the modified value.
     let expected_storage =
@@ -98,7 +98,7 @@ pub(super) fn test_insert_single_leaf_into_empty_trie<T: SparseTrie>(new_trie: f
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained");
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     let expected_harness = SuiteTestHarness::new(BTreeMap::from([(key, value)]));
     assert_eq!(
@@ -136,7 +136,7 @@ pub(super) fn test_insert_multiple_leaves_into_empty_trie<T: SparseTrie>(new_tri
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained");
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, expected_harness.original_root(), "root should match reference 256-leaf trie");
 
     let updates = trie.take_updates();
@@ -174,7 +174,7 @@ pub(super) fn test_update_all_leaves_with_new_values<T: SparseTrie>(new_trie: fn
     })
     .expect("update_leaves should succeed");
 
-    let hash1 = trie.root(0);
+    let hash1 = trie.root(0, None);
     assert_eq!(hash1, expected_old.original_root(), "hash1 should match reference with old values");
 
     // Update all 256 keys with new values.
@@ -184,7 +184,7 @@ pub(super) fn test_update_all_leaves_with_new_values<T: SparseTrie>(new_trie: fn
     })
     .expect("update_leaves should succeed");
 
-    let hash2 = trie.root(0);
+    let hash2 = trie.root(0, None);
     assert_eq!(hash2, expected_new.original_root(), "hash2 should match reference with new values");
     assert_ne!(hash1, hash2, "roots should differ after updating all values");
 }
@@ -212,7 +212,7 @@ pub(super) fn test_two_leaves_at_adjacent_keys_root_correctness<T: SparseTrie>(
         panic!("no proof callback expected on empty trie");
     })
     .expect("update_leaves should succeed");
-    trie.root(0);
+    trie.root(0, None);
 
     // Insert second leaf and compute root.
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_51, value)]));
@@ -220,7 +220,7 @@ pub(super) fn test_two_leaves_at_adjacent_keys_root_correctness<T: SparseTrie>(
         panic!("no proof callback expected — all paths already revealed");
     })
     .expect("update_leaves should succeed");
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     let expected = SuiteTestHarness::new(BTreeMap::from([(key_50, value), (key_51, value)]));
     assert_eq!(root, expected.original_root(), "root should match reference two-leaf trie");
@@ -253,7 +253,7 @@ pub(super) fn test_update_leaves_remove_leaf<T: SparseTrie>(new_trie: fn() -> T)
 
     assert!(leaf_updates.is_empty(), "leaf_updates should be drained after successful removal");
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     // Expected: reference trie with only key1 and key3.
     let expected_storage = BTreeMap::from([(key1, U256::from(1)), (key3, U256::from(3))]);
@@ -299,7 +299,7 @@ pub(super) fn test_remove_leaf_branch_collapses_to_extension<T: SparseTrie>(new_
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_537, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     // Expected: reference trie with only the two remaining leaves.
     let expected_storage = BTreeMap::from([(key_50231, U256::from(1)), (key_50233, U256::from(2))]);
@@ -326,14 +326,14 @@ pub(super) fn test_remove_leaf_branch_collapses_to_leaf<T: SparseTrie>(new_trie:
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to cache hashes and drain initial updates.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
     let _ = trie.take_updates();
 
     // Remove key_a → branch collapses to a single leaf (key_b).
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key_a, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     // Expected: reference trie with only key_b.
     let expected_storage = BTreeMap::from([(key_b, U256::from(200))]);
@@ -369,7 +369,7 @@ pub(super) fn test_remove_last_leaf_produces_empty_root<T: SparseTrie>(new_trie:
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, EMPTY_ROOT_HASH, "removing the only leaf should produce EMPTY_ROOT_HASH");
 }
 
@@ -407,7 +407,7 @@ pub(super) fn test_insert_then_remove_sequence<T: SparseTrie>(new_trie: fn() -> 
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&base_storage);
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-    let root_after_insert = trie.root(0);
+    let root_after_insert = trie.root(0, None);
     assert_eq!(root_after_insert, harness.original_root(), "root after inserting all 6 leaves");
 
     // Remove leaves one at a time in the same order as the original test: k3, k1, k4, k6, k2, k5.
@@ -418,7 +418,7 @@ pub(super) fn test_insert_then_remove_sequence<T: SparseTrie>(new_trie: fn() -> 
         let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
         harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
-        let root = trie.root(0);
+        let root = trie.root(0, None);
         assert_eq!(
             root,
             harness.original_root(),
@@ -429,7 +429,7 @@ pub(super) fn test_insert_then_remove_sequence<T: SparseTrie>(new_trie: fn() -> 
     }
 
     // After all removals, trie should be empty.
-    assert_eq!(trie.root(0), EMPTY_ROOT_HASH, "final root should be EMPTY_ROOT_HASH");
+    assert_eq!(trie.root(0, None), EMPTY_ROOT_HASH, "final root should be EMPTY_ROOT_HASH");
 }
 
 /// Removing a nonexistent key should not invalidate cached hashes.
@@ -449,7 +449,7 @@ pub(super) fn test_remove_nonexistent_leaf_preserves_hashes<T: SparseTrie>(new_t
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root to cache hashes on all nodes.
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
     assert_eq!(root_before, harness.original_root());
 
     // Try to remove a key that doesn't exist in the trie.
@@ -459,7 +459,7 @@ pub(super) fn test_remove_nonexistent_leaf_preserves_hashes<T: SparseTrie>(new_t
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Root should be identical — cached hashes should be preserved.
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
     assert_eq!(
         root_before, root_after,
         "removing a nonexistent leaf should preserve cached hashes and return the same root"
@@ -578,7 +578,7 @@ pub(super) fn test_update_leaves_retry_after_reveal<T: SparseTrie>(new_trie: fn(
     expected_storage.insert(target_key, new_value);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -637,7 +637,7 @@ pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie>(ne
     expected_storage.remove(&revealed_key);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -833,7 +833,7 @@ pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie>(new_trie:
     let harness = SuiteTestHarness::new(base_storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
 
     // Call update_leaves with Touched for an existing key.
     let mut leaf_updates: B256Map<LeafUpdate> = once((key2, LeafUpdate::Touched)).collect();
@@ -849,7 +849,7 @@ pub(super) fn test_update_leaves_touched_fully_revealed<T: SparseTrie>(new_trie:
     // Key should be drained from the map.
     assert!(leaf_updates.is_empty(), "Touched key should be drained from updates map");
     // Root should be unchanged.
-    assert_eq!(trie.root(0), root_before, "root should be unchanged after Touched no-op");
+    assert_eq!(trie.root(0, None), root_before, "root should be unchanged after Touched no-op");
 }
 
 /// `LeafUpdate::Touched` on a path with a blinded node should
@@ -880,7 +880,7 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie>(
     // Reveal only group_a keys, leaving group_b's subtrie blinded.
     let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false, new_trie);
 
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
 
     // Submit Touched for a key in group_b's blinded subtrie.
     let target_key = {
@@ -901,7 +901,11 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie>(
     // Key should remain in the updates map.
     assert!(!leaf_updates.is_empty(), "Touched key should remain in map when blinded");
     // Root should be unchanged (no mutation).
-    assert_eq!(trie.root(0), root_before, "root should be unchanged after Touched on blinded path");
+    assert_eq!(
+        trie.root(0, None),
+        root_before,
+        "root should be unchanged after Touched on blinded path"
+    );
 }
 
 /// Touched on a nonexistent key in an empty trie is drained silently.
@@ -945,7 +949,7 @@ pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: Sparse
     let harness = SuiteTestHarness::new(base_storage);
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
 
     // Key 0x50 does not exist in the trie but its path is fully revealed (no blinded nodes).
     let nonexistent_key = B256::with_last_byte(0x50);
@@ -960,7 +964,7 @@ pub(super) fn test_update_leaves_touched_nonexistent_in_populated_trie<T: Sparse
 
     assert!(leaf_updates.is_empty(), "Touched key should be drained from updates map");
     assert_eq!(callback_count, 0, "no callback should fire for Touched on revealed path");
-    assert_eq!(trie.root(0), root_before, "root should be unchanged after Touched no-op");
+    assert_eq!(trie.root(0, None), root_before, "root should be unchanged after Touched no-op");
     assert_eq!(
         trie.get_leaf_value(&Nibbles::unpack(nonexistent_key)),
         None,
@@ -1023,7 +1027,7 @@ pub(super) fn test_update_leaves_multiple_mixed_updates<T: SparseTrie>(new_trie:
     // apply_changeset merged into existing storage — need a fresh harness for the expected state.
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -1075,7 +1079,7 @@ pub(super) fn test_remove_leaf_marks_ancestors_dirty_unconditionally<T: SparseTr
 
     // Call root() — all ancestors of the removed leaf must be marked dirty
     // even though no hashes were previously cached.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
 
     // Build reference trie with same final state.
     let mut expected_storage = storage;
@@ -1145,7 +1149,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     // Insert all leaves.
     let mut insert_updates = SuiteTestHarness::leaf_updates(&initial_storage);
     harness.reveal_and_update(&mut trie, &mut insert_updates);
-    let root1 = trie.root(0);
+    let root1 = trie.root(0, None);
     assert_eq!(root1, harness.original_root(), "initial root should match");
 
     // Step 1: Remove key_c to collapse the branch at 0x10..
@@ -1153,7 +1157,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     harness.apply_changeset(removal.clone());
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
-    let root2 = trie.root(0);
+    let root2 = trie.root(0, None);
     assert_eq!(root2, harness.original_root(), "root after removal should match");
 
     // Step 2: Re-insert key_c with a new value — this re-creates the branch.
@@ -1161,7 +1165,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     harness.apply_changeset(reinsert.clone());
     let mut reinsert_updates = SuiteTestHarness::leaf_updates(&reinsert);
     harness.reveal_and_update(&mut trie, &mut reinsert_updates);
-    let root3 = trie.root(0);
+    let root3 = trie.root(0, None);
     assert_eq!(root3, harness.original_root(), "root after re-insert should match");
 
     // Step 3: Update key_a — previously could be orphaned if branch collapse
@@ -1170,7 +1174,7 @@ pub(super) fn test_orphaned_value_update_falls_through_to_full_insertion<T: Spar
     harness.apply_changeset(update.clone());
     let mut update_updates = SuiteTestHarness::leaf_updates(&update);
     harness.reveal_and_update(&mut trie, &mut update_updates);
-    let root4 = trie.root(0);
+    let root4 = trie.root(0, None);
     assert_eq!(root4, harness.original_root(), "root after updating key_a should match");
 
     // Verify the invariant: every key with a value must be findable via find_leaf.
@@ -1218,7 +1222,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
 
-    let root_after_removal = trie.root(0);
+    let root_after_removal = trie.root(0, None);
     assert_eq!(
         root_after_removal,
         harness.original_root(),
@@ -1240,7 +1244,7 @@ pub(super) fn test_branch_collapse_updates_leaf_key_len_across_subtries<T: Spars
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);
 
-    let root_after_update = trie.root(0);
+    let root_after_update = trie.root(0, None);
     assert_eq!(
         root_after_update,
         harness.original_root(),
@@ -1270,7 +1274,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute initial root and drain initial updates.
-    let _ = trie.root(0);
+    let _ = trie.root(0, None);
     let _ = trie.take_updates();
 
     // Prune: retain only keys[0] and keys[1] (nibbles 0x0 and 0x1).
@@ -1279,7 +1283,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     trie.prune(&retained);
 
     // Verify root is unchanged after prune.
-    let root_after_prune = trie.root(0);
+    let root_after_prune = trie.root(0, None);
     assert_eq!(root_after_prune, harness.original_root(), "root should be unchanged after prune");
 
     // Now remove keys[0] — this leaves keys[1] and all the blinded subtries.
@@ -1290,7 +1294,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     let mut removal_updates = SuiteTestHarness::leaf_updates(&removal);
     harness.reveal_and_update(&mut trie, &mut removal_updates);
 
-    let root_after_removal = trie.root(0);
+    let root_after_removal = trie.root(0, None);
     assert_eq!(
         root_after_removal,
         harness.original_root(),
@@ -1313,7 +1317,7 @@ pub(super) fn test_remove_leaf_does_not_reveal_blind_subtries<T: SparseTrie>(new
     let mut mod_updates = SuiteTestHarness::leaf_updates(&modification);
     harness.reveal_and_update(&mut trie, &mut mod_updates);
 
-    let root_after_mod = trie.root(0);
+    let root_after_mod = trie.root(0, None);
     assert_eq!(
         root_after_mod,
         harness.original_root(),
@@ -1396,7 +1400,7 @@ pub(super) fn test_branch_collapse_multi_empty_subtries_blinded_remaining<T: Spa
 
     // Root should match reference trie with only key_d8.
     let expected_harness = SuiteTestHarness::new(BTreeMap::from([(key_d8, U256::from(2))]));
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(
         root,
         expected_harness.original_root(),
@@ -1451,7 +1455,7 @@ pub(super) fn test_subtrie_collapse_touched_with_blinded_sibling<T: SparseTrie>(
     let mut trie: T = harness.init_trie_with_targets(&revealed_keys, false, new_trie);
 
     // Verify initial root matches.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, harness.original_root(), "initial root mismatch");
 
     // Delete both 0xAB leaves + Touched on a third 0xAB key (not in the trie).
@@ -1473,7 +1477,7 @@ pub(super) fn test_subtrie_collapse_touched_with_blinded_sibling<T: SparseTrie>(
     expected_storage.remove(&key_ab2);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let actual_root = trie.root(0);
+    let actual_root = trie.root(0, None);
     assert_eq!(actual_root, expected_harness.original_root(), "post-delete root mismatch");
 }
 
@@ -1514,7 +1518,7 @@ pub(super) fn test_subtrie_emptied_by_deletes_with_touched<T: SparseTrie>(new_tr
     let mut trie: T = harness.init_trie_with_targets(&all_keys, false, new_trie);
 
     // Verify initial root matches.
-    let root = trie.root(0);
+    let root = trie.root(0, None);
     assert_eq!(root, harness.original_root(), "initial root mismatch");
 
     // Delete both 0xAB leaves + Touched on a third 0xAB key (not in the trie).
@@ -1535,6 +1539,6 @@ pub(super) fn test_subtrie_emptied_by_deletes_with_touched<T: SparseTrie>(new_tr
     expected_storage.remove(&key_ab2);
     let expected_harness = SuiteTestHarness::new(expected_storage);
 
-    let actual_root = trie.root(0);
+    let actual_root = trie.root(0, None);
     assert_eq!(actual_root, expected_harness.original_root(), "post-delete root mismatch");
 }

--- a/crates/trie/sparse/tests/suite/wipe_clear.rs
+++ b/crates/trie/sparse/tests/suite/wipe_clear.rs
@@ -15,13 +15,13 @@ pub(super) fn test_wipe_resets_to_empty_root<T: SparseTrie>(new_trie: fn() -> T)
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root to confirm the trie is populated.
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
     assert_eq!(root_before, harness.original_root());
     assert_ne!(root_before, EMPTY_ROOT_HASH);
 
     // Wipe and verify empty root.
     trie.wipe();
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
     assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
 }
 
@@ -42,13 +42,13 @@ pub(super) fn test_clear_resets_trie_but_preserves_update_tracking<T: SparseTrie
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to populate the trie fully.
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
     assert_eq!(root_before, harness.original_root());
     assert_ne!(root_before, EMPTY_ROOT_HASH);
 
     // Clear and verify empty root.
     trie.clear();
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
     assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
 
     // take_updates should return empty (non-wiped) updates since tracking is preserved.
@@ -73,7 +73,7 @@ pub(super) fn test_wipe_produces_wiped_updates<T: SparseTrie>(new_trie: fn() -> 
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to populate the trie fully.
-    let root_before = trie.root(0);
+    let root_before = trie.root(0, None);
     assert_eq!(root_before, harness.original_root());
     assert_ne!(root_before, EMPTY_ROOT_HASH);
 
@@ -81,7 +81,7 @@ pub(super) fn test_wipe_produces_wiped_updates<T: SparseTrie>(new_trie: fn() -> 
     trie.wipe();
 
     // Root should be EMPTY_ROOT_HASH after wipe.
-    let root_after = trie.root(0);
+    let root_after = trie.root(0, None);
     assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
 
     // take_updates should return updates with the wiped flag set.
@@ -104,13 +104,13 @@ pub(super) fn test_clear_then_reuse_trie<T: SparseTrie>(new_trie: fn() -> T) {
     let harness_1 = SuiteTestHarness::new(storage_1);
     let mut trie: T = harness_1.init_trie_fully_revealed(false, new_trie);
 
-    let root_1 = trie.root(0);
+    let root_1 = trie.root(0, None);
     assert_eq!(root_1, harness_1.original_root());
     assert_ne!(root_1, EMPTY_ROOT_HASH);
 
     // Phase 2: clear the trie and verify empty.
     trie.clear();
-    assert_eq!(trie.root(0), EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
+    assert_eq!(trie.root(0, None), EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
 
     // Phase 3: build a completely different dataset with 3 leaves.
     let storage_2: BTreeMap<B256, U256> = BTreeMap::from([
@@ -138,7 +138,7 @@ pub(super) fn test_clear_then_reuse_trie<T: SparseTrie>(new_trie: fn() -> T) {
     harness_2.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Compute root and verify against reference.
-    let root_2 = trie.root(0);
+    let root_2 = trie.root(0, None);
 
     // Update the reference harness with the 4th leaf.
     harness_2.apply_changeset(changeset);

--- a/crates/trie/sparse/tests/suite/wipe_clear.rs
+++ b/crates/trie/sparse/tests/suite/wipe_clear.rs
@@ -15,13 +15,13 @@ pub(super) fn test_wipe_resets_to_empty_root<T: SparseTrie>(new_trie: fn() -> T)
     let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
 
     // Compute root to confirm the trie is populated.
-    let root_before = trie.root();
+    let root_before = trie.root(0);
     assert_eq!(root_before, harness.original_root());
     assert_ne!(root_before, EMPTY_ROOT_HASH);
 
     // Wipe and verify empty root.
     trie.wipe();
-    let root_after = trie.root();
+    let root_after = trie.root(0);
     assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
 }
 
@@ -42,13 +42,13 @@ pub(super) fn test_clear_resets_trie_but_preserves_update_tracking<T: SparseTrie
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to populate the trie fully.
-    let root_before = trie.root();
+    let root_before = trie.root(0);
     assert_eq!(root_before, harness.original_root());
     assert_ne!(root_before, EMPTY_ROOT_HASH);
 
     // Clear and verify empty root.
     trie.clear();
-    let root_after = trie.root();
+    let root_after = trie.root(0);
     assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
 
     // take_updates should return empty (non-wiped) updates since tracking is preserved.
@@ -73,7 +73,7 @@ pub(super) fn test_wipe_produces_wiped_updates<T: SparseTrie>(new_trie: fn() -> 
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
     // Compute root to populate the trie fully.
-    let root_before = trie.root();
+    let root_before = trie.root(0);
     assert_eq!(root_before, harness.original_root());
     assert_ne!(root_before, EMPTY_ROOT_HASH);
 
@@ -81,7 +81,7 @@ pub(super) fn test_wipe_produces_wiped_updates<T: SparseTrie>(new_trie: fn() -> 
     trie.wipe();
 
     // Root should be EMPTY_ROOT_HASH after wipe.
-    let root_after = trie.root();
+    let root_after = trie.root(0);
     assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
 
     // take_updates should return updates with the wiped flag set.
@@ -104,13 +104,13 @@ pub(super) fn test_clear_then_reuse_trie<T: SparseTrie>(new_trie: fn() -> T) {
     let harness_1 = SuiteTestHarness::new(storage_1);
     let mut trie: T = harness_1.init_trie_fully_revealed(false, new_trie);
 
-    let root_1 = trie.root();
+    let root_1 = trie.root(0);
     assert_eq!(root_1, harness_1.original_root());
     assert_ne!(root_1, EMPTY_ROOT_HASH);
 
     // Phase 2: clear the trie and verify empty.
     trie.clear();
-    assert_eq!(trie.root(), EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
+    assert_eq!(trie.root(0), EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
 
     // Phase 3: build a completely different dataset with 3 leaves.
     let storage_2: BTreeMap<B256, U256> = BTreeMap::from([
@@ -138,7 +138,7 @@ pub(super) fn test_clear_then_reuse_trie<T: SparseTrie>(new_trie: fn() -> T) {
     harness_2.reveal_and_update(&mut trie, &mut leaf_updates);
 
     // Compute root and verify against reference.
-    let root_2 = trie.root();
+    let root_2 = trie.root(0);
 
     // Update the reference harness with the 4th leaf.
     harness_2.apply_changeset(changeset);

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -251,7 +251,7 @@ where
 
             let storage_root =
                 if let Some(storage_trie) = sparse_trie.storage_trie_mut(&hashed_address) {
-                    storage_trie.root()
+                    storage_trie.root(0)
                 } else {
                     let record_root_node = !self.mode.is_canonical() ||
                         state

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -251,7 +251,7 @@ where
 
             let storage_root =
                 if let Some(storage_trie) = sparse_trie.storage_trie_mut(&hashed_address) {
-                    storage_trie.root(0)
+                    storage_trie.root(0, None)
                 } else {
                     let record_root_node = !self.mode.is_canonical() ||
                         state


### PR DESCRIPTION
Tracks epochs on cached sparse-trie nodes, including empty roots, with the sparse-trie task deriving the current epoch from the parent block number plus one. Empty roots cache the constant empty-root hash while retaining the epoch when they became empty, preventing recent storage tries from being evicted before in-memory descendants may reuse them. When a prune range is pending, final root calculation prunes older nodes in place, avoiding retained-path construction and arena clone/compaction.