### PR TITLE
feat(engine): configure state masking blocks

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -319,6 +319,16 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
     /// This will update the links between blocks and remove all blocks that are [..
     /// `persisted_height`].
     pub fn remove_persisted_blocks(&self, persisted_num_hash: BlockNumHash) {
+        self.remove_persisted_blocks_until(persisted_num_hash, persisted_num_hash.number);
+    }
+
+    /// Removes blocks from the in-memory state through `remove_until` while still reporting the
+    /// provided block as the persisted tip.
+    pub fn remove_persisted_blocks_until(
+        &self,
+        persisted_num_hash: BlockNumHash,
+        remove_until: BlockNumber,
+    ) {
         self.set_persisted(persisted_num_hash);
         // if the persisted hash is not in the canonical in memory state, do nothing, because it
         // means canonical blocks were not actually persisted.
@@ -336,16 +346,15 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
             let mut numbers = self.inner.in_memory_state.numbers.write();
             let mut blocks = self.inner.in_memory_state.blocks.write();
 
-            let BlockNumHash { number: persisted_height, hash: _ } = persisted_num_hash;
+            let remove_until = remove_until.min(persisted_num_hash.number);
 
             // clear all numbers
             numbers.clear();
 
-            // drain all blocks and only keep the ones that are not persisted (below the persisted
-            // height)
+            // Drain all blocks and keep only the suffix that still has to stay in memory.
             let mut old_blocks = blocks
                 .drain()
-                .filter(|(_, b)| b.block_ref().recovered_block().number() > persisted_height)
+                .filter(|(_, b)| b.block_ref().recovered_block().number() > remove_until)
                 .map(|(_, b)| b.block.clone())
                 .collect::<Vec<_>>();
 

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -6,6 +6,9 @@ use core::time::Duration;
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
 pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 7;
 
+/// Number of persisted blocks whose state/trie writes are masked by an in-memory suffix.
+pub const DEFAULT_NUM_STATE_MASKING_BLOCKS: u64 = 0;
+
 /// Maximum number of blocks beyond the in-memory buffer target awaiting persistence before engine
 /// API processing is stalled.
 pub const DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD: u64 = 16;
@@ -51,6 +54,21 @@ const fn assert_backpressure_threshold_invariant(
     );
 }
 
