### PR TITLE
fix(revm): missing execution witness preimages for non-existing accounts

### DIFF
--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -71,9 +71,11 @@ impl ExecutionWitnessRecord {
                 .entry(hashed_address)
                 .or_insert_with(|| HashedStorage::new(account.status.was_destroyed()));
 
-            if let Some(account) = &account.account {
-                self.keys.push(address.to_vec().into());
+            // Emitted for every accessed account, including ones that end execution
+            // non-existing, since their hashed address is a proof target above.
+            self.keys.push(address.to_vec().into());
 
+            if let Some(account) = &account.account {
                 for (slot, value) in &account.storage {
                     let slot = B256::from(*slot);
                     let hashed_slot = keccak256(slot);
@@ -133,5 +135,56 @@ impl ExecutionWitnessRecord {
             .collect();
 
         Ok(exec_witness)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, Address, U256};
+    use revm::{
+        database::{states::CacheAccount, EmptyDB},
+        state::AccountInfo,
+    };
+
+    fn has_key(keys: &[Bytes], address: Address) -> bool {
+        keys.iter().any(|key| key.as_ref() == address.as_slice())
+    }
+
+    #[test]
+    fn keys_include_accessed_nonexisting_accounts() {
+        let existing = address!("0x0000000000000000000000000000000000000001");
+        // accessed, ended non-existing
+        let gone = address!("0x0000000000000000000000000000000000000002");
+        // accessed, never existed
+        let empty = address!("0x0000000000000000000000000000000000000003");
+
+        let mut state = State::builder().with_database(EmptyDB::default()).build();
+        state.cache.accounts.insert(
+            existing,
+            CacheAccount::new_loaded(
+                AccountInfo { balance: U256::from(1u64), ..Default::default() },
+                Default::default(),
+            ),
+        );
+        state.cache.accounts.insert(gone, CacheAccount::new_loaded_not_existing());
+        state.cache.accounts.insert(empty, CacheAccount::new_loaded_not_existing());
+
+        let rec = ExecutionWitnessRecord::from_executed_state(&state, ExecutionWitnessMode::Legacy);
+
+        assert!(has_key(&rec.keys, existing), "no address preimage for an existing account");
+        assert!(
+            has_key(&rec.keys, gone),
+            "no address preimage for an account that ended execution non-existing"
+        );
+        assert!(
+            has_key(&rec.keys, empty),
+            "no address preimage for an account that was accessed but never existed"
+        );
+        assert_eq!(
+            rec.keys.len(),
+            3,
+            "expected exactly one preimage per account and no storage slot keys"
+        );
     }
 }


### PR DESCRIPTION
`debug_executionWitness` can return a witness containing a proof for an account whose address preimage is missing from `keys`, leaving a consumer with a hashed trie key it cannot invert.

That's because, in `ExecutionWitnessRecord::record_executed_state`, the hashed address is inserted into `hashed_state` for every entry in `cache.accounts`, which makes it a proof target. The preimage is only pushed inside a guard:

```rust
if let Some(account) = &account.account {
    self.keys.push(address.to_vec().into());
    ...
}
```

Accounts loaded during execution that end non-existing therefore get a proof and no preimage, for example addresses probed by `BALANCE` that never existed, or contracts created and destroyed in a single transaction.

This moves the push out of the guard, so every entry in `cache.accounts` contributes its preimage. Storage slots stay gated, since a `None` account has none. No duplicates are introduced, as `cache.accounts` is keyed by address. Sibling trie nodes are unaffected, as they are discovered inside `witness()` and never appear in `cache.accounts`.

I've added a unit test in `crates/revm/src/witness.rs`, which fails without the change, and checked it end to end against a local `reth node --dev`, comparing `debug_executionWitness` for the same block across patched and unpatched builds. Addresses that end the block non-existing appear in `keys` only after the change, and nothing else in the array differs.

Found while investigating #23051. I could not check block 24640436 without archive access, so I am not claiming this closes it. If someone can confirm the end-of-block state of `0x28932efcbdaf9e4dfc36f8724a0264caa0efe541`, I'll add a matching regression test.