### PR TITLE
fix(rpc): cap implicit simulate gas limit

### DIFF
--- a/crates/ethereum/node/tests/e2e/simulate.rs
+++ b/crates/ethereum/node/tests/e2e/simulate.rs
@@ -1,12 +1,13 @@
-use crate::utils::eth_payload_attributes;
+use crate::utils::{eth_payload_attributes, eth_payload_attributes_amsterdam};
 use alloy_primitives::{bytes, Address, U256};
 use alloy_provider::{network::EthereumWallet, Provider, ProviderBuilder};
+use alloy_rpc_types_engine::PayloadAttributes;
 use alloy_rpc_types_eth::{
     simulate::{SimBlock, SimulatePayload, SimulatedBlock},
     state::{AccountOverride, StateOverride, StateOverridesBuilder},
     BlockOverrides, TransactionRequest, TransactionTrait as _,
 };
-use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::setup_engine;
 use reth_node_ethereum::EthereumNode;
 use std::sync::Arc;
@@ -97,6 +98,80 @@ async fn test_simulate_v1_no_fields_call_defaults_to_remaining_block_gas() -> ey
     assert_eq!(txs[1].gas_limit(), expected_remaining_gas);
 
     Ok(())
+}
+
+async fn assert_validation_uses_remaining_gas(
+    chain_spec: Arc<ChainSpec>,
+    payload_attributes: fn(u64) -> PayloadAttributes,
+) -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (mut nodes, wallet) =
+        setup_engine::<EthereumNode>(1, chain_spec, false, Default::default(), payload_attributes)
+            .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    let from: Address = "0xc000000000000000000000000000000000000000".parse()?;
+    let state_overrides =
+        StateOverridesBuilder::default().with_balance(from, U256::from(1_000_000_000u64)).build();
+    let tx = TransactionRequest::default()
+        .from(from)
+        .max_fee_per_gas(0)
+        .max_priority_fee_per_gas(0)
+        .nonce(0)
+        // Create an empty contract so Amsterdam exercises the state-gas reservoir.
+        .input(bytes!("0x60006000f3"));
+    let sim_block = SimBlock::default()
+        .with_block_overrides(BlockOverrides {
+            gas_limit: Some(U256::from(30_000_000u64)),
+            base_fee: Some(U256::ZERO),
+            ..Default::default()
+        })
+        .with_state_overrides(state_overrides)
+        .call(tx);
+    let payload =
+        SimulatePayload::default().with_validation().with_full_transactions().extend(sim_block);
+
+    let result: Vec<SimulatedBlock> =
+        provider.raw_request("eth_simulateV1".into(), (&payload, "latest")).await?;
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].calls.len(), 1);
+    assert!(result[0].calls[0].status);
+    let txs = result[0].inner.transactions.as_transactions().expect("expected full transactions");
+    assert_eq!(txs.len(), 1);
+    assert_eq!(txs[0].gas_limit(), 30_000_000);
+    assert!(txs[0].gas_limit() > (1 << 24));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_simulate_v1_validation_omitted_gas_uses_remaining_gas_osaka() -> eyre::Result<()> {
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .osaka_activated()
+            .build(),
+    );
+    assert_validation_uses_remaining_gas(chain_spec, eth_payload_attributes).await
+}
+
+#[tokio::test]
+async fn test_simulate_v1_validation_omitted_gas_uses_remaining_gas_amsterdam() -> eyre::Result<()>
+{
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .amsterdam_activated()
+            .build(),
+    );
+    assert_validation_uses_remaining_gas(chain_spec, eth_payload_attributes_amsterdam).await
 }
 
 #[tokio::test]

--- a/crates/ethereum/node/tests/e2e/simulate.rs
+++ b/crates/ethereum/node/tests/e2e/simulate.rs
@@ -123,10 +123,10 @@ async fn assert_validation_uses_remaining_gas(
         .max_priority_fee_per_gas(0)
         .nonce(0)
         // Create an empty contract so Amsterdam exercises the state-gas reservoir.
-        .input(bytes!("0x60006000f3"));
+        .input(bytes!("0x60006000f3").into());
     let sim_block = SimBlock::default()
         .with_block_overrides(BlockOverrides {
-            gas_limit: Some(U256::from(30_000_000u64)),
+            gas_limit: Some(30_000_000),
             base_fee: Some(U256::ZERO),
             ..Default::default()
         })

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -41,7 +41,7 @@ use reth_rpc_eth_types::{
 use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
 use revm::{
     context::Block,
-    context_interface::{result::ResultAndState, Transaction},
+    context_interface::{result::ResultAndState, Cfg, Transaction},
     Database, DatabaseCommit,
 };
 use revm_inspectors::{access_list::AccessListInspector, transfer::TransferInspector};

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -144,11 +144,16 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     // Always disable EIP-3607
                     evm_env.cfg_env.disable_eip3607 = true;
 
+                    // EIP-7825's transaction gas cap is only active with Amsterdam's
+                    // regular/state-gas accounting.
+                    if !evm_env.cfg_env.is_amsterdam_eip8037_enabled() {
+                        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+                    }
+
                     if !validation {
                         // If not explicitly required, we disable nonce check <https://github.com/paradigmxyz/reth/issues/16108>
                         evm_env.cfg_env.disable_nonce_check = true;
                         evm_env.cfg_env.disable_base_fee = true;
-                        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
                         evm_env.block_env.inner_mut().basefee = 0;
                     }
 


### PR DESCRIPTION
## Fix `eth_simulateV1` implicit gas limits

When `eth_simulateV1` requests omitted the `gas` field, Reth defaulted the transaction gas limit to the remaining block gas. On Osaka-enabled chains, this could exceed the transaction gas cap and cause a premature `-32000` “intrinsic gas too high” error.

This change caps the implicit gas limit at:

```text
min(remaining block gas, transaction gas cap)