### PR TITLE
chore(evm): update evm2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -3570,7 +3570,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "derive-where",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?branch=main?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256)",
  "k256 0.14.0",
  "once_cell",
  "p256",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "evm2-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "evm2",
  "evm2-jit-backend",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-backend"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "eyre",
  "ruint",
@@ -3631,12 +3631,12 @@ dependencies = [
 [[package]]
 name = "evm2-jit-build"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 
 [[package]]
 name = "evm2-jit-builtins"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-codegen"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "alloy-primitives",
  "bitflags",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-context"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "alloy-primitives",
  "evm2",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-llvm"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "evm2-jit-runtime"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "alloy-primitives",
  "crossbeam-channel",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1#eabff3f1760395ef0fdd5581f72552755f1e27f1"
+source = "git+https://github.com/alloy-rs/evm2?branch=main?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256#0c6a259c1dc60d9f8b9d37c219995c2ed0427256"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3875,7 +3875,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "evm2",
- "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=eabff3f1760395ef0fdd5581f72552755f1e27f1)",
+ "evm2-macros 0.1.0 (git+https://github.com/alloy-rs/evm2?rev=0c6a259c1dc60d9f8b9d37c219995c2ed0427256)",
  "eyre",
  "reth-ethereum",
  "reth-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -425,10 +425,10 @@ reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "cd6d1253cd46eec80250776c8c88ee340c15f6f5", default-features = false }
 
 # evm2
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
-evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
-evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1", default-features = false }
-evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1" }
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "0c6a259c1dc60d9f8b9d37c219995c2ed0427256", default-features = false }
+evm2-inspectors = { git = "https://github.com/alloy-rs/evm2", rev = "0c6a259c1dc60d9f8b9d37c219995c2ed0427256", default-features = false }
+evm2-jit = { git = "https://github.com/alloy-rs/evm2", rev = "0c6a259c1dc60d9f8b9d37c219995c2ed0427256", default-features = false }
+evm2-macros = { git = "https://github.com/alloy-rs/evm2", rev = "0c6a259c1dc60d9f8b9d37c219995c2ed0427256" }
 
 # eth
 alloy-dyn-abi = "1.6.1"
@@ -690,4 +690,4 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch."https://github.com/alloy-rs/evm2"]
-evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "eabff3f1760395ef0fdd5581f72552755f1e27f1" }
+evm2 = { git = "https://github.com/alloy-rs/evm2?branch=main", rev = "0c6a259c1dc60d9f8b9d37c219995c2ed0427256" }

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -1203,6 +1203,8 @@ mod tests {
                 address,
                 original: original.as_ref().map(account_info_ref),
                 current: None,
+                created: false,
+                selfdestructed: false,
             })
             .unwrap();
         accumulator.storage_wipe(address).unwrap();

