### PR TITLE
feat(exex): let an `ExEx` catch up to the current head after a pause

### DIFF
--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -120,13 +120,9 @@ where
     }
 
     /// As [`set_notifications_with_head`](Self::set_notifications_with_head), but backfills up to
-    /// `local_head` rather than the head captured at launch.
-    pub fn set_notifications_with_head_and_local_head(
-        &mut self,
-        head: ExExHead,
-        local_head: BlockNumHash,
-    ) {
-        self.notifications.set_with_head_and_local_head(head, local_head);
+    /// the node's current canonical head rather than the head captured at launch.
+    pub fn catch_up_notifications_with_head(&mut self, head: ExExHead) -> eyre::Result<()> {
+        self.notifications.catch_up_with_head(head)
     }
 
     /// Sends an [`ExExEvent::FinishedHeight`] to the ExEx task manager letting it know that this

--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -119,6 +119,16 @@ where
         self.notifications.set_with_head(head);
     }
 
+    /// As [`set_notifications_with_head`](Self::set_notifications_with_head), but backfills up to
+    /// `local_head` rather than the head captured at launch.
+    pub fn set_notifications_with_head_and_local_head(
+        &mut self,
+        head: ExExHead,
+        local_head: BlockNumHash,
+    ) {
+        self.notifications.set_with_head_and_local_head(head, local_head);
+    }
+
     /// Sends an [`ExExEvent::FinishedHeight`] to the ExEx task manager letting it know that this
     /// ExEx has processed the corresponding block.
     ///

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -111,6 +111,30 @@ where
             )),
         }
     }
+
+    /// As [`set_with_head`](ExExNotificationsStream::set_with_head), but backfills up to
+    /// `local_head` rather than the head captured at construction. `local_head` must be a
+    /// canonical block the node has committed.
+    pub fn set_with_head_and_local_head(&mut self, exex_head: ExExHead, local_head: BlockNumHash) {
+        let current = std::mem::replace(&mut self.inner, ExExNotificationsInner::Invalid);
+        let (provider, evm_config, notifications, wal_handle) = match current {
+            ExExNotificationsInner::WithoutHead(n) => {
+                (n.provider, n.evm_config, n.notifications, n.wal_handle)
+            }
+            ExExNotificationsInner::WithHead(n) => {
+                (n.provider, n.evm_config, n.notifications, n.wal_handle)
+            }
+            ExExNotificationsInner::Invalid => unreachable!(),
+        };
+        self.inner = ExExNotificationsInner::WithHead(Box::new(ExExNotificationsWithHead::new(
+            local_head,
+            provider,
+            evm_config,
+            notifications,
+            wal_handle,
+            exex_head,
+        )));
+    }
 }
 
 impl<P, E> ExExNotificationsStream<E::Primitives> for ExExNotifications<P, E>
@@ -607,6 +631,79 @@ mod tests {
         );
 
         // Second notification is the actual notification that we sent before
+        assert_eq!(notifications.next().await.transpose()?, Some(notification));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_with_head_and_local_head_backfills_to_the_supplied_local_head() -> eyre::Result<()>
+    {
+        let mut rng = generators::rng();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let wal = Wal::new(temp_dir.path()).unwrap();
+
+        let provider_factory = create_test_provider_factory();
+        let genesis_hash = init_genesis(&provider_factory)?;
+        let genesis_block = provider_factory
+            .block(genesis_hash.into())?
+            .ok_or_else(|| eyre::eyre!("genesis block not found"))?;
+        let provider = BlockchainProvider::new(provider_factory.clone())?;
+
+        // The node advances to block 1 after the stream is constructed at genesis.
+        let node_head_block = random_block(
+            &mut rng,
+            genesis_block.number + 1,
+            BlockParams { parent: Some(genesis_hash), tx_count: Some(0), ..Default::default() },
+        )
+        .try_recover()?;
+        let local_head = node_head_block.num_hash();
+        let provider_rw = provider_factory.provider_rw()?;
+        provider_rw.insert_block(&node_head_block)?;
+        provider_rw.commit()?;
+
+        let exex_head =
+            ExExHead { block: BlockNumHash { number: genesis_block.number, hash: genesis_hash } };
+        let notification = ExExNotification::ChainCommitted {
+            new: Arc::new(Chain::new(
+                vec![random_block(
+                    &mut rng,
+                    local_head.number + 1,
+                    BlockParams { parent: Some(local_head.hash), ..Default::default() },
+                )
+                .try_recover()?],
+                Default::default(),
+                BTreeMap::new(),
+            )),
+        };
+        let (notifications_tx, notifications_rx) = mpsc::channel(1);
+        notifications_tx.send(notification.clone()).await?;
+
+        let evm_config = EthEvmConfig::mainnet();
+        // Construct with a stale head (genesis); the real head is block 1.
+        let mut notifications = ExExNotifications::new(
+            BlockNumHash { number: genesis_block.number, hash: genesis_hash },
+            provider.clone(),
+            evm_config.clone(),
+            notifications_rx,
+            wal.handle(),
+        );
+        notifications.set_with_head_and_local_head(exex_head, local_head);
+
+        // Backfill runs up to the supplied local head (block 1), which the stale
+        // construction-time head could not have reached.
+        assert_eq!(
+            notifications.next().await.transpose()?,
+            Some(ExExNotification::ChainCommitted {
+                new: Arc::new(
+                    BackfillJobFactory::new(evm_config, provider)
+                        .backfill(1..=1)
+                        .next()
+                        .ok_or_eyre("failed to backfill")??
+                )
+            })
+        );
         assert_eq!(notifications.next().await.transpose()?, Some(notification));
 
         Ok(())

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -89,6 +89,20 @@ where
     Invalid,
 }
 
