### PR TITLE
fix(txpool): enable EIP-2780 intrinsic gas rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=bb4565dc2df8689bb470fef972b9ce13cb1a171d#bb4565dc2df8689bb470fef972b9ce13cb1a171d"
+source = "git+https://github.com/alloy-rs/evm?rev=721c59b9e4f640c9e646c0516e5be7142c956a26#721c59b9e4f640c9e646c0516e5be7142c956a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2399,7 +2399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3359,7 +3359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5119,7 +5119,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7856,7 +7856,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9579,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
 dependencies = [
  "zstd",
 ]
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10678,7 +10678,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "bitvec",
  "paste",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10706,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10736,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "either",
@@ -10749,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "auto_impl",
  "either",
@@ -10784,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.41.2"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=74a378788dac0001905c9119d6b979218725f424#74a378788dac0001905c9119d6b979218725f424"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=4663db6869c18b72438e0d68769dfb9fb80bf10e#4663db6869c18b72438e0d68769dfb9fb80bf10e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10815,7 +10815,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10841,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
+source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",
@@ -10864,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 dependencies = [
  "eyre",
  "ruint",
@@ -10893,12 +10893,12 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 dependencies = [
  "paste",
  "revm-bytecode",
@@ -10913,7 +10913,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
@@ -10944,7 +10944,7 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 dependencies = [
  "revm-context",
  "revm-context-interface",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -10972,7 +10972,7 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#7a667b67cf23c621aa6f28c08df272f845712d4a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11211,7 +11211,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11270,7 +11270,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11291,7 +11291,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12161,7 +12161,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13440,7 +13440,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,8 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
+source = "git+https://github.com/alloy-rs/evm?rev=c135e1a912074039395a4fcbc5067706e8665801#c135e1a912074039395a4fcbc5067706e8665801"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7857,8 +7856,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7878,8 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9582,8 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10132,8 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace77dbcdd59c014fda4565ebfec76cd1fe6f5d98584b4655e8d22a947b9eee3"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10657,8 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
 dependencies = [
  "zstd",
 ]
@@ -10666,8 +10660,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10685,8 +10678,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "bitvec",
  "paste",
@@ -10698,8 +10690,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10715,8 +10706,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10731,8 +10721,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10747,8 +10736,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "either",
@@ -10761,8 +10749,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10780,8 +10767,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "auto_impl",
  "either",
@@ -10818,8 +10804,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10831,8 +10816,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10858,8 +10842,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10869,8 +10852,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",
@@ -14168,3 +14150,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "revm-inspectors"
+version = "0.41.1"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=cdcf766cba13e392791d2f9fb277284820b1b7c9#cdcf766cba13e392791d2f9fb277284820b1b7c9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=1e540975017acd4e1b59aa27c49939f9b69e201e#1e540975017acd4e1b59aa27c49939f9b69e201e"
+source = "git+https://github.com/alloy-rs/evm?rev=bb4565dc2df8689bb470fef972b9ce13cb1a171d#bb4565dc2df8689bb470fef972b9ce13cb1a171d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -705,7 +705,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "arbitrary",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -900,7 +900,7 @@ checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest",
  "serde_json",
  "tower",
@@ -1897,7 +1897,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2399,7 +2399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2905,7 +2905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3359,7 +3359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5119,7 +5119,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7066,7 +7066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7856,7 +7856,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9579,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=05b03df6427fb6ab26f32bff450ec7a0f77e8c1b#05b03df6427fb6ab26f32bff450ec7a0f77e8c1b"
 dependencies = [
  "zstd",
 ]
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10678,7 +10678,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "bitvec",
  "paste",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10706,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10736,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "auto_impl",
  "either",
@@ -10749,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "auto_impl",
  "either",
@@ -10784,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.41.2"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa#1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=74a378788dac0001905c9119d6b979218725f424#74a378788dac0001905c9119d6b979218725f424"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10815,7 +10815,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10841,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
+source = "git+https://github.com/bluealloy/revm?rev=30e04db0a6285a79f613dc404bfc04e4b757b0c9#30e04db0a6285a79f613dc404bfc04e4b757b0c9"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",
@@ -10864,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 dependencies = [
  "eyre",
  "ruint",
@@ -10893,12 +10893,12 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 dependencies = [
  "paste",
  "revm-bytecode",
@@ -10913,7 +10913,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
@@ -10944,7 +10944,7 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 dependencies = [
  "revm-context",
  "revm-context-interface",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -10972,7 +10972,7 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#f6e42055a07b4acb5ece501aa86fe615d2694b79"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11211,7 +11211,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11270,7 +11270,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11291,7 +11291,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12161,7 +12161,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13440,7 +13440,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=c135e1a912074039395a4fcbc5067706e8665801#c135e1a912074039395a4fcbc5067706e8665801"
+source = "git+https://github.com/alloy-rs/evm?rev=1e540975017acd4e1b59aa27c49939f9b69e201e#1e540975017acd4e1b59aa27c49939f9b69e201e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7856,7 +7856,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9579,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=9759d776b6a9acea40e3723120deb658b8970ff1#9759d776b6a9acea40e3723120deb658b8970ff1"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "zstd",
 ]
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10678,7 +10678,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "bitvec",
  "paste",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10706,7 +10706,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -10736,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "either",
@@ -10749,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "either",
@@ -10784,8 +10784,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.41.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e22e1aa328f78e8c3dea6a3a860a3a3c3a77c4a7e775e3fdd3dcbb24a152ac"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa#1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10804,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10816,7 +10815,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10842,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10852,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=35d8fb4f97f90d7232964d3bc9a70c607a1d7f50#35d8fb4f97f90d7232964d3bc9a70c607a1d7f50"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.13.0",
@@ -10865,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "revmc"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10885,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "revmc-backend"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 dependencies = [
  "eyre",
  "ruint",
@@ -10894,12 +10893,12 @@ dependencies = [
 [[package]]
 name = "revmc-build"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 
 [[package]]
 name = "revmc-builtins"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 dependencies = [
  "paste",
  "revm-bytecode",
@@ -10914,7 +10913,7 @@ dependencies = [
 [[package]]
 name = "revmc-codegen"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
@@ -10945,7 +10944,7 @@ dependencies = [
 [[package]]
 name = "revmc-context"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 dependencies = [
  "revm-context",
  "revm-context-interface",
@@ -10960,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "revmc-llvm"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 dependencies = [
  "alloy-primitives",
  "cc",
@@ -10973,7 +10972,7 @@ dependencies = [
 [[package]]
 name = "revmc-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/revmc?branch=main#7e3536d659d3bdd4b433cff7df201d1605cc8853"
+source = "git+https://github.com/paradigmxyz/revmc?branch=glamsterdam-devnet-7#2c74a6fcb274fb85c4a81863c1d8b2b410914542"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14150,8 +14149,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "revm-inspectors"
-version = "0.41.1"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=cdcf766cba13e392791d2f9fb277284820b1b7c9#cdcf766cba13e392791d2f9fb277284820b1b7c9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -695,22 +695,22 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "1e540975017acd4e1b59aa27c49939f9b69e201e" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
-reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "74a378788dac0001905c9119d6b979218725f424" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "bb4565dc2df8689bb470fef972b9ce13cb1a171d" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,8 +324,8 @@ reth-cli = { path = "crates/cli/cli" }
 reth-cli-commands = { path = "crates/cli/commands" }
 reth-cli-runner = { path = "crates/cli/runner" }
 reth-cli-util = { path = "crates/cli/util" }
-reth-codecs = { version = "0.5.0", default-features = false }
-reth-codecs-derive = "0.5.0"
+reth-codecs = { version = "0.5.2", default-features = false }
+reth-codecs-derive = "0.5.2"
 reth-config = { path = "crates/config", default-features = false }
 reth-consensus = { path = "crates/consensus/consensus", default-features = false }
 reth-consensus-common = { path = "crates/consensus/common", default-features = false }
@@ -393,7 +393,7 @@ reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
 reth-payload-util = { path = "crates/payload/util" }
-reth-primitives-traits = { version = "0.5.0", default-features = false }
+reth-primitives-traits = { version = "0.5.2", default-features = false }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
@@ -409,7 +409,7 @@ reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = fal
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
-reth-rpc-traits = { version = "0.5.0", default-features = false }
+reth-rpc-traits = { version = "0.5.2", default-features = false }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }
@@ -428,12 +428,12 @@ reth-trie-common = { path = "crates/trie/common", default-features = false }
 reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
-reth-zstd-compressors = { version = "0.5.0", default-features = false }
+reth-zstd-compressors = { version = "0.5.2", default-features = false }
 
 # revm
 revm = { version = "41.0.0", default-features = false }
 revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "main", default-features = false, features = ["llvm-prefer-static"] }
-revm-inspectors = "0.41.0"
+revm-inspectors = "0.41.1"
 
 # eth
 alloy-dyn-abi = "1.6.0"
@@ -693,3 +693,24 @@ vergen-git2 = "10.0.1"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "cdcf766cba13e392791d2f9fb277284820b1b7c9" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "c135e1a912074039395a4fcbc5067706e8665801" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,7 +432,7 @@ reth-zstd-compressors = { version = "0.5.2", default-features = false }
 
 # revm
 revm = { version = "41.0.0", default-features = false }
-revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "main", default-features = false, features = ["llvm-prefer-static"] }
+revmc = { git = "https://github.com/paradigmxyz/revmc", branch = "glamsterdam-devnet-7", default-features = false, features = ["llvm-prefer-static"] }
 revm-inspectors = "0.41.1"
 
 # eth
@@ -695,22 +695,22 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "cdcf766cba13e392791d2f9fb277284820b1b7c9" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "c135e1a912074039395a4fcbc5067706e8665801" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "9759d776b6a9acea40e3723120deb658b8970ff1" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "1e540975017acd4e1b59aa27c49939f9b69e201e" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -695,22 +695,22 @@ vergen-git2 = "10.0.1"
 ipnet = "2.11"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "74a378788dac0001905c9119d6b979218725f424" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "bb4565dc2df8689bb470fef972b9ce13cb1a171d" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
-reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "05b03df6427fb6ab26f32bff450ec7a0f77e8c1b" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "4663db6869c18b72438e0d68769dfb9fb80bf10e" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "721c59b9e4f640c9e646c0516e5be7142c956a26" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -514,11 +514,8 @@ impl DefaultStateRootStrategy {
             + Sync
             + 'static,
     {
-        let StateRootTaskOptions {
-            parent_state_root,
-            config,
-            pending_sparse_trie_prune_blocks,
-        } = options;
+        let StateRootTaskOptions { parent_state_root, config, pending_sparse_trie_prune_blocks } =
+            options;
         let (updates_tx, from_multi_proof) = crossbeam_channel::unbounded();
         let (cancel_guard, cancel_rx) = StateRootTaskCancelGuard::channel();
 

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -494,15 +494,10 @@ impl fmt::Debug for DefaultStateRootStrategy {
 }
 
 impl DefaultStateRootStrategy {
-    /// Transaction count threshold below which proof workers are halved, since fewer transactions
-    /// produce fewer state changes and most workers would be idle overhead.
-    const SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD: usize = 30;
-
     /// Spawns the default state-root computation pipeline.
     ///
     /// The authoritative update capability taken from the returned handle must be dropped or
     /// explicitly finished after execution so the task observes the end of the update stream.
-    /// An unknown transaction count uses the full proof-worker pool.
     #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     fn spawn_state_root<N, F>(
         &self,
@@ -521,7 +516,6 @@ impl DefaultStateRootStrategy {
     {
         let StateRootTaskOptions {
             parent_state_root,
-            transaction_count,
             config,
             pending_sparse_trie_prune_blocks,
         } = options;
@@ -531,9 +525,7 @@ impl DefaultStateRootStrategy {
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         #[cfg(feature = "trie-debug")]
         let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());
-        let halve_workers = transaction_count
-            .is_some_and(|count| count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD);
-        let proof_handle = ProofWorkerHandle::new(executor, task_ctx, halve_workers);
+        let proof_handle = ProofWorkerHandle::new(executor, task_ctx);
 
         let (state_root_tx, state_root_rx) = mpsc::channel();
         let (hashed_state_tx, hashed_state_rx) = mpsc::channel();
@@ -702,7 +694,6 @@ struct SparseTrieTaskOptions<N: NodePrimitives> {
 
 struct StateRootTaskOptions<'a, N: NodePrimitives> {
     parent_state_root: B256,
-    transaction_count: Option<usize>,
     config: &'a TreeConfig,
     pending_sparse_trie_prune_blocks: Option<Vec<ExecutedBlock<N>>>,
 }
@@ -769,7 +760,6 @@ where
             overlay_factory.clone(),
             StateRootTaskOptions {
                 parent_state_root: env.parent_state_root,
-                transaction_count: Some(env.transaction_count),
                 config,
                 pending_sparse_trie_prune_blocks,
             },
@@ -833,7 +823,6 @@ where
                 StateRootTaskOptions {
                     parent_state_root: ctx.parent_state_root(),
                     // Tx count unknown at FCU time (block built incrementally): full proof workers.
-                    transaction_count: None,
                     config: ctx.config,
                     pending_sparse_trie_prune_blocks,
                 },
@@ -1376,7 +1365,6 @@ mod tests {
             ),
             StateRootTaskOptions {
                 parent_state_root: env.parent_state_root,
-                transaction_count: Some(env.transaction_count),
                 config: &TreeConfig::default(),
                 pending_sparse_trie_prune_blocks: None,
             },

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1209,7 +1209,7 @@ mod tests {
             ),
         );
         let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory));
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1255,7 +1255,7 @@ mod tests {
             ),
         );
         let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory));
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()
@@ -1331,7 +1331,7 @@ mod tests {
             ),
         );
         let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory));
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()
@@ -1376,7 +1376,7 @@ mod tests {
             ),
         );
         let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory));
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -511,6 +511,7 @@ fn jit_runtime_config(jit: &JitArgs) -> RuntimeConfig {
         blocking: jit.blocking,
         no_dedup: default_config.no_dedup,
         no_dse: default_config.no_dse,
+        single_error: default_config.single_error,
         gas_params: default_config.gas_params,
         aot: default_config.aot,
         jit_mode: JitMode::OutOfProcess,

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -47,10 +47,11 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth69;
+    pub const LATEST: Self = Self::Eth71;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Eth71, Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -418,12 +418,12 @@ pub struct EngineArgs {
     pub allow_unwind_canonical_header: bool,
 
     /// Configure the number of storage proof workers in the Tokio blocking pool.
-    /// If not specified, defaults to 2x available parallelism.
+    /// If not specified, defaults to 2x available parallelism, with a minimum of 128.
     #[arg(long = "engine.storage-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().storage_worker_count.map(|v| v.to_string().into())))]
     pub storage_worker_count: Option<usize>,
 
     /// Configure the number of account proof workers in the Tokio blocking pool.
-    /// If not specified, defaults to the same count as storage workers.
+    /// If not specified, defaults to 2x available parallelism, with a minimum of 128.
     #[arg(long = "engine.account-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().account_worker_count.map(|v| v.to_string().into())))]
     pub account_worker_count: Option<usize>,
 

--- a/crates/tasks/src/runtime.rs
+++ b/crates/tasks/src/runtime.rs
@@ -48,6 +48,15 @@ pub const DEFAULT_STATE_TRIE_OVERLAY_WORKER_THREADS: usize = 4;
 /// Default maximum number of concurrent blocking tasks (for RPC tracing guard).
 pub const DEFAULT_MAX_BLOCKING_TASKS: usize = 512;
 
+/// Minimum default size of the proof worker pools.
+///
+/// Proof workers spend most of their time blocked on database reads, so the pool
+/// size acts as an I/O queue depth, not a CPU budget. Deriving it only from
+/// available parallelism starves the disk on small CPU allocations (e.g. the
+/// 6-core EIP-7870 profile yields 12 workers, leaving multiproof computation
+/// dominated by serialized read latency).
+pub const DEFAULT_MIN_PROOF_WORKERS: usize = 128;
+
 /// Configuration for the tokio runtime.
 #[derive(Debug, Clone)]
 pub enum TokioConfig {
@@ -108,10 +117,12 @@ pub struct RayonConfig {
     /// Maximum number of concurrent blocking tasks for the RPC guard semaphore.
     pub max_blocking_tasks: usize,
     /// Number of threads for the proof storage worker pool (trie storage proof workers).
-    /// If `None`, derived from available parallelism.
+    /// If `None`, twice the available parallelism, with a floor of
+    /// [`DEFAULT_MIN_PROOF_WORKERS`].
     pub proof_storage_worker_threads: Option<usize>,
     /// Number of threads for the proof account worker pool (trie account proof workers).
-    /// If `None`, derived from available parallelism.
+    /// If `None`, twice the available parallelism, with a floor of
+    /// [`DEFAULT_MIN_PROOF_WORKERS`].
     pub proof_account_worker_threads: Option<usize>,
     /// Number of threads for the prewarming pool (execution prewarming workers).
     /// If `None`, derived from available parallelism.
@@ -922,13 +933,17 @@ impl RuntimeBuilder {
 
             let blocking_guard = BlockingTaskGuard::new(config.rayon.max_blocking_tasks);
 
-            let proof_storage_worker_threads =
-                config.rayon.proof_storage_worker_threads.unwrap_or(default_threads * 2);
+            let proof_storage_worker_threads = config
+                .rayon
+                .proof_storage_worker_threads
+                .unwrap_or_else(|| (default_threads * 2).max(DEFAULT_MIN_PROOF_WORKERS));
             let proof_storage_worker_pool =
                 WorkerPool::new(proof_storage_worker_threads, "proof-strg");
 
-            let proof_account_worker_threads =
-                config.rayon.proof_account_worker_threads.unwrap_or(default_threads * 2);
+            let proof_account_worker_threads = config
+                .rayon
+                .proof_account_worker_threads
+                .unwrap_or_else(|| (default_threads * 2).max(DEFAULT_MIN_PROOF_WORKERS));
             let proof_account_worker_pool =
                 WorkerPool::new(proof_account_worker_threads, "proof-acct");
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1491,6 +1491,9 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
             .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
             .unwrap_or_default() as u64,
         transaction.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
+        // EIP-2780 only activates at Amsterdam; this pre-check caps `spec_id` at PRAGUE,
+        // so the gas calculation never applies the EIP-2780 adjustment here.
+        None,
     );
 
     let gas_limit = transaction.gas_limit();

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -915,6 +915,10 @@ where
             self.fork_tracker.osaka.store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
+        if self.chain_spec().is_amsterdam_active_at_timestamp(new_tip_block.timestamp()) {
+            self.fork_tracker.amsterdam.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+
         self.fork_tracker
             .tip_timestamp
             .store(new_tip_block.timestamp(), std::sync::atomic::Ordering::Relaxed);
@@ -949,6 +953,12 @@ where
         self.fork_tracker
             .tx_gas_limit_cap
             .store(tx_gas_limit_cap, std::sync::atomic::Ordering::Relaxed);
+        // EIP-2780: the decomposed intrinsic gas model is config-gated, so it is read from the
+        // EVM config rather than derived from the fork alone.
+        self.fork_tracker.amsterdam_eip2780.store(
+            evm_env.cfg_env.is_amsterdam_eip2780_enabled(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
     }
 
     fn max_gas_limit(&self) -> u64 {
@@ -1028,6 +1038,10 @@ pub struct EthTransactionValidatorBuilder<Client, Evm> {
     prague: bool,
     /// Fork indicator whether we are in the Osaka hardfork.
     osaka: bool,
+    /// Fork indicator whether we are in the Amsterdam hardfork.
+    amsterdam: bool,
+    /// Whether the EVM config enables the EIP-2780 decomposed intrinsic gas model.
+    amsterdam_eip2780: bool,
     /// Timestamp of the tip block.
     tip_timestamp: u64,
     /// Max blob count at the block's timestamp.
@@ -1119,6 +1133,8 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
             cancun: chain_spec.is_cancun_active_at_timestamp(tip.timestamp()),
             prague: chain_spec.is_prague_active_at_timestamp(tip.timestamp()),
             osaka: chain_spec.is_osaka_active_at_timestamp(tip.timestamp()),
+            amsterdam: chain_spec.is_amsterdam_active_at_timestamp(tip.timestamp()),
+            amsterdam_eip2780: evm_env.cfg_env.is_amsterdam_eip2780_enabled(),
 
             tip_timestamp: tip.timestamp(),
 
@@ -1196,6 +1212,21 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
     /// Set the Osaka fork.
     pub const fn set_osaka(mut self, osaka: bool) -> Self {
         self.osaka = osaka;
+        self
+    }
+
+    /// Disables the Amsterdam fork.
+    pub const fn no_amsterdam(self) -> Self {
+        self.set_amsterdam(false)
+    }
+
+    /// Set the Amsterdam fork.
+    ///
+    /// This also toggles the EIP-2780 intrinsic gas model, which is enabled by default from
+    /// Amsterdam onwards.
+    pub const fn set_amsterdam(mut self, amsterdam: bool) -> Self {
+        self.amsterdam = amsterdam;
+        self.amsterdam_eip2780 = amsterdam;
         self
     }
 
@@ -1333,6 +1364,8 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
             cancun,
             prague,
             osaka,
+            amsterdam,
+            amsterdam_eip2780,
             tip_timestamp,
             eip2718,
             eip1559,
@@ -1359,6 +1392,8 @@ impl<Client, Evm> EthTransactionValidatorBuilder<Client, Evm> {
             cancun: AtomicBool::new(cancun),
             prague: AtomicBool::new(prague),
             osaka: AtomicBool::new(osaka),
+            amsterdam: AtomicBool::new(amsterdam),
+            amsterdam_eip2780: AtomicBool::new(amsterdam_eip2780),
             tip_timestamp: AtomicU64::new(tip_timestamp),
             max_blob_count: AtomicU64::new(max_blob_count),
             max_initcode_size: AtomicUsize::new(max_initcode_size),
@@ -1423,6 +1458,13 @@ pub struct ForkTracker {
     pub prague: AtomicBool,
     /// Tracks if osaka is activated at the block's timestamp.
     pub osaka: AtomicBool,
+    /// Tracks if amsterdam is activated at the block's timestamp.
+    pub amsterdam: AtomicBool,
+    /// Tracks whether the EVM config enables the EIP-2780 decomposed intrinsic gas model.
+    ///
+    /// This mirrors [`Cfg::is_amsterdam_eip2780_enabled`], which is a config flag rather than a
+    /// pure fork check, so it is tracked separately from [`Self::amsterdam`].
+    pub amsterdam_eip2780: AtomicBool,
     /// Tracks max blob count per transaction at the block's timestamp.
     pub max_blob_count: AtomicU64,
     /// Tracks the timestamp of the tip block.
@@ -1454,6 +1496,16 @@ impl ForkTracker {
         self.osaka.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Returns `true` if Amsterdam fork is activated.
+    pub fn is_amsterdam_activated(&self) -> bool {
+        self.amsterdam.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns `true` if the EIP-2780 decomposed intrinsic gas model is enabled.
+    pub fn is_amsterdam_eip2780_enabled(&self) -> bool {
+        self.amsterdam_eip2780.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Returns the timestamp of the tip block.
     pub fn tip_timestamp(&self) -> u64 {
         self.tip_timestamp.load(std::sync::atomic::Ordering::Relaxed)
@@ -1473,13 +1525,25 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
     fork_tracker: &ForkTracker,
 ) -> Result<(), InvalidPoolTransactionError> {
     use revm::primitives::hardfork::SpecId;
-    let spec_id = if fork_tracker.is_prague_activated() {
+    let spec_id = if fork_tracker.is_amsterdam_activated() {
+        SpecId::AMSTERDAM
+    } else if fork_tracker.is_prague_activated() {
         SpecId::PRAGUE
     } else if fork_tracker.is_shanghai_activated() {
         SpecId::SHANGHAI
     } else {
         SpecId::MERGE
     };
+
+    // EIP-2780 replaces the flat intrinsic base cost with a decomposed one that depends on
+    // `tx.to` and `tx.value`. It is config-gated, so it is tracked separately from the fork.
+    let eip2780 = fork_tracker.is_amsterdam_eip2780_enabled().then(|| {
+        revm::context_interface::cfg::gas_params::Eip2780TxInfo {
+            value: transaction.value(),
+            // Self-transfer: a `Call` whose recipient is the sender itself.
+            is_self_transfer: transaction.kind().to() == Some(&transaction.sender()),
+        }
+    });
 
     let gas = revm::interpreter::gas::calculate_initial_tx_gas(
         spec_id,
@@ -1491,9 +1555,7 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
             .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
             .unwrap_or_default() as u64,
         transaction.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
-        // EIP-2780 only activates at Amsterdam; this pre-check caps `spec_id` at PRAGUE,
-        // so the gas calculation never applies the EIP-2780 adjustment here.
-        None,
+        eip2780,
     );
 
     let gas_limit = transaction.gas_limit();
@@ -1536,6 +1598,79 @@ mod tests {
         EthPooledTransaction::from_pooled(tx.try_into_recovered().unwrap())
     }
 
+    fn eip1559_tx(
+        to: Address,
+        sender: Address,
+        value: u64,
+        gas_limit: u64,
+    ) -> EthPooledTransaction {
+        let tx = alloy_consensus::TxEip1559 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 0,
+            to: to.into(),
+            value: U256::from(value),
+            ..Default::default()
+        };
+        let signed = reth_ethereum_primitives::TransactionSigned::new_unhashed(
+            tx.into(),
+            alloy_primitives::Signature::test_signature(),
+        );
+        EthPooledTransaction::new(
+            alloy_consensus::transaction::Recovered::new_unchecked(signed, sender),
+            200,
+        )
+    }
+
+    /// EIP-2780 replaces the flat 21k intrinsic base with a decomposed one: 12k base, plus a cold
+    /// account access for `tx.to` and a transfer charge when `tx.value` is non-zero, with a
+    /// carve-out for self-transfers.
+    #[test]
+    fn intrinsic_gas_eip2780() {
+        let sender = Address::repeat_byte(1);
+        let recipient = Address::repeat_byte(2);
+
+        let amsterdam = || ForkTracker {
+            shanghai: true.into(),
+            cancun: true.into(),
+            prague: true.into(),
+            osaka: true.into(),
+            amsterdam: true.into(),
+            amsterdam_eip2780: true.into(),
+            tip_timestamp: 0.into(),
+            max_blob_count: 0.into(),
+            max_initcode_size: AtomicUsize::new(MAX_INITCODE_SIZE),
+            tx_gas_limit_cap: AtomicU64::new(0),
+        };
+        let pre_amsterdam = || ForkTracker {
+            amsterdam: false.into(),
+            amsterdam_eip2780: false.into(),
+            ..amsterdam()
+        };
+
+        // Self-transfer: base cost only (12k), where pre-Amsterdam it pays the flat 21k.
+        let self_transfer = eip1559_tx(sender, sender, 1, 15_000);
+        assert!(ensure_intrinsic_gas(&self_transfer, &amsterdam()).is_ok());
+        assert!(ensure_intrinsic_gas(&self_transfer, &pre_amsterdam()).is_err());
+
+        // Zero-value call to another account: base + cold account access (15k).
+        let zero_value = eip1559_tx(recipient, sender, 0, 15_000);
+        assert!(ensure_intrinsic_gas(&zero_value, &amsterdam()).is_ok());
+        assert!(
+            ensure_intrinsic_gas(&eip1559_tx(recipient, sender, 0, 14_999), &amsterdam()).is_err()
+        );
+
+        // Value transfer to another account: base + cold access + transfer log + value cost (21k).
+        assert!(
+            ensure_intrinsic_gas(&eip1559_tx(recipient, sender, 1, 15_000), &amsterdam()).is_err()
+        );
+        assert!(
+            ensure_intrinsic_gas(&eip1559_tx(recipient, sender, 1, 21_000), &amsterdam()).is_ok()
+        );
+    }
+
     // <https://github.com/paradigmxyz/reth/issues/5178>
     #[tokio::test]
     async fn validate_transaction() {
@@ -1545,6 +1680,8 @@ mod tests {
             cancun: false.into(),
             prague: false.into(),
             osaka: false.into(),
+            amsterdam: false.into(),
+            amsterdam_eip2780: false.into(),
             tip_timestamp: 0.into(),
             max_blob_count: 0.into(),
             max_initcode_size: AtomicUsize::new(MAX_INITCODE_SIZE),

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -159,18 +159,13 @@ impl ProofWorkerHandle {
     /// # Parameters
     /// - `runtime`: The centralized runtime used to spawn blocking worker tasks
     /// - `task_ctx`: Shared context with database view and prefix sets
-    /// - `halve_workers`: Whether to halve the worker pool size (for small blocks)
     #[instrument(
         name = "ProofWorkerHandle::new",
         level = "debug",
         target = "trie::proof_task",
         skip_all
     )]
-    pub fn new<Factory>(
-        runtime: &Runtime,
-        task_ctx: ProofTaskCtx<Factory>,
-        halve_workers: bool,
-    ) -> Self
+    pub fn new<Factory>(runtime: &Runtime, task_ctx: ProofTaskCtx<Factory>) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
             + Clone
@@ -183,11 +178,8 @@ impl ProofWorkerHandle {
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
-        let divisor = if halve_workers { 2 } else { 1 };
-        let storage_worker_count =
-            runtime.proof_storage_worker_pool().current_num_threads() / divisor;
-        let account_worker_count =
-            runtime.proof_account_worker_pool().current_num_threads() / divisor;
+        let storage_worker_count = runtime.proof_storage_worker_pool().current_num_threads();
+        let account_worker_count = runtime.proof_account_worker_pool().current_num_threads();
 
         let storage_availability = Arc::new(AvailabilitySheet::new(storage_worker_count));
         let account_availability = Arc::new(AvailabilitySheet::new(account_worker_count));
@@ -196,7 +188,6 @@ impl ProofWorkerHandle {
             target: "trie::proof_task",
             storage_worker_count,
             account_worker_count,
-            halve_workers,
             "Spawning proof worker pools"
         );
 
@@ -1180,7 +1171,7 @@ mod tests {
         let ctx = test_ctx(factory);
 
         let runtime = reth_tasks::Runtime::test();
-        let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false);
+        let proof_handle = ProofWorkerHandle::new(&runtime, ctx);
 
         // Verify handle can be cloned
         let _cloned_handle = proof_handle.clone();

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1043,10 +1043,10 @@ Engine:
           Allow unwinding canonical header to ancestor during forkchoice updates. See `TreeConfig::unwind_canonical_header` for more details
 
       --engine.storage-worker-count <STORAGE_WORKER_COUNT>
-          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism
+          Configure the number of storage proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, with a minimum of 128
 
       --engine.account-worker-count <ACCOUNT_WORKER_COUNT>
-          Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to the same count as storage workers
+          Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to 2x available parallelism, with a minimum of 128
 
       --engine.prewarming-threads <PREWARMING_THREADS>
           Configure the number of prewarming threads. If not specified, defaults to available parallelism


### PR DESCRIPTION
Track Amsterdam activation and its EIP-2780 configuration in the transaction-pool validator, then calculate intrinsic gas with the Amsterdam transaction fields. This prevents valid 12k self-transfers and 15k zero-value calls from being rejected by the pool.

Adds coverage for Amsterdam and pre-Amsterdam intrinsic-gas thresholds.

Validation: `cargo +nightly fmt --all --check`; targeted Rust test could not fetch the pinned `alloy-evm` Git dependency because sandbox Git authentication returned HTTP 401.

Prompted by: @rakita