### PR TITLE
fix(pruner): keep history checkpoint from rewinding on static file walks

### DIFF
--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -129,11 +129,17 @@ impl AccountHistory {
 
         let walker = StaticFileAccountChangesetWalker::new(provider, range);
         for result in walker {
-            if limiter.is_limit_reached() {
+            let (block_number, changeset) = result?;
+            // The walk itself deletes nothing, so an interrupted block cannot be resumed: giving
+            // up the budget inside block N reports checkpoint N-1 and the next run rereads the
+            // same entries, forever. Stop on block boundaries only, overshooting the budget by at
+            // most the rest of one block.
+            if limiter.is_limit_reached() &&
+                last_changeset_pruned_block.is_some_and(|last| last != block_number)
+            {
                 done = false;
                 break;
             }
-            let (block_number, changeset) = result?;
             highest_deleted_accounts.insert(changeset.address, block_number);
             last_changeset_pruned_block = Some(block_number);
             pruned_changesets += 1;
@@ -210,9 +216,19 @@ impl AccountHistory {
             )?;
         trace!(target: "pruner", pruned = %pruned_changesets, %done, "Pruned account history (changesets from database)");
 
+        // The table walk can stop in the middle of a block, so the interrupted block has to be
+        // pruned again on the next run.
+        let last_pruned_block = last_changeset_pruned_block.map(|block_number| {
+            if done {
+                block_number
+            } else {
+                block_number.saturating_sub(1)
+            }
+        });
+
         let result = HistoryPruneResult {
             highest_deleted: highest_deleted_accounts,
-            last_pruned_block: last_changeset_pruned_block,
+            last_pruned_block,
             pruned_count: pruned_changesets,
             done,
         };
@@ -263,11 +279,17 @@ impl AccountHistory {
         // to determine which history shard entries need pruning.
         let walker = StaticFileAccountChangesetWalker::new(provider, range);
         for result in walker {
-            if limiter.is_limit_reached() {
+            let (block_number, changeset) = result?;
+            // Static file changesets are not deleted here, so an interrupted block cannot be
+            // resumed: giving up the budget inside block N reports checkpoint N-1 and the next run
+            // rereads the same entries, forever. Stop on block boundaries only, overshooting the
+            // budget by at most the rest of one block.
+            if limiter.is_limit_reached() &&
+                last_changeset_pruned_block.is_some_and(|last| last != block_number)
+            {
                 done = false;
                 break;
             }
-            let (block_number, changeset) = result?;
             highest_deleted_accounts.insert(changeset.address, block_number);
             last_changeset_pruned_block = Some(block_number);
             changesets_processed += 1;
@@ -275,9 +297,7 @@ impl AccountHistory {
         }
         trace!(target: "pruner", processed = %changesets_processed, %done, "Scanned account changesets from static files");
 
-        let last_changeset_pruned_block = last_changeset_pruned_block
-            .map(|block_number| if done { block_number } else { block_number.saturating_sub(1) })
-            .unwrap_or(range_end);
+        let last_changeset_pruned_block = last_changeset_pruned_block.unwrap_or(range_end);
 
         // Prune RocksDB history shards for affected accounts
         let mut deleted_shards = 0usize;
@@ -761,5 +781,196 @@ mod tests {
         // All changesets should be pruned
         let final_changesets = db.table::<tables::AccountChangeSets>().unwrap();
         assert!(final_changesets.is_empty(), "All changesets up to block 10 should be pruned");
+    }
+
+    /// A block holding at least a whole run's budget of changesets must not stall the `RocksDB`
+    /// path: the walk deletes no changesets, so a checkpoint rewound below such a block would make
+    /// every later run reread it and never advance.
+    #[test]
+    fn dense_block_advances_rocksdb_checkpoint() {
+        use reth_db_api::models::ShardedKey;
+        use reth_provider::RocksDBProviderFactory;
+
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=20,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
+
+        let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();
+        let (changesets, _) = random_changeset_range(
+            &mut rng,
+            blocks.iter(),
+            accounts.into_iter().map(|(addr, acc)| (addr, (acc, Vec::new()))),
+            0..0,
+            0..0,
+        );
+        // `random_changeset_range` emits exactly 2 account changesets per block (sender +
+        // recipient), so a budget of 2 makes every block "dense".
+        assert!(changesets.iter().all(|changeset| changeset.len() == 2));
+
+        db.insert_changesets_to_static_files(changesets.clone(), None)
+            .expect("insert changesets to static files");
+
+        // History index lives in RocksDB on the v2 path.
+        let mut account_blocks: BTreeMap<_, Vec<u64>> = BTreeMap::new();
+        for (block, changeset) in changesets.iter().enumerate() {
+            for (address, _, _) in changeset {
+                account_blocks.entry(*address).or_default().push(block as u64);
+            }
+        }
+        let rocksdb = db.factory.rocksdb_provider();
+        let mut batch = rocksdb.batch();
+        for (address, block_numbers) in &account_blocks {
+            let shard = BlockNumberList::new_pre_sorted(block_numbers.iter().copied());
+            batch
+                .put::<tables::AccountsHistory>(ShardedKey::new(*address, u64::MAX), &shard)
+                .unwrap();
+        }
+        batch.commit().unwrap();
+
+        db.factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let to_block: BlockNumber = 15;
+        let prune_mode = PruneMode::Before(to_block);
+        let segment = AccountHistory::new(prune_mode);
+
+        // Start from a checkpoint in the middle so a rewind can't be masked by block 0.
+        let mut checkpoint = PruneCheckpoint { block_number: Some(4), tx_number: None, prune_mode };
+
+        let run_prune = |checkpoint: PruneCheckpoint, limit: usize| {
+            let input = PruneInput {
+                previous_checkpoint: Some(checkpoint),
+                to_block,
+                limiter: PruneLimiter::default().set_deleted_entries_limit(limit),
+            };
+
+            let provider = db.factory.database_provider_rw().unwrap();
+            provider.set_storage_settings_cache(StorageSettings::v2());
+            let result = segment.prune(&provider, input).unwrap();
+            segment
+                .save_checkpoint(
+                    &provider,
+                    result.checkpoint.unwrap().as_prune_checkpoint(prune_mode),
+                )
+                .unwrap();
+            provider.commit().expect("commit");
+
+            let checkpoint = db
+                .factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::AccountHistory)
+                .unwrap()
+                .unwrap();
+            (result, checkpoint)
+        };
+
+        // The RocksDB path does not halve the limit, so a budget of 2 is exactly one dense block.
+        for _ in 0..3 {
+            let previous = checkpoint.block_number;
+            let (result, next) = run_prune(checkpoint, 2);
+            checkpoint = next;
+
+            assert!(
+                !result.progress.is_finished(),
+                "the range is longer than one run's budget allows"
+            );
+            assert!(
+                checkpoint.block_number > previous,
+                "checkpoint must advance past the dense block, got {:?} after {previous:?}",
+                checkpoint.block_number
+            );
+        }
+        assert_eq!(checkpoint.block_number, Some(7), "one dense block cleared per run");
+
+        // With enough budget the remainder of the range completes in one run.
+        let (result, checkpoint) = run_prune(checkpoint, 1000);
+        assert!(result.progress.is_finished());
+        assert_eq!(checkpoint.block_number, Some(to_block));
+    }
+
+    /// Same guarantee for `prune_static_files`, which shares the changeset walk. `Segment::prune`
+    /// cannot reach it while `storage_v2` short-circuits to the `RocksDB` path, so it is called
+    /// directly.
+    #[test]
+    fn dense_block_advances_static_file_checkpoint() {
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=20,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
+
+        let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();
+        let (changesets, _) = random_changeset_range(
+            &mut rng,
+            blocks.iter(),
+            accounts.into_iter().map(|(addr, acc)| (addr, (acc, Vec::new()))),
+            0..0,
+            0..0,
+        );
+        assert!(changesets.iter().all(|changeset| changeset.len() == 2));
+
+        // Changesets in static files. `StaticFileAccountChangesetWalker` resolves entries through
+        // `ChangeSetReader`, which only reads static files when `storage_v2` is set, so the walk
+        // needs v2 settings even though v2 routes `prune()` to the RocksDB path.
+        db.insert_changesets_to_static_files(changesets, None)
+            .expect("insert changesets to static files");
+        db.factory.set_storage_settings_cache(StorageSettings::v2());
+        assert!(db.table::<tables::AccountChangeSets>().unwrap().is_empty());
+
+        let to_block: BlockNumber = 15;
+        let prune_mode = PruneMode::Before(to_block);
+        let segment = AccountHistory::new(prune_mode);
+
+        let mut checkpoint = PruneCheckpoint { block_number: Some(4), tx_number: None, prune_mode };
+
+        for _ in 0..3 {
+            let previous = checkpoint.block_number;
+            let input = PruneInput {
+                previous_checkpoint: Some(checkpoint),
+                to_block,
+                // Halved internally by ACCOUNT_HISTORY_TABLES_TO_PRUNE, so 4 == one dense block.
+                limiter: PruneLimiter::default()
+                    .set_deleted_entries_limit(2 * ACCOUNT_HISTORY_TABLES_TO_PRUNE),
+            };
+            let range = input.get_next_block_range().unwrap();
+            let range_end = *range.end();
+
+            let provider = db.factory.database_provider_rw().unwrap();
+            provider.set_storage_settings_cache(StorageSettings::v2());
+            let result = segment.prune_static_files(&provider, input, range, range_end).unwrap();
+            segment
+                .save_checkpoint(
+                    &provider,
+                    result.checkpoint.unwrap().as_prune_checkpoint(prune_mode),
+                )
+                .unwrap();
+            provider.commit().expect("commit");
+
+            checkpoint = db
+                .factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::AccountHistory)
+                .unwrap()
+                .unwrap();
+
+            assert!(!result.progress.is_finished());
+            assert!(
+                checkpoint.block_number > previous,
+                "checkpoint must advance past the dense block, got {:?} after {previous:?}",
+                checkpoint.block_number
+            );
+        }
+        assert_eq!(checkpoint.block_number, Some(7), "one dense block cleared per run");
     }
 }

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -29,7 +29,10 @@ pub(crate) struct PrunedIndices {
 pub(crate) struct HistoryPruneResult<K> {
     /// Map of the highest deleted changeset keys to their block numbers.
     pub(crate) highest_deleted: FxHashMap<K, BlockNumber>,
-    /// The last block number that had changesets pruned.
+    /// The highest block number whose changesets are fully pruned, becoming the checkpoint.
+    ///
+    /// Checkpoints have block granularity, so a caller that can stop in the middle of a block
+    /// must report the block before it, and prune the interrupted block again on the next run.
     pub(crate) last_pruned_block: Option<BlockNumber>,
     /// Number of changesets pruned.
     pub(crate) pruned_count: usize,
@@ -56,11 +59,9 @@ where
 {
     let HistoryPruneResult { highest_deleted, last_pruned_block, pruned_count, done } = result;
 
-    // If there's more changesets to prune, set the checkpoint block number to previous,
-    // so we could finish pruning its changesets on the next run.
-    let last_changeset_pruned_block = last_pruned_block
-        .map(|block_number| if done { block_number } else { block_number.saturating_sub(1) })
-        .unwrap_or(range_end);
+    // Nothing was pruned only when the range held no changesets at all, so the whole range is
+    // done.
+    let last_changeset_pruned_block = last_pruned_block.unwrap_or(range_end);
 
     // Sort highest deleted block numbers and turn them into sharded keys.
     // We use `sorted_unstable` because no equal keys exist in the map.

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -127,13 +127,19 @@ impl StorageHistory {
 
         let walker = provider.static_file_provider().walk_storage_changeset_range(range);
         for result in walker {
-            if limiter.is_limit_reached() {
-                done = false;
-                break;
-            }
             let (block_address, entry) = result?;
             let block_number = block_address.block_number();
             let address = block_address.address();
+            // The walk itself deletes nothing, so an interrupted block cannot be resumed: giving
+            // up the budget inside block N reports checkpoint N-1 and the next run rereads the
+            // same entries, forever. Stop on block boundaries only, overshooting the budget by at
+            // most the rest of one block.
+            if limiter.is_limit_reached() &&
+                last_changeset_pruned_block.is_some_and(|last| last != block_number)
+            {
+                done = false;
+                break;
+            }
             highest_deleted_storages.insert((address, entry.key), block_number);
             last_changeset_pruned_block = Some(block_number);
             pruned_changesets += 1;
@@ -212,9 +218,19 @@ impl StorageHistory {
             )?;
         trace!(target: "pruner", deleted = %pruned_changesets, %done, "Pruned storage history (changesets)");
 
+        // The table walk can stop in the middle of a block, so the interrupted block has to be
+        // pruned again on the next run.
+        let last_pruned_block = last_changeset_pruned_block.map(|block_number| {
+            if done {
+                block_number
+            } else {
+                block_number.saturating_sub(1)
+            }
+        });
+
         let result = HistoryPruneResult {
             highest_deleted: highest_deleted_storages,
-            last_pruned_block: last_changeset_pruned_block,
+            last_pruned_block,
             pruned_count: pruned_changesets,
             done,
         };
@@ -264,13 +280,19 @@ impl StorageHistory {
         // pair to determine which history shard entries need pruning.
         let walker = provider.static_file_provider().walk_storage_changeset_range(range);
         for result in walker {
-            if limiter.is_limit_reached() {
-                done = false;
-                break;
-            }
             let (block_address, entry) = result?;
             let block_number = block_address.block_number();
             let address = block_address.address();
+            // Static file changesets are not deleted here, so an interrupted block cannot be
+            // resumed: giving up the budget inside block N reports checkpoint N-1 and the next run
+            // rereads the same entries, forever. Stop on block boundaries only, overshooting the
+            // budget by at most the rest of one block.
+            if limiter.is_limit_reached() &&
+                last_changeset_pruned_block.is_some_and(|last| last != block_number)
+            {
+                done = false;
+                break;
+            }
             highest_deleted_storages.insert((address, entry.key), block_number);
             last_changeset_pruned_block = Some(block_number);
             changesets_processed += 1;
@@ -279,9 +301,7 @@ impl StorageHistory {
 
         trace!(target: "pruner", processed = %changesets_processed, %done, "Scanned storage changesets from static files");
 
-        let last_changeset_pruned_block = last_changeset_pruned_block
-            .map(|block_number| if done { block_number } else { block_number.saturating_sub(1) })
-            .unwrap_or(range_end);
+        let last_changeset_pruned_block = last_changeset_pruned_block.unwrap_or(range_end);
 
         // Prune RocksDB history shards for affected storage slots
         let mut deleted_shards = 0usize;
@@ -771,5 +791,117 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// A block holding at least a whole run's budget of changesets must not stall pruning: the
+    /// walk deletes no changesets, so a checkpoint rewound below such a block would make every
+    /// later run reread it and never advance.
+    #[test]
+    fn dense_block_advances_rocksdb_checkpoint() {
+        use alloy_primitives::U256;
+        use reth_db_api::models::storage_sharded_key::StorageShardedKey;
+        use reth_primitives_traits::StorageEntry;
+        use reth_provider::RocksDBProviderFactory;
+        use reth_storage_api::StorageSettings;
+
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=20,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
+
+        // Two storage changesets per block, so a budget of two makes every block "dense".
+        const ENTRIES_PER_BLOCK: usize = 2;
+        let (address, account) = random_eoa_accounts(&mut rng, 1).into_iter().next().unwrap();
+        let keys = [B256::with_last_byte(1), B256::with_last_byte(2)];
+        let changesets = (0..=20)
+            .map(|_| {
+                vec![(
+                    address,
+                    account,
+                    keys.iter()
+                        .map(|key| StorageEntry { key: *key, value: U256::from(1) })
+                        .collect(),
+                )]
+            })
+            .collect::<Vec<_>>();
+        db.insert_changesets_to_static_files(changesets, None)
+            .expect("insert changesets to static files");
+
+        {
+            let rocksdb = db.factory.rocksdb_provider();
+            let mut batch = rocksdb.batch();
+            for key in keys {
+                batch
+                    .put::<tables::StoragesHistory>(
+                        StorageShardedKey::last(address, key),
+                        &BlockNumberList::new_pre_sorted(0..=20),
+                    )
+                    .expect("insert storage history shard");
+            }
+            batch.commit().expect("commit rocksdb batch");
+        }
+
+        let to_block = 15u64;
+        let prune_mode = PruneMode::Before(to_block);
+        let segment = StorageHistory::new(prune_mode);
+
+        // Start from a checkpoint in the middle so a rewind can't be masked by block 0.
+        let mut checkpoint = PruneCheckpoint { block_number: Some(4), tx_number: None, prune_mode };
+
+        let run_prune = |checkpoint: PruneCheckpoint, limit: usize| {
+            let input = PruneInput {
+                previous_checkpoint: Some(checkpoint),
+                to_block,
+                limiter: PruneLimiter::default().set_deleted_entries_limit(limit),
+            };
+
+            let provider = db.factory.database_provider_rw().unwrap();
+            provider.set_storage_settings_cache(StorageSettings::v2());
+            let result = segment.prune(&provider, input).unwrap();
+            segment
+                .save_checkpoint(
+                    &provider,
+                    result.checkpoint.unwrap().as_prune_checkpoint(prune_mode),
+                )
+                .unwrap();
+            provider.commit().expect("commit");
+
+            let checkpoint = db
+                .factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::StorageHistory)
+                .unwrap()
+                .unwrap();
+            (result, checkpoint)
+        };
+
+        // The RocksDB path does not halve the limit, so this budget is exactly one dense block.
+        for _ in 0..3 {
+            let previous = checkpoint.block_number;
+            let (result, next) = run_prune(checkpoint, ENTRIES_PER_BLOCK);
+            checkpoint = next;
+
+            assert!(
+                !result.progress.is_finished(),
+                "the range is longer than one run's budget allows"
+            );
+            assert!(
+                checkpoint.block_number > previous,
+                "checkpoint must advance past the dense block, got {:?} after {previous:?}",
+                checkpoint.block_number
+            );
+        }
+        assert_eq!(checkpoint.block_number, Some(7), "one dense block cleared per run");
+
+        // With enough budget the remainder of the range completes in one run.
+        let (result, checkpoint) = run_prune(checkpoint, 1000);
+        assert!(result.progress.is_finished());
+        assert_eq!(checkpoint.block_number, Some(to_block));
     }
 }


### PR DESCRIPTION
Closes #26504

The static file changeset walks in account/storage history pruning visit changesets without deleting them, so rewinding the checkpoint below an interrupted block makes every later run reread the same entries — a block holding a whole run's budget of changesets stalls the segment permanently and no changeset jar is reclaimed while it is stalled. Those walks now stop on block boundaries and report the last fully walked block, overshooting the budget by at most the rest of one block; the `-1` rewind stays in `prune_database`, the only walk that can leave a block half-pruned.

Regression tests run a fixed budget repeatedly and assert the checkpoint advances; on `main` all three fail with `checkpoint must advance past the dense block, got Some(4) after Some(4)`.
