### PR TITLE
refactor(engine): add speculative prewarming pools

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -52,6 +52,11 @@ impl BalPrewarmPool {
     /// Spawns `num_threads` long-lived blocking worker threads. Owned by the
     /// [`PayloadProcessor`](super::PayloadProcessor); the threads exit when the pool is dropped.
     pub(crate) fn new(num_threads: usize) -> Arc<Self> {
+        Self::new_named(num_threads, "bal-prewarm")
+    }
+
+    /// Spawns a named pool of long-lived blocking worker threads.
+    pub(crate) fn new_named(num_threads: usize, thread_name: &'static str) -> Arc<Self> {
         let mut workers = Vec::with_capacity(num_threads);
         let mut handles = Vec::with_capacity(num_threads);
         for i in 0..num_threads {
@@ -59,12 +64,17 @@ impl BalPrewarmPool {
             workers.push(tx);
             handles.push(
                 std::thread::Builder::new()
-                    .name(format!("bal-prewarm-{i:03}"))
+                    .name(format!("{thread_name}-{i:03}"))
                     .spawn(move || prewarm_loop(rx))
                     .expect("spawn bal-prewarm thread"),
             );
         }
-        trace!(target: "engine::tree::bal_prewarm_pool", num_threads, "BalPrewarmPool spawned");
+        trace!(
+            target: "engine::tree::bal_prewarm_pool",
+            num_threads,
+            thread_name,
+            "BalPrewarmPool spawned"
+        );
         Arc::new(Self { workers, next: AtomicUsize::new(0), _handles: handles })
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -19,7 +19,7 @@ use reth_evm::{
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{BlockExecutionOutput, BlockReader, StateProviderFactory, StateReader};
 use reth_revm::db::BundleState;
-use reth_tasks::Runtime;
+use reth_tasks::{pool::WorkerPool, Runtime};
 pub use reth_trie_parallel::{
     error::StateRootTaskError,
     state_root_task::{
@@ -45,6 +45,9 @@ pub mod receipt_root_task;
 /// Blocks with fewer transactions than this skip prewarming, since the fixed overhead of spawning
 /// prewarm workers exceeds the execution time saved.
 pub const SMALL_BLOCK_TX_THRESHOLD: usize = 5;
+
+/// Initial number of workers used for speculative storage-read discovery.
+const DEFAULT_SPECULATIVE_PREWARM_THREADS: usize = 1;
 
 /// Type alias for [`PayloadHandle`] returned by payload processor spawn methods.
 type IteratorTx<Evm, I> = RecoveredTx<TxEnvFor<Evm>, <I as ExecutableTxIterator<Evm>>::Recovered>;
@@ -107,6 +110,10 @@ where
     /// Dedicated blocking pool for warming the BAL read-set, created lazily on the first BAL block
     /// (see [`Self::bal_prewarm_pool`]). Its threads exit when the processor is dropped.
     bal_prewarm_pool: OnceLock<Arc<bal_prewarm_pool::BalPrewarmPool>>,
+    /// CPU pool for speculative storage-read discovery.
+    speculative_prewarm_pool: OnceLock<Arc<WorkerPool>>,
+    /// I/O pool that fetches storage discovered by speculative execution.
+    speculative_prewarm_io_pool: OnceLock<Arc<bal_prewarm_pool::BalPrewarmPool>>,
 }
 
 impl<Evm> PayloadProcessor<Evm>
@@ -136,6 +143,8 @@ where
             disable_bal_parallel_state_root: config.disable_bal_parallel_state_root(),
             disable_bal_batch_io: config.disable_bal_batch_io(),
             bal_prewarm_pool: OnceLock::new(),
+            speculative_prewarm_pool: OnceLock::new(),
+            speculative_prewarm_io_pool: OnceLock::new(),
         }
     }
 
@@ -145,6 +154,30 @@ where
         self.bal_prewarm_pool
             .get_or_init(|| {
                 bal_prewarm_pool::BalPrewarmPool::new(bal_prewarm_pool::DEFAULT_BAL_PREWARM_THREADS)
+            })
+            .clone()
+    }
+
+    /// Returns the CPU-only speculative execution pool.
+    fn speculative_prewarm_pool(&self) -> Arc<WorkerPool> {
+        self.speculative_prewarm_pool
+            .get_or_init(|| {
+                Arc::new(WorkerPool::new(
+                    DEFAULT_SPECULATIVE_PREWARM_THREADS,
+                    "speculative-prewarm",
+                ))
+            })
+            .clone()
+    }
+
+    /// Returns the pool that fetches storage discovered by speculative execution.
+    fn speculative_prewarm_io_pool(&self) -> Arc<bal_prewarm_pool::BalPrewarmPool> {
+        self.speculative_prewarm_io_pool
+            .get_or_init(|| {
+                bal_prewarm_pool::BalPrewarmPool::new_named(
+                    bal_prewarm_pool::DEFAULT_BAL_PREWARM_THREADS,
+                    "speculative-prewarm-io",
+                )
             })
             .clone()
     }
@@ -352,7 +385,12 @@ where
         } else {
             PrewarmMode::Transactions { pending: transactions, hints: hint_stream }
         };
+        let transaction_prewarming = matches!(&mode, PrewarmMode::Transactions { .. });
         let saved_cache = self.disable_state_cache.not().then(|| self.cache_for(env.parent_hash));
+        let speculative_prewarm_pool = (transaction_prewarming && saved_cache.is_some())
+            .then(|| self.speculative_prewarm_pool());
+        let speculative_prewarm_io_pool = (transaction_prewarming && saved_cache.is_some())
+            .then(|| self.speculative_prewarm_io_pool());
 
         let executed_tx_index = Arc::new(AtomicUsize::new(0));
         // configure prewarming
@@ -362,6 +400,8 @@ where
             saved_cache: saved_cache.clone(),
             provider: provider_builder,
             bal_prewarm_pool: parallel_bal_execution.then(|| self.bal_prewarm_pool()),
+            speculative_prewarm_pool,
+            speculative_prewarm_io_pool,
             metrics: PrewarmMetrics::default(),
             cache_metrics: self.cache_metrics.clone(),
             cache_state_metrics: self.cache_state_metrics.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -29,7 +29,7 @@ use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     AccountReader, BlockExecutionOutput, BlockReader, StateProviderFactory, StateReader,
 };
