### PR TITLE
chore(rpc): fix IPC server formatting

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -461,7 +461,7 @@ fn process_connection<RpcMiddleware, HttpMiddleware>(
     >,
     <<HttpMiddleware as Layer<TowerServiceNoHttp<RpcMiddleware>>>::Service as Service<String>>::Future:
     Send + Unpin,
- {
+{
     let ProcessConnection {
         http_middleware,
         rpc_middleware,


### PR DESCRIPTION
Removes the stray whitespace that causes the nightly rustfmt check on main to fail.

Prompted by: @pepyakin