### PR TITLE
feat: enable txpool prewarm on nightly

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,7 +91,12 @@ jobs:
           elif [[ "${EVENT_NAME}" == "schedule" ]] || [[ "${BUILD_TYPE}" == "nightly" ]]; then
             echo "targets=nightly" >> "$GITHUB_OUTPUT"
             echo "ethereum_tags=${REGISTRY}/reth:nightly" >> "$GITHUB_OUTPUT"
-            echo "ethereum_set=ethereum.tags=${REGISTRY}/reth:nightly" >> "$GITHUB_OUTPUT"
+            {
+              echo "ethereum_set<<EOF"
+              echo "ethereum.tags=${REGISTRY}/reth:nightly"
+              echo "ethereum.args.RETH_ENGINE_TXPOOL_PREWARMING=true"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
 
           else
             # git-sha build

--- a/Dockerfile.depot
+++ b/Dockerfile.depot
@@ -74,6 +74,10 @@ WORKDIR /app
 # Binary name for entrypoint
 ARG BINARY=reth
 
+# Runtime defaults
+ARG RETH_ENGINE_TXPOOL_PREWARMING=false
+ENV RETH_ENGINE_TXPOOL_PREWARMING=$RETH_ENGINE_TXPOOL_PREWARMING
+
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -348,8 +348,8 @@ pub struct EngineArgs {
     /// Enable best-effort txpool transaction prewarming between payloads.
     #[arg(
         long = "engine.txpool-prewarming",
-        default_value_t = DefaultEngineValues::get_global().txpool_prewarming_enabled,
-        conflicts_with = "state_cache_disabled"
+        env = "RETH_ENGINE_TXPOOL_PREWARMING",
+        default_value_t = DefaultEngineValues::get_global().txpool_prewarming_enabled
     )]
     pub txpool_prewarming_enabled: bool,
 
@@ -651,6 +651,10 @@ impl EngineArgs {
             self.persistence_threshold,
         );
         ensure!(
+            !self.state_cache_disabled || !self.txpool_prewarming_enabled,
+            "--engine.txpool-prewarming conflicts with --engine.disable-state-cache"
+        );
+        ensure!(
             self.bal_parallel_execution_disabled || !self.bal_parallel_state_root_disabled,
             "--engine.disable-bal-parallel-state-root requires --engine.disable-bal-parallel-execution because BAL parallel execution depends on BAL prewarm state-root updates"
         );
@@ -741,15 +745,16 @@ mod tests {
     }
 
     #[test]
-    fn txpool_prewarming_conflicts_with_disabled_state_cache() {
-        let Err(error) = CommandParser::<EngineArgs>::try_parse_from([
-            "reth",
-            "--engine.txpool-prewarming",
-            "--engine.disable-state-cache",
-        ]) else {
-            panic!("conflicting flags must be rejected")
+    fn validate_rejects_txpool_prewarming_with_disabled_state_cache() {
+        let args = EngineArgs {
+            state_cache_disabled: true,
+            txpool_prewarming_enabled: true,
+            ..EngineArgs::default()
         };
-        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        let err = args.validate().unwrap_err().to_string();
+        assert!(err.contains("engine.txpool-prewarming"));
+        assert!(err.contains("engine.disable-state-cache"));
     }
 
     #[test]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1014,6 +1014,8 @@ Engine:
       --engine.txpool-prewarming
           Enable best-effort txpool transaction prewarming between payloads
 
+          [env: RETH_ENGINE_TXPOOL_PREWARMING=]
+
       --engine.state-provider-metrics
           Enable state provider latency metrics. This allows the engine to collect and report stats about how long state provider calls took during execution, but this does introduce slight overhead to state provider calls
 


### PR DESCRIPTION
This PR enables txpool prewarming on scheduled nightly builds. 

This is done by allowing the txpool prewarming turning on via an env flag `RETH_ENGINE_TXPOOL_PREWARMING`. Then, that flag is is enabled for the scheduled nightly builds.
