### PR TITLE
chore(ci): enable identical-code-folding for macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,10 @@ jobs:
             os: macos-14
             profile: maxperf
             allow_fail: false
-            rustflags: ""
+            # Link with Rust's bundled Mach-O LLD to enable safe identical-code-folding,
+            # which reduces binary size. Apple's system linker does not support ICF.
+            # The `$(rustc ...)` substitution is expanded by the shell in the build step.
+            rustflags: "-C link-arg=--ld-path=$(rustc --print sysroot)/lib/rustlib/aarch64-apple-darwin/bin/gcc-ld/ld64.lld -C link-arg=-Wl,--icf=safe"
         build:
           - command: build
             binary: reth


### PR DESCRIPTION
Links macOS release builds with Rust's bundled Mach-O LLD via the cc driver and enables `--icf=safe`, which folds functions that compile to identical machine code. Apple's system linker does not support ICF, and the statically linked LLVM (revmc JIT) produces a large amount of foldable code.

Measured on aarch64-apple-darwin (release profile, link-only A/B with ld64.lld): 128,287,520 -> 124,154,528 bytes (-3.2%), gzipped -2.2%. `--icf=all` adds almost nothing over `safe`. Linux release builds link with mold, which also supports `--icf=safe` since 1.3; left as a follow-up pending measurements ([uv saw no meaningful win on Linux artifacts](https://github.com/astral-sh/uv/pull/19615)).

Prior art: [astral-sh/uv#19615](https://github.com/astral-sh/uv/pull/19615), [astral-sh/ty#3709](https://github.com/astral-sh/ty/pull/3709), [denoland/deno#34478](https://github.com/denoland/deno/pull/34478).