### PR TITLE
feat(engine): trigger persistence by state changes

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -754,6 +754,8 @@ pub struct ExecutedBlock<N: NodePrimitives = EthPrimitives> {
     pub recovered_block: Arc<RecoveredBlock<N::Block>>,
     /// Block's execution outcome.
     pub execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
+    /// Total number of account and storage updates in the hashed post state.
+    pub hashed_post_state_total_len: usize,
     /// Deferred trie data produced by execution.
     ///
     /// This allows deferring the computation of the trie data which can be expensive.
@@ -774,6 +776,7 @@ impl<N: NodePrimitives> Default for ExecutedBlock<N> {
                 },
                 state: Default::default(),
             }),
+            hashed_post_state_total_len: 0,
             trie_data: LazyTrieData::ready(ComputedTrieData::default()),
         }
     }
@@ -797,7 +800,13 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
         trie_data: ComputedTrieData,
     ) -> Self {
-        Self { recovered_block, execution_output, trie_data: LazyTrieData::ready(trie_data) }
+        let hashed_post_state_total_len = trie_data.sorted.hashed_state.total_len();
+        Self {
+            recovered_block,
+            execution_output,
+            hashed_post_state_total_len,
+            trie_data: LazyTrieData::ready(trie_data),
+        }
     }
 
     /// Create a new [`ExecutedBlock`] with deferred trie data.
@@ -816,9 +825,10 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
     pub const fn with_deferred_trie_data(
         recovered_block: Arc<RecoveredBlock<N::Block>>,
         execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
+        hashed_post_state_total_len: usize,
         trie_data: LazyTrieData,
     ) -> Self {
-        Self { recovered_block, execution_output, trie_data }
+        Self { recovered_block, execution_output, hashed_post_state_total_len, trie_data }
     }
 
     /// Returns a reference to an inner [`SealedBlock`]
