### PR TITLE
perf(rpc): reuse a single EVM across transaction replay in tracing RPCs

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -22,7 +22,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
-    EvmEnvFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
+    EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
@@ -791,6 +791,27 @@ pub trait Call:
         I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
         let mut evm = self.evm_config().evm_with_env(db, evm_env);
+        self.replay_transactions_until_with_evm(&mut evm, transactions, target_tx_hash)
+    }
+
+    /// Replays all the transactions until the target transaction is found, on the given EVM.
+    ///
+    /// Unlike [`Self::replay_transactions_until`], which builds an EVM and discards it, this uses
+    /// an EVM the caller holds, so the target transaction can run on the same one.
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator.
+    fn replay_transactions_until_with_evm<'a, DB, I, Txs>(
+        &self,
+        evm: &mut EvmFor<Self::Evm, DB, I>,
+        transactions: Txs,
+        target_tx_hash: B256,
+    ) -> Result<usize, Self::Error>
+    where
+        DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
+        I: InspectorFor<Self::Evm, DB>,
+        Txs: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
+    {
         let mut index = 0;
         for tx in transactions {
             if *tx.tx_hash() == target_tx_hash {

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -181,11 +181,29 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
 
                 this.apply_pre_execution_changes(&block, &mut db)?;
 
-                // replay all transactions prior to the targeted transaction
-                this.replay_transactions_until(&mut db, evm_env.clone(), block_txs, *tx.tx_hash())?;
-
+                // `tx_env` consumes `tx`, so take the hash first
+                let target_hash = *tx.tx_hash();
                 let tx_env = this.evm_config().tx_env(tx);
-                let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
+
+                // The EVM borrows both the database and the inspector, and the callback takes
+                // them by value, so it is scoped to end those borrows before `f` runs.
+                let res = {
+                    // Prefix and target on one EVM, so the target sees the block-scoped state
+                    // the prefix built.
+                    let mut evm = this.evm_config().evm_with_env_and_inspector(
+                        &mut db,
+                        evm_env,
+                        &mut inspector,
+                    );
+
+                    // replay all transactions prior to the targeted transaction, without tracing
+                    evm.disable_inspector();
+                    this.replay_transactions_until_with_evm(&mut evm, block_txs, target_hash)?;
+                    evm.enable_inspector();
+
+                    evm.transact(tx_env).map_err(Self::Error::from_evm_err)?
+                };
+
                 f(tx_info, inspector, res, db)
             })
             .await

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1623,6 +1623,56 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_block_fuses_inspector_between_transactions() {
+        let f = fixture(3);
+
+        let results =
+            f.api.debug_trace_block(f.block_hash.into(), Default::default()).await.unwrap();
+
+        let logs = |i: usize| {
+            let TraceResult::Success { result, .. } = &results[i] else { panic!() };
+            let GethTrace::Default(frame) = result else { panic!() };
+            frame.struct_logs.len()
+        };
+        // transaction 0 calls WRITER and runs opcodes; the rest are bare transfers that run none.
+        // Without fusing the shared inspector between transactions, transaction 0's steps would
+        // still be in the later traces.
+        assert!(logs(0) > 0);
+        assert_eq!(logs(1), 0);
+        assert_eq!(logs(2), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_call_many_replays_prefix_on_one_evm() {
+        // a prefix shorter than the block, so the replay is not skipped in favour of the
+        // committed post-block state
+        let f = fixture(4);
+
+        let bundles = vec![Bundle { transactions: vec![Default::default()], block_override: None }];
+        let context = StateContext {
+            block_number: Some(f.block_hash.into()),
+            transaction_index: Some(alloy_rpc_types_eth::TransactionIndex::Index(3)),
+        };
+        f.api.debug_trace_call_many(bundles, Some(context), None).await.unwrap();
+
+        // one EVM for the pre-execution changes, one for the three prefix transactions, one for
+        // the bundle's call
+        assert_eq!(f.observations.take_evms_created(), 3);
+
+        // the prefix shares the block-start value; the bundle call gets its own EVM and
+        // re-loads from mid-block state — the known gap for simulated calls, not an accident.
+        assert_eq!(
+            f.observations.take_values(),
+            vec![
+                block_start_value(),
+                block_start_value(),
+                block_start_value(),
+                U256::from(WRITTEN_VALUE),
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_intermediate_roots_sees_block_start_context() {
         let f = fixture(3);
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -244,30 +244,46 @@ where
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
-                // replay all transactions prior to the targeted transaction
-                let index = eth_api.replay_transactions_until(
-                    &mut db,
-                    evm_env.clone(),
-                    block_txs,
-                    *tx.tx_hash(),
-                )?;
+                let target_hash = *tx.tx_hash();
+                // the EVM takes `evm_env`, but the block env is still needed for the trace result
+                let block_env = evm_env.block_env.clone();
+
+                let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
+                // Prefix and target on one EVM, so the target sees the block-scoped state the
+                // prefix built.
+                let mut evm =
+                    eth_api.evm_config().evm_with_env_and_inspector(&mut db, evm_env, inspector);
+
+                // replay all transactions prior to the targeted transaction, without tracing them
+                evm.disable_inspector();
+                let mut index = 0;
+                for prior_tx in block_txs {
+                    if *prior_tx.tx_hash() == target_hash {
+                        // reached the target transaction
+                        break
+                    }
+                    let prior_tx_env = eth_api.evm_config().tx_env(prior_tx);
+                    evm.transact_commit(prior_tx_env).map_err(Eth::Error::from_evm_err)?;
+                    index += 1;
+                }
+                evm.enable_inspector();
 
                 let tx_env = eth_api.evm_config().tx_env(&tx);
+                let res = evm.transact(tx_env.clone()).map_err(Eth::Error::from_evm_err)?;
 
-                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                let res =
-                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
+                // split the EVM so the inspector and the database can be borrowed at once
+                let (evm_db, inspector, _) = evm.components_mut();
                 let trace = inspector
                     .get_result(
                         Some(TransactionContext {
                             block_hash: Some(block_hash),
                             tx_index: Some(index),
-                            tx_hash: Some(*tx.tx_hash()),
+                            tx_hash: Some(target_hash),
                         }),
                         &tx_env,
-                        &evm_env.block_env,
+                        &block_env,
                         &res,
-                        &mut db,
+                        evm_db,
                     )
                     .map_err(Eth::Error::from_eth_err)?;
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1318,6 +1318,7 @@ mod tests {
     };
     use alloy_network::Ethereum;
     use alloy_primitives::{address, Signature, TxKind, U256};
+    use alloy_rpc_types_trace::geth::GethDebugBuiltInTracerType;
     use reth_chainspec::ChainSpec;
     use reth_ethereum_primitives::{EthPrimitives, Transaction, TransactionSigned};
     use reth_evm_ethereum::EthEvmConfig;
@@ -1349,6 +1350,8 @@ mod tests {
     const BLOCK_START_VALUE: u64 = 1;
     /// Value [`WRITER`] stores into [`OBSERVED_SLOT`]: `PUSH1 2 PUSH1 0 SSTORE STOP`.
     const WRITTEN_VALUE: u64 = 2;
+    /// Call selector the block's first transaction sends to [`WRITER`].
+    const SELECTOR: [u8; 4] = [0x11, 0x22, 0x33, 0x44];
 
     /// What the block's transactions observed, and how many EVMs were built to run them.
     #[derive(Debug, Default, Clone)]
@@ -1532,17 +1535,19 @@ mod tests {
 
         let transactions: Vec<_> = (0..tx_count)
             .map(|i| {
-                let (to, gas_limit) = if i == 0 {
-                    (TxKind::Call(WRITER), 100_000)
+                let (to, gas_limit, input) = if i == 0 {
+                    // the selector is what the 4byte tracer records; WRITER ignores calldata
+                    (TxKind::Call(WRITER), 100_000, Bytes::from_static(&SELECTOR))
                 } else {
                     // distinct gas limits give distinct signing hashes, hence distinct senders
-                    (TxKind::Call(Address::ZERO), 21_000 + i as u64)
+                    (TxKind::Call(Address::ZERO), 21_000 + i as u64, Bytes::new())
                 };
                 TransactionSigned::new_unhashed(
                     Transaction::Legacy(TxLegacy {
                         gas_limit,
                         gas_price: 0,
                         to,
+                        input,
                         ..Default::default()
                     }),
                     Signature::test_signature(),
@@ -1626,20 +1631,20 @@ mod tests {
     async fn test_debug_trace_block_fuses_inspector_between_transactions() {
         let f = fixture(3);
 
-        let results =
-            f.api.debug_trace_block(f.block_hash.into(), Default::default()).await.unwrap();
+        // the 4byte tracer accumulates a selector map, so without fusing between transactions
+        // transaction 0's selector leaks into the later traces. The struct logger does not.
+        let opts = GethDebugTracingOptions::new_tracer(GethDebugBuiltInTracerType::FourByteTracer);
+        let results = f.api.debug_trace_block(f.block_hash.into(), opts).await.unwrap();
 
-        let logs = |i: usize| {
+        let selectors = |i: usize| {
             let TraceResult::Success { result, .. } = &results[i] else { panic!() };
-            let GethTrace::Default(frame) = result else { panic!() };
-            frame.struct_logs.len()
+            let GethTrace::FourByteTracer(frame) = result else { panic!("{result:?}") };
+            frame.0.clone()
         };
-        // transaction 0 calls WRITER and runs opcodes; the rest are bare transfers that run none.
-        // Without fusing the shared inspector between transactions, transaction 0's steps would
-        // still be in the later traces.
-        assert!(logs(0) > 0);
-        assert_eq!(logs(1), 0);
-        assert_eq!(logs(2), 0);
+        // only transaction 0 sends calldata
+        assert_eq!(selectors(0).len(), 1);
+        assert!(selectors(1).is_empty(), "{:?}", selectors(1));
+        assert!(selectors(2).is_empty(), "{:?}", selectors(2));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1307,3 +1307,328 @@ impl<B: BlockTrait> Default for BadBlockStore<B> {
         Self::new(64)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EthApi, EthApiBuilder};
+    use alloy_consensus::{BlockBody, Header, TxLegacy};
+    use alloy_evm::{
+        eth::EthEvmContext, precompiles::PrecompilesMap, Database, EthEvm, EvmEnv, EvmFactory,
+    };
+    use alloy_network::Ethereum;
+    use alloy_primitives::{address, Signature, TxKind, U256};
+    use reth_chainspec::ChainSpec;
+    use reth_ethereum_primitives::{EthPrimitives, Transaction, TransactionSigned};
+    use reth_evm_ethereum::EthEvmConfig;
+    use reth_network_api::noop::NoopNetwork;
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+    use reth_rpc_convert::RpcConverter;
+    use reth_rpc_eth_api::node::RpcNodeCoreAdapter;
+    use reth_rpc_eth_types::receipt::EthReceiptConverter;
+    use reth_transaction_pool::test_utils::{testing_pool, TestPool};
+    use revm::{
+        context::{
+            result::{EVMError, HaltReason, ResultAndState},
+            BlockEnv, CfgEnv, DBErrorMarker, TxEnv,
+        },
+        inspector::NoOpInspector,
+        primitives::hardfork::SpecId,
+        Inspector,
+    };
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    };
+
+    /// Contract that overwrites [`OBSERVED_SLOT`], called by the block's first transaction.
+    const WRITER: Address = address!("00000000000000000000000000000000000000aa");
+    /// Storage slot [`StatefulEthEvm`] loads its block-scoped value from.
+    const OBSERVED_SLOT: U256 = U256::ZERO;
+    /// Value seeded into [`OBSERVED_SLOT`] before the block runs.
+    const BLOCK_START_VALUE: u64 = 1;
+    /// Value [`WRITER`] stores into [`OBSERVED_SLOT`]: `PUSH1 2 PUSH1 0 SSTORE STOP`.
+    const WRITTEN_VALUE: u64 = 2;
+
+    /// What the block's transactions observed, and how many EVMs were built to run them.
+    #[derive(Debug, Default, Clone)]
+    struct EvmObservations {
+        values: Arc<Mutex<Vec<U256>>>,
+        evms_created: Arc<AtomicUsize>,
+    }
+
+    impl EvmObservations {
+        fn take_values(&self) -> Vec<U256> {
+            std::mem::take(&mut *self.values.lock().unwrap())
+        }
+
+        fn take_evms_created(&self) -> usize {
+            self.evms_created.swap(0, Ordering::Relaxed)
+        }
+    }
+
+    /// An [`EthEvm`] carrying block-scoped state: a value loaded from state on the first
+    /// transaction it runs and stamped with the block number, reloaded only when that number
+    /// changes.
+    ///
+    /// This is what a fresh EVM per transaction breaks: each new instance re-loads the value
+    /// from whatever mid-block state it was handed.
+    struct StatefulEthEvm<DB: Database, I> {
+        inner: EthEvm<DB, I, PrecompilesMap>,
+        cached: Option<(U256, U256)>,
+        observations: EvmObservations,
+    }
+
+    impl<DB, I> Evm for StatefulEthEvm<DB, I>
+    where
+        DB: Database,
+        I: Inspector<EthEvmContext<DB>>,
+    {
+        type DB = DB;
+        type Tx = TxEnv;
+        type Error = EVMError<DB::Error>;
+        type HaltReason = HaltReason;
+        type Spec = SpecId;
+        type BlockEnv = BlockEnv;
+        type Precompiles = PrecompilesMap;
+        type Inspector = I;
+
+        fn transact_raw(
+            &mut self,
+            tx: Self::Tx,
+        ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+            // capture the block number before borrowing the database mutably
+            let block_number = self.inner.block().number;
+            if self.cached.map(|(number, _)| number) != Some(block_number) {
+                let value = self
+                    .inner
+                    .db_mut()
+                    .storage(WRITER, OBSERVED_SLOT)
+                    .map_err(EVMError::Database)?;
+                self.cached = Some((block_number, value));
+            }
+            self.observations.values.lock().unwrap().push(self.cached.expect("just loaded").1);
+            self.inner.transact_raw(tx)
+        }
+
+        /// Delegates without seeding the cache: pre-execution system calls must not stand in for
+        /// the block's first transaction.
+        fn transact_system_call(
+            &mut self,
+            caller: Address,
+            contract: Address,
+            data: Bytes,
+        ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+            self.inner.transact_system_call(caller, contract, data)
+        }
+
+        fn block(&self) -> &Self::BlockEnv {
+            self.inner.block()
+        }
+
+        fn cfg_env(&self) -> &CfgEnv<Self::Spec> {
+            self.inner.cfg_env()
+        }
+
+        fn chain_id(&self) -> u64 {
+            self.inner.chain_id()
+        }
+
+        fn finish(self) -> (Self::DB, EvmEnv<Self::Spec, Self::BlockEnv>) {
+            self.inner.finish()
+        }
+
+        fn set_inspector_enabled(&mut self, enabled: bool) {
+            self.inner.set_inspector_enabled(enabled)
+        }
+
+        fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
+            self.inner.components()
+        }
+
+        fn components_mut(
+            &mut self,
+        ) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
+            self.inner.components_mut()
+        }
+    }
+
+    /// Builds [`StatefulEthEvm`]s and counts how many it has built.
+    #[derive(Debug, Default, Clone)]
+    struct StatefulEvmFactory {
+        observations: EvmObservations,
+    }
+
+    impl EvmFactory for StatefulEvmFactory {
+        type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = StatefulEthEvm<DB, I>;
+        type Context<DB: Database> = EthEvmContext<DB>;
+        type Tx = TxEnv;
+        type Error<DBError: DBErrorMarker> = EVMError<DBError>;
+        type HaltReason = HaltReason;
+        type Spec = SpecId;
+        type BlockEnv = BlockEnv;
+        type Precompiles = PrecompilesMap;
+
+        fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
+            self.observations.evms_created.fetch_add(1, Ordering::Relaxed);
+            StatefulEthEvm {
+                inner: alloy_evm::EthEvmFactory::default().create_evm(db, input),
+                cached: None,
+                observations: self.observations.clone(),
+            }
+        }
+
+        fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
+            &self,
+            db: DB,
+            input: EvmEnv,
+            inspector: I,
+        ) -> Self::Evm<DB, I> {
+            self.observations.evms_created.fetch_add(1, Ordering::Relaxed);
+            StatefulEthEvm {
+                inner: alloy_evm::EthEvmFactory::default()
+                    .create_evm_with_inspector(db, input, inspector),
+                cached: None,
+                observations: self.observations.clone(),
+            }
+        }
+    }
+
+    type StatefulEvmConfig = EthEvmConfig<ChainSpec, StatefulEvmFactory>;
+    type StatefulEthApi = EthApi<
+        RpcNodeCoreAdapter<MockEthProvider, TestPool, NoopNetwork, StatefulEvmConfig>,
+        // the default `EthRpcConverter` pins `EthEvmConfig`'s default factory
+        RpcConverter<Ethereum, StatefulEvmConfig, EthReceiptConverter<ChainSpec>>,
+    >;
+
+    /// A block whose transactions all read the same block-scoped value, the first of which
+    /// rewrites it.
+    ///
+    /// Note the observation assertions cannot tell whether the prefix transactions were
+    /// committed: once the first one caches the value, the rest report it either way. Committing
+    /// is pinned by [`test_debug_trace_call_many_replays_prefix_on_one_evm`], whose bundle call
+    /// runs on its own EVM and so observes the written value.
+    struct Fixture {
+        api: DebugApi<StatefulEthApi>,
+        observations: EvmObservations,
+        block_hash: B256,
+        tx_hashes: Vec<B256>,
+    }
+
+    /// Builds a `tx_count`-transaction block at height 1. Transaction 0 calls [`WRITER`], which
+    /// overwrites [`OBSERVED_SLOT`]; the rest are bare transfers, distinguished by gas limit so
+    /// each recovers to a different (empty, nonce-zero) sender.
+    fn fixture(tx_count: usize) -> Fixture {
+        let provider = MockEthProvider::default().with_recovered_blocks();
+
+        // WRITER holds the block-start value and rewrites it when called
+        provider.add_account(
+            WRITER,
+            ExtendedAccount::new(0, U256::ZERO)
+                // PUSH1 WRITTEN_VALUE, PUSH1 0, SSTORE, STOP
+                .with_bytecode(Bytes::from(vec![0x60, WRITTEN_VALUE as u8, 0x60, 0x00, 0x55, 0x00]))
+                .extend_storage([(B256::ZERO, U256::from(BLOCK_START_VALUE))]),
+        );
+
+        let transactions: Vec<_> = (0..tx_count)
+            .map(|i| {
+                let (to, gas_limit) = if i == 0 {
+                    (TxKind::Call(WRITER), 100_000)
+                } else {
+                    // distinct gas limits give distinct signing hashes, hence distinct senders
+                    (TxKind::Call(Address::ZERO), 21_000 + i as u64)
+                };
+                TransactionSigned::new_unhashed(
+                    Transaction::Legacy(TxLegacy {
+                        gas_limit,
+                        gas_price: 0,
+                        to,
+                        ..Default::default()
+                    }),
+                    Signature::test_signature(),
+                )
+            })
+            .collect();
+        let tx_hashes = transactions.iter().map(|tx| *tx.tx_hash()).collect();
+
+        let parent = Header { number: 0, gas_limit: 30_000_000, ..Default::default() };
+        let parent_hash = parent.hash_slow();
+        let block = reth_ethereum_primitives::Block {
+            header: Header { number: 1, parent_hash, gas_limit: 30_000_000, ..Default::default() },
+            body: BlockBody { transactions, ..Default::default() },
+        };
+        let block_hash = block.header.hash_slow();
+        provider.add_header(parent_hash, parent);
+        provider.add_block(block_hash, block);
+
+        let observations = EvmObservations::default();
+        let evm_config = EthEvmConfig::new_with_evm_factory(
+            provider.chain_spec(),
+            StatefulEvmFactory { observations: observations.clone() },
+        );
+        let eth_api =
+            EthApiBuilder::new(provider, testing_pool(), NoopNetwork::default(), evm_config)
+                .build();
+        let api = DebugApi::new(
+            eth_api,
+            BlockingTaskGuard::new(1),
+            &Runtime::test(),
+            futures::stream::empty::<ConsensusEngineEvent<EthPrimitives>>(),
+        );
+
+        // discard whatever setup cost, so each test measures only its own call
+        observations.take_values();
+        observations.take_evms_created();
+
+        Fixture { api, observations, block_hash, tx_hashes }
+    }
+
+    /// The value every transaction should observe: the one in state before the block ran.
+    fn block_start_value() -> U256 {
+        U256::from(BLOCK_START_VALUE)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_block_sees_block_start_context() {
+        let f = fixture(3);
+
+        let results =
+            f.api.debug_trace_block(f.block_hash.into(), Default::default()).await.unwrap();
+
+        // guards a vacuous fixture: a reverted transaction 0 would never overwrite the value
+        assert_eq!(results.len(), 3);
+        for result in &results {
+            let TraceResult::Success { result, .. } = result else { panic!("{result:?}") };
+            let GethTrace::Default(frame) = result else { panic!("{result:?}") };
+            assert!(!frame.failed, "{frame:?}");
+        }
+
+        // every transaction of the block settles at the value read before the block ran, even
+        // though transaction 0 overwrote it
+        assert_eq!(f.observations.take_values(), vec![block_start_value(); 3]);
+        // one EVM for the pre-execution changes, one for the block's transactions
+        assert_eq!(f.observations.take_evms_created(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_transaction_sees_block_start_context() {
+        let f = fixture(3);
+
+        // target index 2, so the prefix contains the transaction that overwrote the value
+        f.api.debug_trace_transaction(f.tx_hashes[2], Default::default()).await.unwrap();
+
+        // the two prefix transactions plus the target
+        assert_eq!(f.observations.take_values(), vec![block_start_value(); 3]);
+        assert_eq!(f.observations.take_evms_created(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_intermediate_roots_sees_block_start_context() {
+        let f = fixture(3);
+
+        f.api.intermediate_roots(f.block_hash).await.unwrap();
+
+        assert_eq!(f.observations.take_values(), vec![block_start_value(); 3]);
+        assert_eq!(f.observations.take_evms_created(), 2);
+    }
+}

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -445,11 +445,12 @@ where
 
                     let transactions = block.transactions_recovered().take(num_txs);
 
-                    // Execute all transactions until index
+                    // The prefix runs on one EVM, scoped so its borrow of `db` ends before the
+                    // bundle loop below, which needs the database again.
+                    let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
                     for tx in transactions {
                         let tx_env = eth_api.evm_config().tx_env(tx);
-                        let res = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit(res.state);
+                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
                     }
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -768,8 +768,10 @@ where
                     state.merge_transitions(BundleRetention::PlainState);
                     // Compute state root from the accumulated state changes
                     let hashed_state = state.database.hashed_post_state(&state.bundle_state);
-                    let root =
-                        state.database.state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;
+                    let root = state
+                        .database
+                        .state_root(hashed_state)
+                        .map_err(Eth::Error::from_eth_err)?;
                     roots.push(root);
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -123,29 +123,36 @@ where
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
+                let block_hash = block.hash();
+                // the EVM takes `evm_env`, but the block env is still needed per trace result
+                let block_env = evm_env.block_env.clone();
+
+                let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
+                // One EVM for the whole block, as the block executor and the `trace_*` API do:
+                // an EVM's block-scoped state must stay initialized from the block's start state.
+                let mut evm =
+                    eth_api.evm_config().evm_with_env_and_inspector(&mut db, evm_env, inspector);
+
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
-                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
                 while let Some((index, tx)) = transactions.next() {
                     let tx_hash = *tx.tx_hash();
                     let tx_env = eth_api.evm_config().tx_env(tx);
 
-                    let res = eth_api.inspect(
-                        &mut db,
-                        evm_env.clone(),
-                        tx_env.clone(),
-                        &mut inspector,
-                    )?;
+                    let res = evm.transact(tx_env.clone()).map_err(Eth::Error::from_evm_err)?;
+
+                    // split the EVM so the inspector and the database can be borrowed at once
+                    let (evm_db, inspector, _) = evm.components_mut();
                     let result = inspector
                         .get_result(
                             Some(TransactionContext {
-                                block_hash: Some(block.hash()),
+                                block_hash: Some(block_hash),
                                 tx_hash: Some(tx_hash),
                                 tx_index: Some(index),
                             }),
                             &tx_env,
-                            &evm_env.block_env,
+                            &block_env,
                             &res,
-                            &mut db,
+                            evm_db,
                         )
                         .map_err(Eth::Error::from_eth_err)?;
 
@@ -154,7 +161,7 @@ where
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit(res.state)
+                        evm_db.commit(res.state)
                     }
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -728,18 +728,21 @@ where
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
                 let mut roots = Vec::with_capacity(block.body().transactions().len());
+                // One EVM for the whole block; the state is reached through it from here on.
+                let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
                 for tx in block.transactions_recovered() {
                     let tx_env = eth_api.evm_config().tx_env(tx);
-                    {
-                        let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
-                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
-                    }
+                    evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+
+                    // bind once: two `evm.db_mut()` calls in one expression would be two
+                    // simultaneous mutable borrows of the EVM
+                    let state = evm.db_mut();
                     // Merge transitions into cumulative bundle_state
-                    db.merge_transitions(BundleRetention::PlainState);
+                    state.merge_transitions(BundleRetention::PlainState);
                     // Compute state root from the accumulated state changes
-                    let hashed_state = db.database.hashed_post_state(&db.bundle_state);
+                    let hashed_state = state.database.hashed_post_state(&state.bundle_state);
                     let root =
-                        db.database.state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;
+                        state.database.state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;
                     roots.push(root);
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -263,16 +263,8 @@ where
 
                 // replay all transactions prior to the targeted transaction, without tracing them
                 evm.disable_inspector();
-                let mut index = 0;
-                for prior_tx in block_txs {
-                    if *prior_tx.tx_hash() == target_hash {
-                        // reached the target transaction
-                        break
-                    }
-                    let prior_tx_env = eth_api.evm_config().tx_env(prior_tx);
-                    evm.transact_commit(prior_tx_env).map_err(Eth::Error::from_evm_err)?;
-                    index += 1;
-                }
+                let index =
+                    eth_api.replay_transactions_until_with_evm(&mut evm, block_txs, target_hash)?;
                 evm.enable_inspector();
 
                 let tx_env = eth_api.evm_config().tx_env(&tx);
@@ -1325,7 +1317,7 @@ mod tests {
     use reth_network_api::noop::NoopNetwork;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_rpc_convert::RpcConverter;
-    use reth_rpc_eth_api::node::RpcNodeCoreAdapter;
+    use reth_rpc_eth_api::{helpers::Trace, node::RpcNodeCoreAdapter};
     use reth_rpc_eth_types::receipt::EthReceiptConverter;
     use reth_transaction_pool::test_utils::{testing_pool, TestPool};
     use revm::{
@@ -1337,6 +1329,7 @@ mod tests {
         primitives::hardfork::SpecId,
         Inspector,
     };
+    use revm_inspectors::tracing::TracingInspectorConfig;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Mutex,
@@ -1645,6 +1638,29 @@ mod tests {
         assert_eq!(selectors(0).len(), 1);
         assert!(selectors(1).is_empty(), "{:?}", selectors(1));
         assert!(selectors(2).is_empty(), "{:?}", selectors(2));
+    }
+
+    /// Covers `Trace::spawn_trace_transaction_in_block_with_inspector`, which backs
+    /// `trace_transaction`, `trace_get`, `trace_replayTransaction` and the `ots_*` trace
+    /// endpoints. It lives here because the fixture above is private to this module.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_trace_transaction_in_block_sees_block_start_context() {
+        let f = fixture(3);
+
+        f.api
+            .eth_api()
+            .spawn_trace_transaction_in_block(
+                f.tx_hashes[2],
+                TracingInspectorConfig::default_parity(),
+                |_, _, _, _| Ok(()),
+            )
+            .await
+            .unwrap()
+            .expect("transaction should be found");
+
+        // the two prefix transactions plus the target, all on one EVM
+        assert_eq!(f.observations.take_values(), vec![block_start_value(); 3]);
+        assert_eq!(f.observations.take_evms_created(), 2);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -396,6 +396,10 @@ where
                 )?;
 
                 // 3. now execute the trace call on this state
+                //
+                // The call cannot share the replay EVM: `prepare_call_env` produces a different
+                // env and an EVM's env cannot be replaced. So an EVM with block-scoped state
+                // initializes it here from mid-block state.
                 let (evm_env, tx_env) =
                     eth_api.prepare_call_env(evm_env, call, &mut db, overrides)?;
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -161,6 +161,8 @@ where
                 let mut calls = calls.into_iter().peekable();
 
                 while let Some((call, trace_types)) = calls.next() {
+                    // Each call needs its own env and an EVM's env cannot be replaced, so every
+                    // call gets a fresh EVM — one with block-scoped state re-initializes it.
                     let (evm_env, tx_env) = eth_api.prepare_call_env(
                         evm_env.clone(),
                         call,

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1319,9 +1319,122 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> NodePrimitivesProvider
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::Header;
-    use alloy_primitives::BlockHash;
-    use reth_ethereum_primitives::Receipt;
+    use alloy_consensus::{Header, TxLegacy};
+    use alloy_primitives::{BlockHash, Signature, TxKind};
+    use reth_ethereum_primitives::{Receipt, Transaction, TransactionSigned};
+
+    /// Builds a one-transaction block at the given number, signed so senders can be recovered.
+    fn block_with_signed_tx(number: u64) -> reth_ethereum_primitives::Block {
+        let tx = TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                gas_limit: 21_000,
+                to: TxKind::Call(Address::ZERO),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        );
+        reth_ethereum_primitives::Block {
+            header: Header { number, ..Default::default() },
+            body: alloy_consensus::BlockBody { transactions: vec![tx], ..Default::default() },
+        }
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_opt_in() {
+        let provider = MockEthProvider::<EthPrimitives>::new();
+        let hash = BlockHash::random();
+        provider.add_block(hash, block_with_signed_tx(1));
+
+        // the block is in the store, but the lookup is off by default
+        assert!(provider.block(hash.into()).unwrap().is_some());
+        assert!(provider
+            .recovered_block(hash.into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .sealed_block_with_senders(hash.into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_by_hash() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        // deliberately not the header's own hash, which is what tests usually insert under
+        let synthetic_hash = BlockHash::random();
+        let block = block_with_signed_tx(1);
+        assert_ne!(synthetic_hash, block.header.hash_slow());
+        provider.add_block(synthetic_hash, block);
+
+        let recovered =
+            provider.recovered_block(synthetic_hash.into(), TransactionVariant::WithHash).unwrap();
+        let recovered = recovered.expect("block should resolve");
+        assert_eq!(recovered.hash(), synthetic_hash);
+        assert_eq!(recovered.senders().len(), 1);
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_by_number() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        let synthetic_hash = BlockHash::random();
+        let block = block_with_signed_tx(7);
+        let computed_hash = block.header.hash_slow();
+        provider.add_block(synthetic_hash, block);
+
+        let recovered =
+            provider.recovered_block(7u64.into(), TransactionVariant::WithHash).unwrap();
+        let recovered = recovered.expect("block should resolve");
+        // no lookup key to preserve, so the hash comes from the header
+        assert_eq!(recovered.hash(), computed_hash);
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_missing() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        provider.add_block(BlockHash::random(), block_with_signed_tx(1));
+
+        assert!(provider
+            .recovered_block(BlockHash::random().into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .recovered_block(99u64.into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_recovery_failure() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        let hash = BlockHash::random();
+        // r = s = 0 is not a recoverable signature
+        let tx = TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy { gas_limit: 21_000, ..Default::default() }),
+            Signature::new(U256::ZERO, U256::ZERO, false),
+        );
+        provider.add_block(
+            hash,
+            reth_ethereum_primitives::Block {
+                header: Header { number: 1, ..Default::default() },
+                body: alloy_consensus::BlockBody { transactions: vec![tx], ..Default::default() },
+            },
+        );
+
+        assert!(provider.recovered_block(hash.into(), TransactionVariant::WithHash).is_err());
+    }
+
+    #[test]
+    fn test_mock_provider_sealed_block_with_senders() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        let hash = BlockHash::random();
+        provider.add_block(hash, block_with_signed_tx(1));
+
+        let recovered =
+            provider.recovered_block(hash.into(), TransactionVariant::WithHash).unwrap();
+        let sealed =
+            provider.sealed_block_with_senders(hash.into(), TransactionVariant::WithHash).unwrap();
+        assert_eq!(recovered, sealed);
+    }
 
     #[test]
     fn test_mock_provider_receipts() {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -93,6 +93,8 @@ pub struct MockEthProvider<T: NodePrimitives = EthPrimitives, ChainSpec = reth_c
     snap_account_proof: Arc<Mutex<Option<Vec<Bytes>>>>,
     /// Storage proof returned to snap handler tests.
     snap_storage_proof: Arc<Mutex<Option<Vec<Bytes>>>>,
+    /// Whether recovered block lookups resolve against the local block store.
+    recover_block_senders: Arc<AtomicBool>,
     tx: TxMock,
     prune_modes: Arc<PruneModes>,
 }
@@ -135,6 +137,7 @@ where
             snap_storage_range_requests: self.snap_storage_range_requests.clone(),
             snap_account_proof: self.snap_account_proof.clone(),
             snap_storage_proof: self.snap_storage_proof.clone(),
+            recover_block_senders: self.recover_block_senders.clone(),
             tx: self.tx.clone(),
             prune_modes: self.prune_modes.clone(),
         }
@@ -162,6 +165,7 @@ impl<T: NodePrimitives> MockEthProvider<T, reth_chainspec::ChainSpec> {
             snap_storage_range_requests: Default::default(),
             snap_account_proof: Default::default(),
             snap_storage_proof: Default::default(),
+            recover_block_senders: Default::default(),
             tx: Default::default(),
             prune_modes: Default::default(),
         }
@@ -169,6 +173,20 @@ impl<T: NodePrimitives> MockEthProvider<T, reth_chainspec::ChainSpec> {
 }
 
 impl<T: NodePrimitives, ChainSpec> MockEthProvider<T, ChainSpec> {
+    /// Serves [`BlockReader::recovered_block`] and
+    /// [`BlockReader::sealed_block_with_senders`] from the local block store by recovering
+    /// signers, instead of always reporting a miss.
+    ///
+    /// Off by default: these are general provider methods, so resolving them changes which code
+    /// path every consumer that populates `blocks` takes.
+    ///
+    /// Like the rest of this mock's state the flag is shared with clones, including ones taken
+    /// before this call. That is what lets a provider handed to a builder stay in sync.
+    pub fn with_recovered_blocks(self) -> Self {
+        self.recover_block_senders.store(true, Ordering::Relaxed);
+        self
+    }
+
     /// Makes snap state reads return provider errors when `fail` is true.
     pub fn set_snap_state_reads_fail(&self, fail: bool) {
         self.snap_state_reads_fail.store(fail, Ordering::Relaxed);
@@ -321,6 +339,7 @@ impl<T: NodePrimitives, ChainSpec> MockEthProvider<T, ChainSpec> {
             snap_storage_range_requests: self.snap_storage_range_requests,
             snap_account_proof: self.snap_account_proof,
             snap_storage_proof: self.snap_storage_proof,
+            recover_block_senders: self.recover_block_senders,
             tx: self.tx,
             prune_modes: self.prune_modes,
         }
@@ -881,18 +900,28 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> BlockRe
 
     fn recovered_block(
         &self,
-        _id: BlockHashOrNumber,
+        id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        Ok(None)
+        if !self.recover_block_senders.load(Ordering::Relaxed) {
+            return Ok(None)
+        }
+        let Some(block) = self.block(id)? else { return Ok(None) };
+        let senders = block.body().recover_signers()?;
+        Ok(Some(match id {
+            // blocks are keyed by hash here, and tests often insert them under a synthetic hash,
+            // so keep the lookup key rather than recomputing it from the header
+            BlockHashOrNumber::Hash(hash) => RecoveredBlock::new(block, senders, hash),
+            BlockHashOrNumber::Number(_) => RecoveredBlock::new_unhashed(block, senders),
+        }))
     }
 
     fn sealed_block_with_senders(
         &self,
-        _id: BlockHashOrNumber,
-        _transaction_kind: TransactionVariant,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        Ok(None)
+        self.recovered_block(id, transaction_kind)
     }
 
     fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {


### PR DESCRIPTION
Closes #17045.

#17045 asks for the `debug_` endpoints to reuse an EVM the way `trace_*` already does.
They still build a fresh one per transaction. This changes `trace_block`,
`debug_traceTransaction`, the `debug_traceCallMany` prefix and `debug_intermediateRoots`.
It also changes `Trace::spawn_trace_transaction_in_block_with_inspector`, which backs
`trace_transaction`, `trace_get`, `trace_replayTransaction` and the `ots_*` trace
endpoints and had the same split: prefix on one EVM, target on a second.

The issue's TODO suggests reusing the `trace_block` API itself. That doesn't work.
`create_tracer`/`TxTracer` needs `Inspector: Clone` and `DebugInspector` only has
`try_clone`. #20799 stalled on exactly this, so the EVM is driven directly instead.

Saving the constructions is the smaller reason. The bigger one is correctness for
downstream EVMs that carry block-scoped state loaded lazily from the first state they see,
like Celo's fee-currency context or OP's `L1BlockInfo` in revm's `Context::chain` slot. A
per-transaction EVM reloads that from mid-block state.

Stock Ethereum has no such state, so nothing observable changes here and no equivalence
test can demonstrate the fix. The regression test uses a test EVM with that shape instead.
With the fix reverted, `debug_traceBlock` observed `[1, 2, 2]` where it should see
`[1, 1, 1]`.

One thing this does not give you is "one EVM per block". `apply_pre_execution_changes`
still builds its own executor and drops it before the tracing EVM exists, same as
`trace_block*` does today.

Supersedes #20799 and #23177.

### Commits

1. `perf(rpc): replay debug_traceCallMany prefix on a single EVM`: smallest site, sets up the EVM scoping pattern.
2. `perf(rpc): execute debug_intermediateRoots on a single EVM`: hoists the EVM out of the loop and reaches the `State` through it.
3. `perf(rpc): trace debug_traceTransaction on the replay EVM`: the target joins the prefix EVM instead of getting a second one.
4. `perf(rpc): trace whole blocks on a single EVM in the debug API`: the site #17045 points at.
5. `docs(rpc): explain why call simulations cannot share a replay EVM`: guards the two sites left alone on purpose.
6. `feat(provider): opt-in recovered block lookups on MockEthProvider`: unblocks tracing tests over the mock, off by default.
7. `test(provider): cover the recovered block lookup contract on MockEthProvider`: hash, number, miss and recovery-failure semantics.
8. `test(rpc): pin block-scoped EVM context across debug block replay`: the test EVM and the regression it reproduces.
9. `test(rpc): pin the debug_traceCallMany prefix EVM and inspector fusing`: construction counts where the context test cannot reach.
10. `test(rpc): make the inspector fusing assertion discriminate`: the struct logger held it vacuously, the 4byte tracer does not.
11. `perf(rpc): trace the parity transaction path on the replay EVM`: same fix for `trace_*` and `ots_*`, via a shared `Call` helper.