+impl<P, E> ExExNotificationsInner<P, E>
+where
+    E: ConfigureEvm,
+{
+    /// Returns the provider of the underlying stream.
+    fn provider(&self) -> &P {
+        match self {
+            Self::WithoutHead(n) => &n.provider,
+            Self::WithHead(n) => &n.provider,
+            Self::Invalid => unreachable!(),
+        }
+    }
+}
+
 impl<P, E> ExExNotifications<P, E>
 where
     E: ConfigureEvm,
@@ -120,12 +134,7 @@ where
     {
         // Resolve the current canonical head before tearing down the stream state, so a failed
         // lookup leaves the stream untouched.
-        let provider = match &self.inner {
-            ExExNotificationsInner::WithoutHead(n) => &n.provider,
-            ExExNotificationsInner::WithHead(n) => &n.provider,
-            ExExNotificationsInner::Invalid => unreachable!(),
-        };
-        let local_head: BlockNumHash = provider.chain_info()?.into();
+        let local_head: BlockNumHash = self.inner.provider().chain_info()?.into();
 
         let current = std::mem::replace(&mut self.inner, ExExNotificationsInner::Invalid);
         let (provider, evm_config, notifications, wal_handle, backfill_thresholds) = match current {

--- a/crates/exex/exex/src/notifications.rs
+++ b/crates/exex/exex/src/notifications.rs
@@ -6,7 +6,7 @@ use reth_ethereum_primitives::EthPrimitives;
 use reth_evm::ConfigureEvm;
 use reth_exex_types::ExExHead;
 use reth_node_api::NodePrimitives;
-use reth_provider::{BlockReader, Chain, HeaderProvider, StateProviderFactory};
+use reth_provider::{BlockNumReader, BlockReader, Chain, HeaderProvider, StateProviderFactory};
 use reth_stages_api::ExecutionStageThresholds;
 use reth_tracing::tracing::debug;
 use std::{
@@ -112,28 +112,44 @@ where
         }
     }
 
-    /// As [`set_with_head`](ExExNotificationsStream::set_with_head), but backfills up to
-    /// `local_head` rather than the head captured at construction. `local_head` must be a
-    /// canonical block the node has committed.
-    pub fn set_with_head_and_local_head(&mut self, exex_head: ExExHead, local_head: BlockNumHash) {
+    /// As [`set_with_head`](ExExNotificationsStream::set_with_head), but backfills up to the
+    /// node's current canonical head rather than the head captured at construction.
+    pub fn catch_up_with_head(&mut self, exex_head: ExExHead) -> eyre::Result<()>
+    where
+        P: BlockNumReader,
+    {
+        // Resolve the current canonical head before tearing down the stream state, so a failed
+        // lookup leaves the stream untouched.
+        let provider = match &self.inner {
+            ExExNotificationsInner::WithoutHead(n) => &n.provider,
+            ExExNotificationsInner::WithHead(n) => &n.provider,
+            ExExNotificationsInner::Invalid => unreachable!(),
+        };
+        let local_head: BlockNumHash = provider.chain_info()?.into();
+
         let current = std::mem::replace(&mut self.inner, ExExNotificationsInner::Invalid);
-        let (provider, evm_config, notifications, wal_handle) = match current {
+        let (provider, evm_config, notifications, wal_handle, backfill_thresholds) = match current {
             ExExNotificationsInner::WithoutHead(n) => {
-                (n.provider, n.evm_config, n.notifications, n.wal_handle)
+                (n.provider, n.evm_config, n.notifications, n.wal_handle, None)
             }
             ExExNotificationsInner::WithHead(n) => {
-                (n.provider, n.evm_config, n.notifications, n.wal_handle)
+                (n.provider, n.evm_config, n.notifications, n.wal_handle, n.backfill_thresholds)
             }
             ExExNotificationsInner::Invalid => unreachable!(),
         };
-        self.inner = ExExNotificationsInner::WithHead(Box::new(ExExNotificationsWithHead::new(
+        let mut with_head = ExExNotificationsWithHead::new(
             local_head,
             provider,
             evm_config,
             notifications,
             wal_handle,
             exex_head,
-        )));
+        );
+        // Preserve any custom backfill thresholds so the catch-up backfill respects the limits
+        // the ExEx already configured.
+        with_head.backfill_thresholds = backfill_thresholds;
+        self.inner = ExExNotificationsInner::WithHead(Box::new(with_head));
+        Ok(())
     }
 }
 
@@ -637,8 +653,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_with_head_and_local_head_backfills_to_the_supplied_local_head() -> eyre::Result<()>
-    {
+    async fn catch_up_with_head_after_pause_backfills_missed_blocks() -> eyre::Result<()> {
         let mut rng = generators::rng();
 
         let temp_dir = tempfile::tempdir().unwrap();
@@ -651,37 +666,11 @@ mod tests {
             .ok_or_else(|| eyre::eyre!("genesis block not found"))?;
         let provider = BlockchainProvider::new(provider_factory.clone())?;
 
-        // The node advances to block 1 after the stream is constructed at genesis.
-        let node_head_block = random_block(
-            &mut rng,
-            genesis_block.number + 1,
-            BlockParams { parent: Some(genesis_hash), tx_count: Some(0), ..Default::default() },
-        )
-        .try_recover()?;
-        let local_head = node_head_block.num_hash();
-        let provider_rw = provider_factory.provider_rw()?;
-        provider_rw.insert_block(&node_head_block)?;
-        provider_rw.commit()?;
-
         let exex_head =
             ExExHead { block: BlockNumHash { number: genesis_block.number, hash: genesis_hash } };
-        let notification = ExExNotification::ChainCommitted {
-            new: Arc::new(Chain::new(
-                vec![random_block(
-                    &mut rng,
-                    local_head.number + 1,
-                    BlockParams { parent: Some(local_head.hash), ..Default::default() },
-                )
-                .try_recover()?],
-                Default::default(),
-                BTreeMap::new(),
-            )),
-        };
         let (notifications_tx, notifications_rx) = mpsc::channel(1);
-        notifications_tx.send(notification.clone()).await?;
 
         let evm_config = EthEvmConfig::mainnet();
-        // Construct with a stale head (genesis); the real head is block 1.
         let mut notifications = ExExNotifications::new(
             BlockNumHash { number: genesis_block.number, hash: genesis_hash },
             provider.clone(),
@@ -689,10 +678,55 @@ mod tests {
             notifications_rx,
             wal.handle(),
         );
-        notifications.set_with_head_and_local_head(exex_head, local_head);
+        // The ExEx configures its head at launch, as usual.
+        notifications.set_with_head(exex_head);
 
-        // Backfill runs up to the supplied local head (block 1), which the stale
-        // construction-time head could not have reached.
+        // Block 1 is delivered live and consumed, but the ExEx fails to durably process it.
+        let node_head_block = random_block(
+            &mut rng,
+            genesis_block.number + 1,
+            BlockParams { parent: Some(genesis_hash), tx_count: Some(0), ..Default::default() },
+        )
+        .try_recover()?;
+        let node_head = node_head_block.num_hash();
+        let block_1_notification = ExExNotification::ChainCommitted {
+            new: Arc::new(Chain::new(
+                vec![node_head_block.clone()],
+                Default::default(),
+                BTreeMap::new(),
+            )),
+        };
+        notifications_tx.send(block_1_notification.clone()).await?;
+        assert_eq!(notifications.next().await.transpose()?, Some(block_1_notification));
+
+        // Meanwhile the node commits block 1 and advances its canonical head past the
+        // launch-time head.
+        let provider_rw = provider_factory.provider_rw()?;
+        provider_rw.insert_block(&node_head_block)?;
+        provider_rw.commit()?;
+        provider
+            .canonical_in_memory_state()
+            .set_canonical_head(node_head_block.clone_sealed_header());
+
+        // The ExEx recovers still at genesis and catches up, it needs block 1 again, but that
+        // notification is long gone from the channel.
+        notifications.catch_up_with_head(exex_head)?;
+
+        let block_2_notification = ExExNotification::ChainCommitted {
+            new: Arc::new(Chain::new(
+                vec![random_block(
+                    &mut rng,
+                    node_head.number + 1,
+                    BlockParams { parent: Some(node_head.hash), ..Default::default() },
+                )
+                .try_recover()?],
+                Default::default(),
+                BTreeMap::new(),
+            )),
+        };
+        notifications_tx.send(block_2_notification.clone()).await?;
+
+        // Backfill re-delivers block 1 up to the node's current head
         assert_eq!(
             notifications.next().await.transpose()?,
             Some(ExExNotification::ChainCommitted {
@@ -704,7 +738,8 @@ mod tests {
                 )
             })
         );
-        assert_eq!(notifications.next().await.transpose()?, Some(notification));
+        // followed by the live notification for block 2.
+        assert_eq!(notifications.next().await.transpose()?, Some(block_2_notification));
 
         Ok(())
     }


### PR DESCRIPTION
When an `ExEx` starts, it remembers the chain's head at that moment and uses it to catch up. 

If the `ExEx` later stops processing for a while, say, to recover from a problem, the node keeps moving, but the built-in catch-up is still stuck at that original head, so it can't fill in the blocks the `ExEs` missed.