+const fn assert_state_masking_invariant(
+    persistence_threshold: u64,
+    num_state_masking_blocks: u64,
+    memory_block_buffer_target: u64,
+) {
+    let valid_window = match num_state_masking_blocks.checked_add(memory_block_buffer_target) {
+        Some(window) => window < persistence_threshold,
+        None => false,
+    };
+    debug_assert!(
+        num_state_masking_blocks == 0 || valid_window,
+        "num_state_masking_blocks + memory_block_buffer_target must be less than persistence_threshold",
+    );
+}
+
 const fn default_cross_block_cache_size() -> usize {
     if cfg!(test) {
         1024 * 1024 // 1 MB in tests
@@ -84,6 +102,9 @@ pub struct TreeConfig {
     /// Maximum number of blocks to be kept only in memory without triggering
     /// persistence.
     persistence_threshold: u64,
+    /// Number of persisted blocks whose state/trie writes are masked instead of being durably
+    /// written in the current cycle.
+    num_state_masking_blocks: u64,
     /// How close to the canonical head we persist blocks. Represents the ideal
     /// number of most recent blocks to keep in memory for quick access and reorgs.
     ///
@@ -207,8 +228,14 @@ impl Default for TreeConfig {
             DEFAULT_PERSISTENCE_THRESHOLD,
             DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
         );
+        assert_state_masking_invariant(
+            DEFAULT_PERSISTENCE_THRESHOLD,
+            DEFAULT_NUM_STATE_MASKING_BLOCKS,
+            DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
+        );
         Self {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
+            num_state_masking_blocks: DEFAULT_NUM_STATE_MASKING_BLOCKS,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
             block_buffer_limit: DEFAULT_BLOCK_BUFFER_LIMIT,
@@ -251,6 +278,7 @@ impl TreeConfig {
     #[expect(clippy::too_many_arguments)]
     pub const fn new(
         persistence_threshold: u64,
+        num_state_masking_blocks: u64,
         memory_block_buffer_target: u64,
         persistence_backpressure_threshold: u64,
         block_buffer_limit: u32,
@@ -280,8 +308,14 @@ impl TreeConfig {
             persistence_threshold,
             persistence_backpressure_threshold,
         );
+        assert_state_masking_invariant(
+            persistence_threshold,
+            num_state_masking_blocks,
+            memory_block_buffer_target,
+        );
         Self {
             persistence_threshold,
+            num_state_masking_blocks,
             memory_block_buffer_target,
             persistence_backpressure_threshold,
             block_buffer_limit,
@@ -321,6 +355,11 @@ impl TreeConfig {
     /// Return the persistence threshold.
     pub const fn persistence_threshold(&self) -> u64 {
         self.persistence_threshold
+    }
+
+    /// Return the number of persisted blocks whose state/trie writes are masked.
+    pub const fn num_state_masking_blocks(&self) -> u64 {
+        self.num_state_masking_blocks
     }
 
     /// Return the memory block buffer target.
@@ -440,6 +479,22 @@ impl TreeConfig {
             self.persistence_threshold,
             self.persistence_backpressure_threshold,
         );
+        assert_state_masking_invariant(
+            self.persistence_threshold,
+            self.num_state_masking_blocks,
+            self.memory_block_buffer_target,
+        );
+        self
+    }
+
+    /// Setter for the number of persisted blocks whose state/trie writes are masked.
+    pub const fn with_num_state_masking_blocks(mut self, num_state_masking_blocks: u64) -> Self {
+        self.num_state_masking_blocks = num_state_masking_blocks;
+        assert_state_masking_invariant(
+            self.persistence_threshold,
+            self.num_state_masking_blocks,
+            self.memory_block_buffer_target,
+        );
         self
     }
 
@@ -449,6 +504,11 @@ impl TreeConfig {
         memory_block_buffer_target: u64,
     ) -> Self {
         self.memory_block_buffer_target = memory_block_buffer_target;
+        assert_state_masking_invariant(
+            self.persistence_threshold,
+            self.num_state_masking_blocks,
+            self.memory_block_buffer_target,
+        );
         self
     }
 
@@ -755,7 +815,7 @@ impl TreeConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::TreeConfig;
+    use super::{TreeConfig, DEFAULT_NUM_STATE_MASKING_BLOCKS};
 
     #[test]
     fn txpool_prewarming_is_disabled_by_default_and_can_be_enabled() {
@@ -785,5 +845,32 @@ mod tests {
         let _ = TreeConfig::default()
             .with_persistence_threshold(4)
             .with_persistence_backpressure_threshold(4);
+    }
+
+    #[test]
+    fn state_masking_is_disabled_by_default() {
+        assert_eq!(
+            TreeConfig::default().num_state_masking_blocks(),
+            DEFAULT_NUM_STATE_MASKING_BLOCKS
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "num_state_masking_blocks + memory_block_buffer_target must be less than persistence_threshold"
+    )]
+    fn rejects_state_masking_window_at_or_above_persistence_threshold() {
+        let _ = TreeConfig::default()
+            .with_persistence_threshold(4)
+            .with_memory_block_buffer_target(2)
+            .with_num_state_masking_blocks(2);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "num_state_masking_blocks + memory_block_buffer_target must be less than persistence_threshold"
+    )]
+    fn rejects_overflowing_state_masking_window() {
+        let _ = TreeConfig::default().with_num_state_masking_blocks(u64::MAX);
     }
 }

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -7,10 +7,9 @@ use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     providers::ProviderNodeTypes, BalProvider, BlockExecutionWriter, BlockHashReader,
     ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksInput,
-    StageCheckpointReader,
 };
 use reth_prune::{PrunerError, PrunerWithFactory};
-use reth_stages_api::{MetricEvent, MetricEventsSender, StageId};
+use reth_stages_api::{MetricEvent, MetricEventsSender};
 use reth_tasks::spawn_os_thread;
 use std::{
     sync::{
@@ -139,21 +138,14 @@ where
         let provider_rw = self.provider.database_provider_rw()?;
 
         let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
-        provider_rw.remove_block_and_execution_above(new_tip_num)?;
-        let last_state_trie_block =
-            provider_rw.get_stage_checkpoint(StageId::Finish)?.map(|checkpoint| {
-                checkpoint
-                    .finish_stage_checkpoint()
-                    .and_then(|finish| finish.partial_state_trie())
-                    .unwrap_or(checkpoint.block_number)
-            });
+        let frontiers = provider_rw.remove_block_and_execution_above(new_tip_num)?;
         provider_rw.commit()?;
 
         debug!(target: "engine::persistence", ?new_tip_num, ?new_tip_hash, "Removed blocks from disk");
         self.metrics.remove_blocks_above_duration_seconds.record(start_time.elapsed());
         Ok(PersistenceResult {
-            last_block: new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }),
-            last_state_trie_block,
+            last_block: new_tip_hash.map(|hash| BlockNumHash { hash, number: frontiers.db_tip }),
+            last_state_trie_block: Some(frontiers.partial_state_trie),
             commit_duration: None,
         })
     }
@@ -703,7 +695,9 @@ mod tests {
         let pf = provider_factory.clone();
         let reorg_handle = std::thread::spawn(move || {
             let provider_rw = pf.database_provider_rw().unwrap();
-            provider_rw.remove_block_and_execution_above(1).unwrap();
+            let frontiers = provider_rw.remove_block_and_execution_above(1).unwrap();
+            assert_eq!(frontiers.db_tip, 1);
+            assert_eq!(frontiers.partial_state_trie, 1);
             provider_rw.commit().unwrap();
 
             let provider_rw = pf.database_provider_rw().unwrap();

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -7,9 +7,10 @@ use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     providers::ProviderNodeTypes, BalProvider, BlockExecutionWriter, BlockHashReader,
     ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksInput,
+    StageCheckpointReader,
 };
 use reth_prune::{PrunerError, PrunerWithFactory};
-use reth_stages_api::{MetricEvent, MetricEventsSender};
+use reth_stages_api::{MetricEvent, MetricEventsSender, StageId};
 use reth_tasks::spawn_os_thread;
 use std::{
     sync::{
@@ -25,8 +26,10 @@ use tracing::{debug, error, instrument, warn};
 /// Unified result of any persistence operation.
 #[derive(Debug)]
 pub struct PersistenceResult {
-    /// The last block that was persisted, if any.
+    /// The highest block whose non-state/trie outputs are persisted, if any.
     pub last_block: Option<BlockNumHash>,
+    /// The state/trie persistence frontier, if known.
+    pub last_state_trie_block: Option<u64>,
     /// The commit duration, only available for save-blocks operations.
     pub commit_duration: Option<Duration>,
 }
@@ -95,11 +98,11 @@ where
         while let Ok(action) = self.incoming.recv() {
             match action {
                 PersistenceAction::RemoveBlocksAbove(new_tip_num, sender) => {
-                    let last_block = self.on_remove_blocks_above(new_tip_num)?;
+                    let result = self.on_remove_blocks_above(new_tip_num)?;
                     // send new sync metrics based on removed blocks
                     let _ =
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
-                    let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
+                    let _ = sender.send(result);
                 }
                 PersistenceAction::SaveBlocks(blocks, sender) => {
                     let result = self.on_save_blocks(blocks)?;
@@ -130,18 +133,29 @@ where
     fn on_remove_blocks_above(
         &self,
         new_tip_num: u64,
-    ) -> Result<Option<BlockNumHash>, PersistenceError> {
+    ) -> Result<PersistenceResult, PersistenceError> {
         debug!(target: "engine::persistence", ?new_tip_num, "Removing blocks");
         let start_time = Instant::now();
         let provider_rw = self.provider.database_provider_rw()?;
 
         let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
         provider_rw.remove_block_and_execution_above(new_tip_num)?;
+        let last_state_trie_block =
+            provider_rw.get_stage_checkpoint(StageId::Finish)?.map(|checkpoint| {
+                checkpoint
+                    .finish_stage_checkpoint()
+                    .and_then(|finish| finish.partial_state_trie())
+                    .unwrap_or(checkpoint.block_number)
+            });
         provider_rw.commit()?;
 
         debug!(target: "engine::persistence", ?new_tip_num, ?new_tip_hash, "Removed blocks from disk");
         self.metrics.remove_blocks_above_duration_seconds.record(start_time.elapsed());
-        Ok(new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }))
+        Ok(PersistenceResult {
+            last_block: new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }),
+            last_state_trie_block,
+            commit_duration: None,
+        })
     }
 
     #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(block_count = input.persist_rest_blocks().len()))]
@@ -152,6 +166,7 @@ where
         let first_block = input.first_persist_rest_block().recovered_block().num_hash();
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
+        let last_state_trie_block = Some(input.new_partial_state_trie());
 
         let pending_finalized = self.pending_finalized_block.take();
         let pending_safe = self.pending_safe_block.take();
@@ -186,7 +201,11 @@ where
         self.metrics.save_blocks_batch_size.record(block_count as f64);
         self.metrics.save_blocks_duration_seconds.record(elapsed);
 
-        Ok(PersistenceResult { last_block: Some(last_block), commit_duration: Some(elapsed) })
+        Ok(PersistenceResult {
+            last_block: Some(last_block),
+            last_state_trie_block,
+            commit_duration: Some(elapsed),
+        })
     }
 
     fn maybe_run_pruner(&mut self, block_number: u64) -> Result<(), PersistenceError> {

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -28,7 +28,7 @@ pub struct PersistenceResult {
     /// The highest block whose non-state/trie outputs are persisted, if any.
     pub last_block: Option<BlockNumHash>,
     /// The state/trie persistence frontier, if known.
-    pub last_state_trie_block: Option<u64>,
+    pub last_state_trie_block: Option<BlockNumHash>,
     /// The commit duration, only available for save-blocks operations.
     pub commit_duration: Option<Duration>,
 }
@@ -139,15 +139,25 @@ where
 
         let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
         let frontiers = provider_rw.remove_block_and_execution_above(new_tip_num)?;
+        let last_block = new_tip_hash.map(|hash| BlockNumHash { hash, number: frontiers.db_tip });
+        let last_state_trie_block = match last_block {
+            Some(last_block) if frontiers.partial_state_trie == last_block.number => {
+                Some(last_block)
+            }
+            Some(_) => {
+                let hash =
+                    provider_rw.block_hash(frontiers.partial_state_trie)?.ok_or_else(|| {
+                        ProviderError::HeaderNotFound(frontiers.partial_state_trie.into())
+                    })?;
+                Some(BlockNumHash::new(frontiers.partial_state_trie, hash))
+            }
+            None => None,
+        };
         provider_rw.commit()?;
 
         debug!(target: "engine::persistence", ?new_tip_num, ?new_tip_hash, "Removed blocks from disk");
         self.metrics.remove_blocks_above_duration_seconds.record(start_time.elapsed());
-        Ok(PersistenceResult {
-            last_block: new_tip_hash.map(|hash| BlockNumHash { hash, number: frontiers.db_tip }),
-            last_state_trie_block: Some(frontiers.partial_state_trie),
-            commit_duration: None,
-        })
+        Ok(PersistenceResult { last_block, last_state_trie_block, commit_duration: None })
     }
 
     #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(block_count = input.persist_rest_blocks().len()))]
@@ -158,7 +168,10 @@ where
         let first_block = input.first_persist_rest_block().recovered_block().num_hash();
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
-        let last_state_trie_block = Some(input.new_partial_state_trie());
+        let last_state_trie_block_number = input.new_partial_state_trie();
+        // Newly written static-file headers are not readable until commit finalizes their index.
+        let last_state_trie_block =
+            input.state_trie_blocks().last().map(|block| block.recovered_block().num_hash());
 
         let pending_finalized = self.pending_finalized_block.take();
         let pending_safe = self.pending_safe_block.take();
@@ -168,6 +181,14 @@ where
         let start_time = Instant::now();
 
         let provider_rw = self.provider.database_provider_rw()?;
+        let last_state_trie_block = if let Some(last_state_trie_block) = last_state_trie_block {
+            last_state_trie_block
+        } else {
+            let hash = provider_rw.block_hash(last_state_trie_block_number)?.ok_or_else(|| {
+                ProviderError::HeaderNotFound(last_state_trie_block_number.into())
+            })?;
+            BlockNumHash::new(last_state_trie_block_number, hash)
+        };
         provider_rw.save_blocks(&input)?;
 
         if let Some(finalized) = pending_finalized {
@@ -195,7 +216,7 @@ where
 
         Ok(PersistenceResult {
             last_block: Some(last_block),
-            last_state_trie_block,
+            last_state_trie_block: Some(last_state_trie_block),
             commit_duration: Some(elapsed),
         })
     }
@@ -518,8 +539,10 @@ mod tests {
         handle.save_blocks(blocks, tx).unwrap();
 
         let result = rx.recv_timeout(std::time::Duration::from_secs(10)).expect("test timed out");
+        let last_block = result.last_block.unwrap();
 
-        assert_eq!(block_hash, result.last_block.unwrap().hash);
+        assert_eq!(block_hash, last_block.hash);
+        assert_eq!(result.last_state_trie_block, Some(last_block));
     }
 
     #[test]

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -95,27 +95,25 @@ where
         while let Ok(action) = self.incoming.recv() {
             match action {
                 PersistenceAction::RemoveBlocksAbove(new_tip_num, sender) => {
-                    let last_block = self.on_remove_blocks_above(new_tip_num)?;
+                    let result = self.on_remove_blocks_above(new_tip_num)?;
                     // send new sync metrics based on removed blocks
                     let _ =
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
-                    let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
+                    let _ = sender.send(result);
                 }
                 PersistenceAction::SaveBlocks(input, sender) => {
-                    let db_tip_advanced = input.prev_db_tip() < input.new_db_tip();
+                    let new_db_tip = input.new_db_tip();
+                    let db_tip_advanced = input.prev_db_tip() < new_db_tip;
                     let result = self.on_save_blocks(input)?;
-                    let result_number = result.last_block.map(|b| b.number);
 
                     let _ = sender.send(result);
 
-                    if db_tip_advanced &&
-                        let Some(block_number) = result_number
-                    {
+                    if db_tip_advanced {
                         // send new sync metrics based on saved blocks
                         let _ = self
                             .sync_metrics_tx
-                            .send(MetricEvent::SyncHeight { height: block_number });
-                        self.maybe_run_pruner(block_number)?;
+                            .send(MetricEvent::SyncHeight { height: new_db_tip });
+                        self.maybe_run_pruner(new_db_tip)?;
                     }
                 }
                 PersistenceAction::SaveFinalizedBlock(finalized_block) => {
@@ -133,7 +131,7 @@ where
     fn on_remove_blocks_above(
         &self,
         new_tip_num: u64,
-    ) -> Result<Option<BlockNumHash>, PersistenceError> {
+    ) -> Result<PersistenceResult, PersistenceError> {
         debug!(target: "engine::persistence", ?new_tip_num, "Removing blocks");
         let start_time = Instant::now();
         let provider_rw = self.provider.database_provider_rw()?;
@@ -144,7 +142,10 @@ where
 
         debug!(target: "engine::persistence", ?new_tip_num, ?new_tip_hash, "Removed blocks from disk");
         self.metrics.remove_blocks_above_duration_seconds.record(start_time.elapsed());
-        Ok(new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }))
+        Ok(PersistenceResult {
+            last_block: new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }),
+            commit_duration: None,
+        })
     }
 
     #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(block_count = input.persist_rest_blocks().len()))]

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -164,10 +164,6 @@ where
         let first_block = input.first_persist_rest_block().recovered_block().num_hash();
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
-        let last_state_trie_block_number = input.new_partial_state_trie();
-        // Newly written static-file headers are not readable until commit finalizes their index.
-        let last_state_trie_block =
-            input.state_trie_blocks().last().map(|block| block.recovered_block().num_hash());
 
         let pending_finalized = self.pending_finalized_block.take();
         let pending_safe = self.pending_safe_block.take();
@@ -177,13 +173,18 @@ where
         let start_time = Instant::now();
 
         let provider_rw = self.provider.database_provider_rw()?;
-        let last_state_trie_block = if let Some(last_state_trie_block) = last_state_trie_block {
-            last_state_trie_block
+        let last_state_trie_block = if let Some(block) = input.state_trie_blocks().last() {
+            // Newly written static-file headers are not readable until commit finalizes their
+            // index.
+            block.recovered_block().num_hash()
         } else {
-            let hash = provider_rw.block_hash(last_state_trie_block_number)?.ok_or_else(|| {
-                ProviderError::HeaderNotFound(last_state_trie_block_number.into())
-            })?;
-            BlockNumHash::new(last_state_trie_block_number, hash)
+            // If the state/trie frontier did not advance, its block is excluded from
+            // `state_trie_blocks()` and must be loaded from already-persisted storage.
+            let number = input.new_partial_state_trie();
+            let hash = provider_rw
+                .block_hash(number)?
+                .ok_or_else(|| ProviderError::HeaderNotFound(number.into()))?;
+            BlockNumHash::new(number, hash)
         };
         provider_rw.save_blocks(&input)?;
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -25,10 +25,10 @@ use tracing::{debug, error, instrument, warn};
 /// Unified result of any persistence operation.
 #[derive(Debug)]
 pub struct PersistenceResult {
-    /// The highest block whose non-state/trie outputs are persisted, if any.
-    pub last_block: Option<BlockNumHash>,
-    /// The state/trie persistence frontier, if known.
-    pub last_state_trie_block: Option<BlockNumHash>,
+    /// The highest block whose non-state/trie outputs are persisted.
+    pub last_block: BlockNumHash,
+    /// The state/trie persistence frontier.
+    pub last_state_trie_block: BlockNumHash,
     /// The commit duration, only available for save-blocks operations.
     pub commit_duration: Option<Duration>,
 }
@@ -105,17 +105,15 @@ where
                 }
                 PersistenceAction::SaveBlocks(blocks, sender) => {
                     let result = self.on_save_blocks(blocks)?;
-                    let result_number = result.last_block.map(|b| b.number);
+                    let result_number = result.last_block.number;
 
                     let _ = sender.send(result);
 
-                    if let Some(block_number) = result_number {
-                        // send new sync metrics based on saved blocks
-                        let _ = self
-                            .sync_metrics_tx
-                            .send(MetricEvent::SyncHeight { height: block_number });
-                        self.maybe_run_pruner(block_number)?;
-                    }
+                    // send new sync metrics based on saved blocks
+                    let _ = self
+                        .sync_metrics_tx
+                        .send(MetricEvent::SyncHeight { height: result_number });
+                    self.maybe_run_pruner(result_number)?;
                 }
                 PersistenceAction::SaveFinalizedBlock(finalized_block) => {
                     self.pending_finalized_block = Some(finalized_block);
@@ -137,21 +135,19 @@ where
         let start_time = Instant::now();
         let provider_rw = self.provider.database_provider_rw()?;
 
-        let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
+        let new_tip_hash = provider_rw
+            .block_hash(new_tip_num)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(new_tip_num.into()))?;
         let frontiers = provider_rw.remove_block_and_execution_above(new_tip_num)?;
-        let last_block = new_tip_hash.map(|hash| BlockNumHash { hash, number: frontiers.db_tip });
-        let last_state_trie_block = match last_block {
-            Some(last_block) if frontiers.partial_state_trie == last_block.number => {
-                Some(last_block)
-            }
-            Some(_) => {
-                let hash =
-                    provider_rw.block_hash(frontiers.partial_state_trie)?.ok_or_else(|| {
-                        ProviderError::HeaderNotFound(frontiers.partial_state_trie.into())
-                    })?;
-                Some(BlockNumHash::new(frontiers.partial_state_trie, hash))
-            }
-            None => None,
+        debug_assert_eq!(frontiers.db_tip, new_tip_num);
+        let last_block = BlockNumHash::new(new_tip_num, new_tip_hash);
+        let last_state_trie_block = if frontiers.partial_state_trie == new_tip_num {
+            last_block
+        } else {
+            let hash = provider_rw.block_hash(frontiers.partial_state_trie)?.ok_or_else(|| {
+                ProviderError::HeaderNotFound(frontiers.partial_state_trie.into())
+            })?;
+            BlockNumHash::new(frontiers.partial_state_trie, hash)
         };
         provider_rw.commit()?;
 
@@ -214,11 +210,7 @@ where
         self.metrics.save_blocks_batch_size.record(block_count as f64);
         self.metrics.save_blocks_duration_seconds.record(elapsed);
 
-        Ok(PersistenceResult {
-            last_block: Some(last_block),
-            last_state_trie_block: Some(last_state_trie_block),
-            commit_duration: Some(elapsed),
-        })
+        Ok(PersistenceResult { last_block, last_state_trie_block, commit_duration: Some(elapsed) })
     }
 
     fn maybe_run_pruner(&mut self, block_number: u64) -> Result<(), PersistenceError> {
@@ -502,6 +494,25 @@ mod tests {
         service.maybe_run_pruner(2).unwrap();
     }
 
+    #[test]
+    fn test_remove_blocks_above_requires_tip_header() {
+        let provider = create_test_provider_factory();
+        init_genesis(&provider).unwrap();
+
+        let (_finished_exex_height_tx, finished_exex_height_rx) =
+            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+        let pruner =
+            Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
+        let (_db_service_tx, db_service_rx) = std::sync::mpsc::channel();
+        let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
+        let service = PersistenceService::new(provider, db_service_rx, pruner, sync_metrics_tx);
+
+        assert!(matches!(
+            service.on_remove_blocks_above(1),
+            Err(PersistenceError::ProviderError(ProviderError::HeaderNotFound(_)))
+        ));
+    }
+
     #[derive(Debug)]
     struct FailingPruneBalStore;
 
@@ -539,10 +550,10 @@ mod tests {
         handle.save_blocks(blocks, tx).unwrap();
 
         let result = rx.recv_timeout(std::time::Duration::from_secs(10)).expect("test timed out");
-        let last_block = result.last_block.unwrap();
+        let last_block = result.last_block;
 
         assert_eq!(block_hash, last_block.hash);
-        assert_eq!(result.last_state_trie_block, Some(last_block));
+        assert_eq!(result.last_state_trie_block, last_block);
     }
 
     #[test]
@@ -557,7 +568,7 @@ mod tests {
 
         handle.save_blocks(full_save_input(blocks), tx).unwrap();
         let result = rx.recv().unwrap();
-        assert_eq!(last_hash, result.last_block.unwrap().hash);
+        assert_eq!(last_hash, result.last_block.hash);
     }
 
     #[test]
@@ -575,7 +586,7 @@ mod tests {
             handle.save_blocks(full_save_input(blocks), tx).unwrap();
 
             let result = rx.recv().unwrap();
-            assert_eq!(last_hash, result.last_block.unwrap().hash);
+            assert_eq!(last_hash, result.last_block.hash);
         }
     }
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -103,17 +103,20 @@ where
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
                     let _ = sender.send(result);
                 }
-                PersistenceAction::SaveBlocks(blocks, sender) => {
-                    let result = self.on_save_blocks(blocks)?;
+                PersistenceAction::SaveBlocks(input, sender) => {
+                    let db_tip_advanced = input.prev_db_tip() < input.new_db_tip();
+                    let result = self.on_save_blocks(input)?;
                     let result_number = result.last_block.number;
 
                     let _ = sender.send(result);
 
-                    // send new sync metrics based on saved blocks
-                    let _ = self
-                        .sync_metrics_tx
-                        .send(MetricEvent::SyncHeight { height: result_number });
-                    self.maybe_run_pruner(result_number)?;
+                    if db_tip_advanced {
+                        // send new sync metrics based on saved blocks
+                        let _ = self
+                            .sync_metrics_tx
+                            .send(MetricEvent::SyncHeight { height: result_number });
+                        self.maybe_run_pruner(result_number)?;
+                    }
                 }
                 PersistenceAction::SaveFinalizedBlock(finalized_block) => {
                     self.pending_finalized_block = Some(finalized_block);
@@ -161,7 +164,8 @@ where
         &mut self,
         input: SaveBlocksInput<N::Primitives>,
     ) -> Result<PersistenceResult, PersistenceError> {
-        let first_block = input.first_persist_rest_block().recovered_block().num_hash();
+        let first_block =
+            input.first_persist_rest_block().map(|block| block.recovered_block().num_hash());
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -149,7 +149,8 @@ where
         &mut self,
         input: SaveBlocksInput<N::Primitives>,
     ) -> Result<PersistenceResult, PersistenceError> {
-        let first_block = input.first_persist_rest_block().recovered_block().num_hash();
+        let first_block =
+            input.first_persist_rest_block().map(|block| block.recovered_block().num_hash());
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -103,20 +103,17 @@ where
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
                     let _ = sender.send(result);
                 }
-                PersistenceAction::SaveBlocks(input, sender) => {
-                    let db_tip_advanced = input.prev_db_tip() < input.new_db_tip();
-                    let result = self.on_save_blocks(input)?;
+                PersistenceAction::SaveBlocks(blocks, sender) => {
+                    let result = self.on_save_blocks(blocks)?;
                     let result_number = result.last_block.number;
 
                     let _ = sender.send(result);
 
-                    if db_tip_advanced {
-                        // send new sync metrics based on saved blocks
-                        let _ = self
-                            .sync_metrics_tx
-                            .send(MetricEvent::SyncHeight { height: result_number });
-                        self.maybe_run_pruner(result_number)?;
-                    }
+                    // send new sync metrics based on saved blocks
+                    let _ = self
+                        .sync_metrics_tx
+                        .send(MetricEvent::SyncHeight { height: result_number });
+                    self.maybe_run_pruner(result_number)?;
                 }
                 PersistenceAction::SaveFinalizedBlock(finalized_block) => {
                     self.pending_finalized_block = Some(finalized_block);
@@ -159,28 +156,19 @@ where
         Ok(PersistenceResult { last_block, last_state_trie_block, commit_duration: None })
     }
 
-    #[instrument(
-        level = "debug",
-        target = "engine::persistence",
-        skip_all,
-        fields(
-            block_count = input.persist_rest_blocks().len(),
-            state_trie_block_count = input.state_trie_blocks().len()
-        )
-    )]
+    #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(block_count = input.persist_rest_blocks().len()))]
     fn on_save_blocks(
         &mut self,
         input: SaveBlocksInput<N::Primitives>,
     ) -> Result<PersistenceResult, PersistenceError> {
-        let first_block =
-            input.first_persist_rest_block().map(|block| block.recovered_block().num_hash());
+        let first_block = input.first_persist_rest_block().recovered_block().num_hash();
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
 
         let pending_finalized = self.pending_finalized_block.take();
         let pending_safe = self.pending_safe_block.take();
 
-        debug!(target: "engine::persistence", ?block_count, first=?first_block, last=?last_block, "Saving persistence ranges");
+        debug!(target: "engine::persistence", ?block_count, first=?first_block, last=?last_block, "Saving range of blocks");
 
         let start_time = Instant::now();
 
@@ -214,12 +202,10 @@ where
         }
 
         provider_rw.commit()?;
-        if block_count > 0 {
-            let _ = self.provider.bal_store().flush().inspect_err(|err| {
-                warn!(target: "engine::persistence", last=?last_block, ?err, "Failed to flush BAL store");
-            });
-        }
-        debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved persistence ranges");
+        let _ = self.provider.bal_store().flush().inspect_err(|err| {
+            warn!(target: "engine::persistence", last=?last_block, ?err, "Failed to flush BAL store");
+        });
+        debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved range of blocks");
 
         let elapsed = start_time.elapsed();
         self.metrics.save_blocks_batch_size.record(block_count as f64);

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -555,10 +555,9 @@ mod tests {
         handle.save_blocks(blocks, tx).unwrap();
 
         let result = rx.recv_timeout(std::time::Duration::from_secs(10)).expect("test timed out");
-        let last_block = result.last_block;
 
-        assert_eq!(block_hash, last_block.hash);
-        assert_eq!(result.last_state_trie_block, last_block);
+        assert_eq!(block_hash, result.last_block.hash);
+        assert_eq!(result.last_state_trie_block, result.last_block);
     }
 
     #[test]
@@ -735,7 +734,6 @@ mod tests {
         let reorg_handle = std::thread::spawn(move || {
             let provider_rw = pf.database_provider_rw().unwrap();
             let frontiers = provider_rw.remove_block_and_execution_above(1).unwrap();
-            assert_eq!(frontiers.db_tip, 1);
             assert_eq!(frontiers.partial_state_trie, 1);
             provider_rw.commit().unwrap();
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -103,17 +103,20 @@ where
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
                     let _ = sender.send(result);
                 }
-                PersistenceAction::SaveBlocks(blocks, sender) => {
-                    let result = self.on_save_blocks(blocks)?;
+                PersistenceAction::SaveBlocks(input, sender) => {
+                    let db_tip_advanced = input.prev_db_tip() < input.new_db_tip();
+                    let result = self.on_save_blocks(input)?;
                     let result_number = result.last_block.number;
 
                     let _ = sender.send(result);
 
-                    // send new sync metrics based on saved blocks
-                    let _ = self
-                        .sync_metrics_tx
-                        .send(MetricEvent::SyncHeight { height: result_number });
-                    self.maybe_run_pruner(result_number)?;
+                    if db_tip_advanced {
+                        // send new sync metrics based on saved blocks
+                        let _ = self
+                            .sync_metrics_tx
+                            .send(MetricEvent::SyncHeight { height: result_number });
+                        self.maybe_run_pruner(result_number)?;
+                    }
                 }
                 PersistenceAction::SaveFinalizedBlock(finalized_block) => {
                     self.pending_finalized_block = Some(finalized_block);
@@ -156,19 +159,28 @@ where
         Ok(PersistenceResult { last_block, last_state_trie_block, commit_duration: None })
     }
 
-    #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(block_count = input.persist_rest_blocks().len()))]
+    #[instrument(
+        level = "debug",
+        target = "engine::persistence",
+        skip_all,
+        fields(
+            block_count = input.persist_rest_blocks().len(),
+            state_trie_block_count = input.state_trie_blocks().len()
+        )
+    )]
     fn on_save_blocks(
         &mut self,
         input: SaveBlocksInput<N::Primitives>,
     ) -> Result<PersistenceResult, PersistenceError> {
-        let first_block = input.first_persist_rest_block().recovered_block().num_hash();
+        let first_block =
+            input.first_persist_rest_block().map(|block| block.recovered_block().num_hash());
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
 
         let pending_finalized = self.pending_finalized_block.take();
         let pending_safe = self.pending_safe_block.take();
 
-        debug!(target: "engine::persistence", ?block_count, first=?first_block, last=?last_block, "Saving range of blocks");
+        debug!(target: "engine::persistence", ?block_count, first=?first_block, last=?last_block, "Saving persistence ranges");
 
         let start_time = Instant::now();
 
@@ -202,10 +214,12 @@ where
         }
 
         provider_rw.commit()?;
-        let _ = self.provider.bal_store().flush().inspect_err(|err| {
-            warn!(target: "engine::persistence", last=?last_block, ?err, "Failed to flush BAL store");
-        });
-        debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved range of blocks");
+        if block_count > 0 {
+            let _ = self.provider.bal_store().flush().inspect_err(|err| {
+                warn!(target: "engine::persistence", last=?last_block, ?err, "Failed to flush BAL store");
+            });
+        }
+        debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved persistence ranges");
 
         let elapsed = start_time.elapsed();
         self.metrics.save_blocks_batch_size.record(block_count as f64);

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -101,13 +101,16 @@ where
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
                     let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
                 }
-                PersistenceAction::SaveBlocks(blocks, sender) => {
-                    let result = self.on_save_blocks(blocks)?;
+                PersistenceAction::SaveBlocks(input, sender) => {
+                    let db_tip_advanced = input.prev_db_tip() < input.new_db_tip();
+                    let result = self.on_save_blocks(input)?;
                     let result_number = result.last_block.map(|b| b.number);
 
                     let _ = sender.send(result);
 
-                    if let Some(block_number) = result_number {
+                    if db_tip_advanced &&
+                        let Some(block_number) = result_number
+                    {
                         // send new sync metrics based on saved blocks
                         let _ = self
                             .sync_metrics_tx

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1566,7 +1566,7 @@ where
         );
         self.state.tree_state.overlay_manager.evict_cached_changesets(eviction_threshold);
 
-        self.on_new_persisted_block(last_state_trie_persisted_block)?;
+        self.on_new_persisted_block()?;
 
         self.purge_timing_stats(last_persisted_block_number, commit_duration);
 
@@ -2218,10 +2218,9 @@ where
     /// height.
     ///
     /// Assumes that `finish` has been called on the `persistence_state` at least once
-    fn on_new_persisted_block(
-        &mut self,
-        in_memory_persisted_block: BlockNumHash,
-    ) -> ProviderResult<()> {
+    fn on_new_persisted_block(&mut self) -> ProviderResult<()> {
+        let in_memory_persisted_block = self.persistence_state.last_state_trie_persisted_block;
+
         // If we have an on-disk reorg, we need to handle it first before touching the in-memory
         // state.
         if let Some(remove_above) = self.find_disk_reorg()? {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1434,8 +1434,7 @@ where
         if !self.persistence_state.in_progress() {
             if let Some(new_tip_num) = self.find_disk_reorg()? {
                 self.remove_blocks(new_tip_num)
-            } else if self.should_persist() {
-                let input = self.get_save_blocks_input(PersistTarget::Threshold)?;
+            } else if let Some(input) = self.get_save_blocks_input(PersistTarget::Threshold) {
                 self.persist_blocks(input);
             }
         }
@@ -1473,16 +1472,11 @@ where
                 continue
             }
 
-            let canonical_head_number = self.state.tree_state.canonical_block_number();
-            if self.persistence_state.last_persisted_block.number == canonical_head_number &&
-                self.persistence_state.last_state_trie_persisted_block.number ==
-                    canonical_head_number
-            {
+            let Some(input) = self.get_save_blocks_input(PersistTarget::Head) else {
                 debug!(target: "engine::tree", "persistence complete, signaling termination");
                 return Ok(())
-            }
+            };
 
-            let input = self.get_save_blocks_input(PersistTarget::Head)?;
             debug!(target: "engine::tree", count = input.persist_rest_blocks().len(), "persisting remaining blocks before shutdown");
             self.persist_blocks(input);
         }
@@ -2101,58 +2095,61 @@ where
         );
     }
 
-    /// Returns true if the canonical chain length minus the last persisted
-    /// block is greater than the persistence threshold,
-    /// backfill is not running, and no payload is currently being built.
-    pub const fn should_persist(&self) -> bool {
-        if self.building_payload {
-            return false
-        }
-
-        if !self.backfill_sync_state.is_idle() {
-            // can't persist if backfill is running
-            return false
-        }
-
-        let prev_db_tip = self.persistence_state.last_persisted_block.number;
-        let canonical_head_number = self.state.tree_state.canonical_block_number();
-        canonical_head_number.saturating_sub(prev_db_tip) > self.config.persistence_threshold() &&
-            canonical_head_number.saturating_sub(self.config.memory_block_buffer_target()) >
-                prev_db_tip
-    }
-
-    /// Returns the blocks and frontiers for the next persistence cycle.
-    fn get_save_blocks_input(
-        &self,
-        target: PersistTarget,
-    ) -> Result<SaveBlocksInput<N>, AdvancePersistenceError> {
+    /// Returns the blocks and frontiers for the next persistence cycle, if one should start.
+    ///
+    /// Threshold persistence honors the normal scheduling gates and retains the configured
+    /// in-memory block buffer. Head persistence bypasses those gates during shutdown and returns
+    /// `None` once both persistence frontiers have reached the canonical head.
+    fn get_save_blocks_input(&self, target: PersistTarget) -> Option<SaveBlocksInput<N>> {
         // We will calculate the state root using the database, so we need to be sure there are no
         // changes
         debug_assert!(!self.persistence_state.in_progress());
 
-        let mut blocks = Vec::new();
-        let mut current_hash = self.state.tree_state.canonical_block_hash();
         let prev_partial_state_trie = self.persistence_state.last_state_trie_persisted_block.number;
         let prev_db_tip = self.persistence_state.last_persisted_block.number;
         let canonical_head_number = self.state.tree_state.canonical_block_number();
 
-        let new_db_tip = match target {
-            PersistTarget::Head => canonical_head_number,
-            PersistTarget::Threshold => canonical_head_number
-                .saturating_sub(self.config.memory_block_buffer_target())
-                .max(prev_db_tip),
+        let (new_db_tip, new_partial_state_trie) = match target {
+            PersistTarget::Head => (canonical_head_number, canonical_head_number),
+            PersistTarget::Threshold => {
+                if self.building_payload || !self.backfill_sync_state.is_idle() {
+                    return None
+                }
+
+                if canonical_head_number.saturating_sub(prev_db_tip) <=
+                    self.config.persistence_threshold()
+                {
+                    return None
+                }
+
+                let new_db_tip =
+                    canonical_head_number.saturating_sub(self.config.memory_block_buffer_target());
+                if new_db_tip <= prev_db_tip {
+                    return None
+                }
+
+                let new_partial_state_trie = new_db_tip
+                    .saturating_sub(self.config.num_state_masking_blocks())
+                    .max(prev_partial_state_trie);
+                (new_db_tip, new_partial_state_trie)
+            }
         };
 
-        let new_partial_state_trie = match target {
-            PersistTarget::Head => new_db_tip,
-            PersistTarget::Threshold => new_db_tip
-                .saturating_sub(self.config.num_state_masking_blocks())
-                .max(prev_partial_state_trie),
-        };
         debug_assert!(
-            new_db_tip > prev_db_tip || new_partial_state_trie > prev_partial_state_trie,
-            "at least one persistence frontier must advance when saving"
+            new_db_tip >= prev_db_tip,
+            "disk reorg must be resolved before saving blocks"
         );
+        debug_assert!(
+            new_partial_state_trie >= prev_partial_state_trie,
+            "disk reorg must be resolved before saving state/trie"
+        );
+
+        if new_db_tip == prev_db_tip && new_partial_state_trie == prev_partial_state_trie {
+            return None
+        }
+
+        let mut blocks = Vec::new();
+        let mut current_hash = self.state.tree_state.canonical_block_hash();
 
         debug!(
             target: "engine::tree",
@@ -2180,7 +2177,7 @@ where
         // Reverse the order so that the oldest block comes first
         blocks.reverse();
 
-        Ok(SaveBlocksInput::new(
+        Some(SaveBlocksInput::new(
             blocks,
             prev_db_tip,
             prev_partial_state_trie,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -475,6 +475,7 @@ where
 
         let persistence_state = PersistenceState {
             last_persisted_block: BlockNumHash::new(best_block_number, header.hash()),
+            last_state_trie_persisted_block: BlockNumHash::new(best_block_number, header.hash()),
             rx: None,
         };
 
@@ -1415,28 +1416,9 @@ where
 
     /// Helper method to save blocks and set the persistence state. This ensures we keep track of
     /// the current persistence action while we're saving blocks.
-    fn persist_blocks(&mut self, blocks_to_persist: Vec<ExecutedBlock<N>>) {
-        if blocks_to_persist.is_empty() {
-            debug!(target: "engine::tree", "Returned empty set of blocks to persist");
-            return
-        }
-
-        // NOTE: checked non-empty above
-        let highest_num_hash = blocks_to_persist
-            .iter()
-            .max_by_key(|block| block.recovered_block().number())
-            .map(|b| b.recovered_block().num_hash())
-            .expect("Checked non-empty persisting blocks");
-        debug!(target: "engine::tree", count=blocks_to_persist.len(), blocks = ?blocks_to_persist.iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(), "Persisting blocks");
-
-        let previous_tip = self.persistence_state.last_persisted_block.number;
-        let input = SaveBlocksInput::new(
-            blocks_to_persist,
-            previous_tip,
-            previous_tip,
-            highest_num_hash.number,
-            highest_num_hash.number,
-        );
+    fn persist_blocks(&mut self, input: SaveBlocksInput<N>) {
+        let highest_num_hash = input.last_block();
+        debug!(target: "engine::tree", count=input.persist_rest_blocks().len(), blocks = ?input.persist_rest_blocks().iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(), "Persisting blocks");
 
         let (tx, rx) = crossbeam_channel::bounded(1);
         let _ = self.persistence.save_blocks(input, tx);
@@ -1453,9 +1435,8 @@ where
             if let Some(new_tip_num) = self.find_disk_reorg()? {
                 self.remove_blocks(new_tip_num)
             } else if self.should_persist() {
-                let blocks_to_persist =
-                    self.get_canonical_blocks_to_persist(PersistTarget::Threshold)?;
-                self.persist_blocks(blocks_to_persist);
+                let input = self.get_save_blocks_input(PersistTarget::Threshold)?;
+                self.persist_blocks(input);
             }
         }
 
@@ -1484,17 +1465,33 @@ where
                 debug!(target: "engine::tree", ?action, "waiting for in-flight persistence");
                 let result = rx.recv().map_err(|_| AdvancePersistenceError::ChannelClosed)?;
                 self.on_persistence_complete(result, start_time)?;
+                continue
             }
 
-            let blocks_to_persist = self.get_canonical_blocks_to_persist(PersistTarget::Head)?;
-
-            if blocks_to_persist.is_empty() {
-                debug!(target: "engine::tree", "persistence complete, signaling termination");
-                return Ok(())
+            if let Some(new_tip_num) = self.find_disk_reorg()? {
+                self.remove_blocks(new_tip_num);
+                continue
             }
 
-            debug!(target: "engine::tree", count = blocks_to_persist.len(), "persisting remaining blocks before shutdown");
-            self.persist_blocks(blocks_to_persist);
+            let canonical_head_number = self.state.tree_state.canonical_block_number();
+            if self.persistence_state.last_persisted_block.number == canonical_head_number {
+                let state_trie_tip = self.persistence_state.last_state_trie_persisted_block.number;
+                if state_trie_tip == canonical_head_number {
+                    debug!(target: "engine::tree", "persistence complete, signaling termination");
+                    return Ok(())
+                }
+
+                assert!(
+                    state_trie_tip < canonical_head_number,
+                    "state/trie persistence cannot be ahead of the database tip"
+                );
+                self.remove_blocks(state_trie_tip);
+                continue
+            }
+
+            let input = self.get_save_blocks_input(PersistTarget::Head)?;
+            debug!(target: "engine::tree", count = input.persist_rest_blocks().len(), "persisting remaining blocks before shutdown");
+            self.persist_blocks(input);
         }
     }
 
@@ -1541,8 +1538,13 @@ where
             return Ok(())
         };
 
-        debug!(target: "engine::tree", ?last_persisted_block_hash, ?last_persisted_block_number, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
-        self.persistence_state.finish(last_persisted_block_hash, last_persisted_block_number);
+        let last_persisted_block =
+            BlockNumHash::new(last_persisted_block_number, last_persisted_block_hash);
+        let last_state_trie_persisted_block = self
+            .last_state_trie_persisted_block(last_persisted_block, result.last_state_trie_block)?;
+
+        debug!(target: "engine::tree", ?last_persisted_block, ?last_state_trie_persisted_block, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
+        self.persistence_state.finish(last_persisted_block, last_state_trie_persisted_block);
 
         // Evict cached changesets for blocks below the eviction threshold.
         // Keep at least CHANGESET_CACHE_RETENTION_BLOCKS from the persisted tip, and also respect
@@ -1566,11 +1568,39 @@ where
         );
         self.state.tree_state.overlay_manager.evict_cached_changesets(eviction_threshold);
 
-        self.on_new_persisted_block()?;
+        self.on_new_persisted_block(last_state_trie_persisted_block)?;
 
         self.purge_timing_stats(last_persisted_block_number, commit_duration);
 
         Ok(())
+    }
+
+    /// Returns the highest block that can be dropped from memory after persistence completes.
+    fn last_state_trie_persisted_block(
+        &self,
+        last_block: BlockNumHash,
+        last_state_trie_block: Option<u64>,
+    ) -> ProviderResult<BlockNumHash> {
+        let Some(last_state_trie_block) = last_state_trie_block else { return Ok(last_block) };
+        debug_assert!(
+            last_state_trie_block <= last_block.number,
+            "state/trie frontier cannot exceed the last persisted block"
+        );
+        if last_state_trie_block >= last_block.number {
+            return Ok(last_block)
+        }
+
+        let hash = self
+            .canonical_in_memory_state
+            .hash_by_number(last_state_trie_block)
+            .map(Ok)
+            .unwrap_or_else(|| {
+                self.provider
+                    .block_hash(last_state_trie_block)?
+                    .ok_or_else(|| ProviderError::HeaderNotFound(last_state_trie_block.into()))
+            })?;
+
+        Ok(BlockNumHash::new(last_state_trie_block, hash))
     }
 
     /// Handles a message from the engine.
@@ -1895,7 +1925,7 @@ where
             // update the tracked chain height, after backfill sync both the canonical height and
             // persisted height are the same
             self.state.tree_state.set_canonical_head(new_head.num_hash());
-            self.persistence_state.finish(new_head.hash(), new_head.number());
+            self.persistence_state.finish(new_head.num_hash(), new_head.num_hash());
 
             // update the tracked canonical head
             self.canonical_in_memory_state.set_canonical_head(new_head);
@@ -2126,57 +2156,89 @@ where
             return false
         }
 
-        let min_block = self.persistence_state.last_persisted_block.number;
-        self.state.tree_state.canonical_block_number().saturating_sub(min_block) >
-            self.config.persistence_threshold()
+        let prev_db_tip = self.persistence_state.last_persisted_block.number;
+        let canonical_head_number = self.state.tree_state.canonical_block_number();
+        canonical_head_number.saturating_sub(prev_db_tip) > self.config.persistence_threshold() &&
+            canonical_head_number.saturating_sub(self.effective_memory_block_buffer_target()) >
+                prev_db_tip
     }
 
-    /// Returns a batch of consecutive canonical blocks to persist in the range
-    /// `(last_persisted_number .. target]`. The expected order is oldest -> newest.
-    fn get_canonical_blocks_to_persist(
+    /// Returns the in-memory block buffer used for threshold persistence.
+    ///
+    /// A masking suffix requires at least one unpersisted block so a later shutdown can advance
+    /// the database and fully flush state/trie data in the same persistence operation.
+    const fn effective_memory_block_buffer_target(&self) -> u64 {
+        let configured_target = self.config.memory_block_buffer_target();
+        if self.config.num_state_masking_blocks() > 0 && configured_target == 0 {
+            1
+        } else {
+            configured_target
+        }
+    }
+
+    /// Returns the blocks and frontiers for the next persistence cycle.
+    fn get_save_blocks_input(
         &self,
         target: PersistTarget,
-    ) -> Result<Vec<ExecutedBlock<N>>, AdvancePersistenceError> {
+    ) -> Result<SaveBlocksInput<N>, AdvancePersistenceError> {
         // We will calculate the state root using the database, so we need to be sure there are no
         // changes
         debug_assert!(!self.persistence_state.in_progress());
 
-        let mut blocks_to_persist = Vec::new();
+        let mut blocks = Vec::new();
         let mut current_hash = self.state.tree_state.canonical_block_hash();
-        let last_persisted_number = self.persistence_state.last_persisted_block.number;
+        let prev_partial_state_trie = self.persistence_state.last_state_trie_persisted_block.number;
+        let prev_db_tip = self.persistence_state.last_persisted_block.number;
         let canonical_head_number = self.state.tree_state.canonical_block_number();
 
-        let target_number = match target {
+        let new_db_tip = match target {
             PersistTarget::Head => canonical_head_number,
-            PersistTarget::Threshold => {
-                canonical_head_number.saturating_sub(self.config.memory_block_buffer_target())
-            }
+            PersistTarget::Threshold => canonical_head_number
+                .saturating_sub(self.effective_memory_block_buffer_target())
+                .max(prev_db_tip),
+        };
+        debug_assert!(new_db_tip > prev_db_tip, "database tip must advance when saving");
+
+        let new_partial_state_trie = match target {
+            PersistTarget::Head => new_db_tip,
+            PersistTarget::Threshold => new_db_tip
+                .saturating_sub(self.config.num_state_masking_blocks())
+                .max(prev_partial_state_trie),
         };
 
         debug!(
             target: "engine::tree",
             ?current_hash,
-            ?last_persisted_number,
+            ?prev_partial_state_trie,
+            ?prev_db_tip,
             ?canonical_head_number,
-            ?target_number,
-            "Returning canonical blocks to persist"
+            ?new_partial_state_trie,
+            ?new_db_tip,
+            target = ?target,
+            "Returning save input"
         );
         while let Some(block) = self.state.tree_state.blocks_by_hash.get(&current_hash) {
-            if block.recovered_block().number() <= last_persisted_number {
+            if block.recovered_block().number() <= prev_partial_state_trie {
                 break;
             }
 
-            if block.recovered_block().number() <= target_number {
-                blocks_to_persist.push(block.clone());
+            if block.recovered_block().number() <= new_db_tip {
+                blocks.push(block.clone());
             }
 
             current_hash = block.recovered_block().parent_hash();
         }
 
         // Reverse the order so that the oldest block comes first
-        blocks_to_persist.reverse();
+        blocks.reverse();
 
-        Ok(blocks_to_persist)
+        Ok(SaveBlocksInput::new(
+            blocks,
+            prev_db_tip,
+            prev_partial_state_trie,
+            new_db_tip,
+            new_partial_state_trie,
+        ))
     }
 
     /// This clears the blocks from the in-memory tree state that have been persisted to the
@@ -2186,7 +2248,10 @@ where
     /// height.
     ///
     /// Assumes that `finish` has been called on the `persistence_state` at least once
-    fn on_new_persisted_block(&mut self) -> ProviderResult<()> {
+    fn on_new_persisted_block(
+        &mut self,
+        in_memory_persisted_block: BlockNumHash,
+    ) -> ProviderResult<()> {
         // If we have an on-disk reorg, we need to handle it first before touching the in-memory
         // state.
         if let Some(remove_above) = self.find_disk_reorg()? {
@@ -2195,11 +2260,11 @@ where
         }
 
         let finalized = self.state.forkchoice_state_tracker.last_valid_finalized();
-        self.remove_before(self.persistence_state.last_persisted_block, finalized)?;
-        self.canonical_in_memory_state.remove_persisted_blocks(BlockNumHash {
-            number: self.persistence_state.last_persisted_block.number,
-            hash: self.persistence_state.last_persisted_block.hash,
-        });
+        self.remove_before(in_memory_persisted_block, finalized)?;
+        self.canonical_in_memory_state.remove_persisted_blocks_until(
+            self.persistence_state.last_persisted_block,
+            in_memory_persisted_block.number,
+        );
         self.state.set_pending_sparse_trie_prune(self.should_prune_sparse_trie());
         Ok(())
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1467,6 +1467,9 @@ where
                 continue
             }
 
+            // Persistence can finish against a branch that the in-memory canonical chain has
+            // reorged away from. Unwind that stale disk branch before building a head-targeted
+            // save.
             if let Some(new_tip_num) = self.find_disk_reorg()? {
                 self.remove_blocks(new_tip_num);
                 continue

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1528,14 +1528,9 @@ where
         self.metrics.engine.persistence_duration.record(start_time.elapsed());
 
         let commit_duration = result.commit_duration;
-        let Some(last_persisted_block) = result.last_block else {
-            // if this happened, then we persisted no blocks because we sent an empty vec of blocks
-            warn!(target: "engine::tree", "Persistence task completed but did not persist any blocks");
-            return Ok(())
-        };
+        let last_persisted_block = result.last_block;
         let last_persisted_block_number = last_persisted_block.number;
-        let last_state_trie_persisted_block =
-            result.last_state_trie_block.unwrap_or(last_persisted_block);
+        let last_state_trie_persisted_block = result.last_state_trie_block;
         debug_assert!(
             last_state_trie_persisted_block.number <= last_persisted_block.number,
             "state/trie frontier cannot exceed the last persisted block"

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1540,8 +1540,12 @@ where
 
         let last_persisted_block =
             BlockNumHash::new(last_persisted_block_number, last_persisted_block_hash);
-        let last_state_trie_persisted_block = self
-            .last_state_trie_persisted_block(last_persisted_block, result.last_state_trie_block)?;
+        let last_state_trie_persisted_block =
+            result.last_state_trie_block.unwrap_or(last_persisted_block);
+        debug_assert!(
+            last_state_trie_persisted_block.number <= last_persisted_block.number,
+            "state/trie frontier cannot exceed the last persisted block"
+        );
 
         debug!(target: "engine::tree", ?last_persisted_block, ?last_state_trie_persisted_block, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
         self.persistence_state.finish(last_persisted_block, last_state_trie_persisted_block);
@@ -1573,34 +1577,6 @@ where
         self.purge_timing_stats(last_persisted_block_number, commit_duration);
 
         Ok(())
-    }
-
-    /// Returns the highest block that can be dropped from memory after persistence completes.
-    fn last_state_trie_persisted_block(
-        &self,
-        last_block: BlockNumHash,
-        last_state_trie_block: Option<u64>,
-    ) -> ProviderResult<BlockNumHash> {
-        let Some(last_state_trie_block) = last_state_trie_block else { return Ok(last_block) };
-        debug_assert!(
-            last_state_trie_block <= last_block.number,
-            "state/trie frontier cannot exceed the last persisted block"
-        );
-        if last_state_trie_block >= last_block.number {
-            return Ok(last_block)
-        }
-
-        let hash = self
-            .canonical_in_memory_state
-            .hash_by_number(last_state_trie_block)
-            .map(Ok)
-            .unwrap_or_else(|| {
-                self.provider
-                    .block_hash(last_state_trie_block)?
-                    .ok_or_else(|| ProviderError::HeaderNotFound(last_state_trie_block.into()))
-            })?;
-
-        Ok(BlockNumHash::new(last_state_trie_block, hash))
     }
 
     /// Handles a message from the engine.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1474,19 +1474,12 @@ where
             }
 
             let canonical_head_number = self.state.tree_state.canonical_block_number();
-            if self.persistence_state.last_persisted_block.number == canonical_head_number {
-                let state_trie_tip = self.persistence_state.last_state_trie_persisted_block.number;
-                if state_trie_tip == canonical_head_number {
-                    debug!(target: "engine::tree", "persistence complete, signaling termination");
-                    return Ok(())
-                }
-
-                assert!(
-                    state_trie_tip < canonical_head_number,
-                    "state/trie persistence cannot be ahead of the database tip"
-                );
-                self.remove_blocks(state_trie_tip);
-                continue
+            if self.persistence_state.last_persisted_block.number == canonical_head_number &&
+                self.persistence_state.last_state_trie_persisted_block.number ==
+                    canonical_head_number
+            {
+                debug!(target: "engine::tree", "persistence complete, signaling termination");
+                return Ok(())
             }
 
             let input = self.get_save_blocks_input(PersistTarget::Head)?;
@@ -2124,21 +2117,8 @@ where
         let prev_db_tip = self.persistence_state.last_persisted_block.number;
         let canonical_head_number = self.state.tree_state.canonical_block_number();
         canonical_head_number.saturating_sub(prev_db_tip) > self.config.persistence_threshold() &&
-            canonical_head_number.saturating_sub(self.effective_memory_block_buffer_target()) >
+            canonical_head_number.saturating_sub(self.config.memory_block_buffer_target()) >
                 prev_db_tip
-    }
-
-    /// Returns the in-memory block buffer used for threshold persistence.
-    ///
-    /// A masking suffix requires at least one unpersisted block so a later shutdown can advance
-    /// the database and fully flush state/trie data in the same persistence operation.
-    const fn effective_memory_block_buffer_target(&self) -> u64 {
-        let configured_target = self.config.memory_block_buffer_target();
-        if self.config.num_state_masking_blocks() > 0 && configured_target == 0 {
-            1
-        } else {
-            configured_target
-        }
     }
 
     /// Returns the blocks and frontiers for the next persistence cycle.
@@ -2159,10 +2139,9 @@ where
         let new_db_tip = match target {
             PersistTarget::Head => canonical_head_number,
             PersistTarget::Threshold => canonical_head_number
-                .saturating_sub(self.effective_memory_block_buffer_target())
+                .saturating_sub(self.config.memory_block_buffer_target())
                 .max(prev_db_tip),
         };
-        debug_assert!(new_db_tip > prev_db_tip, "database tip must advance when saving");
 
         let new_partial_state_trie = match target {
             PersistTarget::Head => new_db_tip,
@@ -2170,6 +2149,10 @@ where
                 .saturating_sub(self.config.num_state_masking_blocks())
                 .max(prev_partial_state_trie),
         };
+        debug_assert!(
+            new_db_tip > prev_db_tip || new_partial_state_trie > prev_partial_state_trie,
+            "at least one persistence frontier must advance when saving"
+        );
 
         debug!(
             target: "engine::tree",

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1528,18 +1528,12 @@ where
         self.metrics.engine.persistence_duration.record(start_time.elapsed());
 
         let commit_duration = result.commit_duration;
-        let Some(BlockNumHash {
-            hash: last_persisted_block_hash,
-            number: last_persisted_block_number,
-        }) = result.last_block
-        else {
+        let Some(last_persisted_block) = result.last_block else {
             // if this happened, then we persisted no blocks because we sent an empty vec of blocks
             warn!(target: "engine::tree", "Persistence task completed but did not persist any blocks");
             return Ok(())
         };
-
-        let last_persisted_block =
-            BlockNumHash::new(last_persisted_block_number, last_persisted_block_hash);
+        let last_persisted_block_number = last_persisted_block.number;
         let last_state_trie_persisted_block =
             result.last_state_trie_block.unwrap_or(last_persisted_block);
         debug_assert!(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1474,12 +1474,19 @@ where
             }
 
             let canonical_head_number = self.state.tree_state.canonical_block_number();
-            if self.persistence_state.last_persisted_block.number == canonical_head_number &&
-                self.persistence_state.last_state_trie_persisted_block.number ==
-                    canonical_head_number
-            {
-                debug!(target: "engine::tree", "persistence complete, signaling termination");
-                return Ok(())
+            if self.persistence_state.last_persisted_block.number == canonical_head_number {
+                let state_trie_tip = self.persistence_state.last_state_trie_persisted_block.number;
+                if state_trie_tip == canonical_head_number {
+                    debug!(target: "engine::tree", "persistence complete, signaling termination");
+                    return Ok(())
+                }
+
+                assert!(
+                    state_trie_tip < canonical_head_number,
+                    "state/trie persistence cannot be ahead of the database tip"
+                );
+                self.remove_blocks(state_trie_tip);
+                continue
             }
 
             let input = self.get_save_blocks_input(PersistTarget::Head)?;
@@ -2117,8 +2124,21 @@ where
         let prev_db_tip = self.persistence_state.last_persisted_block.number;
         let canonical_head_number = self.state.tree_state.canonical_block_number();
         canonical_head_number.saturating_sub(prev_db_tip) > self.config.persistence_threshold() &&
-            canonical_head_number.saturating_sub(self.config.memory_block_buffer_target()) >
+            canonical_head_number.saturating_sub(self.effective_memory_block_buffer_target()) >
                 prev_db_tip
+    }
+
+    /// Returns the in-memory block buffer used for threshold persistence.
+    ///
+    /// A masking suffix requires at least one unpersisted block so a later shutdown can advance
+    /// the database and fully flush state/trie data in the same persistence operation.
+    const fn effective_memory_block_buffer_target(&self) -> u64 {
+        let configured_target = self.config.memory_block_buffer_target();
+        if self.config.num_state_masking_blocks() > 0 && configured_target == 0 {
+            1
+        } else {
+            configured_target
+        }
     }
 
     /// Returns the blocks and frontiers for the next persistence cycle.
@@ -2139,9 +2159,10 @@ where
         let new_db_tip = match target {
             PersistTarget::Head => canonical_head_number,
             PersistTarget::Threshold => canonical_head_number
-                .saturating_sub(self.config.memory_block_buffer_target())
+                .saturating_sub(self.effective_memory_block_buffer_target())
                 .max(prev_db_tip),
         };
+        debug_assert!(new_db_tip > prev_db_tip, "database tip must advance when saving");
 
         let new_partial_state_trie = match target {
             PersistTarget::Head => new_db_tip,
@@ -2149,10 +2170,6 @@ where
                 .saturating_sub(self.config.num_state_masking_blocks())
                 .max(prev_partial_state_trie),
         };
-        debug_assert!(
-            new_db_tip > prev_db_tip || new_partial_state_trie > prev_partial_state_trie,
-            "at least one persistence frontier must advance when saving"
-        );
 
         debug!(
             target: "engine::tree",

--- a/crates/engine/tree/src/tree/persistence_state.rs
+++ b/crates/engine/tree/src/tree/persistence_state.rs
@@ -22,7 +22,6 @@
 
 use crate::persistence::PersistenceResult;
 use alloy_eips::BlockNumHash;
-use alloy_primitives::B256;
 use crossbeam_channel::Receiver as CrossbeamReceiver;
 use reth_primitives_traits::FastInstant as Instant;
 use tracing::trace;
@@ -30,10 +29,13 @@ use tracing::trace;
 /// The state of the persistence task.
 #[derive(Debug)]
 pub struct PersistenceState {
-    /// Hash and number of the last block persisted.
+    /// Hash and number of the highest block whose non-state/trie outputs are persisted.
     ///
-    /// This tracks the chain height that is persisted on disk
+    /// This tracks the highest canonical block with durable block/static-file/plain-state data.
     pub(crate) last_persisted_block: BlockNumHash,
+    /// Hash and number of the highest block whose state/trie outputs were processed for
+    /// persistence.
+    pub(crate) last_state_trie_persisted_block: BlockNumHash,
     /// Receiver end of channel where the result of the persistence task will be
     /// sent when done. A None value means there's no persistence task in progress.
     pub(crate) rx:
@@ -76,13 +78,18 @@ impl PersistenceState {
     /// Sets state for a finished persistence task.
     pub(crate) fn finish(
         &mut self,
-        last_persisted_block_hash: B256,
-        last_persisted_block_number: u64,
+        last_persisted_block: BlockNumHash,
+        last_state_trie_persisted_block: BlockNumHash,
     ) {
-        trace!(target: "engine::tree", block= %last_persisted_block_number, hash=%last_persisted_block_hash, "updating persistence state");
+        trace!(
+            target: "engine::tree",
+            last_persisted_block = %last_persisted_block.number,
+            last_state_trie_persisted_block = %last_state_trie_persisted_block.number,
+            "updating persistence state"
+        );
         self.rx = None;
-        self.last_persisted_block =
-            BlockNumHash::new(last_persisted_block_number, last_persisted_block_hash);
+        self.last_persisted_block = last_persisted_block;
+        self.last_state_trie_persisted_block = last_state_trie_persisted_block;
     }
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -604,7 +604,7 @@ fn on_new_persisted_block_queues_sparse_trie_prune_request() {
     let persisted = blocks[0].recovered_block().num_hash();
     test_harness.tree.persistence_state.finish(persisted, persisted);
 
-    test_harness.tree.on_new_persisted_block(persisted).unwrap();
+    test_harness.tree.on_new_persisted_block().unwrap();
 
     assert!(test_harness.tree.state.pending_sparse_trie_prune());
 }
@@ -616,7 +616,7 @@ fn on_new_persisted_block_queues_sparse_trie_prune_with_in_memory_blocks() {
     let persisted = blocks[0].recovered_block().num_hash();
     test_harness.tree.persistence_state.finish(persisted, persisted);
 
-    test_harness.tree.on_new_persisted_block(persisted).unwrap();
+    test_harness.tree.on_new_persisted_block().unwrap();
 
     assert!(test_harness.tree.state.pending_sparse_trie_prune());
 }
@@ -636,7 +636,7 @@ fn on_new_persisted_block_skips_sparse_trie_prune_when_state_root_task_disabled(
         let persisted = blocks[0].recovered_block().num_hash();
         test_harness.tree.persistence_state.finish(persisted, persisted);
 
-        test_harness.tree.on_new_persisted_block(persisted).unwrap();
+        test_harness.tree.on_new_persisted_block().unwrap();
 
         assert!(!test_harness.tree.state.pending_sparse_trie_prune());
     }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1252,6 +1252,19 @@ fn test_get_save_blocks_input_with_state_masking_blocks() {
             .collect::<Vec<_>>(),
         vec![4, 5]
     );
+
+    test_harness.tree.config = test_harness.tree.config.clone().with_memory_block_buffer_target(0);
+    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
+    assert_eq!(input.new_db_tip(), 6);
+    assert_eq!(input.new_partial_state_trie(), 4);
+    assert_eq!(
+        input
+            .persist_rest_blocks()
+            .iter()
+            .map(|block| block.recovered_block().number())
+            .collect::<Vec<_>>(),
+        vec![4, 5, 6]
+    );
 }
 
 #[test]
@@ -2406,6 +2419,48 @@ mod forkchoice_updated_tests {
 
         // Ensure we persisted right to the tip
         assert_eq!(last_persisted_number, canonical_tip);
+    }
+
+    #[test]
+    fn test_engine_termination_catches_up_state_trie_at_database_tip() {
+        let chain_spec = MAINNET.clone();
+        let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+        let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..11).collect();
+        let database_tip = blocks.last().unwrap().recovered_block().num_hash();
+        let state_trie_tip = blocks[4].recovered_block().num_hash();
+        let mut test_harness = TestHarness::new(chain_spec).with_blocks(blocks);
+        test_harness.tree.persistence_state.last_persisted_block = database_tip;
+        test_harness.tree.persistence_state.last_state_trie_persisted_block = state_trie_tip;
+
+        let (terminate_tx, terminate_rx) = oneshot::channel();
+        let to_tree_tx = test_harness.to_tree_tx.clone();
+        let action_rx = test_harness.action_rx;
+        spawn_os_thread("engine", || test_harness.tree.run());
+
+        to_tree_tx
+            .send(FromEngine::Event(FromOrchestrator::Terminate { tx: terminate_tx }))
+            .unwrap();
+
+        let action = action_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+        let PersistenceAction::SaveBlocks(input, sender) = action else {
+            panic!("expected state/trie catch-up save, got {action:?}")
+        };
+        assert_eq!(input.prev_db_tip(), database_tip.number);
+        assert_eq!(input.new_db_tip(), database_tip.number);
+        assert_eq!(input.prev_partial_state_trie(), state_trie_tip.number);
+        assert_eq!(input.new_partial_state_trie(), database_tip.number);
+        assert!(input.persist_rest_blocks().is_empty());
+        assert!(!input.state_trie_blocks().is_empty());
+
+        sender
+            .send(PersistenceResult {
+                last_block: database_tip,
+                last_state_trie_block: database_tip,
+                commit_duration: Some(Duration::ZERO),
+            })
+            .unwrap();
+
+        terminate_rx.blocking_recv().unwrap();
     }
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1252,6 +1252,47 @@ fn test_get_save_blocks_input_with_state_masking_blocks() {
             .collect::<Vec<_>>(),
         vec![4, 5]
     );
+
+    test_harness.tree.config = test_harness.tree.config.clone().with_memory_block_buffer_target(0);
+    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
+    assert_eq!(input.new_db_tip(), 6);
+    assert_eq!(input.new_partial_state_trie(), 4);
+    assert_eq!(
+        input
+            .persist_rest_blocks()
+            .iter()
+            .map(|block| block.recovered_block().number())
+            .collect::<Vec<_>>(),
+        vec![4, 5, 6]
+    );
+}
+
+#[test]
+fn test_get_save_blocks_input_catches_up_state_trie_at_database_tip() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..7).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+    test_harness.tree.persistence_state.last_state_trie_persisted_block =
+        blocks[3].recovered_block().num_hash();
+    test_harness.tree.persistence_state.last_persisted_block =
+        blocks[6].recovered_block().num_hash();
+
+    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Head).unwrap();
+
+    assert_eq!(input.prev_partial_state_trie(), 3);
+    assert_eq!(input.prev_db_tip(), 6);
+    assert_eq!(input.new_partial_state_trie(), 6);
+    assert_eq!(input.new_db_tip(), 6);
+    assert!(input.persist_rest_blocks().is_empty());
+    assert_eq!(
+        input
+            .state_trie_blocks()
+            .iter()
+            .map(|block| block.recovered_block().number())
+            .collect::<Vec<_>>(),
+        vec![4, 5, 6]
+    );
+    assert!(input.state_trie_masking_blocks().is_empty());
 }
 
 #[test]
@@ -2406,6 +2447,47 @@ mod forkchoice_updated_tests {
 
         // Ensure we persisted right to the tip
         assert_eq!(last_persisted_number, canonical_tip);
+    }
+
+    #[test]
+    fn test_engine_termination_catches_up_state_trie_at_database_tip() {
+        let chain_spec = MAINNET.clone();
+        let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+        let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..11).collect();
+        let database_tip = blocks.last().unwrap().recovered_block().num_hash();
+        let state_trie_tip = blocks[4].recovered_block().num_hash();
+        let mut test_harness = TestHarness::new(chain_spec).with_blocks(blocks);
+        test_harness.tree.persistence_state.last_persisted_block = database_tip;
+        test_harness.tree.persistence_state.last_state_trie_persisted_block = state_trie_tip;
+
+        let (terminate_tx, terminate_rx) = oneshot::channel();
+        let to_tree_tx = test_harness.to_tree_tx.clone();
+        let action_rx = test_harness.action_rx;
+        spawn_os_thread("engine", || test_harness.tree.run());
+
+        to_tree_tx
+            .send(FromEngine::Event(FromOrchestrator::Terminate { tx: terminate_tx }))
+            .unwrap();
+
+        let action = action_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+        let PersistenceAction::SaveBlocks(input, sender) = action else {
+            panic!("expected state/trie catch-up save, got {action:?}")
+        };
+        assert_eq!(input.prev_db_tip(), database_tip.number);
+        assert_eq!(input.new_db_tip(), database_tip.number);
+        assert_eq!(input.prev_partial_state_trie(), state_trie_tip.number);
+        assert_eq!(input.new_partial_state_trie(), database_tip.number);
+        assert!(input.persist_rest_blocks().is_empty());
+
+        sender
+            .send(PersistenceResult {
+                last_block: database_tip,
+                last_state_trie_block: database_tip,
+                commit_duration: Some(Duration::ZERO),
+            })
+            .unwrap();
+
+        terminate_rx.blocking_recv().unwrap();
     }
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1252,47 +1252,6 @@ fn test_get_save_blocks_input_with_state_masking_blocks() {
             .collect::<Vec<_>>(),
         vec![4, 5]
     );
-
-    test_harness.tree.config = test_harness.tree.config.clone().with_memory_block_buffer_target(0);
-    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
-    assert_eq!(input.new_db_tip(), 6);
-    assert_eq!(input.new_partial_state_trie(), 4);
-    assert_eq!(
-        input
-            .persist_rest_blocks()
-            .iter()
-            .map(|block| block.recovered_block().number())
-            .collect::<Vec<_>>(),
-        vec![4, 5, 6]
-    );
-}
-
-#[test]
-fn test_get_save_blocks_input_catches_up_state_trie_at_database_tip() {
-    let mut test_harness = TestHarness::new(MAINNET.clone());
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..7).collect();
-    test_harness = test_harness.with_blocks(blocks.clone());
-    test_harness.tree.persistence_state.last_state_trie_persisted_block =
-        blocks[3].recovered_block().num_hash();
-    test_harness.tree.persistence_state.last_persisted_block =
-        blocks[6].recovered_block().num_hash();
-
-    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Head).unwrap();
-
-    assert_eq!(input.prev_partial_state_trie(), 3);
-    assert_eq!(input.prev_db_tip(), 6);
-    assert_eq!(input.new_partial_state_trie(), 6);
-    assert_eq!(input.new_db_tip(), 6);
-    assert!(input.persist_rest_blocks().is_empty());
-    assert_eq!(
-        input
-            .state_trie_blocks()
-            .iter()
-            .map(|block| block.recovered_block().number())
-            .collect::<Vec<_>>(),
-        vec![4, 5, 6]
-    );
-    assert!(input.state_trie_masking_blocks().is_empty());
 }
 
 #[test]
@@ -2447,47 +2406,6 @@ mod forkchoice_updated_tests {
 
         // Ensure we persisted right to the tip
         assert_eq!(last_persisted_number, canonical_tip);
-    }
-
-    #[test]
-    fn test_engine_termination_catches_up_state_trie_at_database_tip() {
-        let chain_spec = MAINNET.clone();
-        let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
-        let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..11).collect();
-        let database_tip = blocks.last().unwrap().recovered_block().num_hash();
-        let state_trie_tip = blocks[4].recovered_block().num_hash();
-        let mut test_harness = TestHarness::new(chain_spec).with_blocks(blocks);
-        test_harness.tree.persistence_state.last_persisted_block = database_tip;
-        test_harness.tree.persistence_state.last_state_trie_persisted_block = state_trie_tip;
-
-        let (terminate_tx, terminate_rx) = oneshot::channel();
-        let to_tree_tx = test_harness.to_tree_tx.clone();
-        let action_rx = test_harness.action_rx;
-        spawn_os_thread("engine", || test_harness.tree.run());
-
-        to_tree_tx
-            .send(FromEngine::Event(FromOrchestrator::Terminate { tx: terminate_tx }))
-            .unwrap();
-
-        let action = action_rx.recv_timeout(Duration::from_secs(10)).unwrap();
-        let PersistenceAction::SaveBlocks(input, sender) = action else {
-            panic!("expected state/trie catch-up save, got {action:?}")
-        };
-        assert_eq!(input.prev_db_tip(), database_tip.number);
-        assert_eq!(input.new_db_tip(), database_tip.number);
-        assert_eq!(input.prev_partial_state_trie(), state_trie_tip.number);
-        assert_eq!(input.new_partial_state_trie(), database_tip.number);
-        assert!(input.persist_rest_blocks().is_empty());
-
-        sender
-            .send(PersistenceResult {
-                last_block: database_tip,
-                last_state_trie_block: database_tip,
-                commit_duration: Some(Duration::ZERO),
-            })
-            .unwrap();
-
-        terminate_rx.blocking_recv().unwrap();
     }
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1139,6 +1139,45 @@ fn test_tree_state_on_new_head_deep_fork() {
     }
 }
 
+#[test]
+fn test_get_save_blocks_input_respects_target_eligibility() {
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..6).collect();
+    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
+    let persisted = blocks[1].recovered_block().num_hash();
+    test_harness.tree.persistence_state.last_persisted_block = persisted;
+    test_harness.tree.persistence_state.last_state_trie_persisted_block = persisted;
+    test_harness.tree.config =
+        TreeConfig::default().with_persistence_threshold(1).with_memory_block_buffer_target(1);
+
+    assert!(
+        test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_some(),
+        "threshold persistence should be eligible"
+    );
+
+    test_harness.tree.building_payload = true;
+    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_none());
+    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_some());
+    test_harness.tree.building_payload = false;
+
+    test_harness.tree.backfill_sync_state = BackfillSyncState::Active;
+    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_none());
+    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_some());
+    test_harness.tree.backfill_sync_state = BackfillSyncState::Idle;
+
+    test_harness.tree.config = test_harness.tree.config.clone().with_persistence_threshold(4);
+    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_none());
+    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_some());
+
+    let canonical_head = blocks.last().unwrap().recovered_block().num_hash();
+    test_harness.tree.persistence_state.last_persisted_block = canonical_head;
+    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Head).unwrap();
+    assert!(input.persist_rest_blocks().is_empty());
+    assert_eq!(input.new_partial_state_trie(), canonical_head.number);
+
+    test_harness.tree.persistence_state.last_state_trie_persisted_block = canonical_head;
+    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_none());
+}
+
 #[tokio::test]
 async fn test_get_save_blocks_input() {
     let chain_spec = MAINNET.clone();
@@ -1211,7 +1250,7 @@ async fn test_get_save_blocks_input() {
 #[test]
 fn test_get_save_blocks_input_with_state_masking_blocks() {
     let mut test_harness = TestHarness::new(MAINNET.clone());
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..7).collect();
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..9).collect();
     test_harness = test_harness.with_blocks(blocks.clone());
     test_harness.tree.persistence_state.last_state_trie_persisted_block =
         blocks[1].recovered_block().num_hash();
@@ -1226,15 +1265,15 @@ fn test_get_save_blocks_input_with_state_masking_blocks() {
 
     assert_eq!(input.prev_partial_state_trie(), 1);
     assert_eq!(input.prev_db_tip(), 3);
-    assert_eq!(input.new_partial_state_trie(), 3);
-    assert_eq!(input.new_db_tip(), 5);
+    assert_eq!(input.new_partial_state_trie(), 5);
+    assert_eq!(input.new_db_tip(), 7);
     assert_eq!(
         input
             .persist_rest_blocks()
             .iter()
             .map(|block| block.recovered_block().number())
             .collect::<Vec<_>>(),
-        vec![4, 5]
+        vec![4, 5, 6, 7]
     );
     assert_eq!(
         input
@@ -1242,7 +1281,7 @@ fn test_get_save_blocks_input_with_state_masking_blocks() {
             .iter()
             .map(|block| block.recovered_block().number())
             .collect::<Vec<_>>(),
-        vec![2, 3]
+        vec![2, 3, 4, 5]
     );
     assert_eq!(
         input
@@ -1250,20 +1289,20 @@ fn test_get_save_blocks_input_with_state_masking_blocks() {
             .iter()
             .map(|block| block.recovered_block().number())
             .collect::<Vec<_>>(),
-        vec![4, 5]
+        vec![6, 7]
     );
 
     test_harness.tree.config = test_harness.tree.config.clone().with_memory_block_buffer_target(0);
     let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
-    assert_eq!(input.new_db_tip(), 6);
-    assert_eq!(input.new_partial_state_trie(), 4);
+    assert_eq!(input.new_db_tip(), 8);
+    assert_eq!(input.new_partial_state_trie(), 6);
     assert_eq!(
         input
             .persist_rest_blocks()
             .iter()
             .map(|block| block.recovered_block().number())
             .collect::<Vec<_>>(),
-        vec![4, 5, 6]
+        vec![4, 5, 6, 7, 8]
     );
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1139,47 +1139,8 @@ fn test_tree_state_on_new_head_deep_fork() {
     }
 }
 
-#[test]
-fn test_get_save_blocks_input_respects_target_eligibility() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..6).collect();
-    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
-    let persisted = blocks[1].recovered_block().num_hash();
-    test_harness.tree.persistence_state.last_persisted_block = persisted;
-    test_harness.tree.persistence_state.last_state_trie_persisted_block = persisted;
-    test_harness.tree.config =
-        TreeConfig::default().with_persistence_threshold(1).with_memory_block_buffer_target(1);
-
-    assert!(
-        test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_some(),
-        "threshold persistence should be eligible"
-    );
-
-    test_harness.tree.building_payload = true;
-    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_none());
-    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_some());
-    test_harness.tree.building_payload = false;
-
-    test_harness.tree.backfill_sync_state = BackfillSyncState::Active;
-    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_none());
-    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_some());
-    test_harness.tree.backfill_sync_state = BackfillSyncState::Idle;
-
-    test_harness.tree.config = test_harness.tree.config.clone().with_persistence_threshold(4);
-    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).is_none());
-    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_some());
-
-    let canonical_head = blocks.last().unwrap().recovered_block().num_hash();
-    test_harness.tree.persistence_state.last_persisted_block = canonical_head;
-    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Head).unwrap();
-    assert!(input.persist_rest_blocks().is_empty());
-    assert_eq!(input.new_partial_state_trie(), canonical_head.number);
-
-    test_harness.tree.persistence_state.last_state_trie_persisted_block = canonical_head;
-    assert!(test_harness.tree.get_save_blocks_input(PersistTarget::Head).is_none());
-}
-
 #[tokio::test]
