### PR TITLE
feat(db): add key-only cursor navigation

### DIFF
--- a/crates/storage/db-api/src/common.rs
+++ b/crates/storage/db-api/src/common.rs
@@ -18,5 +18,8 @@ pub type IterPairResult<T> = Option<Result<KeyValue<T>, DatabaseError>>;
 /// A key only result for table `T`.
 pub type KeyOnlyResult<T> = Result<Option<<T as Table>::Key>, DatabaseError>;
 
+/// A subkey only result for `DupSort` table `T`.
+pub type SubKeyOnlyResult<T> = Result<Option<<T as DupSort>::SubKey>, DatabaseError>;
+
 /// A value only result for table `T`.
 pub type ValueOnlyResult<T> = Result<Option<<T as Table>::Value>, DatabaseError>;

--- a/crates/storage/db-api/src/common.rs
+++ b/crates/storage/db-api/src/common.rs
@@ -15,5 +15,8 @@ pub type PairResult<T> = Result<Option<KeyValue<T>>, DatabaseError>;
 /// not there is another entry.
 pub type IterPairResult<T> = Option<Result<KeyValue<T>, DatabaseError>>;
 
+/// A key only result for table `T`.
+pub type KeyOnlyResult<T> = Result<Option<<T as Table>::Key>, DatabaseError>;
+
 /// A value only result for table `T`.
 pub type ValueOnlyResult<T> = Result<Option<<T as Table>::Value>, DatabaseError>;

--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    common::{IterPairResult, PairResult, ValueOnlyResult},
+    common::{IterPairResult, KeyOnlyResult, PairResult, ValueOnlyResult},
     table::{DupSort, Table, TableRow},
     DatabaseError,
 };
