### PR TITLE
perf(ci): use aborting panics for unit test builds

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,7 +41,12 @@ jobs:
           persist-credentials: false
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - run: .github/scripts/install_llvm.sh ubuntu
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned nightly for -Z panic-abort-tests; compiling the test graph with
+      # aborting panics skips unwinding landing-pad codegen, which measurably
+      # reduces test build times and test binary sizes.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-07-12
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -58,10 +63,20 @@ jobs:
         run: |
           cargo nextest run \
             --no-fail-fast \
+            -Z panic-abort-tests \
+            --config 'profile.test.panic="abort"' \
             --features "${{ matrix.features }}" --locked \
             ${{ matrix.exclude_args }} --workspace \
-            --exclude ef-tests --no-tests=warn \
+            --exclude ef-tests --exclude reth-tasks --no-tests=warn \
             -E "!kind(test) and not binary(e2e_testsuite)"
+      - name: Run reth-tasks tests
+        # reth-tasks tests unwinding panic recovery (catch_unwind), which is
+        # incompatible with aborting panics; run it with the default unwind profile.
+        run: |
+          cargo nextest run \
+            --no-fail-fast --locked --no-tests=warn \
+            -p reth-tasks \
+            -E "!kind(test)"
 
   state:
     name: Ethereum state tests

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -619,6 +619,7 @@ mod tests {
     /// A hook dropped by a panic unwind must not finish the stream: the updates are
     /// incomplete, and a finish marker would make the task compute a root from them.
     #[test]
+    #[cfg_attr(panic = "abort", ignore = "asserts drop-during-unwind behavior")]
     fn hook_dropped_during_panic_does_not_finish_stream() {
         let sink = Arc::new(CountingSink::default());
         let hook = StateRootUpdateStream::new(sink.clone()).into_state_hook();


### PR DESCRIPTION
Compiles the unit-test job's test graph with `panic = "abort"` via a pinned nightly and `-Z panic-abort-tests`, removing unwinding landing-pad codegen from test builds. nextest runs each test in its own process, so aborting panics still surface as ordinary test failures.

Measured locally on an 8-crate subset of the test graph (engine-tree, rpc, network, transaction-pool, provider, trie, stages, node-builder; Apple M2 Max, nightly-2026-07-12 for both arms, sccache disabled):

| Metric | unwind | abort | Delta |
| --- | ---: | ---: | ---: |
| Cold test-graph build (859 crates), round 1 / 2 | 415s / 405s | 322s / 280s | -22% / -31% |
| Warm rebuild (dependency-chain ripple) | 105s | 80s | -24% |
| Warm rebuild (all workspace crates) | 63s | 58s | -8% |
| Test binary size (13 binaries) | 1,459,623,392 B | 1,295,951,344 B | -11.2% |

All 1055 tests in the subset pass under aborting panics with the CI filter. `reth-tasks` intentionally tests unwinding panic recovery (`catch_unwind`) and keeps its own unwind-profile invocation. Trade-offs: proptest failures abort instead of shrinking to a minimal input, and the test job moves from stable to a pinned nightly.

Prior art: [astral-sh/uv#20441](https://github.com/astral-sh/uv/pull/20441).