--- a/crates/ethereum/evm/src/execution.rs
+++ b/crates/ethereum/evm/src/execution.rs
@@ -35,8 +35,8 @@ use evm2::Precompiles;
 use evm2::{
     bytecode::Bytecode as ExecutableBytecode,
     evm::{
-        AccountChange, AccountChangeRef, AccountInfo, BlockStateAccumulator, StateChangeSink,
-        StateChangeSource, StateChanges, StorageChange, SystemTx, BEACON_ROOTS_ADDRESS,
+        AccountChangeRef, AccountInfo, AccountInfoRef, BlockStateAccumulator, StateChangeSink,
+        StateChangeSource, StorageChange, SystemTx, BEACON_ROOTS_ADDRESS,
         BUILDER_DEPOSIT_REQUEST_ADDRESS, BUILDER_EXIT_REQUEST_ADDRESS,
         CONSOLIDATION_REQUEST_ADDRESS, HISTORY_STORAGE_ADDRESS, WITHDRAWAL_REQUEST_ADDRESS,
     },
@@ -754,18 +754,14 @@ pub(crate) fn commit_detached_transaction<T: EvmTypes>(
     on_hashed_state_update: &mut impl FnMut(HashedPostState),
     output: TxResultWithState<T>,
 ) -> TxResult<T> {
-    let state_changes = output.state_changes;
-    if evm.state().bal_builder().is_some() {
-        evm.state_mut().overlay_db_mut().bal_context.commit_bal(&state_changes);
-    }
+    let TxResultWithState { result, pending_state, .. } = output;
 
-    let result = {
+    {
         let mut sink = RethStateSink::new(None, block_state, stream_hashed_state);
-        let Ok(()) = state_changes.visit(&mut sink);
+        let Ok(()) = pending_state.visit(&mut sink);
         sink.flush_streamed_hashed_state(on_hashed_state_update);
-        output.result
-    };
-    evm.state_mut().commit_source(&state_changes);
+    }
+    evm.overlay_db_mut().commit_pending(&pending_state);
     result
 }
 
@@ -1001,10 +997,14 @@ fn commit_state_changes<T: EvmTypes>(
     block_state: &mut BlockStateAccumulator,
     stream_hashed_state: bool,
     on_hashed_state_update: &mut impl FnMut(HashedPostState),
-    changes: &StateChanges,
+    changes: &[(Address, Option<AccountInfo>, Option<AccountInfo>)],
 ) {
-    if evm.state().bal_builder().is_some() {
-        evm.state_mut().overlay_db_mut().bal_context.commit_bal(changes);
+    for (address, original, current) in changes {
+        evm.overlay_db_mut().bal_context.commit_account_change(
+            *address,
+            original.as_ref(),
+            current.as_ref(),
+        );
     }
     let result = {
         let mut sink = RethStateSink::new(
@@ -1012,7 +1012,15 @@ fn commit_state_changes<T: EvmTypes>(
             block_state,
             stream_hashed_state,
         );
-        let result = changes.visit(&mut sink);
+        let result = changes.iter().try_for_each(|(address, original, current)| {
+            sink.account(AccountChangeRef {
+                address: *address,
+                original: original.as_ref().map(account_info_ref),
+                current: current.as_ref().map(account_info_ref),
+                created: false,
+                selfdestructed: false,
+            })
+        });
         if result.is_ok() {
             sink.flush_streamed_hashed_state(on_hashed_state_update);
         }
@@ -1056,7 +1064,7 @@ pub(crate) fn post_block_balance_state_changes<T: EvmTypes>(
         return Ok(());
     }
 
-    let mut changes = StateChanges::default();
+    let mut changes = Vec::new();
 
     for (address, increment) in balance_increments {
         let original =
@@ -1072,15 +1080,21 @@ pub(crate) fn post_block_balance_state_changes<T: EvmTypes>(
         if original == current {
             continue
         }
-        let mut change = AccountChange::default();
-        change.original = original;
-        change.current = current;
-        changes.accounts.insert(address, change);
+        changes.push((address, original, current));
     }
 
     commit_state_changes(evm, block_state, stream_hashed_state, on_hashed_state_update, &changes);
 
     Ok(())
+}
+
+const fn account_info_ref(info: &AccountInfo) -> AccountInfoRef<'_> {
+    AccountInfoRef {
+        balance: info.balance,
+        nonce: info.nonce,
+        code_hash: info.code_hash,
+        code: info.code.as_ref(),
+    }
 }
 
 pub(crate) fn base_block_reward<C>(chain_spec: &C, block_number: u64) -> Option<u128>

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -283,6 +283,8 @@ mod tests {
                     code_hash,
                     code: Some(&bytecode),
                 }),
+                created: false,
+                selfdestructed: false,
             })
             .unwrap();
         state.storage_wipe(wiped_address).unwrap();
@@ -317,7 +319,13 @@ mod tests {
             AccountInfoRef { balance: U256::from(1), nonce: 1, code_hash: B256::ZERO, code: None };
         let mut state = BlockStateAccumulator::new();
         state
-            .account(AccountChangeRef { address, original: Some(original), current: None })
+            .account(AccountChangeRef {
+                address,
+                original: Some(original),
+                current: None,
+                created: false,
+                selfdestructed: false,
+            })
             .unwrap();
 
         let indexed = IndexedBlockState::new(state);

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -208,6 +208,8 @@ impl<T> ExecutionOutcome<T> {
                     address,
                     original: original.as_ref().map(account_info_ref_from_reth),
                     current: current.as_ref().map(account_info_ref_from_reth),
+                    created: false,
+                    selfdestructed: false,
                 })
                 .expect("infallible");
             for (slot, (original, current)) in storage {
@@ -673,6 +675,8 @@ fn multi_block_outcome_for_serde() -> ExecutionOutcome {
                 code_hash: KECCAK_EMPTY,
                 code: None,
             }),
+            created: false,
+            selfdestructed: false,
         })
         .unwrap();
     StateChangeSink::storage(
@@ -697,6 +701,8 @@ fn multi_block_outcome_for_serde() -> ExecutionOutcome {
                 code_hash: KECCAK_EMPTY,
                 code: None,
             }),