@@ -17,11 +17,29 @@ pub trait DbCursorRO<T: Table> {
     /// Seeks to the KV pair exactly at `key`.
     fn seek_exact(&mut self, key: T::Key) -> PairResult<T>;
 
+    /// Seeks to the KV pair exactly at `key`, returning only the decoded key.
+    ///
+    /// The value is not decoded and can be retrieved later using [`DbCursorRO::current`].
+    fn seek_exact_key(&mut self, key: T::Key) -> KeyOnlyResult<T>;
+
     /// Seeks to the KV pair whose key is greater than or equal to `key`.
     fn seek(&mut self, key: T::Key) -> PairResult<T>;
 
+    /// Seeks to the KV pair whose key is greater than or equal to `key`, returning only the decoded
+    /// key.
+    ///
+    /// The value is not decoded and can be retrieved later using [`DbCursorRO::current`].
+    fn seek_key(&mut self, key: T::Key) -> KeyOnlyResult<T>;
+
     /// Position the cursor at the next KV pair, returning it.
     fn next(&mut self) -> PairResult<T>;
+
+    /// Position the cursor at the next KV pair, returning only the decoded key.
+    ///
+    /// For dup tables, this can return the same key for the next duplicate value.
+    ///
+    /// The value is not decoded and can be retrieved later using [`DbCursorRO::current`].
+    fn next_key(&mut self) -> KeyOnlyResult<T>;
 
     /// Position the cursor at the previous KV pair, returning it.
     fn prev(&mut self) -> PairResult<T>;

--- a/crates/storage/db-api/src/cursor.rs
+++ b/crates/storage/db-api/src/cursor.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::{
-    common::{IterPairResult, KeyOnlyResult, PairResult, ValueOnlyResult},
-    table::{DupSort, Table, TableRow},
+    common::{IterPairResult, KeyOnlyResult, PairResult, SubKeyOnlyResult, ValueOnlyResult},
+    table::{DupSort, DupSortSubKey, Table, TableRow},
     DatabaseError,
 };
 
@@ -86,6 +86,14 @@ pub trait DbDupCursorRO<T: DupSort> {
     /// Positions the cursor at the next KV pair of the table, returning it.
     fn next_dup(&mut self) -> PairResult<T>;
 
+    /// Positions the cursor at the next duplicate value, returning only its decoded subkey.
+    ///
+    /// The remaining value payload is not decoded and can be retrieved later using
+    /// [`DbCursorRO::current`].
+    fn next_dup_key(&mut self) -> SubKeyOnlyResult<T>
+    where
+        T::SubKey: DupSortSubKey;
+
     /// Positions the cursor at the last duplicate value of the current key.
     fn last_dup(&mut self) -> ValueOnlyResult<T>;
 
@@ -102,6 +110,20 @@ pub trait DbDupCursorRO<T: DupSort> {
     /// The position of the cursor might not correspond to the key/subkey pair if the entry does not
     /// exist.
     fn seek_by_key_subkey(&mut self, key: T::Key, subkey: T::SubKey) -> ValueOnlyResult<T>;
+
+    /// Positions the cursor at the entry greater than or equal to the provided key/subkey pair,
+    /// returning only the decoded subkey.
+    ///
+    /// The remaining value payload is not decoded and can be retrieved later using
+    /// [`DbCursorRO::current`].
+    ///
+    /// # Note
+    ///
+    /// The position of the cursor might not correspond to the key/subkey pair if the entry does not
+    /// exist.
+    fn seek_by_key_subkey_key(&mut self, key: T::Key, subkey: T::SubKey) -> SubKeyOnlyResult<T>
+    where
+        T::SubKey: DupSortSubKey;
 
     /// Get an iterator that walks through the dup table.
     ///

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -4,7 +4,7 @@
 //! are no-ops that return default values without persisting data.
 
 use crate::{
-    common::{IterPairResult, PairResult, ValueOnlyResult},
+    common::{IterPairResult, KeyOnlyResult, PairResult, ValueOnlyResult},
     cursor::{
         DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, RangeWalker,
         ReverseWalker, Walker,
@@ -222,15 +222,33 @@ impl<T: Table> DbCursorRO<T> for CursorMock {
         Ok(None)
     }
 
+    /// Seeks to an exact key match, returning only the key.
+    /// **Mock behavior**: Always returns `None`.
+    fn seek_exact_key(&mut self, _key: T::Key) -> KeyOnlyResult<T> {
+        Ok(None)
+    }
+
     /// Seeks to the first key greater than or equal to the given key.
     /// **Mock behavior**: Always returns `None`.
     fn seek(&mut self, _key: T::Key) -> PairResult<T> {
         Ok(None)
     }
 
+    /// Seeks to the first key greater than or equal to the given key, returning only the key.
+    /// **Mock behavior**: Always returns `None`.
+    fn seek_key(&mut self, _key: T::Key) -> KeyOnlyResult<T> {
+        Ok(None)
+    }
+
     /// Moves to the next entry.
     /// **Mock behavior**: Always returns `None`.
     fn next(&mut self) -> PairResult<T> {
+        Ok(None)
+    }
+
+    /// Moves to the next entry, returning only the key.
+    /// **Mock behavior**: Always returns `None`.
+    fn next_key(&mut self) -> KeyOnlyResult<T> {
         Ok(None)
     }
 

--- a/crates/storage/db-api/src/mock.rs
+++ b/crates/storage/db-api/src/mock.rs
@@ -4,14 +4,14 @@
 //! are no-ops that return default values without persisting data.
 
 use crate::{
-    common::{IterPairResult, KeyOnlyResult, PairResult, ValueOnlyResult},
+    common::{IterPairResult, KeyOnlyResult, PairResult, SubKeyOnlyResult, ValueOnlyResult},
     cursor::{
         DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, RangeWalker,
         ReverseWalker, Walker,
     },
     database::Database,
     database_metrics::DatabaseMetrics,
-    table::{DupSort, Encode, Table, TableImporter},
+    table::{DupSort, DupSortSubKey, Encode, Table, TableImporter},
     transaction::{DbTx, DbTxMut},
     DatabaseError,
 };
@@ -326,6 +326,15 @@ impl<T: DupSort> DbDupCursorRO<T> for CursorMock {
         Ok(None)
     }
 
+    /// Moves to the next duplicate entry, returning only the subkey.
+    /// **Mock behavior**: Always returns `None`.
+    fn next_dup_key(&mut self) -> SubKeyOnlyResult<T>
+    where
+        T::SubKey: DupSortSubKey,
+    {
+        Ok(None)
+    }
+
     /// Moves to the previous duplicate entry.
     /// **Mock behavior**: Always returns `None`.
     fn prev_dup(&mut self) -> PairResult<T> {
@@ -357,6 +366,19 @@ impl<T: DupSort> DbDupCursorRO<T> for CursorMock {
         _key: <T as Table>::Key,
         _subkey: <T as DupSort>::SubKey,
     ) -> ValueOnlyResult<T> {
+        Ok(None)
+    }
+
+    /// Seeks to a specific key-subkey combination, returning only the subkey.
+    /// **Mock behavior**: Always returns `None`.
+    fn seek_by_key_subkey_key(
+        &mut self,
+        _key: <T as Table>::Key,
+        _subkey: <T as DupSort>::SubKey,
+    ) -> SubKeyOnlyResult<T>
+    where
+        T::SubKey: DupSortSubKey,
+    {
         Ok(None)
     }
 

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -250,6 +250,43 @@ add_wrapper_struct!((ClientVersion, CompactClientVersion));
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::table::DupSortSubKey;
+
+    #[test]
+    fn dup_sort_subkeys_decode_checked_prefixes() {
+        let address = Address::with_last_byte(1);
+        let mut address_value = address.encode().to_vec();
+        address_value.extend_from_slice(&[0xaa; 4]);
+        assert_eq!(<Address as DupSortSubKey>::decode_prefix(&address_value).unwrap(), address);
+        assert!(<Address as DupSortSubKey>::decode_prefix(&address_value[..19]).is_err());
+
+        let hash = B256::with_last_byte(2);
+        let mut hash_value = hash.encode().to_vec();
+        hash_value.extend_from_slice(&[0xbb; 4]);
+        assert_eq!(<B256 as DupSortSubKey>::decode_prefix(&hash_value).unwrap(), hash);
+        assert!(<B256 as DupSortSubKey>::decode_prefix(&hash_value[..31]).is_err());
+
+        let stored = StoredNibblesSubKey::from(Nibbles::from_nibbles([1, 2, 3]));
+        let mut stored_value = stored.clone().encode().to_vec();
+        stored_value.extend_from_slice(&[0xcc; 4]);
+        assert_eq!(
+            <StoredNibblesSubKey as DupSortSubKey>::decode_prefix(&stored_value).unwrap(),
+            stored
+        );
+        assert!(<StoredNibblesSubKey as DupSortSubKey>::decode_prefix(&stored_value[..64]).is_err());
+
+        let packed = PackedStoredNibblesSubKey::from(Nibbles::from_nibbles([4, 5, 6]));
+        let mut packed_value = packed.clone().encode().to_vec();
+        packed_value.extend_from_slice(&[0xdd; 4]);
+        assert_eq!(
+            <PackedStoredNibblesSubKey as DupSortSubKey>::decode_prefix(&packed_value).unwrap(),
+            packed
+        );
+        assert!(<PackedStoredNibblesSubKey as DupSortSubKey>::decode_prefix(&packed_value[..32])
+            .is_err());
+    }
+
     // each value in the database has an extra field named flags that encodes metadata about other
     // fields in the value, e.g. offset and length.
     //

--- a/crates/storage/db-api/src/table.rs
+++ b/crates/storage/db-api/src/table.rs
@@ -63,6 +63,39 @@ pub trait Key: Encode + Decode + Ord + Clone + Serialize + for<'a> Deserialize<'
 
 impl<T> Key for T where T: Encode + Decode + Ord + Clone + Serialize + for<'a> Deserialize<'a> {}
 
+/// A database key that can be decoded from the prefix of a `DupSort` value.
+///
+/// `DupSort` values encode their subkey as a prefix followed by the remaining value payload. This
+/// trait decodes only that prefix without decoding the payload.
+pub trait DupSortSubKey: Key {
+    /// Decodes the subkey prefix from an encoded `DupSort` value.
+    fn decode_prefix(value: &[u8]) -> Result<Self, DatabaseError>;
+}
+
+/// An encoded key representation with a statically known byte length.
+pub trait FixedLengthEncoding {
+    /// The encoded length in bytes.
+    ///
+    /// This must equal the length returned by [`AsRef::as_ref`] for every value of the encoded
+    /// type.
+    const LENGTH: usize;
+}
+
+impl<const N: usize> FixedLengthEncoding for [u8; N] {
+    const LENGTH: usize = N;
+}
+
+impl<T> DupSortSubKey for T
+where
+    T: Key,
+    T::Encoded: FixedLengthEncoding,
+{
+    fn decode_prefix(value: &[u8]) -> Result<Self, DatabaseError> {
+        let length = <T::Encoded as FixedLengthEncoding>::LENGTH;
+        Self::decode(value.get(..length).ok_or(DatabaseError::Decode)?)
+    }
+}
+
 /// Generic trait that enforces the database value to implement [`Compress`] and [`Decompress`].
 pub trait Value: Compress + Decompress + Serialize {}
 

--- a/crates/storage/db-api/src/tables/raw.rs
+++ b/crates/storage/db-api/src/tables/raw.rs
@@ -1,5 +1,7 @@
 use crate::{
-    table::{Compress, Decode, Decompress, DupSort, Encode, IntoVec, Key, Table, Value},
+    table::{
+        Compress, Decode, Decompress, DupSort, DupSortSubKey, Encode, IntoVec, Key, Table, Value,
+    },
     DatabaseError,
 };
 use reth_codecs::DecompressError;
@@ -107,6 +109,12 @@ impl<K: Key> Decode for RawKey<K> {
 
     fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
         Ok(Self { key: value, _phantom: std::marker::PhantomData })
+    }
+}
+
+impl<K: DupSortSubKey> DupSortSubKey for RawKey<K> {
+    fn decode_prefix(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self::new(K::decode_prefix(value)?))
     }
 }
 

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -6,7 +6,7 @@ use crate::{
     DatabaseError,
 };
 use reth_db_api::{
-    common::{PairResult, ValueOnlyResult},
+    common::{KeyOnlyResult, PairResult, ValueOnlyResult},
     cursor::{
         DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, RangeWalker,
         ReverseWalker, Walker,
@@ -74,6 +74,23 @@ where
     res.map_err(|e| DatabaseError::Read(e.into()))?.map(decoder::<T>).transpose()
 }
 
+/// Decodes a key from the database, ignoring its value.
+#[expect(clippy::type_complexity)]
+pub fn decode_key<T>(
+    res: Result<Option<(Cow<'_, [u8]>, ())>, impl Into<DatabaseErrorInfo>>,
+) -> KeyOnlyResult<T>
+where
+    T: Table,
+    T::Key: Decode,
+{
+    res.map_err(|e| DatabaseError::Read(e.into()))?
+        .map(|(key, ())| match key {
+            Cow::Borrowed(key) => Decode::decode(key),
+            Cow::Owned(key) => Decode::decode_owned(key),
+        })
+        .transpose()
+}
+
 /// Some types don't support compression (eg. B256), and we don't want to be copying them to the
 /// allocated buffer when we can just use their reference.
 macro_rules! compress_to_buf_or_ref {
@@ -97,12 +114,24 @@ impl<K: TransactionKind, T: Table> DbCursorRO<T> for Cursor<K, T> {
         decode::<T>(self.inner.set_key(key.encode().as_ref()))
     }
 
+    fn seek_exact_key(&mut self, key: <T as Table>::Key) -> KeyOnlyResult<T> {
+        decode_key::<T>(self.inner.set_key::<Cow<'_, [u8]>, ()>(key.encode().as_ref()))
+    }
+
     fn seek(&mut self, key: <T as Table>::Key) -> PairResult<T> {
         decode::<T>(self.inner.set_range(key.encode().as_ref()))
     }
 
+    fn seek_key(&mut self, key: <T as Table>::Key) -> KeyOnlyResult<T> {
+        decode_key::<T>(self.inner.set_range::<Cow<'_, [u8]>, ()>(key.encode().as_ref()))
+    }
+
     fn next(&mut self) -> PairResult<T> {
         decode::<T>(self.inner.next())
+    }
+
+    fn next_key(&mut self) -> KeyOnlyResult<T> {
+        decode_key::<T>(self.inner.next::<Cow<'_, [u8]>, ()>())
     }
 
     fn prev(&mut self) -> PairResult<T> {

--- a/crates/storage/db/src/implementation/mdbx/cursor.rs
+++ b/crates/storage/db/src/implementation/mdbx/cursor.rs
@@ -6,12 +6,12 @@ use crate::{
     DatabaseError,
 };
 use reth_db_api::{
-    common::{KeyOnlyResult, PairResult, ValueOnlyResult},
+    common::{KeyOnlyResult, PairResult, SubKeyOnlyResult, ValueOnlyResult},
     cursor::{
         DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW, DupWalker, RangeWalker,
         ReverseWalker, Walker,
     },
-    table::{Compress, Decode, Decompress, DupSort, Encode, IntoVec, Table},
+    table::{Compress, Decode, Decompress, DupSort, DupSortSubKey, Encode, IntoVec, Table},
 };
 use reth_libmdbx::{Error as MDBXError, TransactionKind, WriteFlags, RO, RW};
 use reth_storage_errors::db::{DatabaseErrorInfo, DatabaseWriteError, DatabaseWriteOperation};
@@ -88,6 +88,19 @@ where
             Cow::Borrowed(key) => Decode::decode(key),
             Cow::Owned(key) => Decode::decode_owned(key),
         })
+        .transpose()
+}
+
+/// Decodes a `DupSort` subkey from the prefix of a database value.
+pub fn decode_subkey<T>(
+    res: Result<Option<Cow<'_, [u8]>>, impl Into<DatabaseErrorInfo>>,
+) -> SubKeyOnlyResult<T>
+where
+    T: DupSort,
+    T::SubKey: DupSortSubKey,
+{
+    res.map_err(|e| DatabaseError::Read(e.into()))?
+        .map(|value| T::SubKey::decode_prefix(value.as_ref()))
         .transpose()
 }
 
@@ -197,6 +210,15 @@ impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for Cursor<K, T> {
         decode::<T>(self.inner.next_dup())
     }
 
+    fn next_dup_key(&mut self) -> SubKeyOnlyResult<T>
+    where
+        T::SubKey: DupSortSubKey,
+    {
+        decode_subkey::<T>(
+            self.inner.next_dup::<(), Cow<'_, [u8]>>().map(|entry| entry.map(|((), value)| value)),
+        )
+    }
+
     /// Returns the last `value` of the current duplicate `key`.
     fn last_dup(&mut self) -> ValueOnlyResult<T> {
         self.inner
@@ -230,6 +252,19 @@ impl<K: TransactionKind, T: DupSort> DbDupCursorRO<T> for Cursor<K, T> {
             .map_err(|e| DatabaseError::Read(e.into()))?
             .map(decode_one::<T>)
             .transpose()
+    }
+
+    fn seek_by_key_subkey_key(
+        &mut self,
+        key: <T as Table>::Key,
+        subkey: <T as DupSort>::SubKey,
+    ) -> SubKeyOnlyResult<T>
+    where
+        T::SubKey: DupSortSubKey,
+    {
+        decode_subkey::<T>(
+            self.inner.get_both_range(key.encode().as_ref(), subkey.encode().as_ref()),
+        )
     }
 
     /// Depending on its arguments, returns an iterator starting at:

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -680,6 +680,7 @@ mod tests {
     use crate::{
         tables::{
             AccountsHistory, CanonicalHeaders, Headers, PlainAccountState, PlainStorageState,
+            RawKey, RawTable, RawValue, TransactionHashNumbers,
         },
         test_utils::*,
         AccountChangeSets,
@@ -1126,6 +1127,84 @@ mod tests {
         let exact = cursor.seek_exact(missing_key).unwrap();
         assert_eq!(exact, None);
         assert!(cursor.current().unwrap().is_none());
+    }
+
+    #[test]
+    fn db_cursor_key_only_navigation() {
+        let (_tempdir, db) = create_test_db(DatabaseEnvKind::RW);
+        let values = [1, 3, 5].map(B256::with_last_byte);
+
+        let tx = db.tx_mut().expect(ERROR_INIT_TX);
+        for (key, value) in [1, 3, 5].into_iter().zip(values) {
+            tx.put::<CanonicalHeaders>(key, value).expect(ERROR_PUT);
+        }
+        tx.commit().expect(ERROR_COMMIT);
+
+        let tx = db.tx().expect(ERROR_INIT_TX);
+        let mut cursor = tx.cursor_read::<CanonicalHeaders>().unwrap();
+
+        assert_eq!(cursor.seek_exact_key(1).unwrap(), Some(1));
+        assert_eq!(cursor.current().unwrap(), Some((1, values[0])));
+
+        assert_eq!(cursor.next_key().unwrap(), Some(3));
+        assert_eq!(cursor.current().unwrap(), Some((3, values[1])));
+
+        assert_eq!(cursor.seek_key(2).unwrap(), Some(3));
+        assert_eq!(cursor.current().unwrap(), Some((3, values[1])));
+
+        assert!(cursor.seek_exact_key(2).unwrap().is_none());
+
+        assert_eq!(cursor.seek_exact_key(5).unwrap(), Some(5));
+        assert_eq!(cursor.current().unwrap(), Some((5, values[2])));
+        assert!(cursor.next_key().unwrap().is_none());
+
+        assert!(cursor.seek_key(6).unwrap().is_none());
+    }
+
+    #[test]
+    fn db_cursor_key_only_navigation_defers_value_decoding() {
+        let (_tempdir, db) = create_test_db(DatabaseEnvKind::RW);
+        let keys = [1, 3, 5].map(B256::with_last_byte);
+
+        let tx = db.tx_mut().expect(ERROR_INIT_TX);
+        for key in &keys {
+            tx.put::<RawTable<TransactionHashNumbers>>(
+                RawKey::new(*key),
+                RawValue::from_vec(vec![0]),
+            )
+            .expect(ERROR_PUT);
+        }
+        tx.commit().expect(ERROR_COMMIT);
+
+        let tx = db.tx().expect(ERROR_INIT_TX);
+        let mut cursor = tx.cursor_read::<TransactionHashNumbers>().unwrap();
+
+        assert_eq!(cursor.seek_exact_key(keys[0]).unwrap(), Some(keys[0]));
+        assert_eq!(cursor.next_key().unwrap(), Some(keys[1]));
+        assert_eq!(cursor.seek_key(B256::with_last_byte(4)).unwrap(), Some(keys[2]));
+        assert!(cursor.current().is_err());
+    }
+
+    #[test]
+    fn db_cursor_key_only_navigation_on_rw_dupsort_cursor() {
+        let (_tempdir, db) = create_test_db(DatabaseEnvKind::RW);
+        let tx = db.tx_mut().expect(ERROR_INIT_TX);
+        let key = Address::random();
+        let entries = [1, 2]
+            .map(|byte| StorageEntry { key: B256::with_last_byte(byte), value: U256::from(byte) });
+        let mut cursor = tx.cursor_dup_write::<PlainStorageState>().unwrap();
+
+        for entry in &entries {
+            cursor.upsert(key, entry).expect(ERROR_UPSERT);
+        }
+
+        assert_eq!(cursor.seek_exact_key(key).unwrap(), Some(key));
+        assert_eq!(cursor.current().unwrap(), Some((key, entries[0])));
+
+        assert_eq!(cursor.next_key().unwrap(), Some(key));
+        assert_eq!(cursor.current().unwrap(), Some((key, entries[1])));
+
+        assert!(cursor.next_key().unwrap().is_none());
     }
 
     #[test]

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -680,7 +680,7 @@ mod tests {
     use crate::{
         tables::{
             AccountsHistory, CanonicalHeaders, Headers, PlainAccountState, PlainStorageState,
-            RawKey, RawTable, RawValue, TransactionHashNumbers,
+            RawDupSort, RawKey, RawTable, RawValue, TransactionHashNumbers,
         },
         test_utils::*,
         AccountChangeSets,
@@ -1205,6 +1205,82 @@ mod tests {
         assert_eq!(cursor.current().unwrap(), Some((key, entries[1])));
 
         assert!(cursor.next_key().unwrap().is_none());
+    }
+
+    #[test]
+    fn db_dup_cursor_subkey_only_navigation() {
+        let (_tempdir, db) = create_test_db(DatabaseEnvKind::RW);
+        let tx = db.tx_mut().expect(ERROR_INIT_TX);
+        let key = Address::with_last_byte(1);
+        let entries = [1, 3, 5]
+            .map(|byte| StorageEntry { key: B256::with_last_byte(byte), value: U256::from(byte) });
+        let mut cursor = tx.cursor_dup_write::<PlainStorageState>().unwrap();
+
+        for entry in &entries {
+            cursor.upsert(key, entry).expect(ERROR_UPSERT);
+        }
+
+        assert_eq!(
+            cursor.seek_by_key_subkey_key(key, B256::with_last_byte(2)).unwrap(),
+            Some(entries[1].key)
+        );
+        assert_eq!(cursor.current().unwrap(), Some((key, entries[1])));
+
+        assert_eq!(cursor.next_dup_key().unwrap(), Some(entries[2].key));
+        assert_eq!(cursor.current().unwrap(), Some((key, entries[2])));
+        assert!(cursor.next_dup_key().unwrap().is_none());
+
+        assert!(cursor
+            .seek_by_key_subkey_key(Address::with_last_byte(2), B256::ZERO)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn db_dup_cursor_address_subkey_only_navigation() {
+        let (_tempdir, db) = create_test_db(DatabaseEnvKind::RW);
+        let tx = db.tx_mut().expect(ERROR_INIT_TX);
+        let block = 1;
+        let entries = [1, 3, 5]
+            .map(|byte| AccountBeforeTx { address: Address::with_last_byte(byte), info: None });
+        let mut cursor = tx.cursor_dup_write::<AccountChangeSets>().unwrap();
+
+        for entry in &entries {
+            cursor.upsert(block, entry).expect(ERROR_UPSERT);
+        }
+
+        assert_eq!(
+            cursor.seek_by_key_subkey_key(block, Address::with_last_byte(2)).unwrap(),
+            Some(entries[1].address)
+        );
+        assert_eq!(cursor.current().unwrap(), Some((block, entries[1].clone())));
+        assert_eq!(cursor.next_dup_key().unwrap(), Some(entries[2].address));
+        assert_eq!(cursor.current().unwrap(), Some((block, entries[2].clone())));
+    }
+
+    #[test]
+    fn db_dup_cursor_subkey_only_navigation_defers_value_decoding() {
+        let (_tempdir, db) = create_test_db(DatabaseEnvKind::RW);
+        let tx = db.tx_mut().expect(ERROR_INIT_TX);
+        let key = Address::with_last_byte(1);
+        let subkeys = [B256::with_last_byte(1), B256::with_last_byte(3)];
+        let mut cursor = tx.cursor_dup_write::<RawDupSort<PlainStorageState>>().unwrap();
+        for subkey in subkeys {
+            let mut malformed_value = subkey.to_vec();
+            // `StorageEntry` values contain at most 32 payload bytes. This oversized payload would
+            // panic if either key-only operation attempted to decode the full value.
+            malformed_value.extend_from_slice(&[0xff; 100]);
+            cursor
+                .upsert(RawKey::new(key), &RawValue::from_vec(malformed_value))
+                .expect(ERROR_UPSERT);
+        }
+        drop(cursor);
+        tx.commit().expect(ERROR_COMMIT);
+
+        let tx = db.tx().expect(ERROR_INIT_TX);
+        let mut cursor = tx.cursor_dup_read::<PlainStorageState>().unwrap();
+        assert_eq!(cursor.seek_by_key_subkey_key(key, subkeys[0]).unwrap(), Some(subkeys[0]));
+        assert_eq!(cursor.next_dup_key().unwrap(), Some(subkeys[1]));
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3132,7 +3132,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
                 DatabaseStorageTrieCursor::new(cursor, *hashed_address);
             *num_entries +=
                 db_storage_trie_cursor.write_storage_trie_updates_sorted(storage_trie_updates)?;
-            cursor = db_storage_trie_cursor.cursor;
+            cursor = db_storage_trie_cursor.into_inner();
         }
         Ok(())
     }

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::B256;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
-    table::{DupSort, Key, Table, Value},
+    table::{DupSort, DupSortSubKey, Key, Table, Value},
     tables::{self, PackedAccountsTrie, PackedStoragesTrie},
     transaction::DbTx,
     DatabaseError,
@@ -25,7 +25,7 @@ pub trait TrieKeyAdapter: Clone + Send + Sync + 'static {
 
     /// The subkey type for storage trie `DupSort` lookups
     /// (e.g., `StoredNibblesSubKey` or `PackedStoredNibblesSubKey`).
-    type StorageSubKey: Key + From<Nibbles> + Clone + PartialEq;
+    type StorageSubKey: Key + DupSortSubKey + From<Nibbles> + Clone + PartialEq;
 
     /// The storage trie entry type that pairs a subkey with a `BranchNodeCompact`.
     type StorageValue: Value + StorageTrieEntryLike<SubKey = Self::StorageSubKey>;
@@ -204,12 +204,58 @@ where
 
 /// A cursor over the account trie.
 #[derive(Debug)]
-pub struct DatabaseAccountTrieCursor<C, A: TrieKeyAdapter>(C, PhantomData<A>);
+pub struct DatabaseAccountTrieCursor<C, A: TrieKeyAdapter> {
+    cursor: C,
+    current_key: Option<Nibbles>,
+    _adapter: PhantomData<A>,
+}
 
 impl<C, A: TrieKeyAdapter> DatabaseAccountTrieCursor<C, A> {
     /// Create a new account trie cursor.
     pub const fn new(cursor: C) -> Self {
-        Self(cursor, PhantomData)
+        Self { cursor, current_key: None, _adapter: PhantomData }
+    }
+}
+
+impl<C, A> DatabaseAccountTrieCursor<C, A>
+where
+    A: TrieTableAdapter,
+    C: DbCursorRO<A::AccountTrieTable>,
+{
+    /// Advances from the current key to the first key greater than or equal to `target`.
+    fn advance_to(&mut self, target: Nibbles) -> Result<Option<Nibbles>, DatabaseError> {
+        let Some(mut current_key) = self.current_key else { return Ok(None) };
+
+        while current_key < target {
+            let next_key = match self.cursor.next_key() {
+                Ok(next_key) => next_key,
+                Err(error) => {
+                    self.current_key = None;
+                    return Err(error)
+                }
+            };
+            let Some(next_key) = next_key else {
+                self.current_key = None;
+                return Ok(None)
+            };
+            current_key = A::account_key_to_nibbles(&next_key);
+            self.current_key = Some(current_key);
+        }
+
+        Ok(Some(current_key))
+    }
+
+    /// Returns and tracks the entry at the underlying cursor's current position.
+    fn current_entry(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let entry = match self.cursor.current() {
+            Ok(entry) => entry.map(|(key, value)| (A::account_key_to_nibbles(&key), value)),
+            Err(error) => {
+                self.current_key = None;
+                return Err(error)
+            }
+        };
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry)
     }
 }
 
@@ -222,32 +268,50 @@ where
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self
-            .0
+        if self.current_key.is_some_and(|current_key| key.starts_with(&current_key)) {
+            return if self.advance_to(key)? == Some(key) { self.current_entry() } else { Ok(None) }
+        }
+
+        self.current_key = None;
+        let entry = self
+            .cursor
             .seek_exact(A::AccountKey::from(key))?
-            .map(|value| (A::account_key_to_nibbles(&value.0), value.1)))
+            .map(|(key, value)| (A::account_key_to_nibbles(&key), value));
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry)
     }
 
     fn seek(
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self
-            .0
+        if self.current_key.is_some_and(|current_key| key.starts_with(&current_key)) {
+            return if self.advance_to(key)?.is_some() { self.current_entry() } else { Ok(None) }
+        }
+
+        self.current_key = None;
+        let entry = self
+            .cursor
             .seek(A::AccountKey::from(key))?
-            .map(|value| (A::account_key_to_nibbles(&value.0), value.1)))
+            .map(|(key, value)| (A::account_key_to_nibbles(&key), value));
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry)
     }
 
     fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self.0.next()?.map(|value| (A::account_key_to_nibbles(&value.0), value.1)))
+        self.current_key = None;
+        let entry =
+            self.cursor.next()?.map(|(key, value)| (A::account_key_to_nibbles(&key), value));
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry)
     }
 
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-        Ok(self.0.current()?.map(|(k, _)| A::account_key_to_nibbles(&k)))
+        Ok(self.current_entry()?.map(|(key, _)| key))
     }
 
     fn reset(&mut self) {
-        // No-op for database cursors
+        self.current_key = None;
     }
 }
 
@@ -255,16 +319,69 @@ where
 #[derive(Debug)]
 pub struct DatabaseStorageTrieCursor<C, A: TrieKeyAdapter> {
     /// The underlying cursor.
-    pub cursor: C,
+    cursor: C,
     /// Hashed address used for cursor positioning.
     hashed_address: B256,
+    /// The subkey at the underlying cursor's current position.
+    current_key: Option<Nibbles>,
     _adapter: PhantomData<A>,
 }
 
 impl<C, A: TrieKeyAdapter> DatabaseStorageTrieCursor<C, A> {
     /// Create a new storage trie cursor.
     pub const fn new(cursor: C, hashed_address: B256) -> Self {
-        Self { cursor, hashed_address, _adapter: PhantomData }
+        Self { cursor, hashed_address, current_key: None, _adapter: PhantomData }
+    }
+
+    /// Consumes the trie cursor and returns the underlying database cursor.
+    pub fn into_inner(self) -> C {
+        self.cursor
+    }
+}
+
+impl<C, A> DatabaseStorageTrieCursor<C, A>
+where
+    A: TrieTableAdapter,
+    C: DbCursorRO<A::StorageTrieTable> + DbDupCursorRO<A::StorageTrieTable>,
+{
+    /// Advances from the current subkey to the first subkey greater than or equal to `target`.
+    fn advance_to(&mut self, target: Nibbles) -> Result<Option<Nibbles>, DatabaseError> {
+        let Some(mut current_key) = self.current_key else { return Ok(None) };
+
+        while current_key < target {
+            let next_key = match self.cursor.next_dup_key() {
+                Ok(next_key) => next_key,
+                Err(error) => {
+                    self.current_key = None;
+                    return Err(error)
+                }
+            };
+            let Some(next_key) = next_key else {
+                self.current_key = None;
+                return Ok(None)
+            };
+            current_key = A::subkey_to_nibbles(&next_key);
+            self.current_key = Some(current_key);
+        }
+
+        Ok(Some(current_key))
+    }
+
+    /// Returns and tracks the entry at the underlying cursor's current position.
+    fn current_entry(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
+        let entry = match self.cursor.current() {
+            Ok(Some((key, value))) if key == self.hashed_address => {
+                let (subkey, node) = value.into_parts();
+                Some((A::subkey_to_nibbles(&subkey), node))
+            }
+            Ok(_) => None,
+            Err(error) => {
+                self.current_key = None;
+                return Err(error)
+            }
+        };
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry)
     }
 }
 
@@ -281,6 +398,8 @@ where
         &mut self,
         updates: &StorageTrieUpdatesSorted,
     ) -> Result<usize, DatabaseError> {
+        self.current_key = None;
+
         // The storage trie for this account has to be deleted.
         if updates.is_deleted() && self.cursor.seek_exact(self.hashed_address)?.is_some() {
             self.cursor.delete_current_duplicates()?;
@@ -321,42 +440,58 @@ where
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        let subkey = A::StorageSubKey::from(key);
-        Ok(self
+        if self.current_key.is_some_and(|current_key| key.starts_with(&current_key)) {
+            return if self.advance_to(key)? == Some(key) { self.current_entry() } else { Ok(None) }
+        }
+
+        self.current_key = None;
+        let entry = self
             .cursor
-            .seek_by_key_subkey(self.hashed_address, subkey.clone())?
-            .filter(|e| *e.nibbles() == subkey)
+            .seek_by_key_subkey(self.hashed_address, A::StorageSubKey::from(key))?
             .map(|value| {
                 let (subkey, node) = value.into_parts();
                 (A::subkey_to_nibbles(&subkey), node)
-            }))
+            });
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry.filter(|(found_key, _)| *found_key == key))
     }
 
     fn seek(
         &mut self,
         key: Nibbles,
     ) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self.cursor.seek_by_key_subkey(self.hashed_address, A::StorageSubKey::from(key))?.map(
-            |value| {
+        if self.current_key.is_some_and(|current_key| key.starts_with(&current_key)) {
+            return if self.advance_to(key)?.is_some() { self.current_entry() } else { Ok(None) }
+        }
+
+        self.current_key = None;
+        let entry = self
+            .cursor
+            .seek_by_key_subkey(self.hashed_address, A::StorageSubKey::from(key))?
+            .map(|value| {
                 let (subkey, node) = value.into_parts();
                 (A::subkey_to_nibbles(&subkey), node)
-            },
-        ))
+            });
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry)
     }
 
     fn next(&mut self) -> Result<Option<(Nibbles, BranchNodeCompact)>, DatabaseError> {
-        Ok(self.cursor.next_dup()?.map(|(_, value)| {
+        self.current_key = None;
+        let entry = self.cursor.next_dup()?.map(|(_, value)| {
             let (subkey, node) = value.into_parts();
             (A::subkey_to_nibbles(&subkey), node)
-        }))
+        });
+        self.current_key = entry.as_ref().map(|(key, _)| *key);
+        Ok(entry)
     }
 
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
-        Ok(self.cursor.current()?.map(|(_, v)| A::subkey_to_nibbles(v.nibbles())))
+        Ok(self.current_entry()?.map(|(key, _)| key))
     }
 
     fn reset(&mut self) {
-        // No-op for database cursors
+        self.current_key = None;
     }
 }
 
