### PR TITLE
fix(trie): include account lifecycle changes in sparse updates

### DIFF
--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -1430,7 +1430,13 @@ mod tests {
 
         let factory = create_test_provider_factory_with_chain_spec(Arc::new(ChainSpec::default()));
         let genesis_hash = init_genesis(&factory).unwrap();
-        let state_updates = create_mock_state_updates(10, 10);
+        let mut state_updates = create_mock_state_updates(10, 10);
+        let mut created_empty_update = EvmState::default();
+        created_empty_update.insert(
+            Address::with_last_byte(0xff),
+            revm::state::Account::default().with_touched_mark().with_created_mark(),
+        );
+        state_updates.push(created_empty_update);
         let mut accumulated_state: HashMap<Address, (Account, HashMap<B256, U256>)> =
             HashMap::default();
 

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1051,12 +1051,15 @@ fn encode_account_leaf_value(
     storage_root: B256,
     account_rlp_buf: &mut Vec<u8>,
 ) -> Vec<u8> {
-    if account.is_none_or(|account| account.is_empty()) && storage_root == EMPTY_ROOT_HASH {
+    // Account existence is explicit in `HashedPostState`: `None` deletes the leaf, while
+    // `Some`, including an empty account, writes it. EIP-161 normalization happens when the
+    // execution state is converted into hashed post state.
+    let Some(account) = account else {
         return Vec::new();
-    }
+    };
 
     account_rlp_buf.clear();
-    account.unwrap_or_default().into_trie_account(storage_root).encode(account_rlp_buf);
+    account.into_trie_account(storage_root).encode(account_rlp_buf);
     account_rlp_buf.clone()
 }
 
@@ -1172,13 +1175,27 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_account_leaf_value_empty_account_and_empty_root_is_empty() {
+    fn test_encode_account_leaf_value_deleted_account_is_empty() {
         let mut account_rlp_buf = vec![0xAB];
         let encoded = encode_account_leaf_value(None, EMPTY_ROOT_HASH, &mut account_rlp_buf);
 
         assert!(encoded.is_empty());
         // Early return should not touch the caller's buffer.
         assert_eq!(account_rlp_buf, vec![0xAB]);
+    }
+
+    #[test]
+    fn test_encode_account_leaf_value_empty_account_is_rlp() {
+        let mut account_rlp_buf = vec![0xAB];
+        let encoded = encode_account_leaf_value(
+            Some(Account::default()),
+            EMPTY_ROOT_HASH,
+            &mut account_rlp_buf,
+        );
+        let decoded = TrieAccount::decode(&mut &encoded[..]).expect("valid account RLP");
+
+        assert_eq!(decoded, TrieAccount::default());
+        assert_eq!(account_rlp_buf, encoded);
     }
 
     #[test]

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -501,8 +501,17 @@ pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
             trace!(target: "trie::parallel::sparse", ?address, ?hashed_address, "Adding account to state update");
 
             let destroyed = account.is_selfdestructed();
-            if account.info != account.original_info() {
-                let info = if destroyed { None } else { Some(account.info.into()) };
+            let explicitly_created = account.is_created();
+            let info_changed = account.info != account.original_info();
+            if destroyed || explicitly_created || info_changed {
+                // Match revm-database transition ordering: creation materializes the account
+                // before the EIP-161 empty-account check, while a non-created account that
+                // becomes empty is deleted.
+                let info = if destroyed || (!explicitly_created && account.is_empty()) {
+                    None
+                } else {
+                    Some(account.info.into())
+                };
                 hashed_state.accounts.insert(hashed_address, info);
             }
 
@@ -529,10 +538,88 @@ pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::{Address, U256};
+    use revm::state::Account;
     use std::{
         sync::atomic::{AtomicUsize, Ordering},
         time::Duration,
     };
+
+    #[test]
+    fn created_empty_account_is_included() {
+        let account = Account::default().with_touched_mark().with_created_mark();
+        let mut state = EvmState::default();
+        state.insert(Address::ZERO, account);
+
+        let hashed_state = evm_state_to_hashed_post_state(state);
+
+        assert!(matches!(hashed_state.accounts.get(&keccak256(Address::ZERO)), Some(Some(_))));
+    }
+
+    #[test]
+    fn locally_created_empty_account_is_included() {
+        let mut account = Account::default().with_touched_mark();
+        account.mark_created_locally();
+        let mut state = EvmState::default();
+        state.insert(Address::ZERO, account);
+
+        let hashed_state = evm_state_to_hashed_post_state(state);
+
+        assert!(matches!(hashed_state.accounts.get(&keccak256(Address::ZERO)), Some(Some(_))));
+    }
+
+    #[test]
+    fn created_non_empty_account_is_included() {
+        let mut account = Account::default().with_touched_mark().with_created_mark();
+        account.info.balance = U256::from(1);
+        let mut state = EvmState::default();
+        state.insert(Address::ZERO, account);
+
+        let hashed_state = evm_state_to_hashed_post_state(state);
+
+        assert!(matches!(
+            hashed_state.accounts.get(&keccak256(Address::ZERO)),
+            Some(Some(account)) if account.balance == U256::from(1)
+        ));
+    }
+
+    #[test]
+    fn emptied_account_is_deleted() {
+        let mut account = Account::default().with_touched_mark();
+        account.original_info_mut().balance = U256::from(1);
+        let mut state = EvmState::default();
+        state.insert(Address::ZERO, account);
+
+        let hashed_state = evm_state_to_hashed_post_state(state);
+
+        assert!(matches!(hashed_state.accounts.get(&keccak256(Address::ZERO)), Some(None)));
+    }
+
+    #[test]
+    fn selfdestruct_takes_precedence_over_creation() {
+        let account =
+            Account::default().with_touched_mark().with_created_mark().with_selfdestruct_mark();
+        let mut state = EvmState::default();
+        state.insert(Address::ZERO, account);
+
+        let hashed_state = evm_state_to_hashed_post_state(state);
+        let hashed_address = keccak256(Address::ZERO);
+
+        assert!(matches!(hashed_state.accounts.get(&hashed_address), Some(None)));
+        assert!(hashed_state.storages[&hashed_address].wiped);
+    }
+
+    #[test]
+    fn unchanged_touched_account_is_omitted() {
+        let account = Account::default().with_touched_mark();
+        let mut state = EvmState::default();
+        state.insert(Address::ZERO, account);
+
+        let hashed_state = evm_state_to_hashed_post_state(state);
+
+        assert!(hashed_state.accounts.is_empty());
+        assert!(hashed_state.storages.is_empty());
+    }
 
     #[derive(Default)]
     struct CountingSink {


### PR DESCRIPTION
closes #26499. lmk if those are too many tests, just couldn't find any other tests for `evm_state_to_hashed_post_state`.
This includes accounts which lifecycle changed (created/destroyed) without their info being changed.
