### PR TITLE
fix(net): recover partial header responses

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -198,7 +198,7 @@ impl Default for HeadersConfig {
     fn default() -> Self {
         Self {
             commit_threshold: 10_000,
-            downloader_request_limit: 1_000,
+            downloader_request_limit: 512,
             downloader_max_concurrent_requests: 100,
             downloader_min_concurrent_requests: 5,
             downloader_max_buffered_responses: 100,

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -198,7 +198,7 @@ impl Default for HeadersConfig {
     fn default() -> Self {
         Self {
             commit_threshold: 10_000,
-            downloader_request_limit: 512,
+            downloader_request_limit: 1_000,
             downloader_max_concurrent_requests: 100,
             downloader_min_concurrent_requests: 5,
             downloader_max_buffered_responses: 100,

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -475,17 +475,19 @@ where
                     .into())
                 }
 
-                if (headers.len() as u64) != request.limit {
+                let received_headers = headers.len() as u64;
+                if received_headers > request.limit {
                     return Err(HeadersResponseError {
                         peer_id: Some(peer_id),
-                        error: DownloadError::HeadersResponseTooShort(GotExpected {
-                            got: headers.len() as u64,
+                        error: DownloadError::HeadersResponseTooLong(GotExpected {
+                            got: received_headers,
                             expected: request.limit,
                         }),
                         request,
                     }
                     .into())
                 }
+                let missing_headers = request.limit - received_headers;
 
                 // sort headers from highest to lowest block number
                 headers.sort_unstable_by_key(|h| Reverse(h.number()));
@@ -515,6 +517,12 @@ where
                     self.try_validate_buffered()
                         .map(Err::<(), ReverseHeadersDownloaderError<H::Header>>)
                         .transpose()?;
+
+                    self.requeue_missing_headers(
+                        requested_block_number,
+                        received_headers,
+                        missing_headers,
+                    );
                 } else if highest.number() > self.existing_local_block_number() {
                     self.metrics.buffered_responses.increment(1.);
                     // can't validate yet
@@ -522,7 +530,12 @@ where
                         headers,
                         request,
                         peer_id,
-                    })
+                    });
+                    self.requeue_missing_headers(
+                        requested_block_number,
+                        received_headers,
+                        missing_headers,
+                    );
                 }
 
                 Ok(())
@@ -596,6 +609,23 @@ where
         trace!(target: "downloaders::headers", ?request, "Submitting headers request");
         self.in_progress_queue.push(self.request_fut(request, priority));
         self.metrics.in_flight_requests.increment(1.);
+    }
+
+    fn requeue_missing_headers(
+        &self,
+        requested_block_number: u64,
+        received_headers: u64,
+        missing_headers: u64,
+    ) {
+        if missing_headers > 0 {
+            self.submit_request(
+                HeadersRequest::falling(
+                    (requested_block_number - received_headers).into(),
+                    missing_headers,
+                ),
+                Priority::High,
+            );
+        }
     }
 
     fn request_fut(
@@ -1125,9 +1155,9 @@ impl Default for ReverseHeadersDownloaderBuilder {
     fn default() -> Self {
         Self {
             stream_batch_size: 10_000,
-            // Besu's default response cap is 512 headers. Staying within that common limit avoids
-            // rejecting a valid capped response as a peer protocol violation.
-            request_limit: 512,
+            // This is just below the max number of headers commonly in a headers response (1024), see also <https://github.com/ethereum/go-ethereum/blob/b0d44338bbcefee044f1f635a84487cbbd8f0538/eth/protocols/eth/handler.go#L38-L40>
+            // with ~500bytes per header this around 0.5MB per request max
+            request_limit: 1_000,
             max_concurrent_requests: 100,
             min_concurrent_requests: 5,
             max_buffered_responses: 100,
@@ -1251,7 +1281,74 @@ mod tests {
     use alloy_eips::{eip1898::BlockWithParent, BlockNumHash};
     use assert_matches::assert_matches;
     use reth_consensus::test_utils::TestConsensus;
-    use reth_network_p2p::test_utils::TestHeadersClient;
+    use reth_network_p2p::{
+        download::DownloadClient, error::PeerRequestResult, test_utils::TestHeadersClient,
+    };
+    use reth_network_peers::WithPeerId;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering as AtomicOrdering},
+        Mutex,
+    };
+
+    #[derive(Clone, Debug)]
+    struct CappedHeadersClient {
+        responses: Arc<Mutex<Vec<Header>>>,
+        requests: Arc<Mutex<Vec<HeadersRequest>>>,
+        bad_messages: Arc<AtomicU64>,
+        response_limit: usize,
+    }
+
+    impl CappedHeadersClient {
+        fn new(responses: Vec<Header>, response_limit: usize) -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(responses)),
+                requests: Default::default(),
+                bad_messages: Default::default(),
+                response_limit,
+            }
+        }
+
+        fn numeric_requests(&self) -> Vec<(u64, u64)> {
+            self.requests
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|request| request.start.as_number().map(|start| (start, request.limit)))
+                .collect()
+        }
+
+        fn bad_message_count(&self) -> u64 {
+            self.bad_messages.load(AtomicOrdering::SeqCst)
+        }
+    }
+
+    impl DownloadClient for CappedHeadersClient {
+        fn report_bad_message(&self, _peer_id: PeerId) {
+            self.bad_messages.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+
+        fn num_connected_peers(&self) -> usize {
+            1
+        }
+    }
+
+    impl HeadersClient for CappedHeadersClient {
+        type Header = Header;
+        type Output = futures::future::Ready<PeerRequestResult<Vec<Header>>>;
+
+        fn get_headers_with_priority(
+            &self,
+            request: HeadersRequest,
+            _priority: Priority,
+        ) -> Self::Output {
+            self.requests.lock().unwrap().push(request.clone());
+            let mut responses = self.responses.lock().unwrap();
+            let response_length = request.limit.min(self.response_limit as u64) as usize;
+            let response = responses.drain(..response_length).collect();
+
+            futures::future::ready(Ok(WithPeerId::new(PeerId::default(), response)))
+        }
+    }
 
     /// Tests that `replace_number` works the same way as `Option::replace`
     #[test]
@@ -1387,7 +1484,7 @@ mod tests {
             ReverseHeadersDownloaderBuilder::default().request_limit,
             HeadersConfig::default().downloader_request_limit
         );
-        assert_eq!(ReverseHeadersDownloaderBuilder::default().request_limit, 512);
+        assert_eq!(ReverseHeadersDownloaderBuilder::default().request_limit, 1_000);
     }
 
     /// Tests that request calc works
