### PR TITLE
refactor(net): add NodeRecord::has_rlpx_endpoint helper

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -390,7 +390,7 @@ pub enum DnsDiscoveryEvent {
 /// Converts an [Enr] into a [`NodeRecord`]
 fn convert_enr_node_record(enr: &Enr<SecretKey>) -> Option<DnsNodeRecordUpdate> {
     // DNS discovery yields RLPx dial targets, so records without a tcp endpoint are skipped.
-    let node_record = NodeRecord::try_from(enr).ok().filter(|record| record.tcp_port != 0)?;
+    let node_record = NodeRecord::try_from(enr).ok().filter(NodeRecord::has_rlpx_endpoint)?;
 
     let fork_id =
         enr.get_decodable::<EnrForkIdEntry>(b"eth").transpose().ok().flatten().map(Into::into);

--- a/crates/net/peers/src/lib.rs
+++ b/crates/net/peers/src/lib.rs
@@ -163,7 +163,7 @@ impl AnyNode {
     pub fn node_record(&self) -> Option<NodeRecord> {
         match self {
             Self::NodeRecord(record) => Some(*record),
-            Self::Enr(enr) => NodeRecord::try_from(enr).ok().filter(|record| record.tcp_port != 0),
+            Self::Enr(enr) => NodeRecord::try_from(enr).ok().filter(NodeRecord::has_rlpx_endpoint),
             Self::PeerId(_) | Self::TrustedPeer(_) => None,
         }
     }

--- a/crates/net/peers/src/node_record.rs
+++ b/crates/net/peers/src/node_record.rs
@@ -117,6 +117,14 @@ impl NodeRecord {
     pub const fn udp_addr(&self) -> SocketAddr {
         SocketAddr::new(self.address, self.udp_port)
     }
+
+    /// Returns `true` if this record advertises an `RLPx` endpoint, i.e. a non-zero tcp port.
+    ///
+    /// Discovery-only records, such as ENRs without a tcp key, convert with a tcp port of 0.
+    #[must_use]
+    pub const fn has_rlpx_endpoint(&self) -> bool {
+        self.tcp_port != 0
+    }
 }
 
 impl fmt::Display for NodeRecord {

--- a/crates/net/peers/src/trusted_peer.rs
+++ b/crates/net/peers/src/trusted_peer.rs
@@ -121,7 +121,7 @@ impl FromStr for TrustedPeer {
             let enr = enr::Enr::<secp256k1::SecretKey>::from_str(s)
                 .map_err(NodeRecordParseError::InvalidUrl)?;
             let mut record = NodeRecord::try_from(&enr)?;
-            if record.tcp_port == 0 {
+            if !record.has_rlpx_endpoint() {
                 // Discovery-only ENRs commonly share their UDP port with the RLPx listener.
                 record.tcp_port = record.udp_port;
             }


### PR DESCRIPTION
Follow-up to #26529.

Names the tcp-port-zero convention as `NodeRecord::has_rlpx_endpoint` and uses it in the three places that checked the port directly.