### PR TITLE
feat(cli): print modular download plans as JSON

### DIFF
--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -90,6 +90,8 @@ mod source;
 mod tui;
 mod verify;
 
+pub use planning::{DownloadPlan, DownloadPlanArchive};
+
 use crate::common::EnvironmentArgs;
 use archive::run_modular_downloads;
 use clap::{builder::RangedU64ValueParser, Parser};
@@ -97,7 +99,7 @@ use config_gen::{config_for_selections, write_config};
 use extract::stream_and_extract;
 use eyre::Result;
 use manifest::{ComponentSelection, SnapshotComponentType, SnapshotManifest};
-use planning::{collect_planned_archives, summarize_download_startup};
+use planning::{collect_planned_archives, summarize_download_startup, PlannedDownloads};
 use progress::{DownloadProgress, DownloadRequestLimiter};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, MAINNET};
 use reth_cli::chainspec::ChainSpecParser;
@@ -143,6 +145,13 @@ pub(crate) enum SelectionPreset {
 struct ResolvedComponents {
     selections: BTreeMap<SnapshotComponentType, ComponentSelection>,
     preset: Option<SelectionPreset>,
+}
+
+struct ResolvedDownload {
+    manifest: SnapshotManifest,
+    selections: BTreeMap<SnapshotComponentType, ComponentSelection>,
+    preset: Option<SelectionPreset>,
+    planned: PlannedDownloads,
 }
 
 /// Global static download defaults
@@ -446,6 +455,10 @@ pub struct DownloadCommand<C: ChainSpecParser> {
     /// including block number, size, and manifest URL.
     #[arg(long, alias = "list-snapshots", conflicts_with_all = ["url", "manifest_url", "manifest_path"])]
     list: bool,
+
+    /// Print the selected modular archive plan as JSON and exit without downloading.
+    #[arg(long, conflicts_with_all = ["url", "list"])]
+    print_plan_json: bool,
 }
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCommand<C> {
@@ -495,20 +508,19 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             return Ok(());
         }
 
-        let manifest = self.load_manifest(chain_id).await?;
-        let ResolvedComponents { mut selections, preset } = self.resolve_components(&manifest)?;
-
-        if matches!(preset, Some(SelectionPreset::Archive)) {
-            inject_archive_only_components(&mut selections, &manifest, !self.without_rocksdb);
+        let ResolvedDownload { manifest, selections, preset, planned } =
+            self.resolve_download(chain_id).await?;
+        if self.print_plan_json {
+            DownloadPlan::from_planned(&manifest, &planned).write_json(std::io::stdout().lock())?;
+            return Ok(())
         }
 
         let target_dir = data_dir.data_dir();
-        let planned_downloads = collect_planned_archives(&manifest, &selections)?;
         if self.force {
             clear_existing_datadir(target_dir)?;
         }
         fs::create_dir_all(target_dir)?;
-        let startup_summary = summarize_download_startup(&planned_downloads.archives, target_dir)?;
+        let startup_summary = summarize_download_startup(&planned.archives, target_dir)?;
         info!(target: "reth::cli",
             reusable = startup_summary.reusable,
             needs_download = startup_summary.needs_download,
@@ -516,14 +528,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         );
 
         info!(target: "reth::cli",
-            archives = planned_downloads.total_archives(),
-            download_total = %DownloadProgress::format_size(planned_downloads.total_download_size),
-            output_total = %DownloadProgress::format_size(planned_downloads.total_output_size),
+            archives = planned.total_archives(),
+            download_total = %DownloadProgress::format_size(planned.total_download_size),
+            output_total = %DownloadProgress::format_size(planned.total_output_size),
             "Downloading all archives"
         );
 
         run_modular_downloads(
-            planned_downloads,
+            planned,
             target_dir,
             self.download_concurrency.max(1),
             cancel_token.clone(),
@@ -533,6 +545,25 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         self.finalize_modular_download(&selections, &manifest, preset, target_dir, &data_dir.db())?;
 
         Ok(())
+    }
+
+    /// Resolves the exact modular archive plan without downloading or modifying the data dir.
+    pub async fn plan(&self) -> Result<DownloadPlan> {
+        let chain_id = self.env.chain.chain().id();
+        let resolved = self.resolve_download(chain_id).await?;
+        Ok(DownloadPlan::from_planned(&resolved.manifest, &resolved.planned))
+    }
+
+    async fn resolve_download(&self, chain_id: u64) -> Result<ResolvedDownload> {
+        let manifest = self.load_manifest(chain_id).await?;
+        let ResolvedComponents { mut selections, preset } = self.resolve_components(&manifest)?;
+
+        if matches!(preset, Some(SelectionPreset::Archive)) {
+            inject_archive_only_components(&mut selections, &manifest, !self.without_rocksdb);
+        }
+
+        let planned = collect_planned_archives(&manifest, &selections)?;
+        Ok(ResolvedDownload { manifest, selections, preset, planned })
     }
 
     /// Loads the manifest and resolves its effective base URL.
@@ -1003,6 +1034,11 @@ impl<C: ChainSpecParser> DownloadCommand<C> {
     pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
         Some(&self.env.chain)
     }
+
+    /// Returns whether this command should print its modular archive plan and exit.
+    pub const fn prints_plan_json(&self) -> bool {
+        self.print_plan_json
+    }
 }
 
 const MAX_DOWNLOAD_RETRIES: u32 = 10;
@@ -1192,6 +1228,32 @@ mod tests {
         .args;
 
         assert!(!args.resumable);
+    }
+
+    #[test]
+    fn test_download_print_plan_json_parses() {
+        let args = CommandParser::<DownloadCommand<EthereumChainSpecParser>>::parse_from([
+            "reth",
+            "--manifest-path",
+            "manifest.json",
+            "--minimal",
+            "--print-plan-json",
+        ])
+        .args;
+
+        assert!(args.prints_plan_json());
+    }
+
+    #[test]
+    fn test_download_print_plan_json_rejects_single_archive() {
+        let result = CommandParser::<DownloadCommand<EthereumChainSpecParser>>::try_parse_from([
+            "reth",
+            "--url",
+            "https://example.com/snapshot.tar.zst",
+            "--print-plan-json",
+        ]);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -147,13 +147,6 @@ struct ResolvedComponents {
     preset: Option<SelectionPreset>,
 }
 
-struct ResolvedDownload {
-    manifest: SnapshotManifest,
-    selections: BTreeMap<SnapshotComponentType, ComponentSelection>,
-    preset: Option<SelectionPreset>,
-    planned: PlannedDownloads,
-}
-
 /// Global static download defaults
 static DOWNLOAD_DEFAULTS: OnceLock<DownloadDefaults> = OnceLock::new();
 
@@ -1039,6 +1032,13 @@ impl<C: ChainSpecParser> DownloadCommand<C> {
     pub const fn prints_plan_json(&self) -> bool {
         self.print_plan_json
     }
+}
+
+struct ResolvedDownload {
+    manifest: SnapshotManifest,
+    selections: BTreeMap<SnapshotComponentType, ComponentSelection>,
+    preset: Option<SelectionPreset>,
+    planned: PlannedDownloads,
 }
 
 const MAX_DOWNLOAD_RETRIES: u32 = 10;

--- a/crates/cli/commands/src/download/planning.rs
+++ b/crates/cli/commands/src/download/planning.rs
@@ -1,7 +1,106 @@
 use super::{manifest::*, verify::OutputVerifier};
 use eyre::Result;
-use std::{collections::BTreeMap, path::Path};
+use serde::Serialize;
+use std::{collections::BTreeMap, io::Write, path::Path};
 use tracing::info;
+
+/// Machine-readable description of the archives selected for a modular snapshot download.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadPlan {
+    /// Version of this JSON schema.
+    pub schema_version: u8,
+    /// Chain ID declared by the snapshot manifest.
+    pub chain_id: u64,
+    /// Block declared by the snapshot manifest.
+    pub block: u64,
+    /// Total compressed bytes for all selected archives.
+    pub total_download_size: u64,
+    /// Total extracted bytes for all selected archives.
+    pub total_output_size: u64,
+    /// Archives selected by the command's component and range flags.
+    pub archives: Vec<DownloadPlanArchive>,
+}
+
+impl DownloadPlan {
+    const SCHEMA_VERSION: u8 = 1;
+
+    pub(crate) fn from_planned(manifest: &SnapshotManifest, planned: &PlannedDownloads) -> Self {
+        Self {
+            schema_version: Self::SCHEMA_VERSION,
+            chain_id: manifest.chain_id,
+            block: manifest.block,
+            total_download_size: planned.total_download_size,
+            total_output_size: planned.total_output_size,
+            archives: planned.archives.iter().map(DownloadPlanArchive::from_planned).collect(),
+        }
+    }
+
+    /// Adds an archive supplied by a command that extends the base Reth snapshot format.
+    pub fn push_archive(&mut self, archive: DownloadPlanArchive) {
+        self.total_download_size = self.total_download_size.saturating_add(archive.download_size);
+        self.total_output_size = self.total_output_size.saturating_add(archive.output_size);
+        self.archives.push(archive);
+    }
+
+    /// Writes the plan as pretty-printed JSON followed by a newline.
+    pub fn write_json(&self, mut writer: impl Write) -> Result<()> {
+        serde_json::to_writer_pretty(&mut writer, self)?;
+        writeln!(writer)?;
+        Ok(())
+    }
+}
+
+/// One concrete archive in a [`DownloadPlan`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadPlanArchive {
+    /// Stable manifest component key, such as `state` or `transactions`.
+    pub component: String,
+    /// Archive file name relative to the manifest's base URL.
+    pub file_name: String,
+    /// Resolved archive source URL.
+    pub url: String,
+    /// Compressed bytes fetched for this archive.
+    pub download_size: u64,
+    /// Extracted bytes produced by this archive.
+    pub output_size: u64,
+    /// Optional checksum of the compressed archive.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blake3: Option<String>,
+}
+
+impl DownloadPlanArchive {
+    /// Creates an archive entry for a download-command extension.
+    pub fn new(
+        component: impl Into<String>,
+        file_name: impl Into<String>,
+        url: impl Into<String>,
+        download_size: u64,
+        output_size: u64,
+        blake3: Option<String>,
+    ) -> Self {
+        Self {
+            component: component.into(),
+            file_name: file_name.into(),
+            url: url.into(),
+            download_size,
+            output_size,
+            blake3,
+        }
+    }
+
+    fn from_planned(planned: &PlannedArchive) -> Self {
+        Self::new(
+            planned.ty.key(),
+            planned.archive.file_name.clone(),
+            planned.archive.url.clone(),
+            planned.archive.size,
+            planned.archive.output_size(),
+            planned.archive.blake3.clone(),
+        )
+    }
+}
 
 /// One archive selected from the manifest, along with its component name.
 #[derive(Debug, Clone)]
