### PR TITLE
fix(net): keep ENR ports paired with their IP address

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -389,8 +389,8 @@ pub enum DnsDiscoveryEvent {
 
 /// Converts an [Enr] into a [`NodeRecord`]
 fn convert_enr_node_record(enr: &Enr<SecretKey>) -> Option<DnsNodeRecordUpdate> {
-    enr.tcp4().or_else(|| enr.tcp6())?;
-    let node_record = NodeRecord::try_from(enr).ok()?;
+    // DNS discovery yields RLPx dial targets, so records without a tcp endpoint are skipped.
+    let node_record = NodeRecord::try_from(enr).ok().filter(|record| record.tcp_port != 0)?;
 
     let fork_id =
         enr.get_decodable::<EnrForkIdEntry>(b"eth").transpose().ok().flatten().map(Into::into);

--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -23,12 +23,11 @@ pub use config::DnsDiscoveryConfig;
 use enr::Enr;
 pub use error::ParseDnsEntryError;
 use reth_ethereum_forks::{EnrForkIdEntry, ForkId};
-use reth_network_peers::{pk2id, NodeRecord};
+use reth_network_peers::NodeRecord;
 use schnellru::{ByLength, LruMap};
 use secp256k1::SecretKey;
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
-    net::IpAddr,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
@@ -390,13 +389,8 @@ pub enum DnsDiscoveryEvent {
 
 /// Converts an [Enr] into a [`NodeRecord`]
 fn convert_enr_node_record(enr: &Enr<SecretKey>) -> Option<DnsNodeRecordUpdate> {
-    let node_record = NodeRecord {
-        address: enr.ip4().map(IpAddr::from).or_else(|| enr.ip6().map(IpAddr::from))?,
-        tcp_port: enr.tcp4().or_else(|| enr.tcp6())?,
-        udp_port: enr.udp4().or_else(|| enr.udp6())?,
-        id: pk2id(&enr.public_key()),
-    }
-    .into_ipv4_mapped();
+    enr.tcp4().or_else(|| enr.tcp6())?;
+    let node_record = NodeRecord::try_from(enr).ok()?;
 
     let fork_id =
         enr.get_decodable::<EnrForkIdEntry>(b"eth").transpose().ok().flatten().map(Into::into);
@@ -416,7 +410,10 @@ mod tests {
     use reth_chainspec::MAINNET;
     use reth_ethereum_forks::{EthereumHardfork, ForkHash};
     use secp256k1::rand::thread_rng;
-    use std::{future::poll_fn, net::Ipv4Addr};
+    use std::{
+        future::poll_fn,
+        net::{IpAddr, Ipv4Addr},
+    };
 
     fn entry_hash(entry_txt: &str) -> String {
         BASE32_NOPAD.encode(&keccak256(entry_txt.as_bytes()).as_slice()[..16])

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -161,19 +161,7 @@ impl AnyNode {
     pub fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),
-            Self::Enr(enr) => {
-                let node_record = NodeRecord {
-                    address: enr
-                        .ip4()
-                        .map(core::net::IpAddr::from)
-                        .or_else(|| enr.ip6().map(core::net::IpAddr::from))?,
-                    tcp_port: enr.tcp4().or_else(|| enr.tcp6())?,
-                    udp_port: enr.udp4().or_else(|| enr.udp6())?,
-                    id: pk2id(&enr.public_key()),
-                }
-                .into_ipv4_mapped();
-                Some(node_record)
-            }
+            Self::Enr(enr) => NodeRecord::try_from(enr).ok(),
             Self::PeerId(_) | Self::TrustedPeer(_) => None,
         }
     }

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -157,11 +157,13 @@ impl AnyNode {
     }
 
     /// Returns the full node record if available.
+    ///
+    /// An ENR that advertises no tcp port has no `RLPx` endpoint, so it does not yield a record.
     #[cfg(feature = "secp256k1")]
     pub fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),
-            Self::Enr(enr) => NodeRecord::try_from(enr).ok(),
+            Self::Enr(enr) => NodeRecord::try_from(enr).ok().filter(|record| record.tcp_port != 0),
             Self::PeerId(_) | Self::TrustedPeer(_) => None,
         }
     }
@@ -344,6 +346,8 @@ mod tests {
                 .parse::<PeerId>()
                 .unwrap()
         );
+        // The spec vector is discovery-only (no tcp key), so it has no RLPx endpoint.
+        assert!(node.node_record().is_none());
         assert_eq!(node.to_string(), url);
     }
 

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -437,5 +437,31 @@ mod tests {
         assert_eq!(record.address, "::1".parse::<IpAddr>().unwrap());
         assert_eq!(record.udp_port, 30401);
         assert_eq!(record.tcp_port, 30403);
+
+        // IPv6-only record with the RLPx port only under the generic `tcp` key, the shape geth
+        // publishes: the generic entry applies to the IPv6 endpoint.
+        let mut builder = Enr::builder();
+        builder.ip6("::1".parse().unwrap()).udp6(30401).tcp4(30303);
+        let enr = builder.build(&sk).unwrap();
+        let record = NodeRecord::try_from(&enr).unwrap();
+
+        assert_eq!(record.address, "::1".parse::<IpAddr>().unwrap());
+        assert_eq!(record.udp_port, 30401);
+        assert_eq!(record.tcp_port, 30303);
+
+        // A full dual-stack record resolves to the IPv4 endpoint.
+        let mut builder = Enr::builder();
+        builder.ip4("10.0.0.1".parse().unwrap()).udp4(30301).tcp4(30303);
+        builder.ip6("::1".parse().unwrap()).udp6(30401).tcp6(30403);
+        let enr = builder.build(&sk).unwrap();
+        let record = NodeRecord::try_from(&enr).unwrap();
+
+        assert_eq!(record.address, "10.0.0.1".parse::<IpAddr>().unwrap());
+        assert_eq!(record.udp_port, 30301);
+        assert_eq!(record.tcp_port, 30303);
+
+        // No udp port in any family is rejected.
+        let enr = Enr::builder().ip4("10.0.0.1".parse().unwrap()).tcp4(30303).build(&sk).unwrap();
+        assert!(NodeRecord::try_from(&enr).is_err());
     }
 }

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -213,22 +213,24 @@ impl TryFrom<&Enr<secp256k1::SecretKey>> for NodeRecord {
     type Error = NodeRecordParseError;
 
     fn try_from(enr: &Enr<secp256k1::SecretKey>) -> Result<Self, Self::Error> {
-        let Some(address) = enr.ip4().map(IpAddr::from).or_else(|| enr.ip6().map(IpAddr::from))
-        else {
-            return Err(NodeRecordParseError::InvalidUrl("ip missing".to_string()))
-        };
-
-        let Some(udp_port) = enr.udp4().or_else(|| enr.udp6()) else {
-            return Err(NodeRecordParseError::InvalidUrl("udp port missing".to_string()))
-        };
-
-        // A discovery-only ENR (e.g. a devp2p bootnode) omits the tcp key; treat that as no RLPx
-        // (port 0) rather than rejecting the record.
-        let tcp_port = enr.tcp4().or_else(|| enr.tcp6()).unwrap_or(0);
+        let endpoint = enr
+            .ip4()
+            .zip(enr.udp4())
+            .map(|(ip, udp)| (IpAddr::from(ip), udp, enr.tcp4().unwrap_or(0)));
+        // Generic `udp` and `tcp` entries also apply to IPv6 when their IPv6-specific counterparts
+        // are absent.
+        let (address, udp_port, tcp_port) = endpoint
+            .or_else(|| {
+                enr.ip6().zip(enr.udp6().or_else(|| enr.udp4())).map(|(ip, udp)| {
+                    (IpAddr::from(ip), udp, enr.tcp6().or_else(|| enr.tcp4()).unwrap_or(0))
+                })
+            })
+            .ok_or_else(|| {
+                NodeRecordParseError::InvalidUrl("ip or matching udp port missing".to_string())
+            })?;
 
         let id = crate::pk2id(&enr.public_key());
-
-        Ok(Self { address, tcp_port, udp_port, id }.into_ipv4_mapped())
+        Ok(Self { address, udp_port, tcp_port, id }.into_ipv4_mapped())
     }
 }
 
@@ -420,5 +422,20 @@ mod tests {
 
         assert_eq!(record.tcp_port, 0);
         assert_eq!(record.udp_port, 30301);
+    }
+
+    #[test]
+    #[cfg(feature = "secp256k1")]
+    fn enr_endpoint_keeps_ip_and_ports_together() {
+        let sk = secp256k1::SecretKey::from_byte_array(&[1u8; 32]).unwrap();
+        let mut builder = Enr::builder();
+        builder.ip4("10.0.0.1".parse().unwrap()).ip6("::1".parse().unwrap());
+        builder.udp6(30401).tcp6(30403);
+        let enr = builder.build(&sk).unwrap();
+        let record = NodeRecord::try_from(&enr).unwrap();
+
+        assert_eq!(record.address, "::1".parse::<IpAddr>().unwrap());
+        assert_eq!(record.udp_port, 30401);
+        assert_eq!(record.tcp_port, 30403);
     }
 }


### PR DESCRIPTION
Alternative to #26496.

Keeps IP addresses paired with their matching ports when deriving `NodeRecord` from an ENR, and makes `AnyNode` and DNS discovery use that derivation. Preserves the existing IPv4-first and discovery-only `tcp=0` behavior.