-use reth_revm::database::StateProviderDatabase;
+use reth_revm::{database::StateProviderDatabase, speculative::SpeculativeDatabase};
 use reth_tasks::{pool::WorkerPool, Runtime};
 use reth_trie_common::MultiProofTargetsV2;
 use std::sync::{
@@ -126,7 +126,7 @@ where
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
         state_root_hint_stream: Option<StateRootHintStream>,
     ) where
-        Tx: ExecutableTxFor<Evm> + Send + 'static,
+        Tx: ExecutableTxFor<Evm> + Clone + Send + 'static,
     {
         let executor = self.executor.clone();
         let ctx = self.ctx.clone();
@@ -142,6 +142,21 @@ where
 
             let ctx = &ctx;
             let pool = executor.prewarming_pool();
+            let speculative_pool = ctx.speculative_prewarm_pool.as_ref();
+            let speculative_io_pool = ctx.speculative_prewarm_io_pool.as_ref();
+            let (speculative_done_tx, speculative_done_rx) = mpsc::channel();
+            let mut speculative_tx_count = 0usize;
+
+            if let (Some(io_pool), Some(saved_cache)) =
+                (speculative_io_pool, ctx.saved_cache.as_ref())
+            {
+                let provider_builder = ctx.provider.clone();
+                io_pool.begin_block(
+                    Arc::new(move || provider_builder.build()),
+                    saved_cache.cache().clone(),
+                    ctx.env.txpool_snapshot.clone(),
+                );
+            }
 
             let mut tx_count = 0usize;
             let state_root_hint_stream = state_root_hint_stream.as_ref();
@@ -165,6 +180,17 @@ where
                     }
 
                     tx_count += 1;
