### PR TITLE
docs(engine): document sparse trie empty account invariant

### DIFF
--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -41,6 +41,14 @@
 //! blocks where the default behavior is wanted, for example before a fork activates. See
 //! `examples/custom-state-root` for the wiring.
 //!
+//! # Empty accounts
+//!
+//! The sparse-trie path treats an account with zero nonce, zero balance, empty bytecode, and an
+//! empty storage root as absent from the account trie. This relies on the post-Merge invariant
+//! established by EIP-7523 (<https://eips.ethereum.org/EIPS/eip-7523>): post-Merge state cannot
+//! contain empty accounts. A custom strategy that replays pre-Merge blocks through the Engine API
+//! must route those blocks to a state-root implementation that supports historical empty accounts.
+//!
 //! Returning empty trie updates in the outcome means the trie tables are no longer maintained:
 //! `eth_getProof` and anything else that reads the stored trie will not work for new blocks.
 //! Sparse-trie cache pruning uses node epochs to retain the in-memory block range.

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1046,6 +1046,11 @@ fn dispatch_with_chunking<T, I>(
 }
 
 /// RLP-encodes the account as a [`TrieAccount`] leaf value, or returns empty for deletions.
+///
+/// `Some(Account::default())` with an empty storage root is encoded as a deletion. This is valid
+/// for post-Merge state because EIP-7523 (<https://eips.ethereum.org/EIPS/eip-7523>) prohibits
+/// empty accounts. Do not use this encoding rule when replaying historical pre-Merge state, where
+/// an empty account and a missing account can have different trie representations.
 fn encode_account_leaf_value(
     account: Option<Account>,
     storage_root: B256,
@@ -1172,9 +1177,23 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_account_leaf_value_empty_account_and_empty_root_is_empty() {
+    fn test_encode_account_leaf_value_deletion_and_empty_root_is_empty() {
         let mut account_rlp_buf = vec![0xAB];
         let encoded = encode_account_leaf_value(None, EMPTY_ROOT_HASH, &mut account_rlp_buf);
+
+        assert!(encoded.is_empty());
+        // Early return should not touch the caller's buffer.
+        assert_eq!(account_rlp_buf, vec![0xAB]);
+    }
+
+    #[test]
+    fn test_encode_account_leaf_value_empty_account_and_empty_root_is_empty() {
+        let mut account_rlp_buf = vec![0xAB];
+        let encoded = encode_account_leaf_value(
+            Some(Account::default()),
+            EMPTY_ROOT_HASH,
+            &mut account_rlp_buf,
+        );
 
         assert!(encoded.is_empty());
         // Early return should not touch the caller's buffer.


### PR DESCRIPTION
Documents the sparse-trie post-Merge empty-account invariant and its historical replay limitation at both the public strategy boundary and the account-leaf encoder. Adds regression coverage for `Some(Account::default())` with an empty storage root.

Context: https://github.com/paradigmxyz/reth/issues/26499

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p reth-engine-tree test_encode_account_leaf_value_empty_account_and_empty_root_is_empty` *(blocked before compilation: fetching pinned `https://github.com/sigp/discv5` returned HTTP 401)*

Prompted by: @mattsse