+            created: false,
+            selfdestructed: false,
         })
         .unwrap();
     block2.storage_wipe(address).unwrap();

--- a/crates/evm/execution-types/src/state.rs
+++ b/crates/evm/execution-types/src/state.rs
@@ -153,6 +153,8 @@ pub fn execution_state_from_init(
                 address,
                 original: original.as_ref().map(account_ref_to_info_ref),
                 current: current.as_ref().map(account_ref_to_info_ref),
+                created: false,
+                selfdestructed: false,
             })
             .expect("infallible");
         for (slot, (original, current)) in storage {
@@ -293,13 +295,14 @@ impl StateChangeSink for StateAndRevertsSink<'_> {
     }
 
     fn account(&mut self, change: AccountChangeRef<'_>) -> Result<(), Self::Error> {
-        let deletes_pre_aggregate_account = change.deleted() &&
+        let deletes_account = change.current.is_none();
+        let deletes_pre_aggregate_account = deletes_account &&
             self.accumulator
                 .accounts()
                 .find(|(address, _)| *address == change.address)
                 .is_none_or(|(_, account)| account.original.is_some());
         self.reverts.account(change)?;
-        if change.deleted() && !self.block_wipes.contains(&change.address) {
+        if deletes_account && !self.block_wipes.contains(&change.address) {
             self.record_storage_wipe(change.address)?;
         }
         self.accumulator.account(change)?;
@@ -508,6 +511,14 @@ mod tests {
     use evm2::evm::{AccountChangeRef, AccountInfoRef, StorageChange, Tee};
     use reth_trie_common::KeccakKeyHasher;
 
+    const fn account_change<'a>(
+        address: Address,
+        original: Option<AccountInfoRef<'a>>,
+        current: Option<AccountInfoRef<'a>>,
+    ) -> AccountChangeRef<'a> {
+        AccountChangeRef { address, original, current, created: false, selfdestructed: false }
+    }
+
     #[test]
     fn revert_account_normalizes_empty_code_hashes() {
         for code_hash in [B256::ZERO, KECCAK_EMPTY] {
@@ -526,9 +537,7 @@ mod tests {
         let original =
             AccountInfoRef { balance: U256::from(1), nonce: 1, code_hash: B256::ZERO, code: None };
         let mut source = BlockStateAccumulator::new();
-        source
-            .account(AccountChangeRef { address, original: Some(original), current: None })
-            .unwrap();
+        source.account(account_change(address, Some(original), None)).unwrap();
         let mut aggregate = BlockStateAccumulator::new();
 
         let reverts = extend_state_and_collect_reverts(&mut aggregate, &source);
@@ -543,13 +552,9 @@ mod tests {
         let account =
             AccountInfoRef { balance: U256::from(1), nonce: 1, code_hash: B256::ZERO, code: None };
         let mut creation = BlockStateAccumulator::new();
-        creation
-            .account(AccountChangeRef { address, original: None, current: Some(account) })
-            .unwrap();
+        creation.account(account_change(address, None, Some(account))).unwrap();
         let mut deletion = BlockStateAccumulator::new();
-        deletion
-            .account(AccountChangeRef { address, original: Some(account), current: None })
-            .unwrap();
+        deletion.account(account_change(address, Some(account), None)).unwrap();
         let mut aggregate = BlockStateAccumulator::new();
 
         extend_state_and_collect_reverts(&mut aggregate, &creation);
@@ -613,8 +618,7 @@ mod tests {
                 },
             )
             .unwrap();
-            tee.account(AccountChangeRef { address, original: Some(original), current: None })
-                .unwrap();
+            tee.account(account_change(address, Some(original), None)).unwrap();
         }
 
         let recomputed =
@@ -645,8 +649,7 @@ mod tests {
                 },
             )
             .unwrap();
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
+            tee.account(account_change(address, None, Some(current))).unwrap();
         }
 
         let recomputed =
@@ -666,8 +669,7 @@ mod tests {
         let mut sink = HashedPostStateSink::<KeccakKeyHasher>::default();
         {
             let mut tee = Tee::new(&mut accumulator, &mut sink);
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
+            tee.account(account_change(address, None, Some(current))).unwrap();
             StateChangeSink::storage(
                 &mut tee,
                 StorageChange {
@@ -700,14 +702,8 @@ mod tests {
         let mut sink = HashedPostStateSink::<KeccakKeyHasher>::default();
         {
             let mut tee = Tee::new(&mut accumulator, &mut sink);
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
-            tee.account(AccountChangeRef {
-                address,
-                original: Some(current),
-                current: Some(updated),
-            })
-            .unwrap();
+            tee.account(account_change(address, None, Some(current))).unwrap();
+            tee.account(account_change(address, Some(current), Some(updated))).unwrap();
             tee.storage_wipe(address).unwrap();
         }
 
@@ -730,8 +726,7 @@ mod tests {
         let mut sink = HashedPostStateSink::<KeccakKeyHasher>::default();
         {
             let mut tee = Tee::new(&mut accumulator, &mut sink);
-            tee.account(AccountChangeRef { address, original: Some(original), current: None })
-                .unwrap();
+            tee.account(account_change(address, Some(original), None)).unwrap();
             tee.storage_wipe(address).unwrap();
             StateChangeSink::storage(
                 &mut tee,
@@ -743,8 +738,7 @@ mod tests {
                 },
             )
             .unwrap();
-            tee.account(AccountChangeRef { address, original: None, current: Some(current) })
-                .unwrap();
+            tee.account(account_change(address, None, Some(current))).unwrap();
         }
 
         let recomputed =

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -357,7 +357,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     for tx in block.transactions_recovered().take(num_txs) {
                         let tx_env = this.evm_config().tx_env(tx.cloned());
                         let result = this.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit_source(&result.state_changes);
+                        db.commit_source(&result.pending_state);
                     }
                 }
 
@@ -413,7 +413,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
 
                         // Commit state changes after each transaction to allow subsequent calls to
                         // see the updates
-                        db.commit_source(&res.state_changes);
+                        db.commit_source(&res.pending_state);
                     }
 
                     all_results.push(bundle_results);
@@ -795,7 +795,7 @@ pub trait Call:
                     }
                     let tx_env = this.evm_config().tx_env(block_tx.cloned());
                     let result = this.transact(&mut db, evm_env.clone(), tx_env)?;
-                    db.commit_source(&result.state_changes);
+                    db.commit_source(&result.pending_state);
                 }
 
                 let tx_env = RpcNodeCore::evm_config(&this).tx_env(tx);
@@ -834,7 +834,7 @@ pub trait Call:
 
             let tx_env = self.evm_config().tx_env(tx.cloned());
             let result = self.transact(&mut *db, evm_env.clone(), tx_env)?;
-            result.state_changes.visit(db).expect("infallible state cache update");
+            result.pending_state.visit(db).expect("infallible state cache update");
             index += 1;
         }
         Ok(index)

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -233,7 +233,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                         block_timestamp: Some(block_timestamp),
                         base_fee,
                     };
-                    let state_changes = result.state_changes.clone();
+                    let state_changes = result.pending_state.clone();
                     let item = f(tx_info, TracingCtx { result, db: &mut db, inspector })?;
                     db.commit_source(&state_changes);
                     results.push(item);

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -150,7 +150,7 @@ where
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit_source(&res.state_changes)
+                        db.commit_source(&res.pending_state)
                     }
                 }
 