+                    if let Some(speculative_pool) = speculative_pool {
+                        speculative_tx_count += 1;
+                        let speculative_ctx = (*ctx).clone();
+                        let speculative_tx = tx.clone();
+                        let speculative_done_tx = speculative_done_tx.clone();
+                        speculative_pool.spawn(move || {
+                            let _done = NotifyOnDrop(Some(speculative_done_tx));
+                            Self::speculative_transact_worker(&speculative_ctx, speculative_tx);
+                        });
+                    }
+
                     let parent_span = Span::current();
                     s.spawn(move |_| {
                         let _enter = trace_span!(
@@ -188,11 +214,46 @@ where
                 }
             });
 
+            for _ in 0..speculative_tx_count {
+                if speculative_done_rx.recv().is_err() {
+                    break;
+                }
+            }
+            if let Some(io_pool) = speculative_io_pool {
+                io_pool.end_block();
+            }
+            if let Some(speculative_pool) = speculative_pool {
+                speculative_pool.clear();
+            }
+
             // All tasks are done — clear per-thread EVM state for the next block.
             pool.clear();
 
             let _ = actions_tx
                 .send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: tx_count });
+        });
+    }
+
+    /// Runs one transaction on the speculative CPU pool and queues its storage reads for I/O.
+    fn speculative_transact_worker<Tx>(ctx: &PrewarmContext<N, P, Evm>, tx: Tx)
+    where
+        Tx: ExecutableTxFor<Evm>,
+    {
+        WorkerPool::with_worker_mut(|worker| {
+            let Some(evm) = worker
+                .get_or_init::<SpeculativePrewarmEvmState<Evm>>(|| ctx.speculative_evm_for_ctx())
+                .as_mut()
+            else {
+                return;
+            };
+
+            let (tx_env, _) = tx.into_parts();
+            let _ = evm.transact(tx_env);
+            let requests = evm.db_mut().take_storage_requests();
+            let Some(io_pool) = ctx.speculative_prewarm_io_pool.as_ref() else { return };
+            for (address, slot) in requests {
+                io_pool.warm_storage(address, B256::new(slot.to_be_bytes()));
+            }
         });
     }
 
@@ -450,7 +511,7 @@ where
     )]
     pub fn run<Tx>(self, mode: PrewarmMode<Tx>, actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>)
     where
-        Tx: ExecutableTxFor<Evm> + Send + 'static,
+        Tx: ExecutableTxFor<Evm> + Clone + Send + 'static,
     {
         // Spawn execution tasks based on mode. The state-root capabilities arrive inside the
         // mode and move into the spawned producers, so they die with the producers instead of
@@ -529,6 +590,10 @@ where
     /// Dedicated blocking pool for warming the BAL read-set. `Some` only on the BAL parallel
     /// execution path; the pool is owned by the [`PayloadProcessor`](super::PayloadProcessor).
     pub(crate) bal_prewarm_pool: Option<Arc<BalPrewarmPool>>,
+    /// Dedicated CPU pool for speculative storage-read discovery.
+    pub(crate) speculative_prewarm_pool: Option<Arc<WorkerPool>>,
+    /// Dedicated I/O pool that fetches speculative storage requests into the cache.
+    pub(crate) speculative_prewarm_io_pool: Option<Arc<BalPrewarmPool>>,
     /// The metrics for the prewarm task.
     pub metrics: PrewarmMetrics,
     /// Metrics for the execution cache.
@@ -558,6 +623,11 @@ where
 type PrewarmEvmState<Evm> =
     Option<EvmFor<Evm, StateProviderDatabase<reth_provider::StateProviderBox>>>;
 
+/// Per-thread EVM state for the independent speculative storage-discovery pool.
+type SpeculativePrewarmEvmState<Evm> = Option<
+    EvmFor<Evm, SpeculativeDatabase<StateProviderDatabase<reth_provider::StateProviderBox>>>,
+>;
+
 impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
     N: NodePrimitives,
@@ -567,27 +637,7 @@ where
     /// Creates a per-thread EVM for prewarming.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn evm_for_ctx(&self) -> PrewarmEvmState<Evm> {
-        let mut state_provider = match self.provider.build() {
-            Ok(provider) => provider,
-            Err(err) => {
-                trace!(
-                    target: "engine::tree::payload_processor::prewarm",
-                    %err,
-                    "Failed to build state provider in prewarm thread"
-                );
-                return None
-            }
-        };
-
-        // Use the caches to create a new provider with caching
-        if let Some(saved_cache) = &self.saved_cache {
-            let caches = saved_cache.cache().clone();
-            state_provider = Box::new(
-                CachedStateProvider::new_prewarm(state_provider, caches)
-                    .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
-            );
-        }
-
+        let state_provider = self.state_provider_for_prewarm()?;
         let state_provider = StateProviderDatabase::new(state_provider);
 
         let mut evm_env = self.env.evm_env.clone();
@@ -617,6 +667,55 @@ where
         }
 
         Some(evm)
