### PR TITLE
fix(net): reply to GetNodeData with empty payload

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -231,6 +231,21 @@ where
         let _ = response.send(Ok(BlockBodies(bodies)));
     }
 
+    /// Replies to `GetNodeData`.
+    ///
+    /// State serving via eth `GetNodeData` was removed; answer with an empty payload so eth/66
+    /// peers receive a response instead of hanging until the request timeout when the oneshot is
+    /// dropped unanswered.
+    fn on_node_data_request(
+        &self,
+        _peer_id: PeerId,
+        _request: GetNodeData,
+        response: oneshot::Sender<RequestResult<NodeData>>,
+    ) {
+        self.metrics.eth_node_data_requests_received_total.increment(1);
+        let _ = response.send(Ok(NodeData(vec![])));
+    }
+
     fn on_receipts_request(
         &self,
         _peer_id: PeerId,
@@ -691,8 +706,8 @@ where
                     IncomingEthRequest::GetBlockBodies { peer_id, request, response } => {
                         this.on_bodies_request(peer_id, request, response)
                     }
-                    IncomingEthRequest::GetNodeData { .. } => {
-                        this.metrics.eth_node_data_requests_received_total.increment(1);
+                    IncomingEthRequest::GetNodeData { peer_id, request, response } => {
+                        this.on_node_data_request(peer_id, request, response)
                     }
                     IncomingEthRequest::GetReceipts { peer_id, request, response } => {
                         this.on_receipts_request(peer_id, request, response)
@@ -988,6 +1003,23 @@ mod tests {
         let cells = rx.await.unwrap().unwrap();
         assert!(cells.hashes.is_empty());
         assert_eq!(get_cells_calls.load(Ordering::Relaxed), MAX_CELLS_SERVE);
+    }
+
+    #[tokio::test]
+    async fn get_node_data_responds_with_empty_payload() {
+        let (peers_tx, _) = mpsc::unbounded_channel();
+        let (_incoming_tx, incoming_rx) = mpsc::channel(1);
+        let handler = EthRequestHandler::<NoopProvider>::new(
+            NoopProvider::default(),
+            PeersHandle::new(peers_tx),
+            incoming_rx,
+        );
+        let (response, rx) = oneshot::channel();
+
+        handler.on_node_data_request(PeerId::default(), GetNodeData(vec![B256::ZERO]), response);
+
+        let node_data = rx.await.expect("response channel must not be dropped").unwrap();
+        assert!(node_data.0.is_empty(), "GetNodeData should reply with empty NodeData");
     }
 
     /// Creates a request handler backed by the mock provider for snap response tests.


### PR DESCRIPTION
`GetNodeData` only bumped metrics and dropped the response oneshot, so eth/66 peers hung until timeout. State serving via this message is gone; reply with empty `NodeData` so the request completes.

## Test plan
- [x] `cargo +1.95 test -p reth-network get_node_data_responds_with_empty_payload --lib`