@@ -318,5 +417,33 @@ mod tests {
         assert_eq!(planned.total_download_size, 40);
         assert_eq!(planned.total_output_size, 400);
         assert_eq!(planned.archives.len(), 2);
+
+        let plan = DownloadPlan::from_planned(&manifest, &planned);
+        assert_eq!(
+            serde_json::to_value(plan).unwrap(),
+            serde_json::json!({
+                "schemaVersion": 1,
+                "chainId": 1,
+                "block": 1_000_000,
+                "totalDownloadSize": 40,
+                "totalOutputSize": 400,
+                "archives": [
+                    {
+                        "component": "state",
+                        "fileName": "state.tar.zst",
+                        "url": "https://example.com/state.tar.zst",
+                        "downloadSize": 10,
+                        "outputSize": 100
+                    },
+                    {
+                        "component": "transactions",
+                        "fileName": "transactions-500000-999999.tar.zst",
+                        "url": "https://example.com/transactions-500000-999999.tar.zst",
+                        "downloadSize": 30,
+                        "outputSize": 300
+                    }
+                ]
+            })
+        );
     }
 }

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -228,6 +228,9 @@ Storage:
 
           Queries the snapshots API and prints all available snapshots for the selected chain, including block number, size, and manifest URL.
 
+      --print-plan-json
+          Print the selected modular archive plan as JSON and exit without downloading
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout


### PR DESCRIPTION
Adds `reth download --print-plan-json` to emit the exact modular archives selected by the existing manifest planner without downloading or mutating the data directory.

The versioned plan type is public so downstream clients can extend the plan with chain-specific snapshot components.