-async fn test_get_save_blocks_input() {
+async fn test_get_canonical_blocks_to_persist() {
     let chain_spec = MAINNET.clone();
     let mut test_harness = TestHarness::new(chain_spec);
     let mut test_block_builder = TestBlockBuilder::eth();
@@ -1210,11 +1171,6 @@ async fn test_get_save_blocks_input() {
             .unwrap();
 
     assert_eq!(blocks_to_persist.len(), expected_blocks_to_persist_length);
-    assert_eq!(input.prev_db_tip(), last_persisted_block_number);
-    assert_eq!(input.prev_partial_state_trie(), last_persisted_block_number);
-    assert_eq!(input.new_db_tip(), canonical_head_number - memory_block_buffer_target);
-    assert_eq!(input.new_partial_state_trie(), input.new_db_tip());
-    assert!(input.state_trie_masking_blocks().is_empty());
     for (i, item) in blocks_to_persist.iter().enumerate().take(expected_blocks_to_persist_length) {
         assert_eq!(item.recovered_block().number, last_persisted_block_number + i as u64 + 1);
     }
@@ -1248,7 +1204,7 @@ async fn test_get_save_blocks_input() {
 }
 
 #[test]
-fn test_get_save_blocks_input_with_state_masking_blocks() {
+fn test_threshold_persistence_with_state_masking_blocks() {
     let mut test_harness = TestHarness::new(MAINNET.clone());
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..9).collect();
     test_harness = test_harness.with_blocks(blocks.clone());
@@ -1261,73 +1217,24 @@ fn test_get_save_blocks_input_with_state_masking_blocks() {
         .with_memory_block_buffer_target(1)
         .with_num_state_masking_blocks(2);
 
-    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
+    test_harness.tree.advance_persistence().unwrap();
+    let action = test_harness.action_rx.recv().unwrap();
+    let PersistenceAction::SaveBlocks(input, sender) = action else {
+        panic!("expected save blocks action, got {action:?}")
+    };
 
-    assert_eq!(input.prev_partial_state_trie(), 1);
-    assert_eq!(input.prev_db_tip(), 3);
-    assert_eq!(input.new_partial_state_trie(), 5);
-    assert_eq!(input.new_db_tip(), 7);
-    assert_eq!(
-        input
-            .persist_rest_blocks()
-            .iter()
-            .map(|block| block.recovered_block().number())
-            .collect::<Vec<_>>(),
-        vec![4, 5, 6, 7]
-    );
-    assert_eq!(
-        input
-            .state_trie_blocks()
-            .iter()
-            .map(|block| block.recovered_block().number())
-            .collect::<Vec<_>>(),
-        vec![2, 3, 4, 5]
-    );
-    assert_eq!(
-        input
-            .state_trie_masking_blocks()
-            .iter()
-            .map(|block| block.recovered_block().number())
-            .collect::<Vec<_>>(),
-        vec![6, 7]
-    );
-
-    test_harness.tree.config = test_harness.tree.config.clone().with_memory_block_buffer_target(0);
-    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
-    assert_eq!(input.new_db_tip(), 8);
-    assert_eq!(input.new_partial_state_trie(), 6);
-    assert_eq!(
-        input
-            .persist_rest_blocks()
-            .iter()
-            .map(|block| block.recovered_block().number())
-            .collect::<Vec<_>>(),
-        vec![4, 5, 6, 7, 8]
-    );
-}
-
-#[test]
-fn test_on_persistence_complete_retains_state_masking_blocks() {
-    let mut test_harness = TestHarness::new(MAINNET.clone());
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..7).collect();
-    test_harness = test_harness.with_blocks(blocks.clone());
-    let previous_tip = blocks[1].recovered_block().num_hash();
-    test_harness.tree.persistence_state.last_persisted_block = previous_tip;
-    test_harness.tree.persistence_state.last_state_trie_persisted_block = previous_tip;
-
-    let persisted_tip = blocks[5].recovered_block().num_hash();
-    let state_trie_tip = blocks[3].recovered_block().num_hash();
-    test_harness
-        .tree
-        .on_persistence_complete(
-            PersistenceResult {
-                last_block: persisted_tip,
-                last_state_trie_block: state_trie_tip,
-                commit_duration: Some(Duration::ZERO),
-            },
-            Instant::now(),
-        )
+    let persisted_tip = blocks[7].recovered_block().num_hash();
+    let state_trie_tip = blocks[5].recovered_block().num_hash();
+    assert_eq!(input.new_db_tip(), persisted_tip.number);
+    assert_eq!(input.new_partial_state_trie(), state_trie_tip.number);
+    sender
+        .send(PersistenceResult {
+            last_block: persisted_tip,
+            last_state_trie_block: state_trie_tip,
+            commit_duration: Some(Duration::ZERO),
+        })
         .unwrap();
+    test_harness.tree.try_poll_persistence().unwrap();
 
     assert_eq!(test_harness.tree.persistence_state.last_persisted_block, persisted_tip);
     assert_eq!(test_harness.tree.persistence_state.last_state_trie_persisted_block, state_trie_tip);
@@ -1336,22 +1243,12 @@ fn test_on_persistence_complete_retains_state_masking_blocks() {
         Some(persisted_tip)
     );
 
-    for block in &blocks[..=state_trie_tip.number as usize] {
-        assert!(test_harness
-            .tree
-            .state
-            .tree_state
-            .executed_block_by_hash(block.recovered_block().hash())
-            .is_none());
-    }
-    for block in &blocks[state_trie_tip.number as usize + 1..] {
-        assert!(test_harness
-            .tree
-            .state
-            .tree_state
-            .executed_block_by_hash(block.recovered_block().hash())
-            .is_some());
-    }
+    let removed_hash = blocks[state_trie_tip.number as usize].recovered_block().hash();
+    let retained_hash = blocks[(state_trie_tip.number + 1) as usize].recovered_block().hash();
+    assert!(test_harness.tree.state.tree_state.executed_block_by_hash(removed_hash).is_none());
+    assert!(test_harness.tree.state.tree_state.executed_block_by_hash(retained_hash).is_some());
+    assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(removed_hash).is_none());
+    assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(retained_hash).is_some());
 }
 
 #[tokio::test]
@@ -2484,12 +2381,9 @@ mod forkchoice_updated_tests {
         let PersistenceAction::SaveBlocks(input, sender) = action else {
             panic!("expected state/trie catch-up save, got {action:?}")
         };
-        assert_eq!(input.prev_db_tip(), database_tip.number);
         assert_eq!(input.new_db_tip(), database_tip.number);
-        assert_eq!(input.prev_partial_state_trie(), state_trie_tip.number);
         assert_eq!(input.new_partial_state_trie(), database_tip.number);
         assert!(input.persist_rest_blocks().is_empty());
-        assert!(!input.state_trie_blocks().is_empty());
 
         sender
             .send(PersistenceResult {

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -896,7 +896,7 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
         persist_tx
             .send(PersistenceResult {
                 last_block: Some(persisted),
-                last_state_trie_block: Some(persisted.number),
+                last_state_trie_block: Some(persisted),
                 commit_duration: Some(Duration::ZERO),
             })
             .unwrap();
@@ -1015,7 +1015,7 @@ async fn test_tree_state_on_new_head_reorg() {
     sender
         .send(PersistenceResult {
             last_block: Some(blocks[1].recovered_block().num_hash()),
-            last_state_trie_block: Some(blocks[1].recovered_block().number),
+            last_state_trie_block: Some(blocks[1].recovered_block().num_hash()),
             commit_duration: Some(Duration::ZERO),
         })
         .unwrap();
@@ -1270,7 +1270,7 @@ fn test_on_persistence_complete_retains_state_masking_blocks() {
         .on_persistence_complete(
             PersistenceResult {
                 last_block: Some(persisted_tip),
-                last_state_trie_block: Some(state_trie_tip.number),
+                last_state_trie_block: Some(state_trie_tip),
                 commit_duration: Some(Duration::ZERO),
             },
             Instant::now(),
@@ -2397,7 +2397,7 @@ mod forkchoice_updated_tests {
                 sender
                     .send(PersistenceResult {
                         last_block: Some(last),
-                        last_state_trie_block: Some(input.new_partial_state_trie()),
+                        last_state_trie_block: Some(last),
                         commit_duration: Some(Duration::ZERO),
                     })
                     .unwrap();

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -895,8 +895,8 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
         std::thread::sleep(Duration::from_millis(10));
         persist_tx
             .send(PersistenceResult {
-                last_block: Some(persisted),
-                last_state_trie_block: Some(persisted),
+                last_block: persisted,
+                last_state_trie_block: persisted,
                 commit_duration: Some(Duration::ZERO),
             })
             .unwrap();
@@ -1014,8 +1014,8 @@ async fn test_tree_state_on_new_head_reorg() {
     // send the response so we can advance again
     sender
         .send(PersistenceResult {
-            last_block: Some(blocks[1].recovered_block().num_hash()),
-            last_state_trie_block: Some(blocks[1].recovered_block().num_hash()),
+            last_block: blocks[1].recovered_block().num_hash(),
+            last_state_trie_block: blocks[1].recovered_block().num_hash(),
             commit_duration: Some(Duration::ZERO),
         })
         .unwrap();
@@ -1269,8 +1269,8 @@ fn test_on_persistence_complete_retains_state_masking_blocks() {
         .tree
         .on_persistence_complete(
             PersistenceResult {
-                last_block: Some(persisted_tip),
-                last_state_trie_block: Some(state_trie_tip),
+                last_block: persisted_tip,
+                last_state_trie_block: state_trie_tip,
                 commit_duration: Some(Duration::ZERO),
             },
             Instant::now(),
@@ -2396,8 +2396,8 @@ mod forkchoice_updated_tests {
                 last_persisted_number = last.number;
                 sender
                     .send(PersistenceResult {
-                        last_block: Some(last),
-                        last_state_trie_block: Some(last),
+                        last_block: last,
+                        last_state_trie_block: last,
                         commit_duration: Some(Duration::ZERO),
                     })
                     .unwrap();

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -243,7 +243,11 @@ impl TestHarness {
             engine_api_tree_state,
             canonical_in_memory_state,
             persistence_handle,
-            PersistenceState { last_persisted_block: BlockNumHash::default(), rx: None },
+            PersistenceState {
+                last_persisted_block: BlockNumHash::default(),
+                last_state_trie_persisted_block: BlockNumHash::default(),
+                rx: None,
+            },
             payload_builder,
             tree_config,
             EngineApiKind::Ethereum,
@@ -597,12 +601,10 @@ async fn test_tree_persist_blocks() {
 fn on_new_persisted_block_queues_sparse_trie_prune_request() {
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
     let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
-    test_harness
-        .tree
-        .persistence_state
-        .finish(blocks[0].recovered_block().hash(), blocks[0].recovered_block().number);
+    let persisted = blocks[0].recovered_block().num_hash();
+    test_harness.tree.persistence_state.finish(persisted, persisted);
 
-    test_harness.tree.on_new_persisted_block().unwrap();
+    test_harness.tree.on_new_persisted_block(persisted).unwrap();
 
     assert!(test_harness.tree.state.pending_sparse_trie_prune());
 }
@@ -611,12 +613,10 @@ fn on_new_persisted_block_queues_sparse_trie_prune_request() {
 fn on_new_persisted_block_queues_sparse_trie_prune_with_in_memory_blocks() {
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
     let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
-    test_harness
-        .tree
-        .persistence_state
-        .finish(blocks[0].recovered_block().hash(), blocks[0].recovered_block().number);
+    let persisted = blocks[0].recovered_block().num_hash();
+    test_harness.tree.persistence_state.finish(persisted, persisted);
 
-    test_harness.tree.on_new_persisted_block().unwrap();
+    test_harness.tree.on_new_persisted_block(persisted).unwrap();
 
     assert!(test_harness.tree.state.pending_sparse_trie_prune());
 }
@@ -633,12 +633,10 @@ fn on_new_persisted_block_skips_sparse_trie_prune_when_state_root_task_disabled(
     for config in configs {
         let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
         test_harness.tree.config = config;
-        test_harness
-            .tree
-            .persistence_state
-            .finish(blocks[0].recovered_block().hash(), blocks[0].recovered_block().number);
+        let persisted = blocks[0].recovered_block().num_hash();
+        test_harness.tree.persistence_state.finish(persisted, persisted);
 
-        test_harness.tree.on_new_persisted_block().unwrap();
+        test_harness.tree.on_new_persisted_block(persisted).unwrap();
 
         assert!(!test_harness.tree.state.pending_sparse_trie_prune());
     }
@@ -898,6 +896,7 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
         persist_tx
             .send(PersistenceResult {
                 last_block: Some(persisted),
+                last_state_trie_block: Some(persisted.number),
                 commit_duration: Some(Duration::ZERO),
             })
             .unwrap();
@@ -1016,6 +1015,7 @@ async fn test_tree_state_on_new_head_reorg() {
     sender
         .send(PersistenceResult {
             last_block: Some(blocks[1].recovered_block().num_hash()),
+            last_state_trie_block: Some(blocks[1].recovered_block().number),
             commit_duration: Some(Duration::ZERO),
         })
         .unwrap();
@@ -1140,7 +1140,7 @@ fn test_tree_state_on_new_head_deep_fork() {
 }
 
 #[tokio::test]
-async fn test_get_canonical_blocks_to_persist() {
+async fn test_get_save_blocks_input() {
     let chain_spec = MAINNET.clone();
     let mut test_harness = TestHarness::new(chain_spec);
     let mut test_block_builder = TestBlockBuilder::eth();
@@ -1153,6 +1153,8 @@ async fn test_get_canonical_blocks_to_persist() {
     let last_persisted_block_number = 3;
     test_harness.tree.persistence_state.last_persisted_block =
         blocks[last_persisted_block_number as usize].recovered_block.num_hash();
+    test_harness.tree.persistence_state.last_state_trie_persisted_block =
+        blocks[last_persisted_block_number as usize].recovered_block.num_hash();
 
     let persistence_threshold = 4;
     let memory_block_buffer_target = 3;
@@ -1160,8 +1162,8 @@ async fn test_get_canonical_blocks_to_persist() {
         .with_persistence_threshold(persistence_threshold)
         .with_memory_block_buffer_target(memory_block_buffer_target);
 
-    let blocks_to_persist =
-        test_harness.tree.get_canonical_blocks_to_persist(PersistTarget::Threshold).unwrap();
+    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
+    let blocks_to_persist = input.persist_rest_blocks();
 
     let expected_blocks_to_persist_length: usize =
         (canonical_head_number - memory_block_buffer_target - last_persisted_block_number)
@@ -1169,6 +1171,11 @@ async fn test_get_canonical_blocks_to_persist() {
             .unwrap();
 
     assert_eq!(blocks_to_persist.len(), expected_blocks_to_persist_length);
+    assert_eq!(input.prev_db_tip(), last_persisted_block_number);
+    assert_eq!(input.prev_partial_state_trie(), last_persisted_block_number);
+    assert_eq!(input.new_db_tip(), canonical_head_number - memory_block_buffer_target);
+    assert_eq!(input.new_partial_state_trie(), input.new_db_tip());
+    assert!(input.state_trie_masking_blocks().is_empty());
     for (i, item) in blocks_to_persist.iter().enumerate().take(expected_blocks_to_persist_length) {
         assert_eq!(item.recovered_block().number, last_persisted_block_number + i as u64 + 1);
     }
@@ -1180,8 +1187,8 @@ async fn test_get_canonical_blocks_to_persist() {
 
     assert!(test_harness.tree.state.tree_state.sealed_header_by_hash(&fork_block_hash).is_some());
 
-    let blocks_to_persist =
-        test_harness.tree.get_canonical_blocks_to_persist(PersistTarget::Threshold).unwrap();
+    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
+    let blocks_to_persist = input.persist_rest_blocks();
     assert_eq!(blocks_to_persist.len(), expected_blocks_to_persist_length);
 
     // check that the fork block is not included in the blocks to persist
@@ -1199,6 +1206,100 @@ async fn test_get_canonical_blocks_to_persist() {
             highest: blocks_to_persist.last().unwrap().recovered_block().num_hash()
         })
     );
+}
+
+#[test]
+fn test_get_save_blocks_input_with_state_masking_blocks() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..7).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+    test_harness.tree.persistence_state.last_state_trie_persisted_block =
+        blocks[1].recovered_block().num_hash();
+    test_harness.tree.persistence_state.last_persisted_block =
+        blocks[3].recovered_block().num_hash();
+    test_harness.tree.config = TreeConfig::default()
+        .with_persistence_threshold(4)
+        .with_memory_block_buffer_target(1)
+        .with_num_state_masking_blocks(2);
+
+    let input = test_harness.tree.get_save_blocks_input(PersistTarget::Threshold).unwrap();
+
+    assert_eq!(input.prev_partial_state_trie(), 1);
+    assert_eq!(input.prev_db_tip(), 3);
+    assert_eq!(input.new_partial_state_trie(), 3);
+    assert_eq!(input.new_db_tip(), 5);
+    assert_eq!(
+        input
+            .persist_rest_blocks()
+            .iter()
+            .map(|block| block.recovered_block().number())
+            .collect::<Vec<_>>(),
+        vec![4, 5]
+    );
+    assert_eq!(
+        input
+            .state_trie_blocks()
+            .iter()
+            .map(|block| block.recovered_block().number())
+            .collect::<Vec<_>>(),
+        vec![2, 3]
+    );
+    assert_eq!(
+        input
+            .state_trie_masking_blocks()
+            .iter()
+            .map(|block| block.recovered_block().number())
+            .collect::<Vec<_>>(),
+        vec![4, 5]
+    );
+}
+
+#[test]
+fn test_on_persistence_complete_retains_state_masking_blocks() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..7).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+    let previous_tip = blocks[1].recovered_block().num_hash();
+    test_harness.tree.persistence_state.last_persisted_block = previous_tip;
+    test_harness.tree.persistence_state.last_state_trie_persisted_block = previous_tip;
+
+    let persisted_tip = blocks[5].recovered_block().num_hash();
+    let state_trie_tip = blocks[3].recovered_block().num_hash();
+    test_harness
+        .tree
+        .on_persistence_complete(
+            PersistenceResult {
+                last_block: Some(persisted_tip),
+                last_state_trie_block: Some(state_trie_tip.number),
+                commit_duration: Some(Duration::ZERO),
+            },
+            Instant::now(),
+        )
+        .unwrap();
+
+    assert_eq!(test_harness.tree.persistence_state.last_persisted_block, persisted_tip);
+    assert_eq!(test_harness.tree.persistence_state.last_state_trie_persisted_block, state_trie_tip);
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_persisted_num_hash(),
+        Some(persisted_tip)
+    );
+
+    for block in &blocks[..=state_trie_tip.number as usize] {
+        assert!(test_harness
+            .tree
+            .state
+            .tree_state
+            .executed_block_by_hash(block.recovered_block().hash())
+            .is_none());
+    }
+    for block in &blocks[state_trie_tip.number as usize + 1..] {
+        assert!(test_harness
+            .tree
+            .state
+            .tree_state
+            .executed_block_by_hash(block.recovered_block().hash())
+            .is_some());
+    }
 }
 
 #[tokio::test]
@@ -2296,6 +2397,7 @@ mod forkchoice_updated_tests {
                 sender
                     .send(PersistenceResult {
                         last_block: Some(last),
+                        last_state_trie_block: Some(input.new_partial_state_trie()),
                         commit_duration: Some(Duration::ZERO),
                     })
                     .unwrap();

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -780,7 +780,6 @@ mod tests {
         let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
         assert_eq!(args.persistence_threshold, 7);
-        assert_eq!(args.num_state_masking_blocks, DEFAULT_NUM_STATE_MASKING_BLOCKS);
         assert_eq!(args.memory_block_buffer_target, None);
         assert_eq!(args.memory_block_buffer_target(), 5);
         assert_eq!(
@@ -1007,7 +1006,6 @@ mod tests {
         ])
         .args;
 
-        assert_eq!(args.num_state_masking_blocks, 7);
         assert_eq!(args.tree_config().num_state_masking_blocks(), 7);
     }
 
@@ -1033,8 +1031,6 @@ mod tests {
 
         let err = args.validate().unwrap_err().to_string();
         assert!(err.contains("engine.num-state-masking-blocks"));
-        assert!(err.contains("engine.memory-block-buffer-target"));
-        assert!(err.contains("engine.persistence-threshold"));
     }
 
     #[test]

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -8,7 +8,7 @@ use eyre::ensure;
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
 use reth_engine_primitives::{
     TreeConfig, DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD, DEFAULT_MULTIPROOF_TASK_CHUNK_SIZE,
-    DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+    DEFAULT_NUM_STATE_MASKING_BLOCKS, DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
 };
 use std::{sync::OnceLock, time::Duration};
 
@@ -27,6 +27,7 @@ static ENGINE_DEFAULTS: OnceLock<DefaultEngineValues> = OnceLock::new();
 pub struct DefaultEngineValues {
     persistence_threshold: u64,
     persistence_backpressure_threshold: u64,
+    num_state_masking_blocks: u64,
     memory_block_buffer_target: u64,
     invalid_header_hit_eviction_threshold: u8,
     state_cache_disabled: bool,
@@ -77,6 +78,12 @@ impl DefaultEngineValues {
     /// Set the default persistence backpressure threshold
     pub const fn with_persistence_backpressure_threshold(mut self, v: u64) -> Self {
         self.persistence_backpressure_threshold = v;
+        self
+    }
+
+    /// Set the default number of state masking blocks.
+    pub const fn with_num_state_masking_blocks(mut self, v: u64) -> Self {
+        self.num_state_masking_blocks = v;
         self
     }
 
@@ -257,6 +264,7 @@ impl Default for DefaultEngineValues {
         Self {
             persistence_threshold: DEFAULT_PERSISTENCE_THRESHOLD,
             persistence_backpressure_threshold: DEFAULT_PERSISTENCE_BACKPRESSURE_THRESHOLD,
+            num_state_masking_blocks: DEFAULT_NUM_STATE_MASKING_BLOCKS,
             memory_block_buffer_target: DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
             invalid_header_hit_eviction_threshold: DEFAULT_INVALID_HEADER_HIT_EVICTION_THRESHOLD,
             state_cache_disabled: false,
@@ -317,6 +325,21 @@ pub struct EngineArgs {
     /// This value must be greater than `--engine.persistence-threshold`.
     #[arg(long = "engine.persistence-backpressure-threshold")]
     pub persistence_backpressure_threshold: Option<u64>,
+
+    /// Configure how many of the blocks being persisted should only mask state/trie writes instead
+    /// of durably persisting their state/trie updates in the current cycle.
+    #[cfg_attr(
+        feature = "partial-persistence",
+        arg(
+            long = "engine.num-state-masking-blocks",
+            default_value_t = DefaultEngineValues::get_global().num_state_masking_blocks
+        )
+    )]
+    #[cfg_attr(
+        not(feature = "partial-persistence"),
+        arg(skip = DefaultEngineValues::get_global().num_state_masking_blocks)
+    )]
+    pub num_state_masking_blocks: u64,
 
     /// Configure the target number of blocks to keep in memory.
     ///
@@ -563,6 +586,7 @@ impl Default for EngineArgs {
         let DefaultEngineValues {
             persistence_threshold,
             persistence_backpressure_threshold: _,
+            num_state_masking_blocks,
             memory_block_buffer_target: _,
             invalid_header_hit_eviction_threshold,
             state_cache_disabled,
@@ -595,6 +619,7 @@ impl Default for EngineArgs {
         Self {
             persistence_threshold,
             persistence_backpressure_threshold: None,
+            num_state_masking_blocks,
             memory_block_buffer_target: None,
             invalid_header_hit_eviction_threshold,
             state_root_task_compare_updates,
@@ -670,6 +695,17 @@ impl EngineArgs {
             self.persistence_threshold,
         );
         ensure!(
+            self.num_state_masking_blocks == 0 ||
+                matches!(
+                    self.num_state_masking_blocks.checked_add(memory_block_buffer_target),
+                    Some(window) if window < self.persistence_threshold
+                ),
+            "--engine.num-state-masking-blocks ({}) + --engine.memory-block-buffer-target ({}) must be less than --engine.persistence-threshold ({})",
+            self.num_state_masking_blocks,
+            memory_block_buffer_target,
+            self.persistence_threshold,
+        );
+        ensure!(
             !self.state_cache_disabled || !self.txpool_prewarming_enabled,
             "--engine.txpool-prewarming conflicts with --engine.disable-state-cache"
         );
@@ -690,6 +726,7 @@ impl EngineArgs {
             .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold())
             .with_persistence_threshold(self.persistence_threshold)
             .with_memory_block_buffer_target(self.memory_block_buffer_target())
+            .with_num_state_masking_blocks(self.num_state_masking_blocks)
             .with_invalid_header_hit_eviction_threshold(self.invalid_header_hit_eviction_threshold)
             .without_state_cache(self.state_cache_disabled)
             .without_prewarming(self.prewarming_disabled)
@@ -743,6 +780,7 @@ mod tests {
         let args = CommandParser::<EngineArgs>::parse_from(["reth"]).args;
         assert_eq!(args, default_args);
         assert_eq!(args.persistence_threshold, 7);
+        assert_eq!(args.num_state_masking_blocks, DEFAULT_NUM_STATE_MASKING_BLOCKS);
         assert_eq!(args.memory_block_buffer_target, None);
         assert_eq!(args.memory_block_buffer_target(), 5);
         assert_eq!(
@@ -843,6 +881,7 @@ mod tests {
         let args = EngineArgs {
             persistence_threshold: 100,
             persistence_backpressure_threshold: Some(101),
+            num_state_masking_blocks: DEFAULT_NUM_STATE_MASKING_BLOCKS,
             memory_block_buffer_target: Some(50),
             invalid_header_hit_eviction_threshold: 7,
             legacy_state_root_task_enabled: true,
@@ -954,6 +993,60 @@ mod tests {
         let err = args.validate().unwrap_err().to_string();
         assert!(err.contains("engine.memory-block-buffer-target"));
         assert!(err.contains("engine.persistence-threshold"));
+    }
+
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn test_parse_num_state_masking_blocks() {
+        let args = CommandParser::<EngineArgs>::parse_from([
+            "reth",
+            "--engine.persistence-threshold",
+            "13",
+            "--engine.num-state-masking-blocks",
+            "7",
+        ])
+        .args;
+
+        assert_eq!(args.num_state_masking_blocks, 7);
+        assert_eq!(args.tree_config().num_state_masking_blocks(), 7);
+    }
+
+    #[cfg(not(feature = "partial-persistence"))]
+    #[test]
+    fn num_state_masking_blocks_is_hidden_without_partial_persistence() {
+        assert!(CommandParser::<EngineArgs>::try_parse_from([
+            "reth",
+            "--engine.num-state-masking-blocks",
+            "1",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn validate_rejects_state_masking_window_at_or_above_threshold() {
+        let args = EngineArgs {
+            persistence_threshold: 4,
+            num_state_masking_blocks: 2,
+            memory_block_buffer_target: Some(2),
+            ..EngineArgs::default()
+        };
+
+        let err = args.validate().unwrap_err().to_string();
+        assert!(err.contains("engine.num-state-masking-blocks"));
+        assert!(err.contains("engine.memory-block-buffer-target"));
+        assert!(err.contains("engine.persistence-threshold"));
+    }
+
+    #[test]
+    fn validate_rejects_overflowing_state_masking_window() {
+        let args = EngineArgs {
+            persistence_threshold: 7,
+            num_state_masking_blocks: u64::MAX,
+            ..EngineArgs::default()
+        };
+
+        let err = args.validate().unwrap_err().to_string();
+        assert!(err.contains("engine.num-state-masking-blocks"));
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -165,12 +165,14 @@ impl<DB: Database, N: NodeTypes> From<DatabaseProviderRW<DB, N>>
     }
 }
 
-/// Mode for [`DatabaseProvider::save_blocks_inner`].
+/// Mode for database persistence writes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SaveBlocksMode {
     /// Full mode: write block structure + receipts + state + trie.
     /// Used by engine/production code.
     Full,
+    /// State/trie only: advance the partial state/trie frontier without rewriting block data.
+    StateTrieOnly,
     /// Blocks only: write block structure (headers, txs, senders, indices).
     /// Receipts/state/trie are skipped - they may come later via separate calls.
     /// Used by `insert_block`.
@@ -179,7 +181,7 @@ enum SaveBlocksMode {
 
 impl SaveBlocksMode {
     /// Returns `true` if this is [`SaveBlocksMode::Full`].
-    const fn with_state(self) -> bool {
+    const fn is_full(self) -> bool {
         matches!(self, Self::Full)
     }
 }
@@ -541,11 +543,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         Ok(StaticFileWriteCtx {
             write_senders: EitherWriterDestination::senders(self).is_static_file() &&
                 self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()),
-            write_receipts: save_mode.with_state() &&
+            write_receipts: save_mode.is_full() &&
                 EitherWriter::receipts_destination(self).is_static_file(),
-            write_account_changesets: save_mode.with_state() &&
+            write_account_changesets: save_mode.is_full() &&
                 EitherWriterDestination::account_changesets(self).is_static_file(),
-            write_storage_changesets: save_mode.with_state() &&
+            write_storage_changesets: save_mode.is_full() &&
                 EitherWriterDestination::storage_changesets(self).is_static_file(),
             tip,
             receipts_prune_mode: self.prune_modes.receipts,
@@ -573,7 +575,15 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ///
     /// Ordinary block data and hashed-state/trie updates advance independently according to the
     /// ranges derived by the input.
-    #[instrument(level = "debug", target = "providers::db", skip_all, fields(block_count = input.persist_rest_blocks().len()))]
+    #[instrument(
+        level = "debug",
+        target = "providers::db",
+        skip_all,
+        fields(
+            block_count = input.persist_rest_blocks().len(),
+            state_trie_block_count = input.state_trie_blocks().len()
+        )
+    )]
     pub fn save_blocks(&self, input: &SaveBlocksInput<N::Primitives>) -> ProviderResult<()> {
         let (db_tip, partial_state_trie) = self
             .get_stage_checkpoint(StageId::Finish)?
@@ -596,14 +606,122 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             ))))
         }
 
-        self.save_blocks_inner(
-            input.persist_rest_blocks(),
+        let partial_state_trie = (input.new_partial_state_trie() < input.new_db_tip())
+            .then_some(input.new_partial_state_trie());
+        let save_mode = if input.prev_db_tip() == input.new_db_tip() {
+            SaveBlocksMode::StateTrieOnly
+        } else {
+            SaveBlocksMode::Full
+        };
+        match save_mode {
+            SaveBlocksMode::StateTrieOnly => self.save_state_trie_only(input, partial_state_trie),
+            SaveBlocksMode::Full => self.save_blocks_inner(
+                input.persist_rest_blocks(),
+                input.state_trie_blocks(),
+                input.state_trie_masking_blocks(),
+                partial_state_trie,
+                SaveBlocksMode::Full,
+            ),
+            SaveBlocksMode::BlocksOnly => unreachable!("save_blocks always writes state"),
+        }
+    }
+
+    /// Advances only the state/trie frontier while leaving already-persisted block data untouched.
+    fn save_state_trie_only(
+        &self,
+        input: &SaveBlocksInput<N::Primitives>,
+        partial_state_trie: Option<BlockNumber>,
+    ) -> ProviderResult<()> {
+        debug_assert_eq!(input.prev_db_tip(), input.new_db_tip());
+        debug_assert!(input.persist_rest_blocks().is_empty());
+        debug_assert!(!input.state_trie_blocks().is_empty());
+
+        let total_start = Instant::now();
+        let mdbx_start = Instant::now();
+        let mut timings = metrics::SaveBlocksTimings::default();
+
+        self.write_state_trie_updates(
             input.state_trie_blocks(),
             input.state_trie_masking_blocks(),
-            (input.new_partial_state_trie() < input.new_db_tip())
-                .then_some(input.new_partial_state_trie()),
-            SaveBlocksMode::Full,
-        )
+            &mut timings,
+        )?;
+
+        let start = Instant::now();
+        self.save_finish_checkpoint(input.new_db_tip(), partial_state_trie)?;
+        timings.update_pipeline_stages = start.elapsed();
+        timings.mdbx = mdbx_start.elapsed();
+        timings.total = total_start.elapsed();
+
+        self.metrics.record_save_blocks(&timings);
+        debug!(
+            target: "providers::db",
+            db_tip = input.new_db_tip(),
+            state_trie_tip = input.new_partial_state_trie(),
+            "Advanced state/trie persistence frontier"
+        );
+
+        Ok(())
+    }
+
+    /// Writes merged hashed-state and trie updates for the advancing state/trie range.
+    fn write_state_trie_updates(
+        &self,
+        state_trie_blocks: &[ExecutedBlock<N::Primitives>],
+        state_trie_masking_blocks: &[ExecutedBlock<N::Primitives>],
+        timings: &mut metrics::SaveBlocksTimings,
+    ) -> ProviderResult<()> {
+        if state_trie_blocks.is_empty() {
+            return Ok(())
+        }
+
+        let start = Instant::now();
+        let batch = state_trie_blocks
+            .iter()
+            .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
+            .collect::<Vec<_>>();
+        let mask = state_trie_masking_blocks
+            .iter()
+            .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
+            .collect::<Vec<_>>();
+        let merged_hashed_state = HashedPostStateSorted::disjointed_merge_batch(&batch, &mask);
+        if !merged_hashed_state.is_empty() {
+            self.write_hashed_state(&merged_hashed_state)?;
+        }
+        timings.write_hashed_state += start.elapsed();
+
+        let start = Instant::now();
+        let batch = state_trie_blocks
+            .iter()
+            .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
+            .collect::<Vec<_>>();
+        let mask = state_trie_masking_blocks
+            .iter()
+            .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
+            .collect::<Vec<_>>();
+        let merged_trie = TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask);
+        if !merged_trie.is_empty() {
+            self.write_trie_updates_sorted(&merged_trie)?;
+        }
+        timings.write_trie_updates += start.elapsed();
+
+        Ok(())
+    }
+
+    /// Updates the Finish checkpoint with the independent database and state/trie frontiers.
+    fn save_finish_checkpoint(
+        &self,
+        db_tip: BlockNumber,
+        partial_state_trie: Option<BlockNumber>,
+    ) -> ProviderResult<()> {
+        let checkpoint = match partial_state_trie {
+            Some(partial_state_trie) => {
+                StageCheckpoint::new(db_tip).with_finish_stage_checkpoint(FinishCheckpoint {
+                    partial_state_trie: Some(partial_state_trie),
+                })
+            }
+            None => StageCheckpoint::new(db_tip),
+        };
+        self.save_stage_checkpoint(StageId::Finish, checkpoint)
     }
 
     fn save_blocks_inner(
@@ -726,7 +844,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 self.insert_block_mdbx_only(recovered_block, tx_nums[i])?;
                 timings.insert_block += start.elapsed();
 
-                if save_mode.with_state() {
+                if save_mode.is_full() {
                     let execution_output = block.execution_outcome();
 
                     // Write state and changesets to the database.
@@ -751,41 +869,16 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // Write all hashed state and trie updates in single batches.
             // This reduces cursor open/close overhead from N calls to 1.
-            if save_mode.with_state() && !state_trie_blocks.is_empty() {
-                let start = Instant::now();
-                let batch = state_trie_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-                    .collect::<Vec<_>>();
-                let mask = state_trie_masking_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-                    .collect::<Vec<_>>();
-                let merged_hashed_state =
-                    HashedPostStateSorted::disjointed_merge_batch(&batch, &mask);
-                if !merged_hashed_state.is_empty() {
-                    self.write_hashed_state(&merged_hashed_state)?;
-                }
-                timings.write_hashed_state += start.elapsed();
-
-                let start = Instant::now();
-                let batch = state_trie_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-                    .collect::<Vec<_>>();
-                let mask = state_trie_masking_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-                    .collect::<Vec<_>>();
-                let merged_trie = TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask);
-                if !merged_trie.is_empty() {
-                    self.write_trie_updates_sorted(&merged_trie)?;
-                }
-                timings.write_trie_updates += start.elapsed();
+            if save_mode.is_full() {
+                self.write_state_trie_updates(
+                    state_trie_blocks,
+                    state_trie_masking_blocks,
+                    &mut timings,
+                )?;
             }
 
             // Full mode: update history indices
-            if save_mode.with_state() {
+            if save_mode.is_full() {
                 let start = Instant::now();
                 self.update_history_indices(first_number..=last_block_number)?;
                 timings.update_history_indices = start.elapsed();
@@ -794,15 +887,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // Update pipeline progress
             let start = Instant::now();
             self.update_pipeline_stages(last_block_number, false)?;
-            if save_mode.with_state() {
-                let checkpoint = match partial_state_trie {
-                    Some(partial_state_trie) => StageCheckpoint::new(last_block_number)
-                        .with_finish_stage_checkpoint(FinishCheckpoint {
-                            partial_state_trie: Some(partial_state_trie),
-                        }),
-                    None => StageCheckpoint::new(last_block_number),
-                };
-                self.save_stage_checkpoint(StageId::Finish, checkpoint)?;
+            if save_mode.is_full() {
+                self.save_finish_checkpoint(last_block_number, partial_state_trie)?;
             }
             timings.update_pipeline_stages = start.elapsed();
 
@@ -4704,7 +4790,8 @@ mod tests {
         );
 
         let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block], 0, 0, 2, 1);
+        let input =
+            SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block.clone()], 0, 0, 2, 1);
         provider_rw.save_blocks(&input).unwrap();
         provider_rw.commit().unwrap();
 
@@ -4751,6 +4838,37 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(masked_entries.is_empty());
+
+        drop(storage_trie);
+        drop(account_trie);
+        drop(hashed_storages);
+        drop(hashed_accounts);
+        drop(provider);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(vec![deferred_trie_block], 2, 1, 2, 2);
+        assert!(input.persist_rest_blocks().is_empty());
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let finish_checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(finish_checkpoint.block_number, 2);
+        assert!(finish_checkpoint.finish_stage_checkpoint().is_none());
+
+        let mut hashed_accounts =
+            provider.tx_ref().cursor_read::<tables::HashedAccounts>().unwrap();
+        let (_, account) = hashed_accounts.seek_exact(masked_account).unwrap().unwrap();
+        assert_eq!(account.nonce, 3);
+
+        let mut hashed_storages =
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap();
+        let storage =
+            hashed_storages.seek_by_key_subkey(masked_storage, masked_slot).unwrap().unwrap();
+        assert_eq!(storage.value, U256::from(4));
+
+        let mut account_trie = provider.tx_ref().cursor_read::<tables::AccountsTrie>().unwrap();
+        assert!(account_trie.seek_exact(StoredNibbles(masked_account_node)).unwrap().is_some());
     }
 
     #[cfg(feature = "partial-persistence")]
@@ -4791,6 +4909,28 @@ mod tests {
         );
 
         let static_files = factory.static_file_provider();
+        assert_eq!(static_files.get_highest_static_file_block(StaticFileSegment::Headers), Some(4));
+        assert_eq!(
+            static_files.get_highest_static_file_block(StaticFileSegment::Transactions),
+            Some(4)
+        );
+        assert_eq!(
+            static_files.get_highest_static_file_block(StaticFileSegment::Receipts),
+            Some(4)
+        );
+
+        drop(provider);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(blocks[2..].to_vec(), 4, 2, 4, 4);
+        assert!(input.persist_rest_blocks().is_empty());
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let checkpoint =
+            factory.provider().unwrap().get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(checkpoint.block_number, 4);
+        assert!(checkpoint.finish_stage_checkpoint().is_none());
         assert_eq!(static_files.get_highest_static_file_block(StaticFileSegment::Headers), Some(4));
         assert_eq!(
             static_files.get_highest_static_file_block(StaticFileSegment::Transactions),

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -15,9 +15,9 @@ use crate::{
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
     DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
     HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
-    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
-    PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
-    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
+    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, PersistenceFrontiers,
+    ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit,
+    RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
     StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
     TransactionsProvider, TransactionsProviderExt, TrieWriter,
 };
@@ -2365,6 +2365,38 @@ impl<TX: DbTxMut, N: NodeTypes> StageCheckpointWriter for DatabaseProvider<TX, N
     }
 }
 
+impl<TX: DbTxMut + DbTx, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Updates pipeline checkpoints after an unwind while preserving an explicitly lagging
+    /// state/trie frontier.
+    fn update_pipeline_stages_after_unwind(
+        &self,
+        block_number: BlockNumber,
+    ) -> ProviderResult<PersistenceFrontiers> {
+        let partial_state_trie = self
+            .get_stage_checkpoint(StageId::Finish)?
+            .map(|checkpoint| {
+                checkpoint
+                    .finish_stage_checkpoint()
+                    .and_then(|finish| finish.partial_state_trie())
+                    .unwrap_or(checkpoint.block_number)
+            })
+            .unwrap_or(block_number)
+            .min(block_number);
+
+        self.update_pipeline_stages(block_number, true)?;
+        if partial_state_trie < block_number {
+            self.save_stage_checkpoint(
+                StageId::Finish,
+                StageCheckpoint::new(block_number).with_finish_stage_checkpoint(FinishCheckpoint {
+                    partial_state_trie: Some(partial_state_trie),
+                }),
+            )?;
+        }
+
+        Ok(PersistenceFrontiers { db_tip: block_number, partial_state_trie })
+    }
+}
+
 impl<TX: DbTx + 'static, N: NodeTypes> StorageReader for DatabaseProvider<TX, N> {
     fn plain_state_storages(
         &self,
@@ -3533,12 +3565,15 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockExecutionWriter
         self.remove_blocks_above(block)?;
 
         // Update pipeline progress
-        self.update_pipeline_stages(block, true)?;
+        self.update_pipeline_stages_after_unwind(block)?;
 
         Ok(Chain::new(blocks, execution_state, BTreeMap::new()))
     }
 
-    fn remove_block_and_execution_above(&self, block: BlockNumber) -> ProviderResult<()> {
+    fn remove_block_and_execution_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<PersistenceFrontiers> {
         self.unwind_trie_state_from(block + 1)?;
 
         // remove execution res
@@ -3549,9 +3584,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockExecutionWriter
         self.remove_blocks_above(block)?;
 
         // Update pipeline progress
-        self.update_pipeline_stages(block, true)?;
-
-        Ok(())
+        self.update_pipeline_stages_after_unwind(block)
     }
 }
 
@@ -4767,6 +4800,49 @@ mod tests {
             static_files.get_highest_static_file_block(StaticFileSegment::Receipts),
             Some(4)
         );
+    }
+
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn remove_block_and_execution_above_returns_persistence_frontiers() {
+        let factory = create_test_provider_factory();
+        let mut test_block_builder = TestBlockBuilder::eth().with_state();
+
+        let genesis = test_block_builder.get_executed_blocks(0..1).next().unwrap();
+        let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        save_genesis(&provider_rw, &genesis).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(blocks, 0, 0, 4, 2);
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let frontiers = provider_rw.remove_block_and_execution_above(3).unwrap();
+        assert_eq!(frontiers, PersistenceFrontiers { db_tip: 3, partial_state_trie: 2 });
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(checkpoint.block_number, 3);
+        assert_eq!(
+            checkpoint.finish_stage_checkpoint().and_then(|finish| finish.partial_state_trie()),
+            Some(2)
+        );
+        drop(provider);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let frontiers = provider_rw.remove_block_and_execution_above(1).unwrap();
+        assert_eq!(frontiers, PersistenceFrontiers { db_tip: 1, partial_state_trie: 1 });
+        provider_rw.commit().unwrap();
+
+        let checkpoint =
+            factory.provider().unwrap().get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(checkpoint.block_number, 1);
+        assert!(checkpoint.finish_stage_checkpoint().is_none());
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -165,14 +165,12 @@ impl<DB: Database, N: NodeTypes> From<DatabaseProviderRW<DB, N>>
     }
 }
 
-/// Mode for database persistence writes.
+/// Mode for [`DatabaseProvider::save_blocks_inner`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SaveBlocksMode {
     /// Full mode: write block structure + receipts + state + trie.
     /// Used by engine/production code.
     Full,
-    /// State/trie only: advance the partial state/trie frontier without rewriting block data.
-    StateTrieOnly,
     /// Blocks only: write block structure (headers, txs, senders, indices).
     /// Receipts/state/trie are skipped - they may come later via separate calls.
     /// Used by `insert_block`.
@@ -181,7 +179,7 @@ enum SaveBlocksMode {
 
 impl SaveBlocksMode {
     /// Returns `true` if this is [`SaveBlocksMode::Full`].
-    const fn is_full(self) -> bool {
+    const fn with_state(self) -> bool {
         matches!(self, Self::Full)
     }
 }
@@ -543,11 +541,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         Ok(StaticFileWriteCtx {
             write_senders: EitherWriterDestination::senders(self).is_static_file() &&
                 self.prune_modes.sender_recovery.is_none_or(|m| !m.is_full()),
-            write_receipts: save_mode.is_full() &&
+            write_receipts: save_mode.with_state() &&
                 EitherWriter::receipts_destination(self).is_static_file(),
-            write_account_changesets: save_mode.is_full() &&
+            write_account_changesets: save_mode.with_state() &&
                 EitherWriterDestination::account_changesets(self).is_static_file(),
-            write_storage_changesets: save_mode.is_full() &&
+            write_storage_changesets: save_mode.with_state() &&
                 EitherWriterDestination::storage_changesets(self).is_static_file(),
             tip,
             receipts_prune_mode: self.prune_modes.receipts,
@@ -575,15 +573,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ///
     /// Ordinary block data and hashed-state/trie updates advance independently according to the
     /// ranges derived by the input.
-    #[instrument(
-        level = "debug",
-        target = "providers::db",
-        skip_all,
-        fields(
-            block_count = input.persist_rest_blocks().len(),
-            state_trie_block_count = input.state_trie_blocks().len()
-        )
-    )]
+    #[instrument(level = "debug", target = "providers::db", skip_all, fields(block_count = input.persist_rest_blocks().len()))]
     pub fn save_blocks(&self, input: &SaveBlocksInput<N::Primitives>) -> ProviderResult<()> {
         let (db_tip, partial_state_trie) = self
             .get_stage_checkpoint(StageId::Finish)?
@@ -606,122 +596,14 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             ))))
         }
 
-        let partial_state_trie = (input.new_partial_state_trie() < input.new_db_tip())
-            .then_some(input.new_partial_state_trie());
-        let save_mode = if input.prev_db_tip() == input.new_db_tip() {
-            SaveBlocksMode::StateTrieOnly
-        } else {
-            SaveBlocksMode::Full
-        };
-        match save_mode {
-            SaveBlocksMode::StateTrieOnly => self.save_state_trie_only(input, partial_state_trie),
-            SaveBlocksMode::Full => self.save_blocks_inner(
-                input.persist_rest_blocks(),
-                input.state_trie_blocks(),
-                input.state_trie_masking_blocks(),
-                partial_state_trie,
-                SaveBlocksMode::Full,
-            ),
-            SaveBlocksMode::BlocksOnly => unreachable!("save_blocks always writes state"),
-        }
-    }
-
-    /// Advances only the state/trie frontier while leaving already-persisted block data untouched.
-    fn save_state_trie_only(
-        &self,
-        input: &SaveBlocksInput<N::Primitives>,
-        partial_state_trie: Option<BlockNumber>,
-    ) -> ProviderResult<()> {
-        debug_assert_eq!(input.prev_db_tip(), input.new_db_tip());
-        debug_assert!(input.persist_rest_blocks().is_empty());
-        debug_assert!(!input.state_trie_blocks().is_empty());
-
-        let total_start = Instant::now();
-        let mdbx_start = Instant::now();
-        let mut timings = metrics::SaveBlocksTimings::default();
-
-        self.write_state_trie_updates(
+        self.save_blocks_inner(
+            input.persist_rest_blocks(),
             input.state_trie_blocks(),
             input.state_trie_masking_blocks(),
-            &mut timings,
-        )?;
-
-        let start = Instant::now();
-        self.save_finish_checkpoint(input.new_db_tip(), partial_state_trie)?;
-        timings.update_pipeline_stages = start.elapsed();
-        timings.mdbx = mdbx_start.elapsed();
-        timings.total = total_start.elapsed();
-
-        self.metrics.record_save_blocks(&timings);
-        debug!(
-            target: "providers::db",
-            db_tip = input.new_db_tip(),
-            state_trie_tip = input.new_partial_state_trie(),
-            "Advanced state/trie persistence frontier"
-        );
-
-        Ok(())
-    }
-
-    /// Writes merged hashed-state and trie updates for the advancing state/trie range.
-    fn write_state_trie_updates(
-        &self,
-        state_trie_blocks: &[ExecutedBlock<N::Primitives>],
-        state_trie_masking_blocks: &[ExecutedBlock<N::Primitives>],
-        timings: &mut metrics::SaveBlocksTimings,
-    ) -> ProviderResult<()> {
-        if state_trie_blocks.is_empty() {
-            return Ok(())
-        }
-
-        let start = Instant::now();
-        let batch = state_trie_blocks
-            .iter()
-            .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-            .collect::<Vec<_>>();
-        let mask = state_trie_masking_blocks
-            .iter()
-            .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-            .collect::<Vec<_>>();
-        let merged_hashed_state = HashedPostStateSorted::disjointed_merge_batch(&batch, &mask);
-        if !merged_hashed_state.is_empty() {
-            self.write_hashed_state(&merged_hashed_state)?;
-        }
-        timings.write_hashed_state += start.elapsed();
-
-        let start = Instant::now();
-        let batch = state_trie_blocks
-            .iter()
-            .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-            .collect::<Vec<_>>();
-        let mask = state_trie_masking_blocks
-            .iter()
-            .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-            .collect::<Vec<_>>();
-        let merged_trie = TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask);
-        if !merged_trie.is_empty() {
-            self.write_trie_updates_sorted(&merged_trie)?;
-        }
-        timings.write_trie_updates += start.elapsed();
-
-        Ok(())
-    }
-
-    /// Updates the Finish checkpoint with the independent database and state/trie frontiers.
-    fn save_finish_checkpoint(
-        &self,
-        db_tip: BlockNumber,
-        partial_state_trie: Option<BlockNumber>,
-    ) -> ProviderResult<()> {
-        let checkpoint = match partial_state_trie {
-            Some(partial_state_trie) => {
-                StageCheckpoint::new(db_tip).with_finish_stage_checkpoint(FinishCheckpoint {
-                    partial_state_trie: Some(partial_state_trie),
-                })
-            }
-            None => StageCheckpoint::new(db_tip),
-        };
-        self.save_stage_checkpoint(StageId::Finish, checkpoint)
+            (input.new_partial_state_trie() < input.new_db_tip())
+                .then_some(input.new_partial_state_trie()),
+            SaveBlocksMode::Full,
+        )
     }
 
     fn save_blocks_inner(
@@ -844,7 +726,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 self.insert_block_mdbx_only(recovered_block, tx_nums[i])?;
                 timings.insert_block += start.elapsed();
 
-                if save_mode.is_full() {
+                if save_mode.with_state() {
                     let execution_output = block.execution_outcome();
 
                     // Write state and changesets to the database.
@@ -869,16 +751,41 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // Write all hashed state and trie updates in single batches.
             // This reduces cursor open/close overhead from N calls to 1.
-            if save_mode.is_full() {
-                self.write_state_trie_updates(
-                    state_trie_blocks,
-                    state_trie_masking_blocks,
-                    &mut timings,
-                )?;
+            if save_mode.with_state() && !state_trie_blocks.is_empty() {
+                let start = Instant::now();
+                let batch = state_trie_blocks
+                    .iter()
+                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
+                    .collect::<Vec<_>>();
+                let mask = state_trie_masking_blocks
+                    .iter()
+                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
+                    .collect::<Vec<_>>();
+                let merged_hashed_state =
+                    HashedPostStateSorted::disjointed_merge_batch(&batch, &mask);
+                if !merged_hashed_state.is_empty() {
+                    self.write_hashed_state(&merged_hashed_state)?;
+                }
+                timings.write_hashed_state += start.elapsed();
+
+                let start = Instant::now();
+                let batch = state_trie_blocks
+                    .iter()
+                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
+                    .collect::<Vec<_>>();
+                let mask = state_trie_masking_blocks
+                    .iter()
+                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
+                    .collect::<Vec<_>>();
+                let merged_trie = TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask);
+                if !merged_trie.is_empty() {
+                    self.write_trie_updates_sorted(&merged_trie)?;
+                }
+                timings.write_trie_updates += start.elapsed();
             }
 
             // Full mode: update history indices
-            if save_mode.is_full() {
+            if save_mode.with_state() {
                 let start = Instant::now();
                 self.update_history_indices(first_number..=last_block_number)?;
                 timings.update_history_indices = start.elapsed();
@@ -887,8 +794,15 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // Update pipeline progress
             let start = Instant::now();
             self.update_pipeline_stages(last_block_number, false)?;
-            if save_mode.is_full() {
-                self.save_finish_checkpoint(last_block_number, partial_state_trie)?;
+            if save_mode.with_state() {
+                let checkpoint = match partial_state_trie {
+                    Some(partial_state_trie) => StageCheckpoint::new(last_block_number)
+                        .with_finish_stage_checkpoint(FinishCheckpoint {
+                            partial_state_trie: Some(partial_state_trie),
+                        }),
+                    None => StageCheckpoint::new(last_block_number),
+                };
+                self.save_stage_checkpoint(StageId::Finish, checkpoint)?;
             }
             timings.update_pipeline_stages = start.elapsed();
 
@@ -4790,8 +4704,7 @@ mod tests {
         );
 
         let provider_rw = factory.provider_rw().unwrap();
-        let input =
-            SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block.clone()], 0, 0, 2, 1);
+        let input = SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block], 0, 0, 2, 1);
         provider_rw.save_blocks(&input).unwrap();
         provider_rw.commit().unwrap();
 
@@ -4838,37 +4751,6 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(masked_entries.is_empty());
-
-        drop(storage_trie);
-        drop(account_trie);
-        drop(hashed_storages);
-        drop(hashed_accounts);
-        drop(provider);
-
-        let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(vec![deferred_trie_block], 2, 1, 2, 2);
-        assert!(input.persist_rest_blocks().is_empty());
-        provider_rw.save_blocks(&input).unwrap();
-        provider_rw.commit().unwrap();
-
-        let provider = factory.provider().unwrap();
-        let finish_checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
-        assert_eq!(finish_checkpoint.block_number, 2);
-        assert!(finish_checkpoint.finish_stage_checkpoint().is_none());
-
-        let mut hashed_accounts =
-            provider.tx_ref().cursor_read::<tables::HashedAccounts>().unwrap();
-        let (_, account) = hashed_accounts.seek_exact(masked_account).unwrap().unwrap();
-        assert_eq!(account.nonce, 3);
-
-        let mut hashed_storages =
-            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap();
-        let storage =
-            hashed_storages.seek_by_key_subkey(masked_storage, masked_slot).unwrap().unwrap();
-        assert_eq!(storage.value, U256::from(4));
-
-        let mut account_trie = provider.tx_ref().cursor_read::<tables::AccountsTrie>().unwrap();
-        assert!(account_trie.seek_exact(StoredNibbles(masked_account_node)).unwrap().is_some());
     }
 
     #[cfg(feature = "partial-persistence")]
@@ -4909,28 +4791,6 @@ mod tests {
         );
 
         let static_files = factory.static_file_provider();
-        assert_eq!(static_files.get_highest_static_file_block(StaticFileSegment::Headers), Some(4));
-        assert_eq!(
-            static_files.get_highest_static_file_block(StaticFileSegment::Transactions),
-            Some(4)
-        );
-        assert_eq!(
-            static_files.get_highest_static_file_block(StaticFileSegment::Receipts),
-            Some(4)
-        );
-
-        drop(provider);
-
-        let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(blocks[2..].to_vec(), 4, 2, 4, 4);
-        assert!(input.persist_rest_blocks().is_empty());
-        provider_rw.save_blocks(&input).unwrap();
-        provider_rw.commit().unwrap();
-
-        let checkpoint =
-            factory.provider().unwrap().get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
-        assert_eq!(checkpoint.block_number, 4);
-        assert!(checkpoint.finish_stage_checkpoint().is_none());
         assert_eq!(static_files.get_highest_static_file_block(StaticFileSegment::Headers), Some(4));
         assert_eq!(
             static_files.get_highest_static_file_block(StaticFileSegment::Transactions),

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -625,20 +625,18 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             .expect("at least one persistence range must be non-empty")
             .recovered_block()
             .number();
-        let first_number =
-            blocks.first().map_or(last_block_number, |block| block.recovered_block().number());
+        let first_number = blocks.first().map(|block| block.recovered_block().number());
 
         debug!(target: "providers::db", block_count, "Writing blocks and execution data to storage");
 
         // Compute tx_nums upfront (both threads need these)
-        let first_tx_num = self
-            .tx
-            .cursor_read::<tables::TransactionBlocks>()?
-            .last()?
-            .map(|(n, _)| n + 1)
-            .unwrap_or_default();
-
-        let tx_nums: SmallVec<[TxNumber; 4]> = {
+        let tx_nums: SmallVec<[TxNumber; 4]> = if first_number.is_some() {
+            let first_tx_num = self
+                .tx
+                .cursor_read::<tables::TransactionBlocks>()?
+                .last()?
+                .map(|(n, _)| n + 1)
+                .unwrap_or_default();
             let mut nums = SmallVec::with_capacity(blocks.len());
             let mut current = first_tx_num;
             for block in blocks {
@@ -646,6 +644,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 current += block.recovered_block().body().transaction_count() as u64;
             }
             nums
+        } else {
+            SmallVec::new()
         };
 
         let mut timings =
@@ -653,10 +653,15 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
         // avoid capturing &self.tx in scope below.
         let sf_provider = &self.static_file_provider;
-        let sf_ctx = self.static_file_write_ctx(save_mode, first_number, last_block_number)?;
-        let rocksdb_provider = self.rocksdb_provider.clone();
-        let rocksdb_ctx = self.rocksdb_write_ctx(first_number);
-        let rocksdb_enabled = rocksdb_ctx.storage_settings.storage_v2;
+        let rocksdb_provider = &self.rocksdb_provider;
+        let sf_ctx = first_number
+            .map(|first_number| {
+                self.static_file_write_ctx(save_mode, first_number, last_block_number)
+            })
+            .transpose()?;
+        let rocksdb_ctx = first_number.map(|first_number| self.rocksdb_write_ctx(first_number));
+        let rocksdb_enabled =
+            rocksdb_ctx.as_ref().is_some_and(|ctx| ctx.storage_settings.storage_v2);
 
         let mut sf_result = None;
         let mut rocksdb_result = None;
@@ -668,21 +673,27 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         let span = tracing::Span::current();
         runtime.storage_pool().in_place_scope(|s| {
             // SF writes
-            s.spawn(|_| {
-                let _guard = span.enter();
-                let start = Instant::now();
-                sf_result = Some(
-                    sf_provider
-                        .write_blocks_data(blocks, &tx_nums, sf_ctx, runtime)
-                        .map(|()| start.elapsed()),
-                );
-            });
+            if sf_ctx.is_some() {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    let start = Instant::now();
+                    let sf_ctx =
+                        sf_ctx.expect("static file context exists when blocks are persisted");
+                    sf_result = Some(
+                        sf_provider
+                            .write_blocks_data(blocks, &tx_nums, sf_ctx, runtime)
+                            .map(|()| start.elapsed()),
+                    );
+                });
+            }
 
             // RocksDB writes
             if rocksdb_enabled {
                 s.spawn(|_| {
                     let _guard = span.enter();
                     let start = Instant::now();
+                    let rocksdb_ctx =
+                        rocksdb_ctx.clone().expect("RocksDB context exists when enabled");
                     rocksdb_result = Some(
                         rocksdb_provider
                             .write_blocks_data(blocks, &tx_nums, rocksdb_ctx, runtime)
@@ -695,7 +706,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let mdbx_start = Instant::now();
 
             // Collect all transaction hashes across all blocks, sort them, and write in batch
-            if !self.cached_storage_settings().storage_v2 &&
+            if first_number.is_some() &&
+                !self.cached_storage_settings().storage_v2 &&
                 self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
             {
                 let start = Instant::now();
@@ -737,6 +749,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
                 if save_mode.with_state() {
                     let execution_output = block.execution_outcome();
+                    let sf_ctx =
+                        sf_ctx.expect("static file context exists when blocks are persisted");
 
                     // Write state and changesets to the database.
                     // Must be written after blocks because of the receipt lookup.
@@ -794,7 +808,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             }
 
             // Full mode: update history indices
-            if save_mode.with_state() && !blocks.is_empty() {
+            if save_mode.with_state() &&
+                let Some(first_number) = first_number
+            {
                 let start = Instant::now();
                 self.update_history_indices(first_number..=last_block_number)?;
                 timings.update_history_indices = start.elapsed();
@@ -802,7 +818,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // Update pipeline progress
             let start = Instant::now();
-            if !blocks.is_empty() {
+            if first_number.is_some() {
                 self.update_pipeline_stages(last_block_number, false)?;
             }
             if save_mode.with_state() {
@@ -823,7 +839,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         })?;
 
         // Collect results from spawned tasks
-        timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
+        if first_number.is_some() {
+            timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
+        }
 
         if rocksdb_enabled {
             timings.rocksdb = rocksdb_result.ok_or_else(|| {
@@ -836,7 +854,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         timings.total = total_start.elapsed();
 
         self.metrics.record_save_blocks(&timings);
-        debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+        if let Some(first_number) = first_number {
+            debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+        }
 
         Ok(())
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -630,23 +630,20 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         debug!(target: "providers::db", block_count, "Writing blocks and execution data to storage");
 
         // Compute tx_nums upfront (both threads need these)
-        let tx_nums: SmallVec<[TxNumber; 4]> = if first_number.is_some() {
+        let mut tx_nums: SmallVec<[TxNumber; 4]> = SmallVec::with_capacity(blocks.len());
+        if !blocks.is_empty() {
             let first_tx_num = self
                 .tx
                 .cursor_read::<tables::TransactionBlocks>()?
                 .last()?
                 .map(|(n, _)| n + 1)
                 .unwrap_or_default();
-            let mut nums = SmallVec::with_capacity(blocks.len());
             let mut current = first_tx_num;
             for block in blocks {
-                nums.push(current);
+                tx_nums.push(current);
                 current += block.recovered_block().body().transaction_count() as u64;
             }
-            nums
-        } else {
-            SmallVec::new()
-        };
+        }
 
         let mut timings =
             metrics::SaveBlocksTimings { batch_size: block_count, ..Default::default() };
@@ -706,7 +703,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let mdbx_start = Instant::now();
 
             // Collect all transaction hashes across all blocks, sort them, and write in batch
-            if first_number.is_some() &&
+            if !blocks.is_empty() &&
                 !self.cached_storage_settings().storage_v2 &&
                 self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
             {
@@ -818,7 +815,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // Update pipeline progress
             let start = Instant::now();
-            if first_number.is_some() {
+            if !blocks.is_empty() {
                 self.update_pipeline_stages(last_block_number, false)?;
             }
             if save_mode.with_state() {
@@ -839,7 +836,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         })?;
 
         // Collect results from spawned tasks
-        if first_number.is_some() {
+        if !blocks.is_empty() {
             timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
         }
 

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4908,22 +4908,10 @@ mod tests {
 
         let provider = factory.provider().unwrap();
         let checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
-        assert_eq!(checkpoint.block_number, 3);
         assert_eq!(
             checkpoint.finish_stage_checkpoint().and_then(|finish| finish.partial_state_trie()),
             Some(2)
         );
-        drop(provider);
-
-        let provider_rw = factory.provider_rw().unwrap();
-        let frontiers = provider_rw.remove_block_and_execution_above(1).unwrap();
-        assert_eq!(frontiers, PersistenceFrontiers { db_tip: 1, partial_state_trie: 1 });
-        provider_rw.commit().unwrap();
-
-        let checkpoint =
-            factory.provider().unwrap().get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
-        assert_eq!(checkpoint.block_number, 1);
-        assert!(checkpoint.finish_stage_checkpoint().is_none());
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -616,8 +616,17 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ) -> ProviderResult<()> {
         let total_start = Instant::now();
         let block_count = blocks.len() as u64;
-        let first_number = blocks.first().unwrap().recovered_block().number();
-        let last_block_number = blocks.last().unwrap().recovered_block().number();
+        // With no new block data, the masking suffix still ends at the database tip. If the
+        // masking suffix is empty, the state/trie range ends there instead.
+        let last_block_number = blocks
+            .last()
+            .or_else(|| state_trie_masking_blocks.last())
+            .or_else(|| state_trie_blocks.last())
+            .expect("at least one persistence range must be non-empty")
+            .recovered_block()
+            .number();
+        let first_number =
+            blocks.first().map_or(last_block_number, |block| block.recovered_block().number());
 
         debug!(target: "providers::db", block_count, "Writing blocks and execution data to storage");
 
@@ -785,7 +794,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             }
 
             // Full mode: update history indices
-            if save_mode.with_state() {
+            if save_mode.with_state() && !blocks.is_empty() {
                 let start = Instant::now();
                 self.update_history_indices(first_number..=last_block_number)?;
                 timings.update_history_indices = start.elapsed();
@@ -793,7 +802,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // Update pipeline progress
             let start = Instant::now();
-            self.update_pipeline_stages(last_block_number, false)?;
+            if !blocks.is_empty() {
+                self.update_pipeline_stages(last_block_number, false)?;
+            }
             if save_mode.with_state() {
                 let checkpoint = match partial_state_trie {
                     Some(partial_state_trie) => StageCheckpoint::new(last_block_number)
@@ -4704,7 +4715,20 @@ mod tests {
         );
 
         let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block], 0, 0, 2, 1);
+        let input = SaveBlocksInput::new(
+            vec![full_persist_block.clone(), deferred_trie_block.clone()],
+            0,
+            0,
+            2,
+            0,
+        );
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input =
+            SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block.clone()], 2, 0, 2, 1);
+        assert!(input.persist_rest_blocks().is_empty());
         provider_rw.save_blocks(&input).unwrap();
         provider_rw.commit().unwrap();
 
@@ -4751,6 +4775,46 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(masked_entries.is_empty());
+
+        drop(storage_trie);
+        drop(account_trie);
+        drop(hashed_storages);
+        drop(hashed_accounts);
+        drop(provider);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(vec![deferred_trie_block], 2, 1, 2, 2);
+        assert!(input.persist_rest_blocks().is_empty());
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let finish_checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(finish_checkpoint.block_number, 2);
+        assert!(finish_checkpoint.finish_stage_checkpoint().is_none());
+
+        let mut hashed_accounts =
+            provider.tx_ref().cursor_read::<tables::HashedAccounts>().unwrap();
+        let (_, account) = hashed_accounts.seek_exact(masked_account).unwrap().unwrap();
+        assert_eq!(account.nonce, 3);
+
+        let mut hashed_storages =
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap();
+        let storage =
+            hashed_storages.seek_by_key_subkey(masked_storage, masked_slot).unwrap().unwrap();
+        assert_eq!(storage.value, U256::from(4));
+
+        let mut account_trie = provider.tx_ref().cursor_read::<tables::AccountsTrie>().unwrap();
+        assert!(account_trie.seek_exact(StoredNibbles(masked_account_node)).unwrap().is_some());
+
+        let mut storage_trie = provider.tx_ref().cursor_dup_read::<tables::StoragesTrie>().unwrap();
+        let masked_entries: Vec<_> = storage_trie
+            .walk_dup(Some(masked_storage), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(masked_entries.len(), 1);
+        assert_eq!(masked_entries[0].1.nibbles.0, masked_storage_node);
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -616,38 +616,49 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ) -> ProviderResult<()> {
         let total_start = Instant::now();
         let block_count = blocks.len() as u64;
-        let first_number = blocks.first().unwrap().recovered_block().number();
-        let last_block_number = blocks.last().unwrap().recovered_block().number();
+        // With no new block data, the masking suffix still ends at the database tip. If the
+        // masking suffix is empty, the state/trie range ends there instead.
+        let last_block_number = blocks
+            .last()
+            .or_else(|| state_trie_masking_blocks.last())
+            .or_else(|| state_trie_blocks.last())
+            .expect("at least one persistence range must be non-empty")
+            .recovered_block()
+            .number();
+        let first_number = blocks.first().map(|block| block.recovered_block().number());
 
         debug!(target: "providers::db", block_count, "Writing blocks and execution data to storage");
 
         // Compute tx_nums upfront (both threads need these)
-        let first_tx_num = self
-            .tx
-            .cursor_read::<tables::TransactionBlocks>()?
-            .last()?
-            .map(|(n, _)| n + 1)
-            .unwrap_or_default();
-
-        let tx_nums: SmallVec<[TxNumber; 4]> = {
-            let mut nums = SmallVec::with_capacity(blocks.len());
+        let mut tx_nums: SmallVec<[TxNumber; 4]> = SmallVec::with_capacity(blocks.len());
+        if !blocks.is_empty() {
+            let first_tx_num = self
+                .tx
+                .cursor_read::<tables::TransactionBlocks>()?
+                .last()?
+                .map(|(n, _)| n + 1)
+                .unwrap_or_default();
             let mut current = first_tx_num;
             for block in blocks {
-                nums.push(current);
+                tx_nums.push(current);
                 current += block.recovered_block().body().transaction_count() as u64;
             }
-            nums
-        };
+        }
 
         let mut timings =
             metrics::SaveBlocksTimings { batch_size: block_count, ..Default::default() };
 
         // avoid capturing &self.tx in scope below.
         let sf_provider = &self.static_file_provider;
-        let sf_ctx = self.static_file_write_ctx(save_mode, first_number, last_block_number)?;
-        let rocksdb_provider = self.rocksdb_provider.clone();
-        let rocksdb_ctx = self.rocksdb_write_ctx(first_number);
-        let rocksdb_enabled = rocksdb_ctx.storage_settings.storage_v2;
+        let rocksdb_provider = &self.rocksdb_provider;
+        let sf_ctx = first_number
+            .map(|first_number| {
+                self.static_file_write_ctx(save_mode, first_number, last_block_number)
+            })
+            .transpose()?;
+        let rocksdb_ctx = first_number.map(|first_number| self.rocksdb_write_ctx(first_number));
+        let rocksdb_enabled =
+            rocksdb_ctx.as_ref().is_some_and(|ctx| ctx.storage_settings.storage_v2);
 
         let mut sf_result = None;
         let mut rocksdb_result = None;
@@ -659,21 +670,27 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         let span = tracing::Span::current();
         runtime.storage_pool().in_place_scope(|s| {
             // SF writes
-            s.spawn(|_| {
-                let _guard = span.enter();
-                let start = Instant::now();
-                sf_result = Some(
-                    sf_provider
-                        .write_blocks_data(blocks, &tx_nums, sf_ctx, runtime)
-                        .map(|()| start.elapsed()),
-                );
-            });
+            if sf_ctx.is_some() {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    let start = Instant::now();
+                    let sf_ctx =
+                        sf_ctx.expect("static file context exists when blocks are persisted");
+                    sf_result = Some(
+                        sf_provider
+                            .write_blocks_data(blocks, &tx_nums, sf_ctx, runtime)
+                            .map(|()| start.elapsed()),
+                    );
+                });
+            }
 
             // RocksDB writes
             if rocksdb_enabled {
                 s.spawn(|_| {
                     let _guard = span.enter();
                     let start = Instant::now();
+                    let rocksdb_ctx =
+                        rocksdb_ctx.clone().expect("RocksDB context exists when enabled");
                     rocksdb_result = Some(
                         rocksdb_provider
                             .write_blocks_data(blocks, &tx_nums, rocksdb_ctx, runtime)
@@ -686,7 +703,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let mdbx_start = Instant::now();
 
             // Collect all transaction hashes across all blocks, sort them, and write in batch
-            if !self.cached_storage_settings().storage_v2 &&
+            if !blocks.is_empty() &&
+                !self.cached_storage_settings().storage_v2 &&
                 self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
             {
                 let start = Instant::now();
@@ -728,6 +746,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
                 if save_mode.with_state() {
                     let execution_output = block.execution_outcome();
+                    let sf_ctx =
+                        sf_ctx.expect("static file context exists when blocks are persisted");
 
                     // Write state and changesets to the database.
                     // Must be written after blocks because of the receipt lookup.
@@ -785,7 +805,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             }
 
             // Full mode: update history indices
-            if save_mode.with_state() {
+            if save_mode.with_state() &&
+                let Some(first_number) = first_number
+            {
                 let start = Instant::now();
                 self.update_history_indices(first_number..=last_block_number)?;
                 timings.update_history_indices = start.elapsed();
@@ -793,7 +815,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // Update pipeline progress
             let start = Instant::now();
-            self.update_pipeline_stages(last_block_number, false)?;
+            if !blocks.is_empty() {
+                self.update_pipeline_stages(last_block_number, false)?;
+            }
             if save_mode.with_state() {
                 let checkpoint = match partial_state_trie {
                     Some(partial_state_trie) => StageCheckpoint::new(last_block_number)
@@ -812,7 +836,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         })?;
 
         // Collect results from spawned tasks
-        timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
+        if !blocks.is_empty() {
+            timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
+        }
 
         if rocksdb_enabled {
             timings.rocksdb = rocksdb_result.ok_or_else(|| {
@@ -825,7 +851,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         timings.total = total_start.elapsed();
 
         self.metrics.record_save_blocks(&timings);
-        debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+        if let Some(first_number) = first_number {
+            debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+        }
 
         Ok(())
     }
@@ -4671,7 +4699,20 @@ mod tests {
         );
 
         let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block], 0, 0, 2, 1);
+        let input = SaveBlocksInput::new(
+            vec![full_persist_block.clone(), deferred_trie_block.clone()],
+            0,
+            0,
+            2,
+            0,
+        );
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input =
+            SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block.clone()], 2, 0, 2, 1);
+        assert!(input.persist_rest_blocks().is_empty());
         provider_rw.save_blocks(&input).unwrap();
         provider_rw.commit().unwrap();
 
@@ -4718,6 +4759,46 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(masked_entries.is_empty());
+
+        drop(storage_trie);
+        drop(account_trie);
+        drop(hashed_storages);
+        drop(hashed_accounts);
+        drop(provider);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(vec![deferred_trie_block], 2, 1, 2, 2);
+        assert!(input.persist_rest_blocks().is_empty());
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let finish_checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(finish_checkpoint.block_number, 2);
+        assert!(finish_checkpoint.finish_stage_checkpoint().is_none());
+
+        let mut hashed_accounts =
+            provider.tx_ref().cursor_read::<tables::HashedAccounts>().unwrap();
+        let (_, account) = hashed_accounts.seek_exact(masked_account).unwrap().unwrap();
+        assert_eq!(account.nonce, 3);
+
+        let mut hashed_storages =
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap();
+        let storage =
+            hashed_storages.seek_by_key_subkey(masked_storage, masked_slot).unwrap().unwrap();
+        assert_eq!(storage.value, U256::from(4));
+
+        let mut account_trie = provider.tx_ref().cursor_read::<tables::AccountsTrie>().unwrap();
+        assert!(account_trie.seek_exact(StoredNibbles(masked_account_node)).unwrap().is_some());
+
+        let mut storage_trie = provider.tx_ref().cursor_dup_read::<tables::StoragesTrie>().unwrap();
+        let masked_entries: Vec<_> = storage_trie
+            .walk_dup(Some(masked_storage), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(masked_entries.len(), 1);
+        assert_eq!(masked_entries[0].1.nibbles.0, masked_storage_node);
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/provider/src/providers/database/save_blocks.rs
+++ b/crates/storage/provider/src/providers/database/save_blocks.rs
@@ -16,7 +16,8 @@ use reth_primitives_traits::NodePrimitives;
 /// `blocks` contains every canonical block in `(prev_partial_state_trie, new_db_tip]`, ordered from
 /// oldest to newest. The four frontiers derive the ranges written during this operation:
 ///
-/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data;
+/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data, if the database
+///   frontier advances;
 /// - `(prev_partial_state_trie, new_partial_state_trie]`: consider hashed-state/trie updates for
 ///   persistence; and
 /// - `(new_partial_state_trie, new_db_tip]`: retain as the masking suffix and do not persist its
@@ -41,14 +42,14 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
     /// Creates an input that advances the existing frontiers to `new_db_tip` and
     /// `new_partial_state_trie`.
     ///
-    /// `new_partial_state_trie` may remain behind `prev_db_tip`. This occurs while a masking
-    /// window is first growing: new block data advances without forcing all previously masked
-    /// hashed-state/trie updates to disk.
+    /// Either frontier may advance independently. `new_partial_state_trie` may remain behind
+    /// `prev_db_tip` while a masking window grows, and `new_db_tip` may remain unchanged while the
+    /// state/trie frontier catches up.
     ///
     /// # Panics
     ///
-    /// Panics if the database frontier does not advance, the state/trie frontier moves backwards
-    /// or exceeds the database frontier, or `blocks` is not the exact contiguous range
+    /// Panics if either frontier moves backwards, neither frontier advances, the state/trie
+    /// frontier exceeds the database frontier, or `blocks` is not the exact contiguous range
     /// `(prev_partial_state_trie, new_db_tip]`.
     pub fn new(
         blocks: Vec<ExecutedBlock<N>>,
@@ -61,10 +62,14 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             prev_partial_state_trie <= prev_db_tip,
             "previous state/trie tip must not exceed previous database tip"
         );
-        assert!(prev_db_tip < new_db_tip, "database tip must advance");
+        assert!(prev_db_tip <= new_db_tip, "database tip must not move backwards");
         assert!(
             prev_partial_state_trie <= new_partial_state_trie,
             "state/trie tip must not move backwards"
+        );
+        assert!(
+            prev_db_tip < new_db_tip || prev_partial_state_trie < new_partial_state_trie,
+            "at least one persistence frontier must advance"
         );
         assert!(
             new_partial_state_trie <= new_db_tip,
@@ -116,11 +121,9 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             .num_hash()
     }
 
-    /// Returns the first newly persisted block.
-    pub fn first_persist_rest_block(&self) -> &ExecutedBlock<N> {
-        self.persist_rest_blocks()
-            .first()
-            .expect("constructor ensures a non-empty persistence range")
+    /// Returns the first block whose block, execution, and history data will be persisted.
+    pub fn first_persist_rest_block(&self) -> Option<&ExecutedBlock<N>> {
+        self.persist_rest_blocks().first()
     }
 
     /// Returns newly persisted blocks whose block, execution, and history data should be written.
@@ -185,7 +188,7 @@ mod tests {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(13..17).collect();
         let input = SaveBlocksInput::new(blocks, 15, 12, 16, 13);
 
-        assert_eq!(input.first_persist_rest_block().recovered_block().number(), 16);
+        assert_eq!(input.first_persist_rest_block().unwrap().recovered_block().number(), 16);
         assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 13);
         assert_eq!(
             input
@@ -198,10 +201,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "database tip must advance")]
-    fn requires_database_tip_to_advance() {
+    fn advances_only_state_trie_frontier() {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(1..2).collect();
-        let _ = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
+        let input = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
+
+        assert!(input.persist_rest_blocks().is_empty());
+        assert!(input.first_persist_rest_block().is_none());
+        assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 1);
+        assert!(input.state_trie_masking_blocks().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one persistence frontier must advance")]
+    fn requires_a_frontier_to_advance() {
+        let _ = SaveBlocksInput::<EthPrimitives>::new(vec![], 1, 1, 1, 1);
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/save_blocks.rs
+++ b/crates/storage/provider/src/providers/database/save_blocks.rs
@@ -16,8 +16,7 @@ use reth_primitives_traits::NodePrimitives;
 /// `blocks` contains every canonical block in `(prev_partial_state_trie, new_db_tip]`, ordered from
 /// oldest to newest. The four frontiers derive the ranges written during this operation:
 ///
-/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data, if the database
-///   frontier advances;
+/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data;
 /// - `(prev_partial_state_trie, new_partial_state_trie]`: consider hashed-state/trie updates for
 ///   persistence; and
 /// - `(new_partial_state_trie, new_db_tip]`: retain as the masking suffix and do not persist its
@@ -42,14 +41,14 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
     /// Creates an input that advances the existing frontiers to `new_db_tip` and
     /// `new_partial_state_trie`.
     ///
-    /// Either frontier may advance independently. `new_partial_state_trie` may remain behind
-    /// `prev_db_tip` while a masking window grows, and `new_db_tip` may remain unchanged while the
-    /// state/trie frontier catches up.
+    /// `new_partial_state_trie` may remain behind `prev_db_tip`. This occurs while a masking
+    /// window is first growing: new block data advances without forcing all previously masked
+    /// hashed-state/trie updates to disk.
     ///
     /// # Panics
     ///
-    /// Panics if either frontier moves backwards, neither frontier advances, the state/trie
-    /// frontier exceeds the database frontier, or `blocks` is not the exact contiguous range
+    /// Panics if the database frontier does not advance, the state/trie frontier moves backwards
+    /// or exceeds the database frontier, or `blocks` is not the exact contiguous range
     /// `(prev_partial_state_trie, new_db_tip]`.
     pub fn new(
         blocks: Vec<ExecutedBlock<N>>,
@@ -62,14 +61,10 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             prev_partial_state_trie <= prev_db_tip,
             "previous state/trie tip must not exceed previous database tip"
         );
-        assert!(prev_db_tip <= new_db_tip, "database tip must not move backwards");
+        assert!(prev_db_tip < new_db_tip, "database tip must advance");
         assert!(
             prev_partial_state_trie <= new_partial_state_trie,
             "state/trie tip must not move backwards"
-        );
-        assert!(
-            prev_db_tip < new_db_tip || prev_partial_state_trie < new_partial_state_trie,
-            "at least one persistence frontier must advance"
         );
         assert!(
             new_partial_state_trie <= new_db_tip,
@@ -121,11 +116,11 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             .num_hash()
     }
 
-    /// Returns the first block whose block, execution, and history data will be persisted.
-    ///
-    /// This is `None` when only the state/trie frontier advances.
-    pub fn first_persist_rest_block(&self) -> Option<&ExecutedBlock<N>> {
-        self.persist_rest_blocks().first()
+    /// Returns the first newly persisted block.
+    pub fn first_persist_rest_block(&self) -> &ExecutedBlock<N> {
+        self.persist_rest_blocks()
+            .first()
+            .expect("constructor ensures a non-empty persistence range")
     }
 
     /// Returns newly persisted blocks whose block, execution, and history data should be written.
@@ -190,7 +185,7 @@ mod tests {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(13..17).collect();
         let input = SaveBlocksInput::new(blocks, 15, 12, 16, 13);
 
-        assert_eq!(input.first_persist_rest_block().unwrap().recovered_block().number(), 16);
+        assert_eq!(input.first_persist_rest_block().recovered_block().number(), 16);
         assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 13);
         assert_eq!(
             input
@@ -203,19 +198,10 @@ mod tests {
     }
 
     #[test]
-    fn advances_only_state_trie_frontier() {
+    #[should_panic(expected = "database tip must advance")]
+    fn requires_database_tip_to_advance() {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(1..2).collect();
-        let input = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
-
-        assert!(input.persist_rest_blocks().is_empty());
-        assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 1);
-        assert!(input.state_trie_masking_blocks().is_empty());
-    }
-
-    #[test]
-    #[should_panic(expected = "at least one persistence frontier must advance")]
-    fn requires_a_frontier_to_advance() {
-        let _ = SaveBlocksInput::<EthPrimitives>::new(vec![], 1, 1, 1, 1);
+        let _ = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/save_blocks.rs
+++ b/crates/storage/provider/src/providers/database/save_blocks.rs
@@ -16,7 +16,8 @@ use reth_primitives_traits::NodePrimitives;
 /// `blocks` contains every canonical block in `(prev_partial_state_trie, new_db_tip]`, ordered from
 /// oldest to newest. The four frontiers derive the ranges written during this operation:
 ///
-/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data;
+/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data, if the database
+///   frontier advances;
 /// - `(prev_partial_state_trie, new_partial_state_trie]`: consider hashed-state/trie updates for
 ///   persistence; and
 /// - `(new_partial_state_trie, new_db_tip]`: retain as the masking suffix and do not persist its
@@ -41,14 +42,14 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
     /// Creates an input that advances the existing frontiers to `new_db_tip` and
     /// `new_partial_state_trie`.
     ///
-    /// `new_partial_state_trie` may remain behind `prev_db_tip`. This occurs while a masking
-    /// window is first growing: new block data advances without forcing all previously masked
-    /// hashed-state/trie updates to disk.
+    /// Either frontier may advance independently. `new_partial_state_trie` may remain behind
+    /// `prev_db_tip` while a masking window grows, and `new_db_tip` may remain unchanged while the
+    /// state/trie frontier catches up.
     ///
     /// # Panics
     ///
-    /// Panics if the database frontier does not advance, the state/trie frontier moves backwards
-    /// or exceeds the database frontier, or `blocks` is not the exact contiguous range
+    /// Panics if either frontier moves backwards, neither frontier advances, the state/trie
+    /// frontier exceeds the database frontier, or `blocks` is not the exact contiguous range
     /// `(prev_partial_state_trie, new_db_tip]`.
     pub fn new(
         blocks: Vec<ExecutedBlock<N>>,
@@ -61,10 +62,14 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             prev_partial_state_trie <= prev_db_tip,
             "previous state/trie tip must not exceed previous database tip"
         );
-        assert!(prev_db_tip < new_db_tip, "database tip must advance");
+        assert!(prev_db_tip <= new_db_tip, "database tip must not move backwards");
         assert!(
             prev_partial_state_trie <= new_partial_state_trie,
             "state/trie tip must not move backwards"
+        );
+        assert!(
+            prev_db_tip < new_db_tip || prev_partial_state_trie < new_partial_state_trie,
+            "at least one persistence frontier must advance"
         );
         assert!(
             new_partial_state_trie <= new_db_tip,
@@ -116,11 +121,11 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             .num_hash()
     }
 
-    /// Returns the first newly persisted block.
-    pub fn first_persist_rest_block(&self) -> &ExecutedBlock<N> {
-        self.persist_rest_blocks()
-            .first()
-            .expect("constructor ensures a non-empty persistence range")
+    /// Returns the first block whose block, execution, and history data will be persisted.
+    ///
+    /// This is `None` when only the state/trie frontier advances.
+    pub fn first_persist_rest_block(&self) -> Option<&ExecutedBlock<N>> {
+        self.persist_rest_blocks().first()
     }
 
     /// Returns newly persisted blocks whose block, execution, and history data should be written.
@@ -185,7 +190,7 @@ mod tests {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(13..17).collect();
         let input = SaveBlocksInput::new(blocks, 15, 12, 16, 13);
 
-        assert_eq!(input.first_persist_rest_block().recovered_block().number(), 16);
+        assert_eq!(input.first_persist_rest_block().unwrap().recovered_block().number(), 16);
         assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 13);
         assert_eq!(
             input
@@ -198,10 +203,19 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "database tip must advance")]
-    fn requires_database_tip_to_advance() {
+    fn advances_only_state_trie_frontier() {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(1..2).collect();
-        let _ = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
+        let input = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
+
+        assert!(input.persist_rest_blocks().is_empty());
+        assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 1);
+        assert!(input.state_trie_masking_blocks().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one persistence frontier must advance")]
+    fn requires_a_frontier_to_advance() {
+        let _ = SaveBlocksInput::<EthPrimitives>::new(vec![], 1, 1, 1, 1);
     }
 
     #[test]

--- a/crates/storage/storage-api/src/block_writer.rs
+++ b/crates/storage/storage-api/src/block_writer.rs
@@ -22,7 +22,12 @@ pub trait BlockExecutionWriter:
     /// Remove all of the blocks above the provided number and their execution result
     ///
     /// The passed block number will stay in the database.
-    fn remove_block_and_execution_above(&self, block: BlockNumber) -> ProviderResult<()>;
+    ///
+    /// Returns the persistence frontiers after removal.
+    fn remove_block_and_execution_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<PersistenceFrontiers>;
 }
 
 impl<T: BlockExecutionWriter> BlockExecutionWriter for &T {
@@ -33,9 +38,23 @@ impl<T: BlockExecutionWriter> BlockExecutionWriter for &T {
         (*self).take_block_and_execution_above(block)
     }
 
-    fn remove_block_and_execution_above(&self, block: BlockNumber) -> ProviderResult<()> {
+    fn remove_block_and_execution_above(
+        &self,
+        block: BlockNumber,
+    ) -> ProviderResult<PersistenceFrontiers> {
         (*self).remove_block_and_execution_above(block)
     }
+}
+
+/// The database and state/trie persistence frontiers.
+///
+/// The state/trie frontier is never ahead of the database frontier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PersistenceFrontiers {
+    /// The highest block whose non-state/trie outputs are persisted.
+    pub db_tip: BlockNumber,
+    /// The highest block whose state/trie outputs are persisted.
+    pub partial_state_trie: BlockNumber,
 }
 
 /// Block Writer


### PR DESCRIPTION
Depends on #26535.

Extracts the `--engine.num-state-masking-blocks` plumbing from #24100.

The flag configures the trailing `SaveBlocksInput` range whose state/trie writes are masked. The engine tracks the block-data and state/trie frontiers independently and flushes a lagging state/trie frontier directly on shutdown. CLI exposure remains behind `partial-persistence`.