@@ -367,6 +502,7 @@ where
 {
     fn set_hashed_address(&mut self, hashed_address: B256) {
         self.hashed_address = hashed_address;
+        self.current_key = None;
     }
 }
 
@@ -374,8 +510,438 @@ where
 mod tests {
     use super::*;
     use alloy_primitives::hex_literal::hex;
-    use reth_db_api::{cursor::DbCursorRW, transaction::DbTxMut};
+    use reth_db_api::{
+        common::{KeyOnlyResult, PairResult, SubKeyOnlyResult, ValueOnlyResult},
+        cursor::{DbCursorRW, DupWalker, RangeWalker, ReverseWalker, Walker},
+        transaction::DbTxMut,
+    };
     use reth_provider::test_utils::create_test_provider_factory;
+    use std::ops::{Bound, RangeBounds};
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct CursorCalls {
+        seek_exact: usize,
+        seek: usize,
+        next: usize,
+        next_key: usize,
+        next_dup: usize,
+        next_dup_key: usize,
+        seek_by_key_subkey: usize,
+        current: usize,
+    }
+
+    struct RecordingCursor<C> {
+        inner: C,
+        calls: CursorCalls,
+    }
+
+    impl<C> RecordingCursor<C> {
+        const fn new(inner: C) -> Self {
+            Self {
+                inner,
+                calls: CursorCalls {
+                    seek_exact: 0,
+                    seek: 0,
+                    next: 0,
+                    next_key: 0,
+                    next_dup: 0,
+                    next_dup_key: 0,
+                    seek_by_key_subkey: 0,
+                    current: 0,
+                },
+            }
+        }
+    }
+
+    impl<T, C> DbDupCursorRO<T> for RecordingCursor<C>
+    where
+        T: DupSort,
+        C: DbDupCursorRO<T>,
+    {
+        fn prev_dup(&mut self) -> PairResult<T> {
+            self.inner.prev_dup()
+        }
+
+        fn next_dup(&mut self) -> PairResult<T> {
+            self.calls.next_dup += 1;
+            self.inner.next_dup()
+        }
+
+        fn next_dup_key(&mut self) -> SubKeyOnlyResult<T>
+        where
+            T::SubKey: DupSortSubKey,
+        {
+            self.calls.next_dup_key += 1;
+            self.inner.next_dup_key()
+        }
+
+        fn last_dup(&mut self) -> ValueOnlyResult<T> {
+            self.inner.last_dup()
+        }
+
+        fn next_no_dup(&mut self) -> PairResult<T> {
+            self.inner.next_no_dup()
+        }
+
+        fn next_dup_val(&mut self) -> ValueOnlyResult<T> {
+            self.inner.next_dup_val()
+        }
+
+        fn seek_by_key_subkey(&mut self, key: T::Key, subkey: T::SubKey) -> ValueOnlyResult<T> {
+            self.calls.seek_by_key_subkey += 1;
+            self.inner.seek_by_key_subkey(key, subkey)
+        }
+
+        fn seek_by_key_subkey_key(&mut self, key: T::Key, subkey: T::SubKey) -> SubKeyOnlyResult<T>
+        where
+            T::SubKey: DupSortSubKey,
+        {
+            self.inner.seek_by_key_subkey_key(key, subkey)
+        }
+
+        fn walk_dup(
+            &mut self,
+            _key: Option<T::Key>,
+            _subkey: Option<T::SubKey>,
+        ) -> Result<DupWalker<'_, T, Self>, DatabaseError> {
+            unreachable!("unused by prefix seek tests")
+        }
+    }
+
+    impl<T, C> DbCursorRO<T> for RecordingCursor<C>
+    where
+        T: Table,
+        C: DbCursorRO<T>,
+    {
+        fn first(&mut self) -> PairResult<T> {
+            self.inner.first()
+        }
+
+        fn seek_exact(&mut self, key: T::Key) -> PairResult<T> {
+            self.calls.seek_exact += 1;
+            self.inner.seek_exact(key)
+        }
+
+        fn seek_exact_key(&mut self, key: T::Key) -> KeyOnlyResult<T> {
+            self.inner.seek_exact_key(key)
+        }
+
+        fn seek(&mut self, key: T::Key) -> PairResult<T> {
+            self.calls.seek += 1;
+            self.inner.seek(key)
+        }
+
+        fn seek_key(&mut self, key: T::Key) -> KeyOnlyResult<T> {
+            self.inner.seek_key(key)
+        }
+
+        fn next(&mut self) -> PairResult<T> {
+            self.calls.next += 1;
+            self.inner.next()
+        }
+
+        fn next_key(&mut self) -> KeyOnlyResult<T> {
+            self.calls.next_key += 1;
+            self.inner.next_key()
+        }
+
+        fn prev(&mut self) -> PairResult<T> {
+            self.inner.prev()
+        }
+
+        fn last(&mut self) -> PairResult<T> {
+            self.inner.last()
+        }
+
+        fn current(&mut self) -> PairResult<T> {
+            self.calls.current += 1;
+            self.inner.current()
+        }
+
+        fn walk(
+            &mut self,
+            start_key: Option<T::Key>,
+        ) -> Result<Walker<'_, T, Self>, DatabaseError> {
+            let start =
+                if let Some(start_key) = start_key { self.seek(start_key) } else { self.first() }
+                    .transpose();
+            Ok(Walker::new(self, start))
+        }
+
+        fn walk_range(
+            &mut self,
+            range: impl RangeBounds<T::Key>,
+        ) -> Result<RangeWalker<'_, T, Self>, DatabaseError> {
+            let start = match range.start_bound().cloned() {
+                Bound::Included(key) => self.seek(key),
+                Bound::Excluded(_) => {
+                    unreachable!("Rust doesn't allow excluded starting bounds")
+                }
+                Bound::Unbounded => self.first(),
+            }
+            .transpose();
+            Ok(RangeWalker::new(self, start, range.end_bound().cloned()))
+        }
+
+        fn walk_back(
+            &mut self,
+            start_key: Option<T::Key>,
+        ) -> Result<ReverseWalker<'_, T, Self>, DatabaseError> {
+            let start =
+                if let Some(start_key) = start_key { self.seek(start_key) } else { self.last() }
+                    .transpose();
+            Ok(ReverseWalker::new(self, start))
+        }
+    }
+
+    fn take_calls<C, A: TrieKeyAdapter>(
+        cursor: &mut DatabaseAccountTrieCursor<RecordingCursor<C>, A>,
+    ) -> CursorCalls {
+        std::mem::take(&mut cursor.cursor.calls)
+    }
+
+    fn take_storage_calls<C, A: TrieKeyAdapter>(
+        cursor: &mut DatabaseStorageTrieCursor<RecordingCursor<C>, A>,
+    ) -> CursorCalls {
+        std::mem::take(&mut cursor.cursor.calls)
+    }
+
+    fn assert_account_trie_prefix_seek<A: TrieTableAdapter>() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let paths = [
+            Nibbles::from_nibbles([0x1]),
+            Nibbles::from_nibbles([0x1, 0x1]),
+            Nibbles::from_nibbles([0x1, 0x3]),
+            Nibbles::from_nibbles([0x1, 0x4]),
+        ];
+        let nodes = [1, 2, 4, 8].map(|mask| BranchNodeCompact::new(mask, mask, 0, vec![], None));
+
+        {
+            let mut cursor = provider.tx_ref().cursor_write::<A::AccountTrieTable>().unwrap();
+            for (path, node) in paths.into_iter().zip(&nodes) {
+                cursor.upsert(A::AccountKey::from(path), node).unwrap();
+            }
+        }
+
+        let db_cursor = provider.tx_ref().cursor_read::<A::AccountTrieTable>().unwrap();
+        let mut cursor = DatabaseAccountTrieCursor::<_, A>::new(RecordingCursor::new(db_cursor));
+
+        assert_eq!(cursor.seek(paths[0]).unwrap().map(|(key, _)| key), Some(paths[0]));
+        take_calls(&mut cursor);
+
+        let between = Nibbles::from_nibbles([0x1, 0x2]);
+        assert_eq!(cursor.seek(between).unwrap(), Some((paths[2], nodes[2].clone())));
+        assert_eq!(
+            take_calls(&mut cursor),
+            CursorCalls { next_key: 2, current: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek_exact(paths[0]).unwrap().map(|(key, _)| key), Some(paths[0]));
+        assert_eq!(take_calls(&mut cursor), CursorCalls { seek_exact: 1, ..Default::default() });
+
+        assert_eq!(cursor.seek_exact(paths[2]).unwrap(), Some((paths[2], nodes[2].clone())));
+        assert_eq!(
+            take_calls(&mut cursor),
+            CursorCalls { next_key: 2, current: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek(paths[0]).unwrap().map(|(key, _)| key), Some(paths[0]));
+        assert_eq!(take_calls(&mut cursor), CursorCalls { seek: 1, ..Default::default() });
+
+        assert_eq!(cursor.seek(paths[0]).unwrap().map(|(key, _)| key), Some(paths[0]));
+        assert_eq!(take_calls(&mut cursor), CursorCalls { current: 1, ..Default::default() });
+
+        assert_eq!(cursor.seek_exact(between).unwrap(), None);
+        assert_eq!(take_calls(&mut cursor), CursorCalls { next_key: 2, ..Default::default() });
+        assert_eq!(cursor.current().unwrap(), Some(paths[2]));
+        take_calls(&mut cursor);
+
+        assert_eq!(cursor.seek_exact(paths[0]).unwrap().map(|(key, _)| key), Some(paths[0]));
+        take_calls(&mut cursor);
+        let after_descendants = Nibbles::from_nibbles([0x1, 0xf]);
+        assert_eq!(cursor.seek_exact(after_descendants).unwrap(), None);
+        assert_eq!(take_calls(&mut cursor), CursorCalls { next_key: 4, ..Default::default() });
+
+        assert_eq!(cursor.seek(paths[0]).unwrap().map(|(key, _)| key), Some(paths[0]));
+        take_calls(&mut cursor);
+        assert_eq!(cursor.next().unwrap(), Some((paths[1], nodes[1].clone())));
+        assert_eq!(take_calls(&mut cursor), CursorCalls { next: 1, ..Default::default() });
+        assert_eq!(cursor.seek(paths[1]).unwrap(), Some((paths[1], nodes[1].clone())));
+        assert_eq!(take_calls(&mut cursor), CursorCalls { current: 1, ..Default::default() });
+
+        assert_eq!(cursor.seek(paths[3]).unwrap(), Some((paths[3], nodes[3].clone())));
+        take_calls(&mut cursor);
+        let after_last = Nibbles::from_nibbles([0x1, 0x4, 0xf]);
+        assert_eq!(cursor.seek(after_last).unwrap(), None);
+        assert_eq!(take_calls(&mut cursor), CursorCalls { next_key: 1, ..Default::default() });
+
+        assert_eq!(cursor.seek(paths[0]).unwrap().map(|(key, _)| key), Some(paths[0]));
+        cursor.reset();
+        take_calls(&mut cursor);
+        assert_eq!(cursor.seek(between).unwrap().map(|(key, _)| key), Some(paths[2]));
+        assert_eq!(take_calls(&mut cursor), CursorCalls { seek: 1, ..Default::default() });
+    }
+
+    #[test]
+    fn test_account_trie_prefix_seek_legacy() {
+        assert_account_trie_prefix_seek::<LegacyKeyAdapter>();
+    }
+
+    #[test]
+    fn test_account_trie_prefix_seek_packed() {
+        assert_account_trie_prefix_seek::<PackedKeyAdapter>();
+    }
+
+    fn assert_storage_trie_prefix_seek<A: TrieTableAdapter>() {
+        let factory = create_test_provider_factory();
+        let provider = factory.provider_rw().unwrap();
+        let hashed_address = B256::with_last_byte(1);
+        let next_hashed_address = B256::with_last_byte(2);
+        let paths = [
+            Nibbles::from_nibbles([0x1]),
+            Nibbles::from_nibbles([0x1, 0x1]),
+            Nibbles::from_nibbles([0x1, 0x3]),
+            Nibbles::from_nibbles([0x1, 0x4]),
+        ];
+        let nodes = [1, 2, 4, 8].map(|mask| BranchNodeCompact::new(mask, mask, 0, vec![], None));
+        let next_node = BranchNodeCompact::new(16, 16, 0, vec![], None);
+
+        {
+            let mut cursor = provider.tx_ref().cursor_dup_write::<A::StorageTrieTable>().unwrap();
+            for (path, node) in paths.into_iter().zip(&nodes) {
+                cursor
+                    .upsert(
+                        hashed_address,
+                        &A::StorageValue::new(A::StorageSubKey::from(path), node.clone()),
+                    )
+                    .unwrap();
+            }
+            cursor
+                .upsert(
+                    next_hashed_address,
+                    &A::StorageValue::new(A::StorageSubKey::from(paths[0]), next_node.clone()),
+                )
+                .unwrap();
+        }
+
+        let db_cursor = provider.tx_ref().cursor_dup_read::<A::StorageTrieTable>().unwrap();
+        let mut cursor =
+            DatabaseStorageTrieCursor::<_, A>::new(RecordingCursor::new(db_cursor), hashed_address);
+
+        assert_eq!(cursor.seek(paths[0]).unwrap(), Some((paths[0], nodes[0].clone())));
+        take_storage_calls(&mut cursor);
+
+        let between = Nibbles::from_nibbles([0x1, 0x2]);
+        assert_eq!(cursor.seek(between).unwrap(), Some((paths[2], nodes[2].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { next_dup_key: 2, current: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek_exact(paths[0]).unwrap(), Some((paths[0], nodes[0].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { seek_by_key_subkey: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek_exact(paths[2]).unwrap(), Some((paths[2], nodes[2].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { next_dup_key: 2, current: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek(paths[0]).unwrap(), Some((paths[0], nodes[0].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { seek_by_key_subkey: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek(paths[0]).unwrap(), Some((paths[0], nodes[0].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { current: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek_exact(between).unwrap(), None);
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { next_dup_key: 2, ..Default::default() }
+        );
+        assert_eq!(cursor.current().unwrap(), Some(paths[2]));
+        take_storage_calls(&mut cursor);
+
+        cursor.reset();
+        assert_eq!(cursor.seek_exact(between).unwrap(), None);
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { seek_by_key_subkey: 1, ..Default::default() }
+        );
+        let after_overshoot = Nibbles::from_nibbles([0x1, 0x3, 0x0]);
+        assert_eq!(cursor.seek_exact(after_overshoot).unwrap(), None);
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { next_dup_key: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek_exact(paths[0]).unwrap(), Some((paths[0], nodes[0].clone())));
+        take_storage_calls(&mut cursor);
+        let after_descendants = Nibbles::from_nibbles([0x1, 0xf]);
+        assert_eq!(cursor.seek_exact(after_descendants).unwrap(), None);
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { next_dup_key: 4, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek(paths[0]).unwrap(), Some((paths[0], nodes[0].clone())));
+        take_storage_calls(&mut cursor);
+        assert_eq!(cursor.next().unwrap(), Some((paths[1], nodes[1].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { next_dup: 1, ..Default::default() }
+        );
+        assert_eq!(cursor.seek(paths[1]).unwrap(), Some((paths[1], nodes[1].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { current: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek(paths[3]).unwrap(), Some((paths[3], nodes[3].clone())));
+        take_storage_calls(&mut cursor);
+        let after_last = Nibbles::from_nibbles([0x1, 0x4, 0xf]);
+        assert_eq!(cursor.seek(after_last).unwrap(), None);
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { next_dup_key: 1, ..Default::default() }
+        );
+
+        assert_eq!(cursor.seek(paths[0]).unwrap(), Some((paths[0], nodes[0].clone())));
+        cursor.reset();
+        take_storage_calls(&mut cursor);
+        assert_eq!(cursor.seek(between).unwrap(), Some((paths[2], nodes[2].clone())));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { seek_by_key_subkey: 1, ..Default::default() }
+        );
+
+        cursor.set_hashed_address(next_hashed_address);
+        take_storage_calls(&mut cursor);
+        assert_eq!(cursor.seek(paths[0]).unwrap(), Some((paths[0], next_node)));
+        assert_eq!(
+            take_storage_calls(&mut cursor),
+            CursorCalls { seek_by_key_subkey: 1, ..Default::default() }
+        );
+    }
+
+    #[test]
+    fn test_storage_trie_prefix_seek_legacy() {
+        assert_storage_trie_prefix_seek::<LegacyKeyAdapter>();
+    }
+
+    #[test]
+    fn test_storage_trie_prefix_seek_packed() {
+        assert_storage_trie_prefix_seek::<PackedKeyAdapter>();
+    }
 
     #[test]
     fn test_account_trie_order() {


### PR DESCRIPTION
Adds key-only navigation for ordinary cursor keys and DupSort subkeys, leaving full value decoding to `current()`. Account and storage trie cursors use it to scan forward when positioned at a prefix of the target, decoding only the final branch node.