### PR TITLE
feat(cli): add configurable dev defaults

### DIFF
--- a/crates/node/core/src/args/dev.rs
+++ b/crates/node/core/src/args/dev.rs
@@ -1,12 +1,15 @@
 //! clap [Args](clap::Args) for Dev testnet configuration
 
-use std::{num::NonZeroUsize, time::Duration};
+use std::{num::NonZeroUsize, sync::OnceLock, time::Duration};
 
-use clap::Args;
-use humantime::parse_duration;
+use clap::{builder::Resettable, Args};
+use humantime::{format_duration, parse_duration};
 use reth_engine_local::DEFAULT_FINALITY_DEPTH;
 
 const DEFAULT_MNEMONIC: &str = "test test test test test test test test test test test junk";
+
+/// Global static dev testnet defaults
+static DEV_DEFAULTS: OnceLock<DefaultDevArgs> = OnceLock::new();
 
 /// Parameters for Dev testnet configuration
 #[derive(Debug, Args, PartialEq, Eq, Clone)]
@@ -19,14 +22,15 @@ pub struct DevArgs {
     /// Disables network discovery and enables local http server.
     /// Prefunds 20 accounts derived by mnemonic "test test test test test test test test test test
     /// test junk" with 10 000 ETH each.
-    #[arg(long = "dev", alias = "auto-mine", help_heading = "Dev testnet", verbatim_doc_comment)]
+    #[arg(long = "dev", alias = "auto-mine", help_heading = "Dev testnet", default_value_t = DefaultDevArgs::get_global().dev, verbatim_doc_comment)]
     pub dev: bool,
 
     /// How many transactions to mine per block.
     #[arg(
         long = "dev.block-max-transactions",
         help_heading = "Dev testnet",
-        conflicts_with = "block_time"
+        conflicts_with = "block_time",
+        default_value = Resettable::from(DefaultDevArgs::get_global().block_max_transactions.map(|v| v.to_string().into()))
     )]
     pub block_max_transactions: Option<usize>,
 
@@ -39,6 +43,7 @@ pub struct DevArgs {
         help_heading = "Dev testnet",
         conflicts_with = "block_max_transactions",
         value_parser = parse_duration,
+        default_value = Resettable::from(DefaultDevArgs::get_global().block_time.map(|v| format_duration(v).to_string().into())),
         verbatim_doc_comment
     )]
     pub block_time: Option<Duration>,
@@ -49,7 +54,7 @@ pub struct DevArgs {
     #[arg(
         long = "dev.finality-depth",
         help_heading = "Dev testnet",
-        default_value_t = DEFAULT_FINALITY_DEPTH,
+        default_value_t = DefaultDevArgs::get_global().finality_depth,
         verbatim_doc_comment
     )]
     pub finality_depth: NonZeroUsize,
@@ -66,6 +71,7 @@ pub struct DevArgs {
         long = "dev.payload-wait-time",
         help_heading = "Dev testnet",
         value_parser = parse_duration,
+        default_value = Resettable::from(DefaultDevArgs::get_global().payload_wait_time.map(|v| format_duration(v).to_string().into())),
         verbatim_doc_comment
     )]
     pub payload_wait_time: Option<Duration>,
@@ -77,12 +83,79 @@ pub struct DevArgs {
         value_name = "MNEMONIC",
         requires = "dev",
         verbatim_doc_comment,
-        default_value = DEFAULT_MNEMONIC
+        default_value_t = DefaultDevArgs::get_global().dev_mnemonic.clone()
     )]
     pub dev_mnemonic: String,
 }
 