@@ -1555,5 +1652,34 @@ mod tests {
         assert_eq!(headers.capacity(), headers.len());
 
         assert!(downloader.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn downloads_capped_header_responses() {
+        let p3 = SealedHeader::default();
+        let p2 = child_header(&p3);
+        let p1 = child_header(&p2);
+        let p0 = child_header(&p1);
+
+        let client = CappedHeadersClient::new(
+            vec![p0.as_ref().clone(), p1.as_ref().clone(), p2.as_ref().clone()],
+            1,
+        );
+        let mut downloader = ReverseHeadersDownloaderBuilder::default()
+            .stream_batch_size(1)
+            .request_limit(2)
+            .min_concurrent_requests(1)
+            .max_concurrent_requests(1)
+            .build(client.clone(), Arc::new(TestConsensus::default()));
+        downloader.update_local_head(p3);
+        downloader.update_sync_target(SyncTarget::Tip(p0.hash()));
+
+        assert_eq!(downloader.next().await.unwrap().unwrap(), vec![p0]);
+        assert_eq!(downloader.next().await.unwrap().unwrap(), vec![p1]);
+        assert_eq!(downloader.next().await.unwrap().unwrap(), vec![p2]);
+        assert!(downloader.next().await.is_none());
+
+        assert_eq!(client.numeric_requests(), vec![(2, 2), (1, 1)]);
+        assert_eq!(client.bad_message_count(), 0);
     }
 }

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -1125,9 +1125,9 @@ impl Default for ReverseHeadersDownloaderBuilder {
     fn default() -> Self {
         Self {
             stream_batch_size: 10_000,
-            // This is just below the max number of headers commonly in a headers response (1024), see also <https://github.com/ethereum/go-ethereum/blob/b0d44338bbcefee044f1f635a84487cbbd8f0538/eth/protocols/eth/handler.go#L38-L40>
-            // with ~500bytes per header this around 0.5MB per request max
-            request_limit: 1_000,
+            // Besu's default response cap is 512 headers. Staying within that common limit avoids
+            // rejecting a valid capped response as a peer protocol violation.
+            request_limit: 512,
             max_concurrent_requests: 100,
             min_concurrent_requests: 5,
             max_buffered_responses: 100,
@@ -1379,6 +1379,15 @@ mod tests {
         let request = calc_next_request(local, next, batch_size);
         assert_eq!(request.start, next.into());
         assert_eq!(request.limit, 1);
+    }
+
+    #[test]
+    fn default_request_limit_matches_sync_config() {
+        assert_eq!(
+            ReverseHeadersDownloaderBuilder::default().request_limit,
+            HeadersConfig::default().downloader_request_limit
+        );
+        assert_eq!(ReverseHeadersDownloaderBuilder::default().request_limit, 512);
     }
 
     /// Tests that request calc works

--- a/crates/net/downloaders/src/headers/reverse_headers.rs
+++ b/crates/net/downloaders/src/headers/reverse_headers.rs
@@ -513,16 +513,18 @@ where
                 if highest.number() == self.next_chain_tip_block_number {
                     // is next response, validate it
                     self.process_next_headers(request, headers, peer_id)?;
-                    // try to validate all buffered responses blocked by this successful response
-                    self.try_validate_buffered()
-                        .map(Err::<(), ReverseHeadersDownloaderError<H::Header>>)
-                        .transpose()?;
-
+                    // request the missing headers before validating buffered responses, because a
+                    // buffered validation error returns early and would otherwise leave the
+                    // remainder of this range unrequested
                     self.requeue_missing_headers(
                         requested_block_number,
                         received_headers,
                         missing_headers,
                     );
+                    // try to validate all buffered responses blocked by this successful response
+                    self.try_validate_buffered()
+                        .map(Err::<(), ReverseHeadersDownloaderError<H::Header>>)
+                        .transpose()?;
                 } else if highest.number() > self.existing_local_block_number() {
                     self.metrics.buffered_responses.increment(1.);
                     // can't validate yet
@@ -611,6 +613,11 @@ where
         self.metrics.in_flight_requests.increment(1.);
     }
 
+    /// Submits a high-priority request for the missing suffix of a partial response.
+    ///
+    /// Peers are allowed to respond with fewer headers than requested, for example due to
+    /// response size limits. Expects that the caller has verified that the response started at
+    /// `requested_block_number` and contained `received_headers` headers.
     fn requeue_missing_headers(
         &self,
         requested_block_number: u64,
@@ -618,6 +625,7 @@ where
         missing_headers: u64,
     ) {
         if missing_headers > 0 {
+            self.metrics.partial_responses.increment(1);
             self.submit_request(
                 HeadersRequest::falling(
                     (requested_block_number - received_headers).into(),
@@ -1484,7 +1492,6 @@ mod tests {
             ReverseHeadersDownloaderBuilder::default().request_limit,
             HeadersConfig::default().downloader_request_limit
         );
-        assert_eq!(ReverseHeadersDownloaderBuilder::default().request_limit, 1_000);
     }
 
     /// Tests that request calc works
@@ -1681,5 +1688,53 @@ mod tests {
 
         assert_eq!(client.numeric_requests(), vec![(2, 2), (1, 1)]);
         assert_eq!(client.bad_message_count(), 0);
+    }
+
+    #[test]
+    fn requeues_missing_headers_for_buffered_partial_response() {
+        let client = CappedHeadersClient::new(Vec::new(), 0);
+        let mut downloader = ReverseHeadersDownloaderBuilder::default()
+            .build(client.clone(), Arc::new(TestConsensus::default()));
+        downloader.local_head = Some(SealedHeader::default());
+        downloader.sync_target = Some(SyncTargetBlock::from_number(10));
+        downloader.next_chain_tip_block_number = 10;
+
+        // a partial response that can't be validated yet is buffered, but the missing suffix must
+        // be requested immediately
+        let request = HeadersRequest::falling(5u64.into(), 3);
+        let response = vec![Header { number: 5, ..Default::default() }];
+        let outcome = downloader.on_headers_outcome(HeadersRequestOutcome {
+            request,
+            outcome: Ok(WithPeerId::new(PeerId::default(), response)),
+        });
+
+        assert!(outcome.is_ok());
+        assert_eq!(downloader.buffered_responses.len(), 1);
+        assert_eq!(client.numeric_requests(), vec![(4, 2)]);
+        assert_eq!(client.bad_message_count(), 0);
+    }
+
+    #[test]
+    fn rejects_over_long_headers_response() {
+        let client = CappedHeadersClient::new(Vec::new(), 0);
+        let mut downloader = ReverseHeadersDownloaderBuilder::default()
+            .build(client.clone(), Arc::new(TestConsensus::default()));
+
+        let request = HeadersRequest::falling(5u64.into(), 1);
+        let response = vec![
+            Header { number: 5, ..Default::default() },
+            Header { number: 4, ..Default::default() },
+        ];
+        let outcome = downloader.on_headers_outcome(HeadersRequestOutcome {
+            request,
+            outcome: Ok(WithPeerId::new(PeerId::default(), response)),
+        });
+
+        assert_matches!(
+            outcome,
+            Err(ReverseHeadersDownloaderError::Response(err))
+                if matches!(err.error, DownloadError::HeadersResponseTooLong(_))
+        );
+        assert!(client.numeric_requests().is_empty());
     }
 }

--- a/crates/net/downloaders/src/metrics.rs
+++ b/crates/net/downloaders/src/metrics.rs
@@ -103,6 +103,8 @@ pub struct HeaderDownloaderMetrics {
     pub total_flushed: Counter,
     /// Number of items that were successfully downloaded
     pub total_downloaded: Counter,
+    /// Number of responses that contained fewer headers than requested
+    pub partial_responses: Counter,
     /// The number of requests (can contain more than 1 item) currently in-flight.
     pub in_flight_requests: Gauge,
     /// The number of responses (can contain more than 1 item) in the internal buffer of the

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -1057,6 +1057,41 @@ mod tests {
         assert!(fetcher.peers[&peer_id].state.is_idle());
     }
 
+    #[tokio::test]
+    async fn test_partial_header_response_triggers_followup() {
+        let (mut fetcher, peer_id) = fetcher_with_peer();
+
+        let (followup_tx, _followup_rx) = oneshot::channel();
+        fetcher.queued_requests.push_back(DownloadRequest::GetBlockHeaders {
+            request: HeadersRequest::falling(1u64.into(), 1),
+            response: followup_tx,
+            priority: Priority::High,
+        });
+
+        let (response_tx, mut response_rx) = oneshot::channel();
+        fetcher.inflight_headers_requests.insert(
+            peer_id,
+            Request { request: HeadersRequest::falling(2u64.into(), 2), response: response_tx },
+        );
+        fetcher.peers.get_mut(&peer_id).unwrap().state = PeerState::GetBlockHeaders;
+
+        let header = Header { number: 2, ..Default::default() };
+        let outcome = fetcher.on_block_headers_response(peer_id, Ok(vec![header]));
+
+        let Some(BlockResponseOutcome::Request(
+            dispatched_peer,
+            BlockRequest::GetBlockHeaders(request),
+        )) = outcome
+        else {
+            panic!("expected a header followup request")
+        };
+        assert_eq!(dispatched_peer, peer_id);
+        assert_eq!(request.start_block, 1u64.into());
+        assert_eq!(request.limit, 1);
+        assert!(!fetcher.peers[&peer_id].last_response_likely_bad);
+        assert!(response_rx.try_recv().is_ok());
+    }
+
     #[test]
     fn test_peer_is_better_none_requirement() {
         let peer1 = Peer {

--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -33,7 +33,7 @@ impl<H: BlockHeader> EthResponseValidator for RequestResult<Vec<H>> {
             Ok(headers) => {
                 let request_length = headers.len() as u64;
 
-                if request_length <= 1 && request.limit != request_length {
+                if (request_length == 0 && request.limit > 0) || request_length > request.limit {
                     return true
                 }
 
@@ -231,6 +231,16 @@ mod tests {
         let request =
             HeadersRequest { start: 0u64.into(), limit: 1, direction: Default::default() };
         let headers: Vec<Header> = vec![];
+        assert!(Ok(headers).is_likely_bad_headers_response(&request));
+
+        let request =
+            HeadersRequest { start: 0u64.into(), limit: 2, direction: Default::default() };
+        let headers = vec![Header::default()];
+        assert!(!Ok(headers).is_likely_bad_headers_response(&request));
+
+        let request =
+            HeadersRequest { start: 0u64.into(), limit: 1, direction: Default::default() };
+        let headers = vec![Header::default(), Header::default()];
         assert!(Ok(headers).is_likely_bad_headers_response(&request));
     }
 }

--- a/crates/net/p2p/src/error.rs
+++ b/crates/net/p2p/src/error.rs
@@ -154,9 +154,9 @@ pub enum DownloadError {
     /// Received a response to a request with unexpected start block
     #[display("headers response starts at unexpected block: {_0}")]
     HeadersResponseStartBlockMismatch(GotExpected<u64>),
-    /// Received headers with less than expected items.
-    #[display("received less headers than expected: {_0}")]
-    HeadersResponseTooShort(GotExpected<u64>),
+    /// Received more headers than requested.
+    #[display("received more headers than requested: {_0}")]
+    HeadersResponseTooLong(GotExpected<u64>),
 
     /* ==================== BODIES ERRORS ==================== */
     /// Block validation failed


### PR DESCRIPTION
Peers may cap `BlockHeaders` responses below the requested limit, which the eth wire protocol permits due to response size limits. Treat a non-empty, correctly-started short response as valid and queue the exact remaining suffix at high priority. The suffix is requested before buffered responses are validated, because a buffered validation error returns early and would otherwise leave the remainder of the range unrequested. The length check now only rejects over-long responses, so `HeadersResponseTooLong` replaces the `HeadersResponseTooShort` error variant.

The network fetcher no longer classifies valid partial responses as bad or suppresses a direct follow-up. Empty, oversized, and wrong-start responses remain rejected. Since short responses no longer carry a reputation penalty, capped responses are tracked in a new `downloaders.headers.partial_responses` metric to keep them observable; follow-up requests go through the fetcher to the best idle peer, so a consistently capping peer does not pin the missing range to itself.

Coverage exercises the capped downloader response, a buffered partial response, over-long rejection, and the one-header fetcher path including no bad-message report and follow-up dispatch.