@@ -438,7 +438,7 @@ where
                     for tx in transactions {
                         let tx_env = eth_api.evm_config().tx_env(tx.cloned());
                         let res = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit_source(&res.state_changes);
+                        db.commit_source(&res.pending_state);
                     }
                 }
 
@@ -472,7 +472,7 @@ where
                         // If there is no transactions, but more bundles, commit to the database too
                         if transactions.peek().is_some() || bundles.peek().is_some() {
                             inspector.fuse().map_err(Eth::Error::from_eth_err)?;
-                            db.commit_source(&res.state_changes);
+                            db.commit_source(&res.pending_state);
                         }
                         results.push(trace);
                     }
@@ -667,7 +667,7 @@ where
                 for tx in block.transactions_recovered().take(tx_index + 1) {
                     let tx_env = eth_api.evm_config().tx_env(tx.cloned());
                     let result = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                    db.commit_source(&result.state_changes);
+                    db.commit_source(&result.pending_state);
                 }
 
                 f(&mut db)
@@ -773,10 +773,10 @@ where
                     let tx_env = eth_api.evm_config().tx_env(tx.cloned());
                     let result = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
                     result
-                        .state_changes
+                        .pending_state
                         .visit(&mut state)
                         .expect("state accumulator is infallible");
-                    db.commit_source(&result.state_changes);
+                    db.commit_source(&result.pending_state);
                     let hashed_state = db.db.inner().hashed_post_state(&state);
                     let root =
                         db.db.inner().state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;

