### PR TITLE
fix(nix): support release archive builds

### DIFF
--- a/crates/node/core/build.rs
+++ b/crates/node/core/build.rs
@@ -17,7 +17,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let git_builder = Git2::builder().describe(false, true, None).dirty(true).sha(false).build();
 
-    emitter.add_instructions(&git_builder)?;
+    // Source archives do not contain a Git repository, but still need complete version metadata.
+    emitter.default_on_error().add_instructions(&git_builder)?;
 
     emitter.emit_and_set()?;
     let sha = env::var("VERGEN_GIT_SHA")?;

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,8 @@
             llvm22.llvm.dev
           ];
           buildInputs = prev.buildInputs or [] ++ [
+            llvm22Pkgs.libffi
+            llvm22Pkgs.libxml2
             llvm22.llvm.lib
           ];
           LLVM_SYS_221_PREFIX = "${llvm22.llvm.dev}";


### PR DESCRIPTION
Closes #26456

Allows source-archive builds to use vergen’s fallback Git metadata and adds LLVM 22’s required `libffi` and `libxml2` Nix link inputs. Builds from Git worktrees continue to use real metadata.

Validated the exact source-archive path at this commit:

```bash
nix build --print-build-logs \
  "github:1sgtpepper/reth/44cfcfbcde2dcfa741d445254256ec744b1b8224#reth"

./result/bin/reth --version
```

```text
Reth Version: 2.4.1
Commit SHA: VERGEN_IDEMPOTENT_OUTPUT
Build Timestamp: 1980-01-01T00:00:00.000000000Z
Build Features: asm_keccak,jemalloc,keccak_cache_global,min_trace_logs,otlp,otlp_logs
Build Profile: maxperf
```

Fork CI: 31 checks passed; 2 scheduled-only jobs skipped.