### PR TITLE
fix: add missing dev-dependency features for standalone test builds

### DIFF
--- a/crates/engine/primitives/Cargo.toml
+++ b/crates/engine/primitives/Cargo.toml
@@ -39,6 +39,9 @@ auto_impl.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+alloy-primitives = { workspace = true, features = ["getrandom"] }
+
 [features]
 default = ["std"]
 trie-debug = []

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -16,4 +16,4 @@ reth-db-api.workspace = true
 rayon.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["getrandom"] }

--- a/crates/payload/util/Cargo.toml
+++ b/crates/payload/util/Cargo.toml
@@ -18,3 +18,7 @@ reth-transaction-pool.workspace = true
 # alloy
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
+
+[dev-dependencies]
+reth-transaction-pool = { workspace = true, features = ["test-utils"] }
+alloy-primitives = { workspace = true, features = ["getrandom"] }


### PR DESCRIPTION
`cargo check -p reth-etl --tests --locked` (same for reth-payload-util and reth-engine-primitives) failed to compile because the tests use `random()` from alloy-primitives (gated behind `getrandom`) and `reth_transaction_pool::test_utils` (gated behind `test-utils`) without declaring those features, relying on feature unification with other workspace members. Workspace-wide builds pass, standalone builds didn't.

Declares the features in dev-dependencies. Swept the workspace for the same pattern (`random()`/`random_with()` and cross-crate `test_utils` imports, resolved per-package with `cargo tree`); these three crates were the only ones affected.