### PR TITLE
fix(net): make discv5 follow --discovery.port

### DIFF
--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -20,7 +20,7 @@ use reth_cli_util::{get_secret_key, load_secret_key::SecretKeyError};
 use reth_config::Config;
 use reth_discv4::{NodeRecord, DEFAULT_DISCOVERY_ADDR, DEFAULT_DISCOVERY_PORT};
 use reth_discv5::{
-    discv5::ListenConfig, DEFAULT_COUNT_BOOTSTRAP_LOOKUPS, DEFAULT_DISCOVERY_V5_PORT,
+    discv5::ListenConfig, DEFAULT_COUNT_BOOTSTRAP_LOOKUPS,
     DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL, DEFAULT_SECONDS_LOOKUP_INTERVAL,
 };
 use reth_net_banlist::IpFilter;
@@ -897,8 +897,8 @@ impl Default for DefaultDiscoveryArgs {
             port: DEFAULT_DISCOVERY_PORT,
             discv5_addr: None,
             discv5_addr_ipv6: None,
-            discv5_port: Some(DEFAULT_DISCOVERY_V5_PORT),
-            discv5_port_ipv6: Some(DEFAULT_DISCOVERY_V5_PORT),
+            discv5_port: None,
+            discv5_port_ipv6: None,
             discv5_lookup_interval: DEFAULT_SECONDS_LOOKUP_INTERVAL,
             discv5_bootstrap_lookup_interval: DEFAULT_SECONDS_BOOTSTRAP_LOOKUP_INTERVAL,
             discv5_bootstrap_lookup_countdown: DEFAULT_COUNT_BOOTSTRAP_LOOKUPS,
@@ -959,13 +959,15 @@ pub struct DiscoveryArgs {
 
     /// The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is
     /// IPv4, or `--discovery.v5.addr` is set.
+    ///
+    /// If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
     #[arg(id = "discovery.v5.port", long = "discovery.v5.port", value_name = "DISCOVERY_V5_PORT", default_value = Resettable::from(DefaultDiscoveryArgs::get_global().discv5_port.map(|p| OsStr::from(p.to_string()))))]
     pub discv5_port: Option<u16>,
 
     /// The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is
     /// IPv6, or `--discovery.addr.ipv6` is set.
     ///
-    /// If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
+    /// If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
     #[arg(id = "discovery.v5.port.ipv6", long = "discovery.v5.port.ipv6", value_name = "DISCOVERY_V5_PORT_IPV6", default_value = Resettable::from(DefaultDiscoveryArgs::get_global().discv5_port_ipv6.map(|p| OsStr::from(p.to_string()))))]
     pub discv5_port_ipv6: Option<u16>,
 

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -112,16 +112,14 @@ Networking:
           The UDP IPv6 address to use for devp2p peer discovery version 5. Overwritten by `RLPx` address, if it's also IPv6
 
       --discovery.v5.port <DISCOVERY_V5_PORT>
-          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
+          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set.
 
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
-          If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
-
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -52,16 +52,14 @@ Networking:
           The UDP IPv6 address to use for devp2p peer discovery version 5. Overwritten by `RLPx` address, if it's also IPv6
 
       --discovery.v5.port <DISCOVERY_V5_PORT>
-          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
+          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set.
 
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
-          If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
-
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -52,16 +52,14 @@ Networking:
           The UDP IPv6 address to use for devp2p peer discovery version 5. Overwritten by `RLPx` address, if it's also IPv6
 
       --discovery.v5.port <DISCOVERY_V5_PORT>
-          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
+          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set.
 
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
-          If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
-
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -211,16 +211,14 @@ Networking:
           The UDP IPv6 address to use for devp2p peer discovery version 5. Overwritten by `RLPx` address, if it's also IPv6
 
       --discovery.v5.port <DISCOVERY_V5_PORT>
-          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
+          The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set.
 
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
-          If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
-
-          [default: 9200]
+          If not provided, discv5 uses the same port as discv4 (`--discovery.port`).
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program


### PR DESCRIPTION
## Problem

`--discovery.port` only sets the discv4 socket. discv5 binds its own default of `9200` and signs an ENR advertising it, so an operator who opens a single UDP discovery port advertises one they have not opened. There is no error at startup, and it stays invisible until inbound discovery silently fails from outside the host.

I hit this bringing up a discv5-only devnet. Across seven ELs, reth was the only one whose reported discovery port differed from the one provisioned:

```
geth        ports: {"discovery": 30303, "listener": 30303}
besu        ports: {"discovery": 30303, "listener": 30303}
erigon      ports: {"discovery": 30303, "listener": 30303}
reth        ports: {"discovery": 9200,  "listener": 30303}   <-- only 30303 was published
nethermind  ports: {"discovery": 30303, "listener": 30303}
nimbus-eth1 ports: {"discovery": 30303, "listener": 30303}
ethrex      ports: {"discovery": 30303, "listener": 30303}
```

It peered anyway there, because that environment happened not to filter UDP between hosts — which is exactly what makes it easy to ship broken.

## Cause

`discovery_v5_builder` already implements the intended fallback, and the `--discovery.v5.port.ipv6` doc comment already promised it:

```rust
discv5_port.unwrap_or(*port)
discv5_port_ipv6.unwrap_or(*port)
```

> If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).

But `DefaultDiscoveryArgs::default()` set both to `Some(DEFAULT_DISCOVERY_V5_PORT)`, and clap wires that in as `default_value`, so the `None` branch is unreachable from the CLI. The generated help shows the contradiction directly — `[default: 9200]` printed immediately below the claim that it defaults to `--discovery.port`.

## Change

Default both to `None` so the existing fallback engages.

- `--discovery.v5.port` / `--discovery.v5.port.ipv6` still override it.
- `adjust_instance_ports` is unaffected: `self.port` is offset unconditionally, and the fallback inherits the offset value. Previously the `.map()` offset the v5 ports separately; now they follow the already-offset discv4 port.
- `with_unused_ports()` keeps setting explicit `Some(0)`.
- `DEFAULT_DISCOVERY_V5_PORT` stays exported from `reth-discv5`; it is still used for `DEFAULT_DISCOVERY_V5_LISTEN_CONFIG` and as the ENR fallback in `config.rs`. Dropped only from this file's imports, since it no longer has a use there.

**This changes the default discv5 port from 9200 to `--discovery.port` (30303).** That is the point of the change, but it is a behaviour change for anyone relying on the current default, so flagging it prominently — happy to reduce this to a docs-only correction of the flag descriptions if you would rather keep 9200.

Generated CLI pages updated to match; `make update-book-cli` needs a build, so those were edited to the output clap will produce (the `[default: 9200]` lines go away with the default unset).

## Testing

No test asserts the 9200 default. I could not run `cargo test` locally (no Rust toolchain on this machine beyond `rustfmt`, which was run on the changed file), so CI is the real check here.