### PR TITLE
fix(discv5): default to port 30303

### DIFF
--- a/crates/net/discv5/src/config.rs
+++ b/crates/net/discv5/src/config.rs
@@ -30,8 +30,8 @@ pub const DEFAULT_DISCOVERY_V5_ADDR_IPV6: Ipv6Addr = Ipv6Addr::UNSPECIFIED;
 
 /// The default port for discv5 via UDP.
 ///
-/// Default is port 9200.
-pub const DEFAULT_DISCOVERY_V5_PORT: u16 = 9200;
+/// Default is port 30303.
+pub const DEFAULT_DISCOVERY_V5_PORT: u16 = 30303;
 
 /// The default [`discv5::ListenConfig`].
 ///

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -1365,6 +1365,14 @@ mod tests {
     }
 
     #[test]
+    fn discovery_defaults_use_same_port() {
+        let defaults = DefaultDiscoveryArgs::default();
+
+        assert_eq!(defaults.discv5_port, Some(defaults.port));
+        assert_eq!(defaults.discv5_port_ipv6, Some(defaults.port));
+    }
+
+    #[test]
     fn net_if_uses_resolved_addr_for_default_discovery_addr() {
         let args =
             CommandParser::<NetworkArgs>::parse_from(["reth", "--net-if.experimental", "en0"]).args;

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -114,14 +114,14 @@ Networking:
       --discovery.v5.port <DISCOVERY_V5_PORT>
           The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
           If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -54,14 +54,14 @@ Networking:
       --discovery.v5.port <DISCOVERY_V5_PORT>
           The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
           If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -54,14 +54,14 @@ Networking:
       --discovery.v5.port <DISCOVERY_V5_PORT>
           The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
           If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -213,14 +213,14 @@ Networking:
       --discovery.v5.port <DISCOVERY_V5_PORT>
           The UDP IPv4 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv4, or `--discovery.v5.addr` is set
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.port.ipv6 <DISCOVERY_V5_PORT_IPV6>
           The UDP IPv6 port to use for devp2p peer discovery version 5. Not used unless `--addr` is IPv6, or `--discovery.addr.ipv6` is set.
 
           If not provided, discovery V5 defaults to same port as discovery V4 (--discovery.port).
 
-          [default: 9200]
+          [default: 30303]
 
       --discovery.v5.lookup-interval <DISCOVERY_V5_LOOKUP_INTERVAL>
           The interval in seconds at which to carry out periodic lookup queries, for the whole run of the program

--- a/docs/vocs/docs/pages/run/faq/ports.mdx
+++ b/docs/vocs/docs/pages/run/faq/ports.mdx
@@ -15,9 +15,9 @@ This section provides essential information about the ports used by the system, 
 
 ## Discovery v5 Port
 
--   **Port:** `9200`
+-   **Port:** `30303`
 -   **Protocol:** UDP
--   **Purpose:** Used for discv5 peer discovery protocol. This is enabled by default and can be disabled with `--disable-discv5-discovery`. It operates independently from the legacy discv4 discovery on port 30303.
+-   **Purpose:** Used for discv5 peer discovery protocol. This is enabled by default and can be disabled with `--disable-discv5-discovery`. It shares the UDP port with the legacy discv4 discovery by default.
 -   **Exposure Recommendation:** This port should be exposed to allow peer discovery.
 
 ## Metrics Port


### PR DESCRIPTION
Defaults discv5 to port 30303 so it shares the standard UDP discovery port with discv4 out of the box.

Updates the generated CLI reference and ports FAQ, with regression coverage to keep both defaults aligned.
