### PR TITLE
fix(rpc): align debug trace error codes

### DIFF
--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -135,6 +135,15 @@ pub enum EthApiError {
     /// Thrown when a requested transaction is not found
     #[error("transaction not found")]
     TransactionNotFound,
+    /// Thrown when a transaction requested by a tracing method is not found
+    #[error("transaction not found")]
+    TracingTransactionNotFound,
+    /// Thrown when a block requested by a tracing method is not found
+    #[error("block not found")]
+    TracingBlockNotFound(BlockId),
+    /// Thrown when a tracing method is called for the genesis block
+    #[error("genesis is not traceable")]
+    GenesisNotTraceable,
     /// Some feature is unsupported
     #[error("unsupported")]
     Unsupported(&'static str),
@@ -302,6 +311,16 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::UnknownBlockOrTxIndex | EthApiError::TransactionNotFound => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }
+            EthApiError::TracingTransactionNotFound | EthApiError::GenesisNotTraceable => {
+                rpc_error_with_code(
+                    jsonrpsee_types::error::CALL_EXECUTION_FAILED_CODE,
+                    error.to_string(),
+                )
+            }
+            EthApiError::TracingBlockNotFound(id) => rpc_error_with_code(
+                jsonrpsee_types::error::CALL_EXECUTION_FAILED_CODE,
+                format!("block not found: {}", block_id_to_str(id)),
+            ),
             EthApiError::HeaderNotFound(id) | EthApiError::ReceiptsNotFound(id) => {
                 rpc_error_with_code(
                     EthRpcErrorCode::ResourceNotFound.code(),
@@ -1152,6 +1171,20 @@ mod tests {
     fn timed_out_error() {
         let err = EthApiError::ExecutionTimedOut(Duration::from_secs(10));
         assert_eq!(err.to_string(), "execution aborted (timeout = 10s)");
+    }
+
+    #[test]
+    fn tracing_lookup_errors_use_call_execution_failed_code() {
+        let errors = [
+            EthApiError::TracingTransactionNotFound,
+            EthApiError::TracingBlockNotFound(BlockId::number(1)),
+            EthApiError::GenesisNotTraceable,
+        ];
+
+        for error in errors {
+            let error: jsonrpsee_types::error::ErrorObject<'static> = error.into();
+            assert_eq!(error.code(), -32000);
+        }
     }
 
     #[test]

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -317,10 +317,16 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                     error.to_string(),
                 )
             }
-            EthApiError::TracingBlockNotFound(id) => rpc_error_with_code(
-                jsonrpsee_types::error::CALL_EXECUTION_FAILED_CODE,
-                format!("block not found: {}", block_id_to_str(id)),
-            ),
+            EthApiError::TracingBlockNotFound(id) => {
+                let id = match id {
+                    BlockId::Hash(hash) => hash.block_hash.to_string(),
+                    BlockId::Number(number) => number.to_string(),
+                };
+                rpc_error_with_code(
+                    jsonrpsee_types::error::CALL_EXECUTION_FAILED_CODE,
+                    format!("block {id} not found"),
+                )
+            }
             EthApiError::HeaderNotFound(id) | EthApiError::ReceiptsNotFound(id) => {
                 rpc_error_with_code(
                     EthRpcErrorCode::ResourceNotFound.code(),
@@ -1175,15 +1181,21 @@ mod tests {
 
     #[test]
     fn tracing_lookup_errors_use_call_execution_failed_code() {
-        let errors = [
-            EthApiError::TracingTransactionNotFound,
-            EthApiError::TracingBlockNotFound(BlockId::number(1)),
-            EthApiError::GenesisNotTraceable,
+        let cases = [
+            (EthApiError::TracingTransactionNotFound, "transaction not found"),
+            (
+                EthApiError::TracingBlockNotFound(BlockId::hash(b256!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
+                ))),
+                "block 0x0000000000000000000000000000000000000000000000000000000000000001 not found",
+            ),
+            (EthApiError::GenesisNotTraceable, "genesis is not traceable"),
         ];
 
-        for error in errors {
+        for (error, message) in cases {
             let error: jsonrpsee_types::error::ErrorObject<'static> = error.into();
             assert_eq!(error.code(), -32000);
+            assert_eq!(error.message(), message);
         }
     }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -206,7 +206,11 @@ where
             .eth_api()
             .recovered_block(block_id)
             .await?
-            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+            .ok_or(EthApiError::TracingBlockNotFound(block_id))?;
+        // Tracing requires the parent state, which does not exist for the genesis block.
+        if block.number() == 0 {
+            return Err(EthApiError::GenesisNotTraceable.into())
+        }
         let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
 
         self.trace_block(block, evm_env, opts).await
@@ -221,7 +225,7 @@ where
         opts: GethDebugTracingOptions,
     ) -> Result<GethTrace, Eth::Error> {
         let (transaction, block) = match self.eth_api().transaction_and_block(tx_hash).await? {
-            None => return Err(EthApiError::TransactionNotFound.into()),
+            None => return Err(EthApiError::TracingTransactionNotFound.into()),
             Some(res) => res,
         };
         let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;


### PR DESCRIPTION
Aligns debug trace lookup failures with the `-32000` error code specified by [ethereum/execution-apis#762](https://github.com/ethereum/execution-apis/pull/762).

This covers unknown transactions, missing blocks, and genesis block traces while preserving existing resource-not-found behavior for other RPC methods.