--- a/crates/rpc/rpc/src/eth/bundle.rs
+++ b/crates/rpc/rpc/src/eth/bundle.rs
@@ -157,9 +157,7 @@ where
                 let mut hasher = Keccak256::new();
 
                 let mut results = Vec::with_capacity(transactions.len());
-                let mut transactions = transactions.into_iter().peekable();
-
-                while let Some(tx) = transactions.next() {
+                for tx in transactions {
                     let signer = tx.signer();
                     let tx = {
                         let mut tx = <Eth::Pool as TransactionPool>::Transaction::from_pooled(tx);
@@ -181,7 +179,7 @@ where
                     let tx_env = eth_api.evm_config().tx_env(tx.clone());
                     let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
                     let result = result_and_state.result;
-                    let state = result_and_state.state_changes;
+                    let state = result_and_state.pending_state;
 
                     let gas_price = tx
                         .effective_tip_per_gas(basefee)
@@ -192,11 +190,14 @@ where
                     let gas_fees = U256::from(gas_used) * U256::from(gas_price);
                     total_gas_fees += gas_fees;
 
-                    // coinbase is always present in the result state
-                    coinbase_balance_after_tx = state
-                        .accounts
-                        .get(&coinbase)
-                        .and_then(|acc| acc.current.as_ref())
+                    db.commit_source(&state);
+                    coinbase_balance_after_tx = db
+                        .get_account(&coinbase)
+                        .map_err(|code| {
+                            Eth::Error::from_eth_err(EthApiError::EvmCustom(
+                                db.error(code).to_string(),
+                            ))
+                        })?
                         .map(|acc| acc.balance)
                         .unwrap_or(coinbase_balance_before_tx);
                     let coinbase_diff =
@@ -228,14 +229,6 @@ where
                         revert,
                     };
                     results.push(tx_res);
-
-                    // need to apply the state changes of this call before executing the
-                    // next call
-                    if transactions.peek().is_some() {
-                        // need to apply the state changes of this call before executing
-                        // the next call
-                        db.commit_source(&state);
-                    }
                 }
 
                 // populate the response

--- a/crates/rpc/rpc/src/eth/sim_bundle.rs
+++ b/crates/rpc/rpc/src/eth/sim_bundle.rs
@@ -335,7 +335,7 @@ where
                     let tx_env = eth_api.evm_config().tx_env(item.tx.clone());
                     let result_and_state = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
                     let result = result_and_state.result;
-                    let state = result_and_state.state_changes;
+                    let state = result_and_state.pending_state;
 
                     if !result.status && !item.can_revert {
                         return Err(EthApiError::InvalidParams(
@@ -347,11 +347,10 @@ where
                     let gas_used = result.tx_gas_used();
                     total_gas_used += gas_used;
 
-                    // coinbase is always present in the result state
-                    let coinbase_balance_after_tx = state
-                        .accounts
-                        .get(&coinbase)
-                        .and_then(|acc| acc.current.as_ref())
+                    db.commit_source(&state);
+                    let coinbase_balance_after_tx = db
+                        .get_account(&coinbase)
+                        .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))?
                         .map(|acc| acc.balance)
                         .unwrap_or(coinbase_balance_before_tx);
 
@@ -390,9 +389,6 @@ where
                             .collect();
                         flat_logs.push(tx_logs);
                     }
-
-                    // Apply state changes
-                    db.commit_source(&state);
                 }
 
                 let body_logs =

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -196,7 +196,7 @@ where
                     // need to apply the state changes of this call before executing the
                     // next call
                     if calls.peek().is_some() {
-                        db.commit_source(&res.state_changes)
+                        db.commit_source(&res.pending_state)
                     }
                 }
 
@@ -571,7 +571,7 @@ where
                     // If statediffs were requested, populate them with the account balance and
                     // nonce from pre-state
                     if let Some(ref mut state_diff) = full_trace.state_diff {
-                        populate_state_diff(state_diff, db, &result.state_changes)
+                        populate_state_diff(state_diff, db, &result.pending_state)
                             .map_err(|code| EthApiError::EvmCustom(db.error(code).to_string()))
                             .map_err(Eth::Error::from_eth_err)?;
                     }


### PR DESCRIPTION
Updates evm2 to alloy-rs/evm2@0c6a259c1dc60d9f8b9d37c219995c2ed0427256 and adapts Reth to the new pending-state, BAL, and account-lifecycle APIs. This also removes JIT runtime configuration fields no longer exposed upstream.