@@ -1239,6 +1249,16 @@ mod tests {
         assert_eq!(state.hash(), block.recovered_block().hash());
         assert_eq!(state.number(), number);
         assert_eq!(state.state_root(), block.recovered_block().state_root);
+    }
+
+    #[test]
+    fn executed_block_tracks_hashed_post_state_total_len() {
+        let mut test_block_builder: TestBlockBuilder<EthPrimitives> =
+            TestBlockBuilder::default().with_state();
+        let block = test_block_builder.get_executed_block_with_number(1, B256::random());
+
+        assert_ne!(block.hashed_post_state_total_len, 0);
+        assert_eq!(block.hashed_post_state_total_len, block.hashed_state().total_len());
     }
 
     #[test]

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -278,6 +278,7 @@ impl TreeConfig {
         persistence_threshold: u64,
         memory_block_buffer_target: u64,
         persistence_backpressure_threshold: u64,
+        persistence_state_changes_backpressure_threshold: usize,
         block_buffer_limit: u32,
         max_invalid_header_cache_length: u32,
         invalid_header_hit_eviction_threshold: u8,
@@ -301,8 +302,6 @@ impl TreeConfig {
         share_execution_cache_with_payload_builder: bool,
         share_sparse_trie_with_payload_builder: bool,
     ) -> Self {
-        let persistence_state_changes_backpressure_threshold =
-            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD.saturating_mul(2);
         assert_backpressure_threshold_invariant(
             persistence_threshold,
             persistence_backpressure_threshold,

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -6,16 +6,8 @@ use core::time::Duration;
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
 pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 200;
 
-/// Maximum number of blocks beyond the in-memory buffer target awaiting persistence before engine
-/// API processing is stalled.
-pub const DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD: u64 = 400;
-
 /// Triggers persistence when the number of hashed post state changes reaches this threshold.
 pub const DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD: usize = 180_000;
-
-/// Maximum number of hashed post state changes awaiting persistence before engine API processing
-/// is stalled.
-pub const DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD: usize = 360_000;
 
 /// How close to the canonical head we persist blocks.
 pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 5;
@@ -227,21 +219,23 @@ pub struct TreeConfig {
 
 impl Default for TreeConfig {
     fn default() -> Self {
+        let persistence_backpressure_threshold = DEFAULT_PERSISTENCE_THRESHOLD.saturating_mul(2);
+        let persistence_state_changes_backpressure_threshold =
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD.saturating_mul(2);
         assert_backpressure_threshold_invariant(
             DEFAULT_PERSISTENCE_THRESHOLD,
-            DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+            persistence_backpressure_threshold,
         );
         assert_state_changes_backpressure_threshold_invariant(
             DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
-            DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
+            persistence_state_changes_backpressure_threshold,
         );
         Self {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
             persistence_state_changes_threshold: DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
-            persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
-            persistence_state_changes_backpressure_threshold:
-                DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
+            persistence_backpressure_threshold,
+            persistence_state_changes_backpressure_threshold,
             block_buffer_limit: DEFAULT_BLOCK_BUFFER_LIMIT,
             max_invalid_header_cache_length: DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH,
             invalid_header_hit_eviction_threshold: DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD,
@@ -307,21 +301,22 @@ impl TreeConfig {
         share_execution_cache_with_payload_builder: bool,
         share_sparse_trie_with_payload_builder: bool,
     ) -> Self {
+        let persistence_state_changes_backpressure_threshold =
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD.saturating_mul(2);
         assert_backpressure_threshold_invariant(
             persistence_threshold,
             persistence_backpressure_threshold,
         );
         assert_state_changes_backpressure_threshold_invariant(
             DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
-            DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
+            persistence_state_changes_backpressure_threshold,
         );
         Self {
             persistence_threshold,
             persistence_state_changes_threshold: DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
             memory_block_buffer_target,
             persistence_backpressure_threshold,
-            persistence_state_changes_backpressure_threshold:
-                DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
+            persistence_state_changes_backpressure_threshold,
             block_buffer_limit,
             max_invalid_header_cache_length,
             invalid_header_hit_eviction_threshold,
@@ -862,26 +857,21 @@ impl TreeConfig {
 #[cfg(test)]
 mod tests {
     use super::{
-        TreeConfig, DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
-        DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
-        DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD, DEFAULT_PERSISTENCE_THRESHOLD,
+        TreeConfig, DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD, DEFAULT_PERSISTENCE_THRESHOLD,
     };
 
     #[test]
     fn persistence_threshold_defaults() {
         let config = TreeConfig::default();
         assert_eq!(config.persistence_threshold(), DEFAULT_PERSISTENCE_THRESHOLD);
-        assert_eq!(
-            config.persistence_backpressure_threshold(),
-            DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD
-        );
+        assert_eq!(config.persistence_backpressure_threshold(), DEFAULT_PERSISTENCE_THRESHOLD * 2);
         assert_eq!(
             config.persistence_state_changes_threshold(),
             DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD
         );
         assert_eq!(
             config.persistence_state_changes_backpressure_threshold(),
-            DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD * 2
         );
     }
 

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -4,11 +4,18 @@ use alloy_eips::merge::EPOCH_SLOTS;
 use core::time::Duration;
 
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
-pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 7;
+pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 200;
 
 /// Maximum number of blocks beyond the in-memory buffer target awaiting persistence before engine
 /// API processing is stalled.
-pub const DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD: u64 = 16;
+pub const DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD: u64 = 400;
+
+/// Triggers persistence when the number of hashed post state changes reaches this threshold.
+pub const DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD: usize = 180_000;
+
+/// Maximum number of hashed post state changes awaiting persistence before engine API processing
+/// is stalled.
+pub const DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD: usize = 360_000;
 
 /// How close to the canonical head we persist blocks.
 pub const DEFAULT_MEMORY_BLOCK_BUFFER_TARGET: u64 = 5;
@@ -51,6 +58,17 @@ const fn assert_backpressure_threshold_invariant(
     );
 }
 
+const fn assert_state_changes_backpressure_threshold_invariant(
+    persistence_state_changes_threshold: usize,
+    persistence_state_changes_backpressure_threshold: usize,
+) {
+    debug_assert!(
+        persistence_state_changes_backpressure_threshold >
+            persistence_state_changes_threshold,
+        "persistence_state_changes_backpressure_threshold must be greater than persistence_state_changes_threshold",
+    );
+}
+
 const fn default_cross_block_cache_size() -> usize {
     if cfg!(test) {
         1024 * 1024 // 1 MB in tests
@@ -84,6 +102,9 @@ pub struct TreeConfig {
     /// Maximum number of blocks to be kept only in memory without triggering
     /// persistence.
     persistence_threshold: u64,
+    /// Maximum number of hashed post state changes to keep in memory before triggering
+    /// persistence.
+    persistence_state_changes_threshold: usize,
     /// How close to the canonical head we persist blocks. Represents the ideal
     /// number of most recent blocks to keep in memory for quick access and reorgs.
     ///
@@ -92,6 +113,9 @@ pub struct TreeConfig {
     /// Maximum number of blocks beyond the in-memory buffer target awaiting persistence before
     /// engine API processing is stalled.
     persistence_backpressure_threshold: u64,
+    /// Maximum number of hashed post state changes awaiting persistence before engine API
+    /// processing is stalled.
+    persistence_state_changes_backpressure_threshold: usize,
     /// Number of pending blocks that cannot be executed due to missing parent and
     /// are kept in cache.
     block_buffer_limit: u32,
@@ -207,10 +231,17 @@ impl Default for TreeConfig {
             DEFAULT_PERSISTENCE_THRESHOLD,
             DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
         );
+        assert_state_changes_backpressure_threshold_invariant(
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
+            DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
+        );
         Self {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
+            persistence_state_changes_threshold: DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+            persistence_state_changes_backpressure_threshold:
+                DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
             block_buffer_limit: DEFAULT_BLOCK_BUFFER_LIMIT,
             max_invalid_header_cache_length: DEFAULT_MAX_INVALID_HEADER_CACHE_LENGTH,
             invalid_header_hit_eviction_threshold: DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD,
@@ -280,10 +311,17 @@ impl TreeConfig {
             persistence_threshold,
             persistence_backpressure_threshold,
         );
+        assert_state_changes_backpressure_threshold_invariant(
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
+            DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
+        );
         Self {
             persistence_threshold,
+            persistence_state_changes_threshold: DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
             memory_block_buffer_target,
             persistence_backpressure_threshold,
+            persistence_state_changes_backpressure_threshold:
+                DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
             block_buffer_limit,
             max_invalid_header_cache_length,
             invalid_header_hit_eviction_threshold,
@@ -323,6 +361,11 @@ impl TreeConfig {
         self.persistence_threshold
     }
 
+    /// Return the persistence state changes threshold.
+    pub const fn persistence_state_changes_threshold(&self) -> usize {
+        self.persistence_state_changes_threshold
+    }
+
     /// Return the memory block buffer target.
     pub const fn memory_block_buffer_target(&self) -> u64 {
         self.memory_block_buffer_target
@@ -331,6 +374,11 @@ impl TreeConfig {
     /// Return the persistence backpressure threshold.
     pub const fn persistence_backpressure_threshold(&self) -> u64 {
         self.persistence_backpressure_threshold
+    }
+
+    /// Return the persistence state changes backpressure threshold.
+    pub const fn persistence_state_changes_backpressure_threshold(&self) -> usize {
+        self.persistence_state_changes_backpressure_threshold
     }
 
     /// Return the block buffer limit.
@@ -443,6 +491,50 @@ impl TreeConfig {
         self
     }
 
+    /// Sets the persistence and backpressure block thresholds atomically.
+    pub const fn with_persistence_thresholds(
+        mut self,
+        persistence_threshold: u64,
+        persistence_backpressure_threshold: u64,
+    ) -> Self {
+        assert_backpressure_threshold_invariant(
+            persistence_threshold,
+            persistence_backpressure_threshold,
+        );
+        self.persistence_threshold = persistence_threshold;
+        self.persistence_backpressure_threshold = persistence_backpressure_threshold;
+        self
+    }
+
+    /// Setter for persistence state changes threshold.
+    pub const fn with_persistence_state_changes_threshold(
+        mut self,
+        persistence_state_changes_threshold: usize,
+    ) -> Self {
+        self.persistence_state_changes_threshold = persistence_state_changes_threshold;
+        assert_state_changes_backpressure_threshold_invariant(
+            self.persistence_state_changes_threshold,
+            self.persistence_state_changes_backpressure_threshold,
+        );
+        self
+    }
+
+    /// Sets the persistence and backpressure state changes thresholds atomically.
+    pub const fn with_persistence_state_changes_thresholds(
+        mut self,
+        persistence_state_changes_threshold: usize,
+        persistence_state_changes_backpressure_threshold: usize,
+    ) -> Self {
+        assert_state_changes_backpressure_threshold_invariant(
+            persistence_state_changes_threshold,
+            persistence_state_changes_backpressure_threshold,
+        );
+        self.persistence_state_changes_threshold = persistence_state_changes_threshold;
+        self.persistence_state_changes_backpressure_threshold =
+            persistence_state_changes_backpressure_threshold;
+        self
+    }
+
     /// Setter for memory block buffer target.
     pub const fn with_memory_block_buffer_target(
         mut self,
@@ -461,6 +553,20 @@ impl TreeConfig {
         assert_backpressure_threshold_invariant(
             self.persistence_threshold,
             self.persistence_backpressure_threshold,
+        );
+        self
+    }
+
+    /// Setter for persistence state changes backpressure threshold.
+    pub const fn with_persistence_state_changes_backpressure_threshold(
+        mut self,
+        persistence_state_changes_backpressure_threshold: usize,
+    ) -> Self {
+        self.persistence_state_changes_backpressure_threshold =
+            persistence_state_changes_backpressure_threshold;
+        assert_state_changes_backpressure_threshold_invariant(
+            self.persistence_state_changes_threshold,
+            self.persistence_state_changes_backpressure_threshold,
         );
         self
     }
@@ -755,7 +861,29 @@ impl TreeConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::TreeConfig;
+    use super::{
+        TreeConfig, DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+        DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD,
+        DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD, DEFAULT_PERSISTENCE_THRESHOLD,
+    };
+
+    #[test]
+    fn persistence_threshold_defaults() {
+        let config = TreeConfig::default();
+        assert_eq!(config.persistence_threshold(), DEFAULT_PERSISTENCE_THRESHOLD);
+        assert_eq!(
+            config.persistence_backpressure_threshold(),
+            DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD
+        );
+        assert_eq!(
+            config.persistence_state_changes_threshold(),
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD
+        );
+        assert_eq!(
+            config.persistence_state_changes_backpressure_threshold(),
+            DEFAULT_PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD
+        );
+    }
 
     #[test]
     fn txpool_prewarming_is_disabled_by_default_and_can_be_enabled() {
@@ -785,5 +913,13 @@ mod tests {
         let _ = TreeConfig::default()
             .with_persistence_threshold(4)
             .with_persistence_backpressure_threshold(4);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "persistence_state_changes_backpressure_threshold must be greater than persistence_state_changes_threshold"
+    )]
+    fn rejects_state_changes_backpressure_threshold_at_or_below_persistence_threshold() {
+        let _ = TreeConfig::default().with_persistence_state_changes_thresholds(4, 4);
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -545,14 +545,43 @@ where
         self.persistence_gap().saturating_sub(self.config.memory_block_buffer_target())
     }
 
+    /// Returns the total number of hashed post state changes in canonical blocks that are
+    /// eligible for persistence, excluding the configured in-memory block buffer.
+    fn persistence_state_changes(&self) -> usize {
+        let last_persisted_block = self.persistence_state.last_persisted_block.number;
+        let target_block = self
+            .state
+            .tree_state
+            .canonical_block_number()
+            .saturating_sub(self.config.memory_block_buffer_target());
+        let mut current_hash = self.state.tree_state.canonical_block_hash();
+        let mut state_changes = 0usize;
+
+        while let Some(block) = self.state.tree_state.blocks_by_hash.get(&current_hash) {
+            if block.block_number() <= last_persisted_block {
+                break
+            }
+
+            if block.block_number() <= target_block {
+                state_changes = state_changes.saturating_add(block.hashed_post_state_total_len);
+            }
+            current_hash = block.recovered_block().parent_hash();
+        }
+
+        state_changes
+    }
+
     /// Returns `true` when the main loop should stop draining the tree input channel.
     ///
-    /// This is the case when persistence is already running and the number of blocks beyond the
-    /// configured in-memory buffer has reached the configured threshold.
-    const fn should_backpressure(&self) -> bool {
+    /// This is the case when persistence is already running and either the number of blocks or
+    /// hashed post state changes beyond the configured in-memory buffer has reached its configured
+    /// threshold.
+    fn should_backpressure(&self) -> bool {
         self.persistence_state.in_progress() &&
-            self.persistence_backpressure_gap() >=
-                self.config.persistence_backpressure_threshold()
+            (self.persistence_backpressure_gap() >=
+                self.config.persistence_backpressure_threshold() ||
+                self.persistence_state_changes() >=
+                    self.config.persistence_state_changes_backpressure_threshold())
     }
 
     /// Run the engine API handler.
@@ -2111,10 +2140,10 @@ where
         );
     }
 
-    /// Returns true if the canonical chain length minus the last persisted
-    /// block is greater than the persistence threshold,
-    /// backfill is not running, and no payload is currently being built.
-    pub const fn should_persist(&self) -> bool {
+    /// Returns true if the canonical chain length exceeds its persistence threshold or the hashed
+    /// post state changes reach theirs, backfill is not running, and no payload is currently being
+    /// built.
+    pub fn should_persist(&self) -> bool {
         if self.building_payload {
             return false
         }
@@ -2124,9 +2153,8 @@ where
             return false
         }
 
-        let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
-            self.config.persistence_threshold()
+        self.persistence_gap() > self.config.persistence_threshold() ||
+            self.persistence_state_changes() >= self.config.persistence_state_changes_threshold()
     }
 
     /// Returns a batch of consecutive canonical blocks to persist in the range

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1539,6 +1539,7 @@ where
             Ok(state) => state,
             Err(handle) => handle.get().clone(),
         };
+        let hashed_post_state_total_len = hashed_state.total_len();
         let (deferred_trie_data, deferred_trie_task) =
             LazyTrieData::pending(hashed_state, trie_output);
         let block_validation_metrics = self.metrics.block_validation.clone();
@@ -1573,7 +1574,12 @@ where
         // Spawn task that computes trie data asynchronously.
         self.runtime.spawn_blocking_named(DEFERRED_TRIE_WORKER_NAME, compute_trie_input_task);
 
-        ExecutedBlock::with_deferred_trie_data(block, execution_outcome, deferred_trie_data)
+        ExecutedBlock::with_deferred_trie_data(
+            block,
+            execution_outcome,
+            hashed_post_state_total_len,
+            deferred_trie_data,
+        )
     }
 
     fn calculate_timing_stats(

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -528,7 +528,7 @@ impl TestBlockFactory {
 
 #[test]
 fn test_tree_persist_block_batch() {
-    let tree_config = TreeConfig::default();
+    let tree_config = TreeConfig::default().with_persistence_thresholds(7, 16);
     let chain_spec = MAINNET.clone();
     let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
 
@@ -537,7 +537,8 @@ fn test_tree_persist_block_batch() {
     let blocks: Vec<_> = test_block_builder
         .get_executed_blocks(1..tree_config.persistence_threshold() + 2)
         .collect();
-    let mut test_harness = TestHarness::new(chain_spec).with_blocks(blocks);
+    let mut test_harness =
+        TestHarness::with_config(chain_spec, tree_config.clone()).with_blocks(blocks);
 
     let mut blocks = vec![];
     for idx in 0..tree_config.max_execute_block_batch_size() * 2 {
@@ -568,7 +569,7 @@ fn test_tree_persist_block_batch() {
 
 #[tokio::test]
 async fn test_tree_persist_blocks() {
-    let tree_config = TreeConfig::default();
+    let tree_config = TreeConfig::default().with_persistence_thresholds(7, 16);
     let chain_spec = MAINNET.clone();
     let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
 
@@ -577,7 +578,8 @@ async fn test_tree_persist_blocks() {
     let blocks: Vec<_> = test_block_builder
         .get_executed_blocks(1..tree_config.persistence_threshold() + 2)
         .collect();
-    let test_harness = TestHarness::new(chain_spec).with_blocks(blocks.clone());
+    let test_harness =
+        TestHarness::with_config(chain_spec, tree_config.clone()).with_blocks(blocks.clone());
     spawn_os_thread("engine", || test_harness.tree.run());
 
     // send a message to the tree to enter the main loop.
@@ -949,6 +951,82 @@ fn test_backpressure_excludes_in_memory_buffer() {
 
         assert_eq!(test_harness.tree.should_backpressure(), expected_backpressure);
     }
+}
+
+#[test]
+fn state_changes_persistence_excludes_memory_buffer_and_forks() {
+    let mut test_block_builder = TestBlockBuilder::eth();
+    let mut blocks: Vec<_> = test_block_builder.get_executed_blocks(1..8).collect();
+    blocks[5].hashed_post_state_total_len = 10;
+    blocks[6].hashed_post_state_total_len = 10;
+
+    let config = TreeConfig::default()
+        .with_persistence_thresholds(100, 200)
+        .with_memory_block_buffer_target(2)
+        .with_persistence_state_changes_thresholds(10, 20);
+    let mut test_harness =
+        TestHarness::with_config(MAINNET.clone(), config).with_blocks(blocks.clone());
+
+    assert_eq!(test_harness.tree.persistence_state_changes(), 0);
+    assert!(!test_harness.tree.should_persist());
+
+    let mut fork =
+        test_block_builder.get_executed_block_with_number(6, blocks[4].recovered_block().hash());
+    fork.hashed_post_state_total_len = usize::MAX;
+    test_harness.tree.state.tree_state.insert_executed(fork);
+    assert_eq!(test_harness.tree.persistence_state_changes(), 0);
+
+    let eligible_hash = blocks[4].recovered_block().hash();
+    test_harness
+        .tree
+        .state
+        .tree_state
+        .blocks_by_hash
+        .get_mut(&eligible_hash)
+        .unwrap()
+        .hashed_post_state_total_len = 10;
+
+    assert_eq!(test_harness.tree.persistence_state_changes(), 10);
+    assert!(test_harness.tree.should_persist());
+
+    test_harness.tree.persistence_state.last_persisted_block =
+        blocks[4].recovered_block().num_hash();
+    assert_eq!(test_harness.tree.persistence_state_changes(), 0);
+    assert!(!test_harness.tree.should_persist());
+}
+
+#[test]
+fn state_changes_backpressure_excludes_in_memory_buffer() {
+    let mut blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..8).collect();
+    blocks[5].hashed_post_state_total_len = 20;
+    blocks[6].hashed_post_state_total_len = 20;
+
+    let config = TreeConfig::default()
+        .with_persistence_thresholds(100, 200)
+        .with_memory_block_buffer_target(2)
+        .with_persistence_state_changes_thresholds(10, 20);
+    let mut test_harness =
+        TestHarness::with_config(MAINNET.clone(), config).with_blocks(blocks.clone());
+
+    let (_persist_tx, persist_rx) = crossbeam_channel::bounded(1);
+    let persisted = blocks.last().unwrap().recovered_block().num_hash();
+    test_harness.tree.persistence_state.start_save(persisted, persist_rx);
+
+    assert_eq!(test_harness.tree.persistence_state_changes(), 0);
+    assert!(!test_harness.tree.should_backpressure());
+
+    let eligible_hash = blocks[4].recovered_block().hash();
+    test_harness
+        .tree
+        .state
+        .tree_state
+        .blocks_by_hash
+        .get_mut(&eligible_hash)
+        .unwrap()
+        .hashed_post_state_total_len = 20;
+
+    assert_eq!(test_harness.tree.persistence_state_changes(), 20);
+    assert!(test_harness.tree.should_backpressure());
 }
 
 #[tokio::test]

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -8,7 +8,7 @@ use eyre::ensure;
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
 use reth_engine_primitives::{
     TreeConfig, DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
-    DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+    DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD, DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
 };
 use std::{sync::OnceLock, time::Duration};
 
@@ -26,6 +26,7 @@ static ENGINE_DEFAULTS: OnceLock<DefaultEngineValues> = OnceLock::new();
 #[derive(Debug, Clone)]
 pub struct DefaultEngineValues {
     persistence_threshold: u64,
+    persistence_state_changes_threshold: usize,
     persistence_backpressure_threshold: u64,
     memory_block_buffer_target: u64,
     invalid_header_hit_eviction_threshold: u8,
@@ -70,6 +71,12 @@ impl DefaultEngineValues {
     /// Set the default persistence threshold
     pub const fn with_persistence_threshold(mut self, v: u64) -> Self {
         self.persistence_threshold = v;
+        self
+    }
+
+    /// Set the default persistence state changes threshold
+    pub const fn with_persistence_state_changes_threshold(mut self, v: usize) -> Self {
+        self.persistence_state_changes_threshold = v;
         self
     }
 
@@ -249,6 +256,7 @@ impl Default for DefaultEngineValues {
     fn default() -> Self {
         Self {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
+            persistence_state_changes_threshold: DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
             persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             invalid_header_hit_eviction_threshold: DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD,
@@ -300,6 +308,13 @@ pub struct EngineArgs {
     #[arg(long = "engine.persistence-threshold", default_value_t = DefaultEngineValues::get_global().persistence_threshold)]
     pub persistence_threshold: u64,
 
+    /// Configure the hashed post state changes threshold for persistence.
+    ///
+    /// This counts account and storage updates in canonical blocks beyond the configured
+    /// in-memory buffer.
+    #[arg(long = "engine.persistence-state-changes-threshold", default_value_t = DefaultEngineValues::get_global().persistence_state_changes_threshold)]
+    pub persistence_state_changes_threshold: usize,
+
     /// Configure the maximum number of blocks beyond the in-memory buffer target that may await
     /// persistence before engine API processing stalls.
     ///
@@ -309,6 +324,15 @@ pub struct EngineArgs {
     /// This value must be greater than `--engine.persistence-threshold`.
     #[arg(long = "engine.persistence-backpressure-threshold")]
     pub persistence_backpressure_threshold: Option<u64>,
+
+    /// Configure the maximum number of hashed post state changes that may await persistence
+    /// before engine API processing stalls.
+    ///
+    /// If omitted, this defaults to twice `--engine.persistence-state-changes-threshold`.
+    ///
+    /// This value must be greater than `--engine.persistence-state-changes-threshold`.
+    #[arg(long = "engine.persistence-state-changes-backpressure-threshold")]
+    pub persistence_state_changes_backpressure_threshold: Option<usize>,
 
     /// Configure the target number of blocks to keep in memory.
     ///
@@ -545,6 +569,7 @@ impl Default for EngineArgs {
     fn default() -> Self {
         let DefaultEngineValues {
             persistence_threshold,
+            persistence_state_changes_threshold,
             persistence_backpressure_threshold: _,
             memory_block_buffer_target: _,
             invalid_header_hit_eviction_threshold,
@@ -576,7 +601,9 @@ impl Default for EngineArgs {
         } = DefaultEngineValues::get_global().clone();
         Self {
             persistence_threshold,
+            persistence_state_changes_threshold,
             persistence_backpressure_threshold: None,
+            persistence_state_changes_backpressure_threshold: None,
             memory_block_buffer_target: None,
             invalid_header_hit_eviction_threshold,
             state_root_task_compare_updates,
@@ -634,15 +661,34 @@ impl EngineArgs {
         })
     }
 
+    /// Returns the effective persistence state changes backpressure threshold.
+    pub fn persistence_state_changes_backpressure_threshold(&self) -> usize {
+        self.persistence_state_changes_backpressure_threshold
+            .unwrap_or_else(|| self.persistence_state_changes_threshold.saturating_mul(2))
+    }
+
     /// Validates cross-field engine arguments.
     pub fn validate(&self) -> eyre::Result<()> {
         let persistence_backpressure_threshold = self.persistence_backpressure_threshold();
+        let persistence_state_changes_backpressure_threshold =
+            self.persistence_state_changes_backpressure_threshold();
         let memory_block_buffer_target = self.memory_block_buffer_target();
         ensure!(
             persistence_backpressure_threshold > self.persistence_threshold,
             "--engine.persistence-backpressure-threshold ({}) must be greater than --engine.persistence-threshold ({})",
             persistence_backpressure_threshold,
             self.persistence_threshold
+        );
+        ensure!(
+            self.persistence_state_changes_threshold > 0,
+            "--engine.persistence-state-changes-threshold must be greater than zero"
+        );
+        ensure!(
+            persistence_state_changes_backpressure_threshold >
+                self.persistence_state_changes_threshold,
+            "--engine.persistence-state-changes-backpressure-threshold ({}) must be greater than --engine.persistence-state-changes-threshold ({})",
+            persistence_state_changes_backpressure_threshold,
+            self.persistence_state_changes_threshold
         );
         ensure!(
             memory_block_buffer_target <= self.persistence_threshold,
@@ -668,8 +714,14 @@ impl EngineArgs {
             tracing::warn!(target: "reth::cli", "--engine.legacy-state-root has no effect anymore, use --engine.state-root-fallback to force synchronous state root computation");
         }
         let config = TreeConfig::default()
-            .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold())
-            .with_persistence_threshold(self.persistence_threshold)
+            .with_persistence_thresholds(
+                self.persistence_threshold,
+                self.persistence_backpressure_threshold(),
+            )
+            .with_persistence_state_changes_thresholds(
+                self.persistence_state_changes_threshold,
+                self.persistence_state_changes_backpressure_threshold(),
+            )
             .with_memory_block_buffer_target(self.memory_block_buffer_target())
             .with_invalid_header_hit_eviction_threshold(self.invalid_header_hit_eviction_threshold)
             .without_state_cache(self.state_cache_disabled)
@@ -723,12 +775,20 @@ mod tests {
         let default_args = EngineArgs::default();
         let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
-        assert_eq!(args.persistence_threshold, 7);
+        assert_eq!(args.persistence_threshold, 200);
+        assert_eq!(
+            args.persistence_state_changes_threshold,
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD
+        );
         assert_eq!(args.memory_block_buffer_target, None);
         assert_eq!(args.memory_block_buffer_target(), 5);
         assert_eq!(
             args.persistence_backpressure_threshold(),
             DefaultEngineValues::get_global().persistence_backpressure_threshold
+        );
+        assert_eq!(
+            args.persistence_state_changes_backpressure_threshold(),
+            DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD * 2
         );
     }
 
@@ -762,18 +822,18 @@ mod tests {
         let args = CommandParser::<EngineArgs>::parse_from([
             "reth",
             "--engine.persistence-threshold",
-            "100",
+            "300",
             "--engine.memory-block-buffer-target",
             "50",
         ])
         .args;
 
-        assert_eq!(args.persistence_backpressure_threshold(), 200);
+        assert_eq!(args.persistence_backpressure_threshold(), 600);
 
         let tree_config = args.tree_config();
-        assert_eq!(tree_config.persistence_threshold(), 100);
+        assert_eq!(tree_config.persistence_threshold(), 300);
         assert_eq!(tree_config.memory_block_buffer_target(), 50);
-        assert_eq!(tree_config.persistence_backpressure_threshold(), 200);
+        assert_eq!(tree_config.persistence_backpressure_threshold(), 600);
     }
 
     #[test]
@@ -808,11 +868,43 @@ mod tests {
     }
 
     #[test]
+    fn state_changes_backpressure_threshold_uses_runtime_persistence_threshold() {
+        let args = CommandParser::<EngineArgs>::parse_from([
+            "reth",
+            "--engine.persistence-state-changes-threshold",
+            "12000",
+        ])
+        .args;
+
+        assert_eq!(args.persistence_state_changes_backpressure_threshold(), 24_000);
+
+        let tree_config = args.tree_config();
+        assert_eq!(tree_config.persistence_state_changes_threshold(), 12_000);
+        assert_eq!(tree_config.persistence_state_changes_backpressure_threshold(), 24_000);
+    }
+
+    #[test]
+    fn explicit_state_changes_backpressure_threshold_overrides_runtime_default() {
+        let args = CommandParser::<EngineArgs>::parse_from([
+            "reth",
+            "--engine.persistence-state-changes-threshold",
+            "12000",
+            "--engine.persistence-state-changes-backpressure-threshold",
+            "24001",
+        ])
+        .args;
+
+        assert_eq!(args.persistence_state_changes_backpressure_threshold(), 24_001);
+    }
+
+    #[test]
     #[allow(deprecated)]
     fn engine_args() {
         let args = EngineArgs {
             persistence_threshold: 100,
+            persistence_state_changes_threshold: 12_000,
             persistence_backpressure_threshold: Some(101),
+            persistence_state_changes_backpressure_threshold: Some(24_001),
             memory_block_buffer_target: Some(50),
             invalid_header_hit_eviction_threshold: 7,
             legacy_state_root_task_enabled: true,
@@ -857,6 +949,10 @@ mod tests {
             "100",
             "--engine.persistence-backpressure-threshold",
             "101",
+            "--engine.persistence-state-changes-threshold",
+            "12000",
+            "--engine.persistence-state-changes-backpressure-threshold",
+            "24001",
             "--engine.memory-block-buffer-target",
             "50",
             "--engine.invalid-header-cache-hit-eviction-threshold",
@@ -907,6 +1003,27 @@ mod tests {
         let err = args.validate().unwrap_err().to_string();
         assert!(err.contains("engine.persistence-backpressure-threshold"));
         assert!(err.contains("engine.persistence-threshold"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_state_changes_backpressure_threshold() {
+        let args = EngineArgs {
+            persistence_state_changes_threshold: 10,
+            persistence_state_changes_backpressure_threshold: Some(10),
+            ..EngineArgs::default()
+        };
+
+        let err = args.validate().unwrap_err().to_string();
+        assert!(err.contains("engine.persistence-state-changes-backpressure-threshold"));
+        assert!(err.contains("engine.persistence-state-changes-threshold"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_state_changes_threshold() {
+        let args = EngineArgs { persistence_state_changes_threshold: 0, ..EngineArgs::default() };
+
+        let err = args.validate().unwrap_err().to_string();
+        assert!(err.contains("engine.persistence-state-changes-threshold"));
     }
 
     #[test]

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -8,7 +8,7 @@ use eyre::ensure;
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
 use reth_engine_primitives::{
     TreeConfig, DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
-    DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD, DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
+    DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
 };
 use std::{sync::OnceLock, time::Duration};
 
@@ -27,7 +27,6 @@ static ENGINE_DEFAULTS: OnceLock<DefaultEngineValues> = OnceLock::new();
 pub struct DefaultEngineValues {
     persistence_threshold: u64,
     persistence_state_changes_threshold: usize,
-    persistence_backpressure_threshold: u64,
     memory_block_buffer_target: u64,
     invalid_header_hit_eviction_threshold: u8,
     state_cache_disabled: bool,
@@ -77,12 +76,6 @@ impl DefaultEngineValues {
     /// Set the default persistence state changes threshold
     pub const fn with_persistence_state_changes_threshold(mut self, v: usize) -> Self {
         self.persistence_state_changes_threshold = v;
-        self
-    }
-
-    /// Set the default persistence backpressure threshold
-    pub const fn with_persistence_backpressure_threshold(mut self, v: u64) -> Self {
-        self.persistence_backpressure_threshold = v;
         self
     }
 
@@ -257,7 +250,6 @@ impl Default for DefaultEngineValues {
         Self {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
             persistence_state_changes_threshold: DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD,
-            persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             invalid_header_hit_eviction_threshold: DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD,
             state_cache_disabled: false,
@@ -289,12 +281,6 @@ impl Default for DefaultEngineValues {
     }
 }
 
-fn default_persistence_backpressure_threshold(persistence_threshold: u64) -> u64 {
-    DefaultEngineValues::get_global()
-        .persistence_backpressure_threshold
-        .max(persistence_threshold.saturating_mul(2))
-}
-
 /// Parameters for configuring the engine driver.
 #[derive(Debug, Clone, Args, PartialEq, Eq)]
 #[command(next_help_heading = "Engine")]
@@ -318,8 +304,8 @@ pub struct EngineArgs {
     /// Configure the maximum number of blocks beyond the in-memory buffer target that may await
     /// persistence before engine API processing stalls.
     ///
-    /// If omitted, this defaults to the larger of the default backpressure threshold and twice
-    /// `--engine.persistence-threshold`.
+    /// If omitted, this defaults to twice `--engine.persistence-threshold`, or `1` if the
+    /// persistence threshold is zero.
     ///
     /// This value must be greater than `--engine.persistence-threshold`.
     #[arg(long = "engine.persistence-backpressure-threshold")]
@@ -570,7 +556,6 @@ impl Default for EngineArgs {
         let DefaultEngineValues {
             persistence_threshold,
             persistence_state_changes_threshold,
-            persistence_backpressure_threshold: _,
             memory_block_buffer_target: _,
             invalid_header_hit_eviction_threshold,
             state_cache_disabled,
@@ -656,9 +641,8 @@ impl EngineArgs {
 
     /// Returns the effective persistence backpressure threshold.
     pub fn persistence_backpressure_threshold(&self) -> u64 {
-        self.persistence_backpressure_threshold.unwrap_or_else(|| {
-            default_persistence_backpressure_threshold(self.persistence_threshold)
-        })
+        self.persistence_backpressure_threshold
+            .unwrap_or_else(|| self.persistence_threshold.saturating_mul(2).max(1))
     }
 
     /// Returns the effective persistence state changes backpressure threshold.
@@ -782,10 +766,7 @@ mod tests {
         );
         assert_eq!(args.memory_block_buffer_target, None);
         assert_eq!(args.memory_block_buffer_target(), 5);
-        assert_eq!(
-            args.persistence_backpressure_threshold(),
-            DefaultEngineValues::get_global().persistence_backpressure_threshold
-        );
+        assert_eq!(args.persistence_backpressure_threshold(), args.persistence_threshold * 2);
         assert_eq!(
             args.persistence_state_changes_backpressure_threshold(),
             DEFAULT_PERSISTENCE_STATE_CHANGES_THRESHOLD * 2
@@ -822,22 +803,22 @@ mod tests {
         let args = CommandParser::<EngineArgs>::parse_from([
             "reth",
             "--engine.persistence-threshold",
-            "300",
+            "100",
             "--engine.memory-block-buffer-target",
             "50",
         ])
         .args;
 
-        assert_eq!(args.persistence_backpressure_threshold(), 600);
+        assert_eq!(args.persistence_backpressure_threshold(), 200);
 
         let tree_config = args.tree_config();
-        assert_eq!(tree_config.persistence_threshold(), 300);
+        assert_eq!(tree_config.persistence_threshold(), 100);
         assert_eq!(tree_config.memory_block_buffer_target(), 50);
-        assert_eq!(tree_config.persistence_backpressure_threshold(), 600);
+        assert_eq!(tree_config.persistence_backpressure_threshold(), 200);
     }
 
     #[test]
-    fn default_backpressure_threshold_uses_global_default_when_larger() {
+    fn default_backpressure_threshold_tracks_small_persistence_threshold() {
         let args = CommandParser::<EngineArgs>::parse_from([
             "reth",
             "--engine.persistence-threshold",
@@ -845,10 +826,21 @@ mod tests {
         ])
         .args;
 
-        assert_eq!(
-            args.persistence_backpressure_threshold(),
-            DefaultEngineValues::get_global().persistence_backpressure_threshold
-        );
+        assert_eq!(args.persistence_backpressure_threshold(), 8);
+        assert_eq!(args.tree_config().persistence_backpressure_threshold(), 8);
+    }
+
+    #[test]
+    fn default_backpressure_threshold_supports_zero_persistence_threshold() {
+        let args = CommandParser::<EngineArgs>::parse_from([
+            "reth",
+            "--engine.persistence-threshold",
+            "0",
+        ])
+        .args;
+
+        assert_eq!(args.persistence_backpressure_threshold(), 1);
+        args.validate().unwrap();
     }
 
     #[test]

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -99,6 +99,12 @@ impl HashedPostState {
         self.accounts.is_empty() && self.storages.is_empty()
     }
 
+    /// Returns the total number of updates including all accounts and storage updates.
+    pub fn total_len(&self) -> usize {
+        self.accounts.len() +
+            self.storages.values().map(|storage| storage.storage.len()).sum::<usize>()
+    }
+
     /// Construct [`TriePrefixSetsMut`] from hashed post state.
     /// The prefix sets contain the hashed account and storage keys that have been changed in the
     /// post state.
@@ -910,6 +916,30 @@ mod tests {
         database::{states::StorageSlot, StorageWithOriginalValues},
         state::{AccountInfo, Bytecode},
     };
+
+    #[test]
+    fn total_len_counts_accounts_and_storage_updates() {
+        let state = HashedPostState::default()
+            .with_accounts([
+                (B256::with_last_byte(1), Some(Account::default())),
+                (B256::with_last_byte(2), None),
+            ])
+            .with_storages([
+                (
+                    B256::with_last_byte(3),
+                    HashedStorage::from_iter(
+                        false,
+                        [
+                            (B256::with_last_byte(4), U256::from(1)),
+                            (B256::with_last_byte(5), U256::from(2)),
+                        ],
+                    ),
+                ),
+                (B256::with_last_byte(6), HashedStorage::new(true)),
+            ]);
+
+        assert_eq!(state.total_len(), 4);
+    }
 
     #[test]
     fn hashed_state_wiped_extension() {

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -996,7 +996,7 @@ Engine:
       --engine.persistence-backpressure-threshold <PERSISTENCE_BACKPRESSURE_THRESHOLD>
           Configure the maximum number of blocks beyond the in-memory buffer target that may await persistence before engine API processing stalls.
 
-          If omitted, this defaults to the larger of the default backpressure threshold and twice `--engine.persistence-threshold`.
+          If omitted, this defaults to twice `--engine.persistence-threshold`, or `1` if the persistence threshold is zero.
 
           This value must be greater than `--engine.persistence-threshold`.
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -984,7 +984,14 @@ Engine:
 
           To persist blocks as fast as the node receives them, set this value to zero. This will cause more frequent DB writes.
 
-          [default: 7]
+          [default: 200]
+
+      --engine.persistence-state-changes-threshold <PERSISTENCE_STATE_CHANGES_THRESHOLD>
+          Configure the hashed post state changes threshold for persistence.
+
+          This counts account and storage updates in canonical blocks beyond the configured in-memory buffer.
+
+          [default: 180000]
 
       --engine.persistence-backpressure-threshold <PERSISTENCE_BACKPRESSURE_THRESHOLD>
           Configure the maximum number of blocks beyond the in-memory buffer target that may await persistence before engine API processing stalls.
@@ -992,6 +999,13 @@ Engine:
           If omitted, this defaults to the larger of the default backpressure threshold and twice `--engine.persistence-threshold`.
 
           This value must be greater than `--engine.persistence-threshold`.
+
+      --engine.persistence-state-changes-backpressure-threshold <PERSISTENCE_STATE_CHANGES_BACKPRESSURE_THRESHOLD>
+          Configure the maximum number of hashed post state changes that may await persistence before engine API processing stalls.
+
+          If omitted, this defaults to twice `--engine.persistence-state-changes-threshold`.
+
+          This value must be greater than `--engine.persistence-state-changes-threshold`.
 
       --engine.memory-block-buffer-target <MEMORY_BLOCK_BUFFER_TARGET>
           Configure the target number of blocks to keep in memory.


### PR DESCRIPTION
Tracks each executed block's hashed post-state update count and uses it alongside block count to trigger persistence and backpressure, excluding the in-memory buffer.

Adds state-change threshold CLI flags with a 180,000 default, derives both implicit backpressure thresholds from their runtime base values, and raises the block persistence default to 200.