### PR TITLE
fix(net): derive ENR node records from a single address family

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -23,12 +23,11 @@ pub use config::DnsDiscoveryConfig;
 use enr::Enr;
 pub use error::ParseDnsEntryError;
 use reth_ethereum_forks::{EnrForkIdEntry, ForkId};
-use reth_network_peers::{pk2id, NodeRecord};
+use reth_network_peers::NodeRecord;
 use schnellru::{ByLength, LruMap};
 use secp256k1::SecretKey;
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
-    net::IpAddr,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
@@ -390,13 +389,7 @@ pub enum DnsDiscoveryEvent {
 
 /// Converts an [Enr] into a [`NodeRecord`]
 fn convert_enr_node_record(enr: &Enr<SecretKey>) -> Option<DnsNodeRecordUpdate> {
-    let node_record = NodeRecord {
-        address: enr.ip4().map(IpAddr::from).or_else(|| enr.ip6().map(IpAddr::from))?,
-        tcp_port: enr.tcp4().or_else(|| enr.tcp6())?,
-        udp_port: enr.udp4().or_else(|| enr.udp6())?,
-        id: pk2id(&enr.public_key()),
-    }
-    .into_ipv4_mapped();
+    let node_record = NodeRecord::try_from(enr).ok().filter(|record| record.tcp_port != 0)?;
 
     let fork_id =
         enr.get_decodable::<EnrForkIdEntry>(b"eth").transpose().ok().flatten().map(Into::into);
@@ -416,7 +409,10 @@ mod tests {
     use reth_chainspec::MAINNET;
     use reth_ethereum_forks::{EthereumHardfork, ForkHash};
     use secp256k1::rand::thread_rng;
-    use std::{future::poll_fn, net::Ipv4Addr};
+    use std::{
+        future::poll_fn,
+        net::{IpAddr, Ipv4Addr},
+    };
 
     fn entry_hash(entry_txt: &str) -> String {
         BASE32_NOPAD.encode(&keccak256(entry_txt.as_bytes()).as_slice()[..16])

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -157,22 +157,15 @@ impl AnyNode {
     }
 
     /// Returns the full node record if available.
+    ///
+    /// An ENR that advertises no tcp port has no RLPx endpoint, so it does not yield a record.
     #[cfg(feature = "secp256k1")]
     pub fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),
             Self::Enr(enr) => {
-                let node_record = NodeRecord {
-                    address: enr
-                        .ip4()
-                        .map(core::net::IpAddr::from)
-                        .or_else(|| enr.ip6().map(core::net::IpAddr::from))?,
-                    tcp_port: enr.tcp4().or_else(|| enr.tcp6())?,
-                    udp_port: enr.udp4().or_else(|| enr.udp6())?,
-                    id: pk2id(&enr.public_key()),
-                }
-                .into_ipv4_mapped();
-                Some(node_record)
+                let node_record = NodeRecord::try_from(enr).ok()?;
+                (node_record.tcp_port != 0).then_some(node_record)
             }
             Self::PeerId(_) | Self::TrustedPeer(_) => None,
         }

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -212,23 +212,39 @@ impl TryFrom<Enr<secp256k1::SecretKey>> for NodeRecord {
 impl TryFrom<&Enr<secp256k1::SecretKey>> for NodeRecord {
     type Error = NodeRecordParseError;
 
+    /// Endpoint keys are read from a single address family, because mixing them yields an address
+    /// and a port that don't belong together. A family that also advertises a tcp port wins, since
+    /// a record without one has no RLPx endpoint (port 0) even though it stays dialable for
+    /// discovery.
     fn try_from(enr: &Enr<secp256k1::SecretKey>) -> Result<Self, Self::Error> {
-        let Some(address) = enr.ip4().map(IpAddr::from).or_else(|| enr.ip6().map(IpAddr::from))
-        else {
-            return Err(NodeRecordParseError::InvalidUrl("ip missing".to_string()))
-        };
-
-        let Some(udp_port) = enr.udp4().or_else(|| enr.udp6()) else {
-            return Err(NodeRecordParseError::InvalidUrl("udp port missing".to_string()))
-        };
-
-        // A discovery-only ENR (e.g. a devp2p bootnode) omits the tcp key; treat that as no RLPx
-        // (port 0) rather than rejecting the record.
-        let tcp_port = enr.tcp4().or_else(|| enr.tcp6()).unwrap_or(0);
-
         let id = crate::pk2id(&enr.public_key());
+        let endpoint = |ip: IpAddr, udp_port, tcp_port: Option<u16>| Self {
+            address: ip,
+            udp_port,
+            tcp_port: tcp_port.unwrap_or(0),
+            id,
+        };
 
-        Ok(Self { address, tcp_port, udp_port, id }.into_ipv4_mapped())
+        let v4 = enr
+            .ip4()
+            .zip(enr.udp4())
+            .map(|(ip, udp_port)| endpoint(ip.into(), udp_port, enr.tcp4()));
+        let v6 = enr
+            .ip6()
+            .zip(enr.udp6())
+            .map(|(ip, udp_port)| endpoint(ip.into(), udp_port, enr.tcp6()));
+
+        let has_rlpx = |record: &Self| record.tcp_port != 0;
+        v4.filter(has_rlpx)
+            .or_else(|| v6.filter(has_rlpx))
+            .or(v4)
+            .or(v6)
+            .map(Self::into_ipv4_mapped)
+            .ok_or_else(|| {
+                NodeRecordParseError::InvalidUrl(
+                    "no ip and udp port for a single address family".to_string(),
+                )
+            })
     }
 }
 
@@ -238,6 +254,48 @@ mod tests {
     use alloy_rlp::Decodable;
     use rand::{rng, Rng, RngCore};
     use std::net::Ipv6Addr;
+
+    #[cfg(feature = "secp256k1")]
+    #[test]
+    fn test_enr_endpoint_single_family() {
+        let key = secp256k1::SecretKey::new(&mut rand_08::thread_rng());
+        let enr = enr::Enr::builder()
+            .ip4("10.0.0.1".parse().unwrap())
+            .udp4(30301)
+            .ip6("::1".parse().unwrap())
+            .udp6(30401)
+            .tcp6(30403)
+            .build(&key)
+            .unwrap();
+
+        let record = NodeRecord::try_from(&enr).unwrap();
+        assert_eq!(record.address, "::1".parse::<IpAddr>().unwrap());
+        assert_eq!(record.udp_port, 30401);
+        assert_eq!(record.tcp_port, 30403);
+
+        let enr = enr::Enr::builder()
+            .ip4("10.0.0.1".parse().unwrap())
+            .udp4(30301)
+            .tcp4(30303)
+            .ip6("::1".parse().unwrap())
+            .udp6(30401)
+            .tcp6(30403)
+            .build(&key)
+            .unwrap();
+
+        let record = NodeRecord::try_from(&enr).unwrap();
+        assert_eq!(record.address, "10.0.0.1".parse::<IpAddr>().unwrap());
+        assert_eq!(record.udp_port, 30301);
+        assert_eq!(record.tcp_port, 30303);
+
+        let enr = enr::Enr::builder().ip6("::1".parse().unwrap()).udp6(30401).build(&key).unwrap();
+        let record = NodeRecord::try_from(&enr).unwrap();
+        assert_eq!(record.address, "::1".parse::<IpAddr>().unwrap());
+        assert_eq!(record.udp_port, 30401);
+
+        let enr = enr::Enr::builder().ip4("10.0.0.1".parse().unwrap()).build(&key).unwrap();
+        assert!(NodeRecord::try_from(&enr).is_err());
+    }
 
     #[test]
     fn test_mapped_ipv6() {


### PR DESCRIPTION
## Description

`NodeRecord::try_from(&Enr)` reads `ip4`-then-`ip6`, `udp4`-then-`udp6` and
`tcp4`-then-`tcp6` independently, so a partial dual-stack ENR (say `ip4` without `udp4`,
plus a complete IPv6 endpoint) yields a record whose address and ports come from different
families. The resulting socket never existed, so discovery contacts nothing.

Endpoints are now taken from one address family, preferring whichever family advertises a
tcp port, since a record without one has no RLPx endpoint even though it stays dialable for
discovery. `AnyNode::node_record()` and the DNS resolver's `convert_enr_node_record()`
carried their own copies of the same conversion with the same flaw; both now delegate to it.

Behavior changes:
- `AnyNode::node_record()` returns `None` for an ENR advertising `tcp=0` (previously `Some`
  with an unreachable RLPx port).
- DNS-resolved records require `ip` and `udp` within one family, where before any
  combination was accepted.

Discovery-only ENRs still convert with `tcp=0` (#26089), and fully-populated dual-stack or
single-family records are unaffected.

Independent of #26448 and #26402 (disjoint files, merges clean either way), but #26448
routes user-supplied ENRs into this conversion, so landing this first avoids exposing the
mixed-family case on that new CLI surface. #26402 has its own family-aware derivation for
the bootnode command that additionally prefers a served family; it could be simplified onto
this helper later.
