### PR TITLE
chore: make jit build feature opt-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,8 @@ jobs:
       - name: Build Reth
         env:
           CC: clang
+          # jit is not a default feature; keep release artifacts JIT-capable
+          FEATURES: jit
         run: |
           if [ "${{ matrix.configs.native }}" = "true" ]; then
             make PROFILE=${{ matrix.configs.profile }} EXTRA_RUSTFLAGS="${{ matrix.configs.rustflags }}" ${{ matrix.build.command }}-native-${{ matrix.configs.target }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ ENV BUILD_PROFILE=$BUILD_PROFILE
 ARG RUSTFLAGS=""
 ENV RUSTFLAGS="$RUSTFLAGS"
 
-# Extra Cargo features
-ARG FEATURES=""
+# Extra Cargo features. jit is not a default feature; enable it here so
+# images built from this Dockerfile match the published release binaries.
+ARG FEATURES="jit"
 ENV FEATURES=$FEATURES
 
 # Builds dependencies

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -11,7 +11,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && \
     /tmp/install_llvm.sh && rm /tmp/install_llvm.sh
 WORKDIR /app
 COPY . .
-RUN RUSTFLAGS_REPRODUCIBLE_EXTRA="-Clink-arg=-fuse-ld=mold" make build-reth-reproducible && \
+RUN FEATURES="jit" RUSTFLAGS_REPRODUCIBLE_EXTRA="-Clink-arg=-fuse-ld=mold" make build-reth-reproducible && \
   PROFILE=${PROFILE:-reproducible} VERSION=$VERSION make build-deb-x86_64-unknown-linux-gnu
 
 FROM scratch AS artifacts

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -89,13 +89,15 @@ default = [
     "otlp-logs",
     "reth-revm/portable",
     "js-tracer",
-    "jit",
     "keccak-cache-global",
     "asm-keccak",
     "gmp",
     "min-trace-logs",
 ]
 
+# Experimental revmc JIT (runtime opt-in via --jit). Not a default feature
+# because it statically links LLVM 22 and requires llvm-config at build time;
+# release artifacts enable it via the FEATURES build variable.
 jit = [
     "reth-ethereum-cli/jit",
     "reth-node-ethereum/jit",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,8 +12,10 @@ variable "BUILD_PROFILE" {
   default = "maxperf-symbols"
 }
 
+// jit is not a default cargo feature; enable it here so published images
+// stay JIT-capable (runtime opt-in via --jit)
 variable "FEATURES" {
-  default = ""
+  default = "jit"
 }
 
 // Git info for vergen (since .git is excluded from Docker context)
@@ -77,7 +79,7 @@ target "ethereum-profiling" {
     BINARY        = "reth"
     MANIFEST_PATH = "bin/reth"
     BUILD_PROFILE = "profiling"
-    FEATURES      = "jemalloc-prof"
+    FEATURES      = "jemalloc-prof jit"
   }
   tags = ["${REGISTRY}/reth:nightly-profiling"]
 }

--- a/docs/vocs/docs/pages/installation/source.mdx
+++ b/docs/vocs/docs/pages/installation/source.mdx
@@ -37,6 +37,10 @@ operating system:
 
 These are needed to build bindings for Reth's database.
 
+Building with the experimental EVM JIT (`--features jit`, enabled in the official release
+binaries and Docker images) additionally requires LLVM 22 with `llvm-config` available on
+`PATH`. The default build does not include the JIT and does not need LLVM 22.
+
 The Minimum Supported Rust Version (MSRV) of this project is 1.88.0. If you already have a version of Rust installed,
 you can check your version by running `rustc --version`. To update your version of Rust, run `rustup update`.
 


### PR DESCRIPTION
Since #23230, `jit` is part of `bin/reth`'s default features, which makes LLVM 22 (`llvm-config` on `PATH` + static libs) a hard prerequisite for every local build of the binary: `cargo build -p reth`, `cargo install --locked --path bin/reth`, `make install`, and any workspace-wide `check`/`clippy`/`nextest` that includes the bin crate. The build-from-source docs never picked up that prerequisite, so the documented install path fails on machines without LLVM 22. Statically linking LLVM also grows the binary from 79,742,064 to 128,287,520 bytes (+61%; aarch64-apple-darwin, release profile — #23230 measured +118 MB on x86_64-linux maxperf).

The JIT is runtime opt-in (`--jit`, off by default, experimental): a binary built without the feature behaves identically unless `--jit` is passed, in which case it errors at startup. The CLI args are not feature-gated, so `--help` and the generated CLI docs are unchanged.

This removes `jit` from the default set and enables it explicitly wherever artifacts are produced, so everything we ship is unchanged: release binaries (`FEATURES: jit` in release.yml, passed through `make build-native-*`), docker images including nightly-profiling/hive/kurtosis (bake `FEATURES` default), plain `docker build` (`ARG FEATURES="jit"`), and reproducible builds. Per-PR compile coverage of the jit code remains through the `--all-features` clippy/udeps/doc-test jobs.

Draft on purpose — flipping the default is a product decision: the JIT's upside (#23230's Derek runs with `--jit` showed roughly -0.6% to -4% mean latency, up to -19% p99) against LLVM 22 contributor friction and binary size, with `--jit` users needing a jit-enabled build (released binaries/images, `make install FEATURES=jit`, or `cargo build --features jit`). If this lands, a follow-up can drop the now-unneeded `install_llvm.sh` steps from default-feature CI jobs (unit, integration, e2e, stage, sync, book).
