### PR TITLE
feat(provider): support trie-only save_blocks

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -95,27 +95,25 @@ where
         while let Ok(action) = self.incoming.recv() {
             match action {
                 PersistenceAction::RemoveBlocksAbove(new_tip_num, sender) => {
-                    let last_block = self.on_remove_blocks_above(new_tip_num)?;
+                    let result = self.on_remove_blocks_above(new_tip_num)?;
                     // send new sync metrics based on removed blocks
                     let _ =
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
-                    let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
+                    let _ = sender.send(result);
                 }
                 PersistenceAction::SaveBlocks(input, sender) => {
-                    let db_tip_advanced = input.prev_db_tip() < input.new_db_tip();
+                    let new_db_tip = input.new_db_tip();
+                    let db_tip_advanced = input.prev_db_tip() < new_db_tip;
                     let result = self.on_save_blocks(input)?;
-                    let result_number = result.last_block.map(|b| b.number);
 
                     let _ = sender.send(result);
 
-                    if db_tip_advanced &&
-                        let Some(block_number) = result_number
-                    {
+                    if db_tip_advanced {
                         // send new sync metrics based on saved blocks
                         let _ = self
                             .sync_metrics_tx
-                            .send(MetricEvent::SyncHeight { height: block_number });
-                        self.maybe_run_pruner(block_number)?;
+                            .send(MetricEvent::SyncHeight { height: new_db_tip });
+                        self.maybe_run_pruner(new_db_tip)?;
                     }
                 }
                 PersistenceAction::SaveFinalizedBlock(finalized_block) => {
@@ -133,7 +131,7 @@ where
     fn on_remove_blocks_above(
         &self,
         new_tip_num: u64,
-    ) -> Result<Option<BlockNumHash>, PersistenceError> {
+    ) -> Result<PersistenceResult, PersistenceError> {
         debug!(target: "engine::persistence", ?new_tip_num, "Removing blocks");
         let start_time = Instant::now();
         let provider_rw = self.provider.database_provider_rw()?;
@@ -144,7 +142,10 @@ where
 
         debug!(target: "engine::persistence", ?new_tip_num, ?new_tip_hash, "Removed blocks from disk");
         self.metrics.remove_blocks_above_duration_seconds.record(start_time.elapsed());
-        Ok(new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }))
+        Ok(PersistenceResult {
+            last_block: new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }),
+            commit_duration: None,
+        })
     }
 
     #[instrument(level = "debug", target = "engine::persistence", skip_all, fields(block_count = input.persist_rest_blocks().len()))]

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -149,7 +149,8 @@ where
         &mut self,
         input: SaveBlocksInput<N::Primitives>,
     ) -> Result<PersistenceResult, PersistenceError> {
-        let first_block = input.first_persist_rest_block().recovered_block().num_hash();
+        let first_block =
+            input.first_persist_rest_block().map(|block| block.recovered_block().num_hash());
         let last_block = input.last_block();
         let block_count = input.persist_rest_blocks().len();
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -101,13 +101,16 @@ where
                         self.sync_metrics_tx.send(MetricEvent::SyncHeight { height: new_tip_num });
                     let _ = sender.send(PersistenceResult { last_block, commit_duration: None });
                 }