-impl Default for DevArgs {
+/// Default values for dev testnet CLI arguments that can be customized.
+///
+/// Global defaults can be set via [`DefaultDevArgs::try_init`].
+#[derive(Debug, Clone)]
+pub struct DefaultDevArgs {
+    /// Default for `--dev`.
+    pub dev: bool,
+    /// Default maximum number of transactions to mine per block.
+    pub block_max_transactions: Option<usize>,
+    /// Default interval between blocks.
+    pub block_time: Option<Duration>,
+    /// Default number of confirmations required before finalization.
+    pub finality_depth: NonZeroUsize,
+    /// Default time to wait before resolving a payload.
+    pub payload_wait_time: Option<Duration>,
+    /// Default mnemonic used to derive dev accounts.
+    pub dev_mnemonic: String,
+}
+
+impl DefaultDevArgs {
+    /// Initialize the global dev testnet defaults with this configuration.
+    pub fn try_init(self) -> Result<(), Self> {
+        DEV_DEFAULTS.set(self)
+    }
+
+    /// Get a reference to the global dev testnet defaults.
+    pub fn get_global() -> &'static Self {
+        DEV_DEFAULTS.get_or_init(Self::default)
+    }
+
+    /// Set whether dev mode is enabled by default.
+    pub const fn with_dev(mut self, dev: bool) -> Self {
+        self.dev = dev;
+        self
+    }
+
+    /// Set the default maximum number of transactions to mine per block.
+    pub const fn with_block_max_transactions(mut self, count: Option<usize>) -> Self {
+        self.block_max_transactions = count;
+        self
+    }
+
+    /// Set the default interval between blocks.
+    pub const fn with_block_time(mut self, block_time: Option<Duration>) -> Self {
+        self.block_time = block_time;
+        self
+    }
+
+    /// Set the default number of confirmations required before finalization.
+    pub const fn with_finality_depth(mut self, finality_depth: NonZeroUsize) -> Self {
+        self.finality_depth = finality_depth;
+        self
+    }
+
+    /// Set the default time to wait before resolving a payload.
+    pub const fn with_payload_wait_time(mut self, payload_wait_time: Option<Duration>) -> Self {
+        self.payload_wait_time = payload_wait_time;
+        self
+    }
+
+    /// Set the default mnemonic used to derive dev accounts.
+    pub fn with_dev_mnemonic(mut self, dev_mnemonic: String) -> Self {
+        self.dev_mnemonic = dev_mnemonic;
+        self
+    }
+}
+
+impl Default for DefaultDevArgs {
     fn default() -> Self {
         Self {
             dev: false,
@@ -91,6 +164,27 @@ impl Default for DevArgs {
             finality_depth: DEFAULT_FINALITY_DEPTH,
             payload_wait_time: None,
             dev_mnemonic: DEFAULT_MNEMONIC.to_string(),
+        }
+    }
+}
+
+impl Default for DevArgs {
+    fn default() -> Self {
+        let DefaultDevArgs {
+            dev,
+            block_max_transactions,
+            block_time,
+            finality_depth,
+            payload_wait_time,
+            dev_mnemonic,
+        } = DefaultDevArgs::get_global().clone();
+        Self {
+            dev,
+            block_max_transactions,
+            block_time,
+            finality_depth,
+            payload_wait_time,
+            dev_mnemonic,
         }
     }
 }

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -50,7 +50,7 @@ pub use txpool::{DefaultTxPoolValues, TxPoolArgs};
 
 /// DevArgs for configuring the dev testnet
 mod dev;
-pub use dev::DevArgs;
+pub use dev::{DefaultDevArgs, DevArgs};
 
 /// PruneArgs for configuring the pruning and full node
 mod pruning;

--- a/crates/node/core/tests/default_dev_args.rs
+++ b/crates/node/core/tests/default_dev_args.rs
@@ -1,0 +1,35 @@
+//! Integration tests for customizable dev CLI defaults.
+
+use std::{num::NonZeroUsize, time::Duration};
+
+use clap::{Args, Parser};
+use reth_node_core::args::{DefaultDevArgs, DevArgs};
+
+#[derive(Parser)]
+struct CommandParser<T: Args> {
+    #[command(flatten)]
+    args: T,
+}
+
+#[test]
+fn custom_dev_defaults_apply_to_cli_and_default() {
+    let defaults = DefaultDevArgs::default()
+        .with_dev(true)
+        .with_block_max_transactions(Some(3))
+        .with_finality_depth(NonZeroUsize::new(2).unwrap())
+        .with_payload_wait_time(Some(Duration::from_millis(250)))
+        .with_dev_mnemonic("custom mnemonic".to_string());
+    defaults.try_init().unwrap();
+
+    let expected = DevArgs {
+        dev: true,
+        block_max_transactions: Some(3),
+        block_time: None,
+        finality_depth: NonZeroUsize::new(2).unwrap(),
+        payload_wait_time: Some(Duration::from_millis(250)),
+        dev_mnemonic: "custom mnemonic".to_string(),
+    };
+
+    assert_eq!(CommandParser::<DevArgs>::parse_from(["reth"]).args, expected);
+    assert_eq!(DevArgs::default(), expected);
+}


### PR DESCRIPTION
Adds a global, customizable `DefaultDevArgs` configuration and wires it into clap parsing and `DevArgs::default()`. This lets downstream node implementations override dev-mode defaults before parsing while preserving reth’s existing CLI behavior.