+    }
+
+    /// Creates an EVM for the independent speculative storage-discovery pool.
+    fn speculative_evm_for_ctx(&self) -> SpeculativePrewarmEvmState<Evm> {
+        let state_provider = self.state_provider_for_prewarm()?;
+        let state_provider = SpeculativeDatabase::new(StateProviderDatabase::new(state_provider));
+        let mut evm_env = self.env.evm_env.clone();
+        evm_env.cfg_env.disable_nonce_check = true;
+        evm_env.cfg_env.disable_balance_check = true;
+
+        let spec_id = *evm_env.spec_id();
+        let mut evm = self.evm_config.evm_with_env(state_provider, evm_env);
+        if !self.precompile_cache_disabled {
+            evm.precompiles_mut().map_cacheable_precompiles(|address, precompile| {
+                CachedPrecompile::wrap(
+                    precompile,
+                    self.precompile_cache_map.cache_for_address(*address),
+                    spec_id,
+                    None,
+                )
+            });
+        }
+
+        Some(evm)
+    }
+
+    /// Builds a cache-filling state provider for either prewarming lane.
+    fn state_provider_for_prewarm(&self) -> Option<reth_provider::StateProviderBox> {
+        let mut state_provider = match self.provider.build() {
+            Ok(provider) => provider,
+            Err(err) => {
+                trace!(
+                    target: "engine::tree::payload_processor::prewarm",
+                    %err,
+                    "Failed to build state provider in prewarm thread"
+                );
+                return None
+            }
+        };
+
+        if let Some(saved_cache) = &self.saved_cache {
+            let caches = saved_cache.cache().clone();
+            state_provider = Box::new(
+                CachedStateProvider::new_prewarm(state_provider, caches)
+                    .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
+            );
+        }
+
+        Some(state_provider)
     }
 
     /// Returns `true` if prewarming should stop.
@@ -893,6 +992,17 @@ pub enum PrewarmTaskEvent<R> {
         /// Number of transactions executed
         executed_transactions: usize,
     },
+}
+
+/// Sends a completion notification even if a speculative worker unwinds.
+struct NotifyOnDrop(Option<Sender<()>>);
+
+impl Drop for NotifyOnDrop {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
 }
 
 /// Metrics for transactions prewarming.

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -20,6 +20,8 @@ pub mod cancelled;
 
 /// Contains glue code for integrating reth database into revm's [Database].
 pub mod database;
+/// Database adapter for discovering storage reads without blocking on them.
+pub mod speculative;
 
 pub use revm::{database as db, inspector};
 