-                PersistenceAction::SaveBlocks(blocks, sender) => {
-                    let result = self.on_save_blocks(blocks)?;
+                PersistenceAction::SaveBlocks(input, sender) => {
+                    let db_tip_advanced = input.prev_db_tip() < input.new_db_tip();
+                    let result = self.on_save_blocks(input)?;
                     let result_number = result.last_block.map(|b| b.number);
 
                     let _ = sender.send(result);
 
-                    if let Some(block_number) = result_number {
+                    if db_tip_advanced &&
+                        let Some(block_number) = result_number
+                    {
                         // send new sync metrics based on saved blocks
                         let _ = self
                             .sync_metrics_tx

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -616,38 +616,49 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ) -> ProviderResult<()> {
         let total_start = Instant::now();
         let block_count = blocks.len() as u64;
-        let first_number = blocks.first().unwrap().recovered_block().number();
-        let last_block_number = blocks.last().unwrap().recovered_block().number();
+        // With no new block data, the masking suffix still ends at the database tip. If the
+        // masking suffix is empty, the state/trie range ends there instead.
+        let last_block_number = blocks
+            .last()
+            .or_else(|| state_trie_masking_blocks.last())
+            .or_else(|| state_trie_blocks.last())
+            .expect("at least one persistence range must be non-empty")
+            .recovered_block()
+            .number();
+        let first_number = blocks.first().map(|block| block.recovered_block().number());
 
         debug!(target: "providers::db", block_count, "Writing blocks and execution data to storage");
 
         // Compute tx_nums upfront (both threads need these)
-        let first_tx_num = self
-            .tx
-            .cursor_read::<tables::TransactionBlocks>()?
-            .last()?
-            .map(|(n, _)| n + 1)
-            .unwrap_or_default();
-
-        let tx_nums: SmallVec<[TxNumber; 4]> = {
-            let mut nums = SmallVec::with_capacity(blocks.len());
+        let mut tx_nums: SmallVec<[TxNumber; 4]> = SmallVec::with_capacity(blocks.len());
+        if !blocks.is_empty() {
+            let first_tx_num = self
+                .tx
+                .cursor_read::<tables::TransactionBlocks>()?
+                .last()?
+                .map(|(n, _)| n + 1)
+                .unwrap_or_default();
             let mut current = first_tx_num;
             for block in blocks {
-                nums.push(current);
+                tx_nums.push(current);
                 current += block.recovered_block().body().transaction_count() as u64;
             }
-            nums
-        };
+        }
 
         let mut timings =
             metrics::SaveBlocksTimings { batch_size: block_count, ..Default::default() };
 
         // avoid capturing &self.tx in scope below.
         let sf_provider = &self.static_file_provider;
-        let sf_ctx = self.static_file_write_ctx(save_mode, first_number, last_block_number)?;
-        let rocksdb_provider = self.rocksdb_provider.clone();
-        let rocksdb_ctx = self.rocksdb_write_ctx(first_number);
-        let rocksdb_enabled = rocksdb_ctx.storage_settings.storage_v2;
+        let rocksdb_provider = &self.rocksdb_provider;
+        let sf_ctx = first_number
+            .map(|first_number| {
+                self.static_file_write_ctx(save_mode, first_number, last_block_number)
+            })
+            .transpose()?;
+        let rocksdb_ctx = first_number.map(|first_number| self.rocksdb_write_ctx(first_number));
+        let rocksdb_enabled =
+            rocksdb_ctx.as_ref().is_some_and(|ctx| ctx.storage_settings.storage_v2);
 
         let mut sf_result = None;
         let mut rocksdb_result = None;
@@ -659,21 +670,27 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         let span = tracing::Span::current();
         runtime.storage_pool().in_place_scope(|s| {
             // SF writes
-            s.spawn(|_| {
-                let _guard = span.enter();
-                let start = Instant::now();
-                sf_result = Some(
-                    sf_provider
-                        .write_blocks_data(blocks, &tx_nums, sf_ctx, runtime)
-                        .map(|()| start.elapsed()),
-                );
-            });
+            if sf_ctx.is_some() {
+                s.spawn(|_| {
+                    let _guard = span.enter();
+                    let start = Instant::now();
+                    let sf_ctx =
+                        sf_ctx.expect("static file context exists when blocks are persisted");
+                    sf_result = Some(
+                        sf_provider
+                            .write_blocks_data(blocks, &tx_nums, sf_ctx, runtime)
+                            .map(|()| start.elapsed()),
+                    );
+                });
+            }
 
             // RocksDB writes
             if rocksdb_enabled {
                 s.spawn(|_| {
                     let _guard = span.enter();
                     let start = Instant::now();
+                    let rocksdb_ctx =
+                        rocksdb_ctx.clone().expect("RocksDB context exists when enabled");
                     rocksdb_result = Some(
                         rocksdb_provider
                             .write_blocks_data(blocks, &tx_nums, rocksdb_ctx, runtime)
@@ -686,7 +703,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let mdbx_start = Instant::now();
 
             // Collect all transaction hashes across all blocks, sort them, and write in batch
-            if !self.cached_storage_settings().storage_v2 &&
+            if !blocks.is_empty() &&
+                !self.cached_storage_settings().storage_v2 &&
                 self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full())
             {
                 let start = Instant::now();
@@ -728,6 +746,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
                 if save_mode.with_state() {
                     let execution_output = block.execution_outcome();
+                    let sf_ctx =
+                        sf_ctx.expect("static file context exists when blocks are persisted");
 
                     // Write state and changesets to the database.
                     // Must be written after blocks because of the receipt lookup.
@@ -785,7 +805,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             }
 
             // Full mode: update history indices
-            if save_mode.with_state() {
+            if save_mode.with_state() &&
+                let Some(first_number) = first_number
+            {
                 let start = Instant::now();
                 self.update_history_indices(first_number..=last_block_number)?;
                 timings.update_history_indices = start.elapsed();
@@ -793,7 +815,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
             // Update pipeline progress
             let start = Instant::now();
-            self.update_pipeline_stages(last_block_number, false)?;
+            if !blocks.is_empty() {
+                self.update_pipeline_stages(last_block_number, false)?;
+            }
             if save_mode.with_state() {
                 let checkpoint = match partial_state_trie {
                     Some(partial_state_trie) => StageCheckpoint::new(last_block_number)
@@ -812,7 +836,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         })?;
 
         // Collect results from spawned tasks
-        timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
+        if !blocks.is_empty() {
+            timings.sf = sf_result.ok_or(StaticFileWriterError::ThreadPanic("static file"))??;
+        }
 
         if rocksdb_enabled {
             timings.rocksdb = rocksdb_result.ok_or_else(|| {
@@ -825,7 +851,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         timings.total = total_start.elapsed();
 
         self.metrics.record_save_blocks(&timings);
-        debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+        if let Some(first_number) = first_number {
+            debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
+        }
 
         Ok(())
     }
@@ -4671,7 +4699,20 @@ mod tests {
         );
 
         let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block], 0, 0, 2, 1);
+        let input = SaveBlocksInput::new(
+            vec![full_persist_block.clone(), deferred_trie_block.clone()],
+            0,
+            0,
+            2,
+            0,
+        );
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input =
+            SaveBlocksInput::new(vec![full_persist_block, deferred_trie_block.clone()], 2, 0, 2, 1);
+        assert!(input.persist_rest_blocks().is_empty());
         provider_rw.save_blocks(&input).unwrap();
         provider_rw.commit().unwrap();
 
@@ -4718,6 +4759,46 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(masked_entries.is_empty());
+
+        drop(storage_trie);
+        drop(account_trie);
+        drop(hashed_storages);
+        drop(hashed_accounts);
+        drop(provider);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(vec![deferred_trie_block], 2, 1, 2, 2);
+        assert!(input.persist_rest_blocks().is_empty());
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let finish_checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(finish_checkpoint.block_number, 2);
+        assert!(finish_checkpoint.finish_stage_checkpoint().is_none());
+
+        let mut hashed_accounts =
+            provider.tx_ref().cursor_read::<tables::HashedAccounts>().unwrap();
+        let (_, account) = hashed_accounts.seek_exact(masked_account).unwrap().unwrap();
+        assert_eq!(account.nonce, 3);
+
+        let mut hashed_storages =
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap();
+        let storage =
+            hashed_storages.seek_by_key_subkey(masked_storage, masked_slot).unwrap().unwrap();
+        assert_eq!(storage.value, U256::from(4));
+
+        let mut account_trie = provider.tx_ref().cursor_read::<tables::AccountsTrie>().unwrap();
+        assert!(account_trie.seek_exact(StoredNibbles(masked_account_node)).unwrap().is_some());
+
+        let mut storage_trie = provider.tx_ref().cursor_dup_read::<tables::StoragesTrie>().unwrap();
+        let masked_entries: Vec<_> = storage_trie
+            .walk_dup(Some(masked_storage), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(masked_entries.len(), 1);
+        assert_eq!(masked_entries[0].1.nibbles.0, masked_storage_node);
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/provider/src/providers/database/save_blocks.rs
+++ b/crates/storage/provider/src/providers/database/save_blocks.rs
@@ -16,7 +16,8 @@ use reth_primitives_traits::NodePrimitives;
 /// `blocks` contains every canonical block in `(prev_partial_state_trie, new_db_tip]`, ordered from
 /// oldest to newest. The four frontiers derive the ranges written during this operation:
 ///
-/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data;
+/// - `(prev_db_tip, new_db_tip]`: persist block, execution, and history data, if the database
+///   frontier advances;
 /// - `(prev_partial_state_trie, new_partial_state_trie]`: consider hashed-state/trie updates for
 ///   persistence; and
 /// - `(new_partial_state_trie, new_db_tip]`: retain as the masking suffix and do not persist its
@@ -41,14 +42,14 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
     /// Creates an input that advances the existing frontiers to `new_db_tip` and
     /// `new_partial_state_trie`.
     ///
-    /// `new_partial_state_trie` may remain behind `prev_db_tip`. This occurs while a masking
-    /// window is first growing: new block data advances without forcing all previously masked
-    /// hashed-state/trie updates to disk.
+    /// Either frontier may advance independently. `new_partial_state_trie` may remain behind
+    /// `prev_db_tip` while a masking window grows, and `new_db_tip` may remain unchanged while the
+    /// state/trie frontier catches up.
     ///
     /// # Panics
     ///
-    /// Panics if the database frontier does not advance, the state/trie frontier moves backwards
-    /// or exceeds the database frontier, or `blocks` is not the exact contiguous range
+    /// Panics if either frontier moves backwards, neither frontier advances, the state/trie
+    /// frontier exceeds the database frontier, or `blocks` is not the exact contiguous range
     /// `(prev_partial_state_trie, new_db_tip]`.
     pub fn new(
         blocks: Vec<ExecutedBlock<N>>,
@@ -61,10 +62,14 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             prev_partial_state_trie <= prev_db_tip,
             "previous state/trie tip must not exceed previous database tip"
         );
-        assert!(prev_db_tip < new_db_tip, "database tip must advance");
+        assert!(prev_db_tip <= new_db_tip, "database tip must not move backwards");
         assert!(
             prev_partial_state_trie <= new_partial_state_trie,
             "state/trie tip must not move backwards"
+        );
+        assert!(
+            prev_db_tip < new_db_tip || prev_partial_state_trie < new_partial_state_trie,
+            "at least one persistence frontier must advance"
         );
         assert!(
             new_partial_state_trie <= new_db_tip,
@@ -116,11 +121,9 @@ impl<N: NodePrimitives> SaveBlocksInput<N> {
             .num_hash()
     }
 
-    /// Returns the first newly persisted block.
-    pub fn first_persist_rest_block(&self) -> &ExecutedBlock<N> {
-        self.persist_rest_blocks()
-            .first()
-            .expect("constructor ensures a non-empty persistence range")
+    /// Returns the first block whose block, execution, and history data will be persisted.
+    pub fn first_persist_rest_block(&self) -> Option<&ExecutedBlock<N>> {
+        self.persist_rest_blocks().first()
     }
 
     /// Returns newly persisted blocks whose block, execution, and history data should be written.
@@ -185,7 +188,7 @@ mod tests {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(13..17).collect();
         let input = SaveBlocksInput::new(blocks, 15, 12, 16, 13);
 
-        assert_eq!(input.first_persist_rest_block().recovered_block().number(), 16);
+        assert_eq!(input.first_persist_rest_block().unwrap().recovered_block().number(), 16);
         assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 13);
         assert_eq!(
             input
@@ -198,10 +201,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "database tip must advance")]
-    fn requires_database_tip_to_advance() {
+    fn advances_only_state_trie_frontier() {
         let blocks = TestBlockBuilder::eth().get_executed_blocks(1..2).collect();
-        let _ = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
+        let input = SaveBlocksInput::new(blocks, 1, 0, 1, 1);
+
+        assert!(input.persist_rest_blocks().is_empty());
+        assert!(input.first_persist_rest_block().is_none());
+        assert_eq!(input.state_trie_blocks()[0].recovered_block().number(), 1);
+        assert!(input.state_trie_masking_blocks().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one persistence frontier must advance")]
+    fn requires_a_frontier_to_advance() {
+        let _ = SaveBlocksInput::<EthPrimitives>::new(vec![], 1, 1, 1, 1);
     }
 
     #[test]


### PR DESCRIPTION
Allows `SaveBlocksInput` to advance the state/trie frontier while leaving the database frontier unchanged.

Empty block-data ranges skip block, static-file, history, and pipeline writes while still applying hashed-state/trie updates and updating the Finish checkpoint. Persistence also skips sync-height updates and pruning when only the state/trie frontier advances.