--- a/crates/revm/src/speculative.rs
+++ b/crates/revm/src/speculative.rs
@@ -1,0 +1,154 @@
+//! Speculative EVM database reads.
+//!
+//! [`SpeculativeDatabase`] delegates account, bytecode, and block-hash reads so execution can
+//! follow the contract's real control flow. Storage reads are recorded and return zero instead of
+//! reaching the backing database. The recorded read set can then be fetched in parallel before a
+//! canonical execution pass.
+
+use alloc::collections::BTreeSet;
+use alloy_primitives::{Address, B256, U256};
+use core::mem;
+use revm::{bytecode::Bytecode, state::AccountInfo, Database};
+
+/// A storage slot requested during speculative execution.
+pub type StorageRequest = (Address, U256);
+
+/// A database adapter that records storage reads and returns zero for them.
+///
+/// Account and bytecode reads still reach the inner database. Returning empty values for those
+/// reads would prevent the EVM from entering contract bytecode and discovering its storage slots.
+#[derive(Clone, Debug)]
+pub struct SpeculativeDatabase<DB> {
+    inner: DB,
+    speculate_storage: bool,
+    storage_requests: BTreeSet<StorageRequest>,
+}
+
+impl<DB> SpeculativeDatabase<DB> {
+    /// Creates a speculative database backed by `inner`.
+    pub const fn new(inner: DB) -> Self {
+        Self { inner, speculate_storage: true, storage_requests: BTreeSet::new() }
+    }
+
+    /// Creates an adapter that delegates storage reads without recording them.
+    ///
+    /// This keeps the database type stable when speculative reads are unavailable.
+    pub const fn passthrough(inner: DB) -> Self {
+        Self { inner, speculate_storage: false, storage_requests: BTreeSet::new() }
+    }
+
+    /// Returns the inner database.
+    pub const fn inner(&self) -> &DB {
+        &self.inner
+    }
+
+    /// Returns mutable access to the inner database.
+    pub const fn inner_mut(&mut self) -> &mut DB {
+        &mut self.inner
+    }
+
+    /// Consumes the adapter and returns the inner database.
+    pub fn into_inner(self) -> DB {
+        self.inner
+    }
+
+    /// Returns the storage requests observed since the last call to
+    /// [`take_storage_requests`](Self::take_storage_requests).
+    pub const fn storage_requests(&self) -> &BTreeSet<StorageRequest> {
+        &self.storage_requests
+    }
+
+    /// Takes all unique storage requests observed so far.
+    pub fn take_storage_requests(&mut self) -> BTreeSet<StorageRequest> {
+        mem::take(&mut self.storage_requests)
+    }
+}
+
+impl<DB: Database> Database for SpeculativeDatabase<DB> {
+    type Error = DB::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.inner.basic(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.inner.code_by_hash(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        if !self.speculate_storage {
+            return self.inner.storage(address, index)
+        }
+        self.storage_requests.insert((address, index));
+        Ok(U256::ZERO)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.inner.block_hash(number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::convert::Infallible;
+
+    #[derive(Clone, Debug, Default)]
+    struct TestDatabase {
+        storage_reads: usize,
+    }
+
+    impl Database for TestDatabase {
+        type Error = Infallible;
+
+        fn basic(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(Some(AccountInfo::default()))
+        }
+
+        fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn storage(&mut self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+            self.storage_reads += 1;
+            Ok(U256::from(1))
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    #[test]
+    fn records_unique_storage_reads_without_accessing_inner_database() {
+        let address = Address::repeat_byte(0x11);
+        let slot = U256::from(42);
+        let mut db = SpeculativeDatabase::new(TestDatabase::default());
+
+        assert_eq!(db.storage(address, slot).unwrap(), U256::ZERO);
+        assert_eq!(db.storage(address, slot).unwrap(), U256::ZERO);
+        assert_eq!(db.inner().storage_reads, 0);
+        assert_eq!(db.storage_requests(), &BTreeSet::from([(address, slot)]));
+
+        assert_eq!(db.take_storage_requests(), BTreeSet::from([(address, slot)]));
+        assert!(db.storage_requests().is_empty());
+    }
+
+    #[test]
+    fn delegates_non_storage_reads() {
+        let mut db = SpeculativeDatabase::new(TestDatabase::default());
+
+        assert!(db.basic(Address::ZERO).unwrap().is_some());
+        assert_eq!(db.code_by_hash(B256::ZERO).unwrap(), Bytecode::default());
+        assert_eq!(db.block_hash(1).unwrap(), B256::ZERO);
+    }
+
+    #[test]
+    fn passthrough_delegates_storage_reads() {
+        let mut db = SpeculativeDatabase::passthrough(TestDatabase::default());
+
+        assert_eq!(db.storage(Address::ZERO, U256::ZERO).unwrap(), U256::from(1));
+        assert_eq!(db.inner().storage_reads, 1);
+        assert!(db.storage_requests().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
Refactors payload prewarming to split speculative storage discovery onto dedicated CPU and I/O pools.

The speculative path now records storage reads through a new `SpeculativeDatabase`, warms the discovered slots in parallel, and keeps the existing BAL prewarm path unchanged apart from a small thread-naming cleanup.