### PR TITLE
feat(stages): handle partial trie unwinds

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -572,7 +572,7 @@ where
                 )
                 .builder();
                 let stages = if walk_all_changed_branch_children {
-                    stages.set(MerkleStage::new_unwind(true))
+                    stages.set(MerkleStage::unwind_with_changed_branch_children())
                 } else {
                     stages
                 };

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -78,8 +78,9 @@ use reth_prune::{PruneMode, PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
 use reth_rpc_layer::JwtSecret;
 use reth_stages::{
-    sets::DefaultStages, stages::EraImportSource, MetricEvent, PipelineBuilder, PipelineTarget,
-    StageCheckpoint, StageId, StageSet,
+    sets::DefaultStages,
+    stages::{EraImportSource, MerkleStage},
+    MetricEvent, PipelineBuilder, PipelineTarget, StageCheckpoint, StageId, StageSet,
 };
 use reth_static_file::{blocks_per_file_for_prune_distance, StaticFileProducer, StaticFileSegment};
 use reth_storage_overlay::OverlayManager;
@@ -548,69 +549,87 @@ where
         let partial_trie_unwind = partial_trie_unwind_target(
             factory.database_provider_ro()?.get_stage_checkpoint(StageId::Finish)?,
         )?;
+        // The partial state-trie recovery must run first so Merkle's unwind can retain the
+        // complete changed branch. A lower storage-layer target is unwound afterwards.
+        let storage_unwind = [rocksdb_unwind, static_file_unwind].into_iter().flatten().min();
+        let storage_unwind = storage_unwind.filter(|unwind_block| {
+            partial_trie_unwind.is_none_or(|partial_trie| *unwind_block < partial_trie)
+        });
 
-        // Take the minimum block number to ensure all storage layers are consistent.
-        let unwind_target =
-            [rocksdb_unwind, static_file_unwind, partial_trie_unwind].into_iter().flatten().min();
-
-        if let Some(unwind_block) = unwind_target {
-            let inconsistency_source = [
-                rocksdb_unwind.map(|_| "RocksDB"),
-                static_file_unwind.map(|_| "static file"),
-                partial_trie_unwind.map(|_| "partial state trie"),
-            ]
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .join(" and ");
-            // A partial frontier at genesis is valid while the first masking window is in memory,
-            // so losing that window requires unwinding to genesis. Keep rejecting block-zero
-            // targets caused only by cross-store inconsistency because that can leave MDBX with a
-            // huge free list.
-            assert!(
-                unwind_block != 0 || partial_trie_unwind == Some(0),
-                "A {inconsistency_source} inconsistency was found that would trigger an unwind to block 0"
-            );
-
-            let unwind_target = PipelineTarget::Unwind(unwind_block);
-
-            info!(target: "reth::cli", %unwind_target, %inconsistency_source, "Executing unwind after consistency check.");
-
-            let (_tip_tx, tip_rx) = watch::channel(B256::ZERO);
-
-            // Builds an unwind-only pipeline
-            let pipeline = PipelineBuilder::default()
-                .add_stages(
-                    DefaultStages::new(
-                        factory.clone(),
-                        tip_rx,
-                        Arc::new(NoopConsensus::default()),
-                        NoopHeaderDownloader::default(),
-                        NoopBodiesDownloader::default(),
-                        NoopEvmConfig::<Evm>::default(),
-                        self.toml_config().stages.clone(),
-                        self.prune_modes(),
-                        None,
-                    )
-                    .builder()
-                    .disable_all(disabled_stages),
+        if partial_trie_unwind.is_some() || storage_unwind.is_some() {
+            let build_unwind_pipeline = |walk_all_changed_branch_children| {
+                let (_tip_tx, tip_rx) = watch::channel(B256::ZERO);
+                let stages = DefaultStages::new(
+                    factory.clone(),
+                    tip_rx,
+                    Arc::new(NoopConsensus::default()),
+                    NoopHeaderDownloader::default(),
+                    NoopBodiesDownloader::default(),
+                    NoopEvmConfig::<Evm>::default(),
+                    self.toml_config().stages.clone(),
+                    self.prune_modes(),
+                    None,
                 )
-                .build(
+                .builder();
+                let stages = if walk_all_changed_branch_children {
+                    stages.set(MerkleStage::new_unwind(true))
+                } else {
+                    stages
+                };
+
+                PipelineBuilder::default().add_stages(stages.disable_all(disabled_stages)).build(
                     factory.clone(),
                     StaticFileProducer::new(factory.clone(), self.prune_modes()),
-                );
+                )
+            };
+            let mut unwinds = Vec::with_capacity(2);
 
-            // Unwinds to block
+            if let Some(unwind_block) = partial_trie_unwind {
+                unwinds.push((
+                    PipelineTarget::Unwind(unwind_block),
+                    "partial state trie".to_owned(),
+                    build_unwind_pipeline(true),
+                ));
+            }
+
+            if let Some(unwind_block) = storage_unwind {
+                // Highly unlikely to happen, and given its destructive nature, it's better to
+                // panic instead. Unwinding to 0 would leave MDBX with a huge free list size.
+                let inconsistency_source = match (rocksdb_unwind, static_file_unwind) {
+                    (Some(_), Some(_)) => "RocksDB and static file",
+                    (Some(_), None) => "RocksDB",
+                    (None, Some(_)) => "static file",
+                    (None, None) => unreachable!(),
+                };
+                assert_ne!(
+                    unwind_block, 0,
+                    "A {inconsistency_source} inconsistency was found that would trigger an unwind to block 0"
+                );
+                unwinds.push((
+                    PipelineTarget::Unwind(unwind_block),
+                    inconsistency_source.to_owned(),
+                    build_unwind_pipeline(false),
+                ));
+            }
+
             let (tx, rx) = oneshot::channel();
 
             // Pipeline should be run as blocking and panic if it fails.
             self.task_executor().spawn_critical_blocking_task("pipeline task", async move {
-                let (_, result) = pipeline.run_as_fut(Some(unwind_target)).await;
+                let result: Result<(), reth_stages::PipelineError> = async {
+                    for (unwind_target, inconsistency_source, pipeline) in unwinds {
+                        info!(target: "reth::cli", %unwind_target, %inconsistency_source, "Executing unwind after consistency check.");
+                        let (_, result) = pipeline.run_as_fut(Some(unwind_target)).await;
+                        result.inspect_err(|err| {
+                            error!(target: "reth::cli", %unwind_target, %inconsistency_source, %err, "failed to run unwind");
+                        })?;
+                    }
+                    Ok(())
+                }
+                .await;
                 let _ = tx.send(result);
             });
-            rx.await?.inspect_err(|err| {
-                error!(target: "reth::cli", %unwind_target, %inconsistency_source, %err, "failed to run unwind")
-            })?;
+            rx.await??;
         }
 
         Ok(factory)

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -570,7 +570,7 @@ where
         if partial_trie_unwind_target.is_some() || storage_unwind.is_some() {
             let build_unwind_pipeline = |walk_all_changed_branch_children| {
                 let (_tip_tx, tip_rx) = watch::channel(B256::ZERO);
-                let stages = DefaultStages::new(
+                let mut stages = DefaultStages::new(
                     factory.clone(),
                     tip_rx,
                     Arc::new(NoopConsensus::default()),
@@ -581,19 +581,14 @@ where
                     self.prune_modes(),
                     None,
                 )
-                .builder();
-                let stages = if walk_all_changed_branch_children {
-                    stages.set(MerkleStage::new_unwind(true))
-                } else {
-                    stages
-                };
-                let stages = stages.disable_all(disabled_stages);
-                let stages = if walk_all_changed_branch_children {
+                .builder()
+                .disable_all(disabled_stages);
+
+                if walk_all_changed_branch_children {
                     // Partial trie recovery is not complete until Merkle has unwound.
-                    stages.enable(StageId::MerkleUnwind)
-                } else {
-                    stages
-                };
+                    stages =
+                        stages.set(MerkleStage::new_unwind(true)).enable(StageId::MerkleUnwind);
+                }
 
                 PipelineBuilder::default().add_stages(stages).build(
                     factory.clone(),

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -82,7 +82,7 @@ use reth_rpc_layer::JwtSecret;
 use reth_stages::{
     sets::DefaultStages,
     stages::{EraImportSource, MerkleStage},
-    MetricEvent, PipelineBuilder, PipelineTarget, StageCheckpoint, StageId, StageSet,
+    MetricEvent, PipelineBuilder, PipelineTarget, StageId, StageSet,
 };
 use reth_static_file::{blocks_per_file_for_prune_distance, StaticFileProducer, StaticFileSegment};
 use reth_storage_overlay::OverlayManager;
@@ -552,10 +552,7 @@ where
         // Finish is committed before Merkle during unwind, so this marker is authoritative when
         // resuming an interrupted partial trie unwind.
         let (partial_trie_unwind, has_persisted_partial_trie_unwind) =
-            get_partial_trie_unwind_marker(
-                &provider_ro,
-                provider_ro.get_stage_checkpoint(StageId::Finish)?,
-            )?;
+            get_partial_trie_unwind_marker(&provider_ro)?;
         drop(provider_ro);
         let persist_partial_trie_unwind =
             !has_persisted_partial_trie_unwind && partial_trie_unwind.is_some();
@@ -1407,8 +1404,7 @@ pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) 
 }
 
 fn get_partial_trie_unwind_marker(
-    provider: &impl MetadataProvider,
-    finish_checkpoint: Option<StageCheckpoint>,
+    provider: &(impl MetadataProvider + StageCheckpointReader),
 ) -> ProviderResult<(Option<PartialStateTrieUnwindMarker>, bool)> {
     if let Some(marker) = provider.get_metadata(PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY)? {
         let marker = serde_json::from_slice::<PartialStateTrieUnwindMarker>(&marker)
@@ -1422,7 +1418,9 @@ fn get_partial_trie_unwind_marker(
         return Ok((Some(marker), true))
     }
 
-    let Some(finish_checkpoint) = finish_checkpoint else { return Ok((None, false)) };
+    let Some(finish_checkpoint) = provider.get_stage_checkpoint(StageId::Finish)? else {
+        return Ok((None, false))
+    };
     let Some(partial_state_trie) =
         finish_checkpoint.finish_stage_checkpoint().and_then(|finish| finish.partial_state_trie())
     else {
@@ -1470,16 +1468,31 @@ mod tests {
     use reth_config::Config;
     use reth_db_api::models::PartialStateTrieUnwindMarker;
     use reth_node_core::args::PruningArgs;
-    use reth_provider::{MetadataProvider, ProviderResult};
-    use reth_stages::{FinishCheckpoint, StageCheckpoint};
+    use reth_provider::{MetadataProvider, ProviderResult, StageCheckpointReader};
+    use reth_stages::{FinishCheckpoint, StageCheckpoint, StageId};
 
     const EXTENSION: &str = "toml";
 
-    struct MockMetadataProvider(Option<Vec<u8>>);
+    struct MockProvider(Option<Vec<u8>>, Option<StageCheckpoint>);
 
-    impl MetadataProvider for MockMetadataProvider {
+    impl MetadataProvider for MockProvider {
         fn get_metadata(&self, _: &str) -> ProviderResult<Option<Vec<u8>>> {
             Ok(self.0.clone())
+        }
+    }
+
+    impl StageCheckpointReader for MockProvider {
+        fn get_stage_checkpoint(&self, id: StageId) -> ProviderResult<Option<StageCheckpoint>> {
+            assert_eq!(id, StageId::Finish);
+            Ok(self.1)
+        }
+
+        fn get_stage_checkpoint_progress(&self, _: StageId) -> ProviderResult<Option<Vec<u8>>> {
+            Ok(None)
+        }
+
+        fn get_all_checkpoints(&self) -> ProviderResult<Vec<(String, StageCheckpoint)>> {
+            Ok(Vec::new())
         }
     }
 
@@ -1545,8 +1558,7 @@ mod tests {
             );
 
         assert_eq!(
-            get_partial_trie_unwind_marker(&MockMetadataProvider(None), Some(finish_checkpoint))
-                .unwrap(),
+            get_partial_trie_unwind_marker(&MockProvider(None, Some(finish_checkpoint))).unwrap(),
             (expected, false)
         );
 
@@ -1561,8 +1573,7 @@ mod tests {
             );
 
         assert_eq!(
-            get_partial_trie_unwind_marker(&MockMetadataProvider(None), Some(genesis_checkpoint))
-                .unwrap(),
+            get_partial_trie_unwind_marker(&MockProvider(None, Some(genesis_checkpoint))).unwrap(),
             (expected, false)
         );
     }
@@ -1573,18 +1584,18 @@ mod tests {
             PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 21 };
 
         assert_eq!(
-            get_partial_trie_unwind_marker(
-                &MockMetadataProvider(Some(serde_json::to_vec(&marker).unwrap())),
+            get_partial_trie_unwind_marker(&MockProvider(
+                Some(serde_json::to_vec(&marker).unwrap()),
                 Some(StageCheckpoint::new(21)),
-            )
+            ),)
             .unwrap(),
             (Some(marker), true)
         );
         assert_eq!(
-            get_partial_trie_unwind_marker(
-                &MockMetadataProvider(Some(serde_json::to_vec(&marker).unwrap())),
-                None,
-            )
+            get_partial_trie_unwind_marker(&MockProvider(
+                Some(serde_json::to_vec(&marker).unwrap()),
+                None
+            ),)
             .unwrap(),
             (Some(marker), true)
         );
@@ -1600,33 +1611,28 @@ mod tests {
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: None });
 
         assert_eq!(
-            get_partial_trie_unwind_marker(
-                &MockMetadataProvider(None),
-                Some(matching_finish_checkpoint),
-            )
+            get_partial_trie_unwind_marker(&MockProvider(None, Some(matching_finish_checkpoint)),)
+                .unwrap(),
+            (None, false)
+        );
+        assert_eq!(
+            get_partial_trie_unwind_marker(&MockProvider(
+                None,
+                Some(missing_partial_finish_checkpoint)
+            ),)
             .unwrap(),
             (None, false)
         );
         assert_eq!(
-            get_partial_trie_unwind_marker(
-                &MockMetadataProvider(None),
-                Some(missing_partial_finish_checkpoint),
-            )
-            .unwrap(),
-            (None, false)
-        );
-        assert_eq!(
-            get_partial_trie_unwind_marker(&MockMetadataProvider(None), None).unwrap(),
+            get_partial_trie_unwind_marker(&MockProvider(None, None)).unwrap(),
             (None, false)
         );
 
         let partial_frontier = ahead_finish_checkpoint
             .finish_stage_checkpoint()
             .and_then(|finish| finish.partial_state_trie());
-        let result = get_partial_trie_unwind_marker(
-            &MockMetadataProvider(None),
-            Some(ahead_finish_checkpoint),
-        );
+        let result =
+            get_partial_trie_unwind_marker(&MockProvider(None, Some(ahead_finish_checkpoint)));
         if partial_frontier.is_some() {
             let error = result.unwrap_err();
             assert!(error.to_string().contains("ahead of Finish"), "unexpected error: {error}");
@@ -1639,10 +1645,10 @@ mod tests {
     fn get_partial_trie_unwind_marker_rejects_invalid_persisted_marker() {
         let marker =
             PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 42 };
-        let error = get_partial_trie_unwind_marker(
-            &MockMetadataProvider(Some(serde_json::to_vec(&marker).unwrap())),
+        let error = get_partial_trie_unwind_marker(&MockProvider(
+            Some(serde_json::to_vec(&marker).unwrap()),
             None,
-        )
+        ))
         .unwrap_err();
 
         assert!(error.to_string().contains("is not below original Finish"));
@@ -1650,8 +1656,6 @@ mod tests {
 
     #[test]
     fn get_partial_trie_unwind_marker_rejects_malformed_metadata() {
-        assert!(
-            get_partial_trie_unwind_marker(&MockMetadataProvider(Some(vec![0xff])), None).is_err()
-        );
+        assert!(get_partial_trie_unwind_marker(&MockProvider(Some(vec![0xff]), None)).is_err());
     }
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -551,16 +551,14 @@ where
         let provider_ro = factory.database_provider_ro()?;
         // Finish is committed before Merkle during unwind, so this marker is authoritative when
         // resuming an interrupted partial trie unwind.
-        let persisted_partial_trie_unwind =
-            provider_ro.get_metadata(PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY)?;
-        let persist_partial_trie_unwind = persisted_partial_trie_unwind.is_none();
-        let partial_trie_unwind = partial_trie_unwind_marker(
-            persisted_partial_trie_unwind,
-            provider_ro.get_stage_checkpoint(StageId::Finish)?,
-        )?;
+        let (partial_trie_unwind, has_persisted_partial_trie_unwind) =
+            get_partial_trie_unwind_marker(
+                &provider_ro,
+                provider_ro.get_stage_checkpoint(StageId::Finish)?,
+            )?;
         drop(provider_ro);
         let persist_partial_trie_unwind =
-            persist_partial_trie_unwind && partial_trie_unwind.is_some();
+            !has_persisted_partial_trie_unwind && partial_trie_unwind.is_some();
         let partial_trie_unwind_target =
             partial_trie_unwind.map(|marker| marker.partial_state_trie);
         // Recover the partial state trie first. Its unwind enables
@@ -1408,11 +1406,11 @@ pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) 
         .build()
 }
 
-fn partial_trie_unwind_marker(
-    persisted_marker: Option<Vec<u8>>,
+fn get_partial_trie_unwind_marker(
+    provider: &impl MetadataProvider,
     finish_checkpoint: Option<StageCheckpoint>,
-) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
-    if let Some(marker) = persisted_marker {
+) -> ProviderResult<(Option<PartialStateTrieUnwindMarker>, bool)> {
+    if let Some(marker) = provider.get_metadata(PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY)? {
         let marker = serde_json::from_slice::<PartialStateTrieUnwindMarker>(&marker)
             .map_err(ProviderError::other)?;
         if marker.partial_state_trie >= marker.finish_block_number {
@@ -1421,14 +1419,14 @@ fn partial_trie_unwind_marker(
                 marker.partial_state_trie, marker.finish_block_number,
             ))))
         }
-        return Ok(Some(marker))
+        return Ok((Some(marker), true))
     }
 
-    let Some(finish_checkpoint) = finish_checkpoint else { return Ok(None) };
+    let Some(finish_checkpoint) = finish_checkpoint else { return Ok((None, false)) };
     let Some(partial_state_trie) =
         finish_checkpoint.finish_stage_checkpoint().and_then(|finish| finish.partial_state_trie())
     else {
-        return Ok(None)
+        return Ok((None, false))
     };
 
     if partial_state_trie > finish_checkpoint.block_number {
@@ -1438,11 +1436,14 @@ fn partial_trie_unwind_marker(
         ))))
     }
 
-    Ok((partial_state_trie < finish_checkpoint.block_number).then_some(
-        PartialStateTrieUnwindMarker {
-            finish_block_number: finish_checkpoint.block_number,
-            partial_state_trie,
-        },
+    Ok((
+        (partial_state_trie < finish_checkpoint.block_number).then_some(
+            PartialStateTrieUnwindMarker {
+                finish_block_number: finish_checkpoint.block_number,
+                partial_state_trie,
+            },
+        ),
+        false,
     ))
 }
 
@@ -1465,13 +1466,22 @@ fn delete_partial_trie_unwind_marker(provider: &impl MetadataWriter) -> Provider
 
 #[cfg(test)]
 mod tests {
-    use super::{partial_trie_unwind_marker, LaunchContext, NodeConfig};
+    use super::{get_partial_trie_unwind_marker, LaunchContext, NodeConfig};
     use reth_config::Config;
     use reth_db_api::models::PartialStateTrieUnwindMarker;
     use reth_node_core::args::PruningArgs;
+    use reth_provider::{MetadataProvider, ProviderResult};
     use reth_stages::{FinishCheckpoint, StageCheckpoint};
 
     const EXTENSION: &str = "toml";
+
+    struct MockMetadataProvider(Option<Vec<u8>>);
+
+    impl MetadataProvider for MockMetadataProvider {
+        fn get_metadata(&self, _: &str) -> ProviderResult<Option<Vec<u8>>> {
+            Ok(self.0.clone())
+        }
+    }
 
     fn with_tempdir(filename: &str, proc: fn(&std::path::Path)) {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -1523,7 +1533,7 @@ mod tests {
     }
 
     #[test]
-    fn partial_trie_unwind_marker_uses_partial_finish_checkpoint() {
+    fn get_partial_trie_unwind_marker_uses_partial_finish_checkpoint() {
         let finish_checkpoint = StageCheckpoint::new(42)
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(21) });
         let expected =
@@ -1534,7 +1544,11 @@ mod tests {
                 },
             );
 
-        assert_eq!(partial_trie_unwind_marker(None, Some(finish_checkpoint)).unwrap(), expected);
+        assert_eq!(
+            get_partial_trie_unwind_marker(&MockMetadataProvider(None), Some(finish_checkpoint))
+                .unwrap(),
+            (expected, false)
+        );
 
         let genesis_checkpoint = StageCheckpoint::new(42)
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(0) });
@@ -1546,30 +1560,38 @@ mod tests {
                 },
             );
 
-        assert_eq!(partial_trie_unwind_marker(None, Some(genesis_checkpoint)).unwrap(), expected);
+        assert_eq!(
+            get_partial_trie_unwind_marker(&MockMetadataProvider(None), Some(genesis_checkpoint))
+                .unwrap(),
+            (expected, false)
+        );
     }
 
     #[test]
-    fn partial_trie_unwind_marker_resumes_persisted_unwind() {
+    fn get_partial_trie_unwind_marker_resumes_persisted_unwind() {
         let marker =
             PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 21 };
 
         assert_eq!(
-            partial_trie_unwind_marker(
-                Some(serde_json::to_vec(&marker).unwrap()),
+            get_partial_trie_unwind_marker(
+                &MockMetadataProvider(Some(serde_json::to_vec(&marker).unwrap())),
                 Some(StageCheckpoint::new(21)),
             )
             .unwrap(),
-            Some(marker)
+            (Some(marker), true)
         );
         assert_eq!(
-            partial_trie_unwind_marker(Some(serde_json::to_vec(&marker).unwrap()), None).unwrap(),
-            Some(marker)
+            get_partial_trie_unwind_marker(
+                &MockMetadataProvider(Some(serde_json::to_vec(&marker).unwrap())),
+                None,
+            )
+            .unwrap(),
+            (Some(marker), true)
         );
     }
 
     #[test]
-    fn partial_trie_unwind_marker_ignores_non_lagging_or_missing_partial_checkpoint() {
+    fn get_partial_trie_unwind_marker_ignores_non_lagging_or_missing_partial_checkpoint() {
         let matching_finish_checkpoint = StageCheckpoint::new(42)
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(42) });
         let ahead_finish_checkpoint = StageCheckpoint::new(42)
@@ -1578,39 +1600,58 @@ mod tests {
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: None });
 
         assert_eq!(
-            partial_trie_unwind_marker(None, Some(matching_finish_checkpoint)).unwrap(),
-            None
+            get_partial_trie_unwind_marker(
+                &MockMetadataProvider(None),
+                Some(matching_finish_checkpoint),
+            )
+            .unwrap(),
+            (None, false)
         );
         assert_eq!(
-            partial_trie_unwind_marker(None, Some(missing_partial_finish_checkpoint)).unwrap(),
-            None
+            get_partial_trie_unwind_marker(
+                &MockMetadataProvider(None),
+                Some(missing_partial_finish_checkpoint),
+            )
+            .unwrap(),
+            (None, false)
         );
-        assert_eq!(partial_trie_unwind_marker(None, None).unwrap(), None);
+        assert_eq!(
+            get_partial_trie_unwind_marker(&MockMetadataProvider(None), None).unwrap(),
+            (None, false)
+        );
 
         let partial_frontier = ahead_finish_checkpoint
             .finish_stage_checkpoint()
             .and_then(|finish| finish.partial_state_trie());
-        let result = partial_trie_unwind_marker(None, Some(ahead_finish_checkpoint));
+        let result = get_partial_trie_unwind_marker(
+            &MockMetadataProvider(None),
+            Some(ahead_finish_checkpoint),
+        );
         if partial_frontier.is_some() {
             let error = result.unwrap_err();
             assert!(error.to_string().contains("ahead of Finish"), "unexpected error: {error}");
         } else {
-            assert_eq!(result.unwrap(), None);
+            assert_eq!(result.unwrap(), (None, false));
         }
     }
 
     #[test]
-    fn partial_trie_unwind_marker_rejects_invalid_persisted_marker() {
+    fn get_partial_trie_unwind_marker_rejects_invalid_persisted_marker() {
         let marker =
             PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 42 };
-        let error = partial_trie_unwind_marker(Some(serde_json::to_vec(&marker).unwrap()), None)
-            .unwrap_err();
+        let error = get_partial_trie_unwind_marker(
+            &MockMetadataProvider(Some(serde_json::to_vec(&marker).unwrap())),
+            None,
+        )
+        .unwrap_err();
 
         assert!(error.to_string().contains("is not below original Finish"));
     }
 
     #[test]
-    fn partial_trie_unwind_marker_rejects_malformed_metadata() {
-        assert!(partial_trie_unwind_marker(Some(vec![0xff]), None).is_err());
+    fn get_partial_trie_unwind_marker_rejects_malformed_metadata() {
+        assert!(
+            get_partial_trie_unwind_marker(&MockMetadataProvider(Some(vec![0xff])), None).is_err()
+        );
     }
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -549,8 +549,10 @@ where
         let partial_trie_unwind = partial_trie_unwind_target(
             factory.database_provider_ro()?.get_stage_checkpoint(StageId::Finish)?,
         )?;
-        // The partial state-trie recovery must run first so Merkle's unwind can retain the
-        // complete changed branch. A lower storage-layer target is unwound afterwards.
+        // Recover the partial state trie first. Its unwind enables
+        // `walk_all_changed_branch_children`, which is more expensive than a normal unwind, so
+        // it only runs to the partial trie target. A lower storage-layer target is then unwound
+        // normally.
         let storage_unwind = [rocksdb_unwind, static_file_unwind].into_iter().flatten().min();
         let storage_unwind = storage_unwind.filter(|unwind_block| {
             partial_trie_unwind.is_none_or(|partial_trie| *unwind_block < partial_trie)

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -69,16 +69,17 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BalConfig, BalStoreHandle, BlockHashReader, BlockNumReader, InMemoryBalStore, ProviderError,
-    ProviderFactory, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
-    StaticFileProviderBuilder, StaticFileProviderFactory, StorageSettingsCache,
+    BalConfig, BalStoreHandle, BlockHashReader, BlockNumReader, DatabaseProviderFactory,
+    InMemoryBalStore, ProviderError, ProviderFactory, ProviderResult, RocksDBProviderFactory,
+    StageCheckpointReader, StaticFileProviderBuilder, StaticFileProviderFactory,
+    StorageSettingsCache,
 };
 use reth_prune::{PruneMode, PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
 use reth_rpc_layer::JwtSecret;
 use reth_stages::{
     sets::DefaultStages, stages::EraImportSource, MetricEvent, PipelineBuilder, PipelineTarget,
-    StageId, StageSet,
+    StageCheckpoint, StageId, StageSet,
 };
 use reth_static_file::{blocks_per_file_for_prune_distance, StaticFileProducer, StaticFileSegment};
 use reth_storage_overlay::OverlayManager;
@@ -544,23 +545,31 @@ where
         // the unwind targets for each storage layer if inconsistencies are
         // found.
         let (rocksdb_unwind, static_file_unwind) = factory.check_consistency()?;
+        let partial_trie_unwind = partial_trie_unwind_target(
+            factory.database_provider_ro()?.get_stage_checkpoint(StageId::Finish)?,
+        )?;
 
         // Take the minimum block number to ensure all storage layers are consistent.
-        let unwind_target = [rocksdb_unwind, static_file_unwind].into_iter().flatten().min();
+        let unwind_target =
+            [rocksdb_unwind, static_file_unwind, partial_trie_unwind].into_iter().flatten().min();
 
         if let Some(unwind_block) = unwind_target {
-            // Highly unlikely to happen, and given its destructive nature, it's better to panic
-            // instead. Unwinding to 0 would leave MDBX with a huge free list size.
-            let inconsistency_source = match (rocksdb_unwind, static_file_unwind) {
-                (Some(_), Some(_)) => "RocksDB and static file",
-                (Some(_), None) => "RocksDB",
-                (None, Some(_)) => "static file",
-                (None, None) => unreachable!(),
-            };
-            assert_ne!(
-                unwind_block, 0,
-                "A {} inconsistency was found that would trigger an unwind to block 0",
-                inconsistency_source
+            let inconsistency_source = [
+                rocksdb_unwind.map(|_| "RocksDB"),
+                static_file_unwind.map(|_| "static file"),
+                partial_trie_unwind.map(|_| "partial state trie"),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join(" and ");
+            // A partial frontier at genesis is valid while the first masking window is in memory,
+            // so losing that window requires unwinding to genesis. Keep rejecting block-zero
+            // targets caused only by cross-store inconsistency because that can leave MDBX with a
+            // huge free list.
+            assert!(
+                unwind_block != 0 || partial_trie_unwind == Some(0),
+                "A {inconsistency_source} inconsistency was found that would trigger an unwind to block 0"
             );
 
             let unwind_target = PipelineTarget::Unwind(unwind_block);
@@ -1336,11 +1345,32 @@ pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) 
         .build()
 }
 
+fn partial_trie_unwind_target(
+    finish_checkpoint: Option<StageCheckpoint>,
+) -> ProviderResult<Option<BlockNumber>> {
+    let Some(finish_checkpoint) = finish_checkpoint else { return Ok(None) };
+    let Some(partial_state_trie) =
+        finish_checkpoint.finish_stage_checkpoint().and_then(|finish| finish.partial_state_trie())
+    else {
+        return Ok(None)
+    };
+
+    if partial_state_trie > finish_checkpoint.block_number {
+        return Err(ProviderError::other(std::io::Error::other(format!(
+            "partial state trie frontier #{partial_state_trie} is ahead of Finish #{}",
+            finish_checkpoint.block_number,
+        ))))
+    }
+
+    Ok((partial_state_trie < finish_checkpoint.block_number).then_some(partial_state_trie))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{LaunchContext, NodeConfig};
+    use super::{partial_trie_unwind_target, LaunchContext, NodeConfig};
     use reth_config::Config;
     use reth_node_core::args::PruningArgs;
+    use reth_stages::{FinishCheckpoint, StageCheckpoint};
 
     const EXTENSION: &str = "toml";
 
@@ -1391,5 +1421,48 @@ mod tests {
 
             assert_eq!(reth_config, loaded_config);
         })
+    }
+
+    #[test]
+    fn partial_trie_unwind_target_uses_partial_finish_checkpoint() {
+        let finish_checkpoint = StageCheckpoint::new(42)
+            .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(21) });
+        let expected = finish_checkpoint.finish_stage_checkpoint().unwrap().partial_state_trie();
+
+        assert_eq!(partial_trie_unwind_target(Some(finish_checkpoint)).unwrap(), expected);
+
+        let genesis_checkpoint = StageCheckpoint::new(42)
+            .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(0) });
+        let expected = genesis_checkpoint.finish_stage_checkpoint().unwrap().partial_state_trie();
+
+        assert_eq!(partial_trie_unwind_target(Some(genesis_checkpoint)).unwrap(), expected);
+    }
+
+    #[test]
+    fn partial_trie_unwind_target_ignores_non_lagging_or_missing_partial_checkpoint() {
+        let matching_finish_checkpoint = StageCheckpoint::new(42)
+            .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(42) });
+        let ahead_finish_checkpoint = StageCheckpoint::new(42)
+            .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(43) });
+        let missing_partial_finish_checkpoint = StageCheckpoint::new(42)
+            .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: None });
+
+        assert_eq!(partial_trie_unwind_target(Some(matching_finish_checkpoint)).unwrap(), None);
+        assert_eq!(
+            partial_trie_unwind_target(Some(missing_partial_finish_checkpoint)).unwrap(),
+            None
+        );
+        assert_eq!(partial_trie_unwind_target(None).unwrap(), None);
+
+        let partial_frontier = ahead_finish_checkpoint
+            .finish_stage_checkpoint()
+            .and_then(|finish| finish.partial_state_trie());
+        let result = partial_trie_unwind_target(Some(ahead_finish_checkpoint));
+        if partial_frontier.is_some() {
+            let error = result.unwrap_err();
+            assert!(error.to_string().contains("ahead of Finish"), "unexpected error: {error}");
+        } else {
+            assert_eq!(result.unwrap(), None);
+        }
     }
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -551,7 +551,7 @@ where
         let provider_ro = factory.database_provider_ro()?;
         // Finish is committed before Merkle during unwind, so this marker is authoritative when
         // resuming an interrupted partial trie unwind.
-        let persisted_partial_trie_unwind = provider_ro.partial_state_trie_unwind()?;
+        let persisted_partial_trie_unwind = read_partial_trie_unwind_marker(&provider_ro)?;
         let partial_trie_unwind = partial_trie_unwind_marker(
             persisted_partial_trie_unwind,
             provider_ro.get_stage_checkpoint(StageId::Finish)?,
@@ -638,7 +638,8 @@ where
             if persist_partial_trie_unwind {
                 // The marker must be durable before any unwind stage can commit.
                 let provider_rw = factory.database_provider_rw()?;
-                provider_rw.write_partial_state_trie_unwind(
+                write_partial_trie_unwind_marker(
+                    &provider_rw,
                     partial_trie_unwind.expect("partial trie unwind marker must exist"),
                 )?;
                 provider_rw.commit()?;
@@ -661,7 +662,7 @@ where
 
                         if clear_partial_trie_unwind {
                             let provider_rw = factory.database_provider_rw()?;
-                            provider_rw.delete_partial_state_trie_unwind()?;
+                            delete_partial_trie_unwind_marker(&provider_rw)?;
                             provider_rw.commit()?;
                         }
                     }
@@ -1441,9 +1442,42 @@ fn partial_trie_unwind_marker(
     ))
 }
 
+/// Metadata key for a partial state trie unwind that has not completed yet.
+const PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY: &str = "partial_state_trie_unwind";
+
+fn read_partial_trie_unwind_marker(
+    provider: &impl MetadataProvider,
+) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
+    decode_partial_trie_unwind_marker(
+        provider.get_metadata(PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY)?,
+    )
+}
+
+fn decode_partial_trie_unwind_marker(
+    marker: Option<Vec<u8>>,
+) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
+    marker.map(|bytes| serde_json::from_slice(&bytes).map_err(ProviderError::other)).transpose()
+}
+
+fn write_partial_trie_unwind_marker(
+    provider: &impl MetadataWriter,
+    marker: PartialStateTrieUnwindMarker,
+) -> ProviderResult<()> {
+    provider.write_metadata(
+        PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY,
+        serde_json::to_vec(&marker).map_err(ProviderError::other)?,
+    )
+}
+
+fn delete_partial_trie_unwind_marker(provider: &impl MetadataWriter) -> ProviderResult<()> {
+    provider.delete_metadata(PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{partial_trie_unwind_marker, LaunchContext, NodeConfig};
+    use super::{
+        decode_partial_trie_unwind_marker, partial_trie_unwind_marker, LaunchContext, NodeConfig,
+    };
     use reth_config::Config;
     use reth_db_api::models::PartialStateTrieUnwindMarker;
     use reth_node_core::args::PruningArgs;
@@ -1577,5 +1611,10 @@ mod tests {
         let error = partial_trie_unwind_marker(Some(marker), None).unwrap_err();
 
         assert!(error.to_string().contains("is not below original Finish"));
+    }
+
+    #[test]
+    fn partial_trie_unwind_marker_rejects_malformed_metadata() {
+        assert!(decode_partial_trie_unwind_marker(Some(vec![0xff])).is_err());
     }
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -572,7 +572,7 @@ where
                 )
                 .builder();
                 let stages = if walk_all_changed_branch_children {
-                    stages.set(MerkleStage::unwind_with_changed_branch_children())
+                    stages.set(MerkleStage::new_unwind(true))
                 } else {
                     stages
                 };

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -551,14 +551,16 @@ where
         let provider_ro = factory.database_provider_ro()?;
         // Finish is committed before Merkle during unwind, so this marker is authoritative when
         // resuming an interrupted partial trie unwind.
-        let persisted_partial_trie_unwind = read_partial_trie_unwind_marker(&provider_ro)?;
+        let persisted_partial_trie_unwind =
+            provider_ro.get_metadata(PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY)?;
+        let persist_partial_trie_unwind = persisted_partial_trie_unwind.is_none();
         let partial_trie_unwind = partial_trie_unwind_marker(
             persisted_partial_trie_unwind,
             provider_ro.get_stage_checkpoint(StageId::Finish)?,
         )?;
         drop(provider_ro);
         let persist_partial_trie_unwind =
-            persisted_partial_trie_unwind.is_none() && partial_trie_unwind.is_some();
+            persist_partial_trie_unwind && partial_trie_unwind.is_some();
         let partial_trie_unwind_target =
             partial_trie_unwind.map(|marker| marker.partial_state_trie);
         // Recover the partial state trie first. Its unwind enables
@@ -1407,10 +1409,12 @@ pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) 
 }
 
 fn partial_trie_unwind_marker(
-    persisted_marker: Option<PartialStateTrieUnwindMarker>,
+    persisted_marker: Option<Vec<u8>>,
     finish_checkpoint: Option<StageCheckpoint>,
 ) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
     if let Some(marker) = persisted_marker {
+        let marker = serde_json::from_slice::<PartialStateTrieUnwindMarker>(&marker)
+            .map_err(ProviderError::other)?;
         if marker.partial_state_trie >= marker.finish_block_number {
             return Err(ProviderError::other(std::io::Error::other(format!(
                 "partial state trie unwind target #{} is not below original Finish #{}",
@@ -1445,20 +1449,6 @@ fn partial_trie_unwind_marker(
 /// Metadata key for a partial state trie unwind that has not completed yet.
 const PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY: &str = "partial_state_trie_unwind";
 
-fn read_partial_trie_unwind_marker(
-    provider: &impl MetadataProvider,
-) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
-    decode_partial_trie_unwind_marker(
-        provider.get_metadata(PARTIAL_STATE_TRIE_UNWIND_METADATA_KEY)?,
-    )
-}
-
-fn decode_partial_trie_unwind_marker(
-    marker: Option<Vec<u8>>,
-) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
-    marker.map(|bytes| serde_json::from_slice(&bytes).map_err(ProviderError::other)).transpose()
-}
-
 fn write_partial_trie_unwind_marker(
     provider: &impl MetadataWriter,
     marker: PartialStateTrieUnwindMarker,
@@ -1475,9 +1465,7 @@ fn delete_partial_trie_unwind_marker(provider: &impl MetadataWriter) -> Provider
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        decode_partial_trie_unwind_marker, partial_trie_unwind_marker, LaunchContext, NodeConfig,
-    };
+    use super::{partial_trie_unwind_marker, LaunchContext, NodeConfig};
     use reth_config::Config;
     use reth_db_api::models::PartialStateTrieUnwindMarker;
     use reth_node_core::args::PruningArgs;
@@ -1567,10 +1555,17 @@ mod tests {
             PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 21 };
 
         assert_eq!(
-            partial_trie_unwind_marker(Some(marker), Some(StageCheckpoint::new(21))).unwrap(),
+            partial_trie_unwind_marker(
+                Some(serde_json::to_vec(&marker).unwrap()),
+                Some(StageCheckpoint::new(21)),
+            )
+            .unwrap(),
             Some(marker)
         );
-        assert_eq!(partial_trie_unwind_marker(Some(marker), None).unwrap(), Some(marker));
+        assert_eq!(
+            partial_trie_unwind_marker(Some(serde_json::to_vec(&marker).unwrap()), None).unwrap(),
+            Some(marker)
+        );
     }
 
     #[test]
@@ -1608,13 +1603,14 @@ mod tests {
     fn partial_trie_unwind_marker_rejects_invalid_persisted_marker() {
         let marker =
             PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 42 };
-        let error = partial_trie_unwind_marker(Some(marker), None).unwrap_err();
+        let error = partial_trie_unwind_marker(Some(serde_json::to_vec(&marker).unwrap()), None)
+            .unwrap_err();
 
         assert!(error.to_string().contains("is not below original Finish"));
     }
 
     #[test]
     fn partial_trie_unwind_marker_rejects_malformed_metadata() {
-        assert!(decode_partial_trie_unwind_marker(Some(vec![0xff])).is_err());
+        assert!(partial_trie_unwind_marker(Some(vec![0xff]), None).is_err());
     }
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -41,7 +41,9 @@ use rayon::ThreadPoolBuilder;
 use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks};
 use reth_config::{config::EtlConfig, PruneConfig};
 use reth_consensus::noop::NoopConsensus;
-use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
+use reth_db_api::{
+    database::Database, database_metrics::DatabaseMetrics, models::PartialStateTrieUnwindMarker,
+};
 use reth_db_common::init::{
     init_genesis_with_settings, init_genesis_with_settings_and_validate, InitStorageError,
 };
@@ -69,10 +71,10 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BalConfig, BalStoreHandle, BlockHashReader, BlockNumReader, DatabaseProviderFactory,
-    InMemoryBalStore, ProviderError, ProviderFactory, ProviderResult, RocksDBProviderFactory,
-    StageCheckpointReader, StaticFileProviderBuilder, StaticFileProviderFactory,
-    StorageSettingsCache,
+    BalConfig, BalStoreHandle, BlockHashReader, BlockNumReader, DBProvider,
+    DatabaseProviderFactory, InMemoryBalStore, MetadataProvider, MetadataWriter, ProviderError,
+    ProviderFactory, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
+    StaticFileProviderBuilder, StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_prune::{PruneMode, PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
@@ -546,19 +548,29 @@ where
         // the unwind targets for each storage layer if inconsistencies are
         // found.
         let (rocksdb_unwind, static_file_unwind) = factory.check_consistency()?;
-        let partial_trie_unwind = partial_trie_unwind_target(
-            factory.database_provider_ro()?.get_stage_checkpoint(StageId::Finish)?,
+        let provider_ro = factory.database_provider_ro()?;
+        // Finish is committed before Merkle during unwind, so this marker is authoritative when
+        // resuming an interrupted partial trie unwind.
+        let persisted_partial_trie_unwind = provider_ro.partial_state_trie_unwind()?;
+        let partial_trie_unwind = partial_trie_unwind_marker(
+            persisted_partial_trie_unwind,
+            provider_ro.get_stage_checkpoint(StageId::Finish)?,
         )?;
+        drop(provider_ro);
+        let persist_partial_trie_unwind =
+            persisted_partial_trie_unwind.is_none() && partial_trie_unwind.is_some();
+        let partial_trie_unwind_target =
+            partial_trie_unwind.map(|marker| marker.partial_state_trie);
         // Recover the partial state trie first. Its unwind enables
         // `walk_all_changed_branch_children`, which is more expensive than a normal unwind, so
         // it only runs to the partial trie target. A lower storage-layer target is then unwound
         // normally.
         let storage_unwind = [rocksdb_unwind, static_file_unwind].into_iter().flatten().min();
         let storage_unwind = storage_unwind.filter(|unwind_block| {
-            partial_trie_unwind.is_none_or(|partial_trie| *unwind_block < partial_trie)
+            partial_trie_unwind_target.is_none_or(|partial_trie| *unwind_block < partial_trie)
         });
 
-        if partial_trie_unwind.is_some() || storage_unwind.is_some() {
+        if partial_trie_unwind_target.is_some() || storage_unwind.is_some() {
             let build_unwind_pipeline = |walk_all_changed_branch_children| {
                 let (_tip_tx, tip_rx) = watch::channel(B256::ZERO);
                 let stages = DefaultStages::new(
@@ -578,19 +590,27 @@ where
                 } else {
                     stages
                 };
+                let stages = stages.disable_all(disabled_stages);
+                let stages = if walk_all_changed_branch_children {
+                    // Partial trie recovery is not complete until Merkle has unwound.
+                    stages.enable(StageId::MerkleUnwind)
+                } else {
+                    stages
+                };
 
-                PipelineBuilder::default().add_stages(stages.disable_all(disabled_stages)).build(
+                PipelineBuilder::default().add_stages(stages).build(
                     factory.clone(),
                     StaticFileProducer::new(factory.clone(), self.prune_modes()),
                 )
             };
             let mut unwinds = Vec::with_capacity(2);
 
-            if let Some(unwind_block) = partial_trie_unwind {
+            if let Some(unwind_block) = partial_trie_unwind_target {
                 unwinds.push((
                     PipelineTarget::Unwind(unwind_block),
                     "partial state trie".to_owned(),
                     build_unwind_pipeline(true),
+                    true,
                 ));
             }
 
@@ -611,20 +631,39 @@ where
                     PipelineTarget::Unwind(unwind_block),
                     inconsistency_source.to_owned(),
                     build_unwind_pipeline(false),
+                    false,
                 ));
             }
 
+            if persist_partial_trie_unwind {
+                // The marker must be durable before any unwind stage can commit.
+                let provider_rw = factory.database_provider_rw()?;
+                provider_rw.write_partial_state_trie_unwind(
+                    partial_trie_unwind.expect("partial trie unwind marker must exist"),
+                )?;
+                provider_rw.commit()?;
+            }
+
             let (tx, rx) = oneshot::channel();
+            let factory = factory.clone();
 
             // Pipeline should be run as blocking and panic if it fails.
             self.task_executor().spawn_critical_blocking_task("pipeline task", async move {
                 let result: Result<(), reth_stages::PipelineError> = async {
-                    for (unwind_target, inconsistency_source, pipeline) in unwinds {
+                    for (unwind_target, inconsistency_source, pipeline, clear_partial_trie_unwind) in
+                        unwinds
+                    {
                         info!(target: "reth::cli", %unwind_target, %inconsistency_source, "Executing unwind after consistency check.");
                         let (_, result) = pipeline.run_as_fut(Some(unwind_target)).await;
                         result.inspect_err(|err| {
                             error!(target: "reth::cli", %unwind_target, %inconsistency_source, %err, "failed to run unwind");
                         })?;
+
+                        if clear_partial_trie_unwind {
+                            let provider_rw = factory.database_provider_rw()?;
+                            provider_rw.delete_partial_state_trie_unwind()?;
+                            provider_rw.commit()?;
+                        }
                     }
                     Ok(())
                 }
@@ -1366,9 +1405,20 @@ pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) 
         .build()
 }
 
-fn partial_trie_unwind_target(
+fn partial_trie_unwind_marker(
+    persisted_marker: Option<PartialStateTrieUnwindMarker>,
     finish_checkpoint: Option<StageCheckpoint>,
-) -> ProviderResult<Option<BlockNumber>> {
+) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
+    if let Some(marker) = persisted_marker {
+        if marker.partial_state_trie >= marker.finish_block_number {
+            return Err(ProviderError::other(std::io::Error::other(format!(
+                "partial state trie unwind target #{} is not below original Finish #{}",
+                marker.partial_state_trie, marker.finish_block_number,
+            ))))
+        }
+        return Ok(Some(marker))
+    }
+
     let Some(finish_checkpoint) = finish_checkpoint else { return Ok(None) };
     let Some(partial_state_trie) =
         finish_checkpoint.finish_stage_checkpoint().and_then(|finish| finish.partial_state_trie())
@@ -1383,13 +1433,19 @@ fn partial_trie_unwind_target(
         ))))
     }
 
-    Ok((partial_state_trie < finish_checkpoint.block_number).then_some(partial_state_trie))
+    Ok((partial_state_trie < finish_checkpoint.block_number).then_some(
+        PartialStateTrieUnwindMarker {
+            finish_block_number: finish_checkpoint.block_number,
+            partial_state_trie,
+        },
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{partial_trie_unwind_target, LaunchContext, NodeConfig};
+    use super::{partial_trie_unwind_marker, LaunchContext, NodeConfig};
     use reth_config::Config;
+    use reth_db_api::models::PartialStateTrieUnwindMarker;
     use reth_node_core::args::PruningArgs;
     use reth_stages::{FinishCheckpoint, StageCheckpoint};
 
@@ -1445,22 +1501,46 @@ mod tests {
     }
 
     #[test]
-    fn partial_trie_unwind_target_uses_partial_finish_checkpoint() {
+    fn partial_trie_unwind_marker_uses_partial_finish_checkpoint() {
         let finish_checkpoint = StageCheckpoint::new(42)
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(21) });
-        let expected = finish_checkpoint.finish_stage_checkpoint().unwrap().partial_state_trie();
+        let expected =
+            finish_checkpoint.finish_stage_checkpoint().unwrap().partial_state_trie().map(
+                |partial_state_trie| PartialStateTrieUnwindMarker {
+                    finish_block_number: finish_checkpoint.block_number,
+                    partial_state_trie,
+                },
+            );
 
-        assert_eq!(partial_trie_unwind_target(Some(finish_checkpoint)).unwrap(), expected);
+        assert_eq!(partial_trie_unwind_marker(None, Some(finish_checkpoint)).unwrap(), expected);
 
         let genesis_checkpoint = StageCheckpoint::new(42)
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(0) });
-        let expected = genesis_checkpoint.finish_stage_checkpoint().unwrap().partial_state_trie();
+        let expected =
+            genesis_checkpoint.finish_stage_checkpoint().unwrap().partial_state_trie().map(
+                |partial_state_trie| PartialStateTrieUnwindMarker {
+                    finish_block_number: genesis_checkpoint.block_number,
+                    partial_state_trie,
+                },
+            );
 
-        assert_eq!(partial_trie_unwind_target(Some(genesis_checkpoint)).unwrap(), expected);
+        assert_eq!(partial_trie_unwind_marker(None, Some(genesis_checkpoint)).unwrap(), expected);
     }
 
     #[test]
-    fn partial_trie_unwind_target_ignores_non_lagging_or_missing_partial_checkpoint() {
+    fn partial_trie_unwind_marker_resumes_persisted_unwind() {
+        let marker =
+            PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 21 };
+
+        assert_eq!(
+            partial_trie_unwind_marker(Some(marker), Some(StageCheckpoint::new(21))).unwrap(),
+            Some(marker)
+        );
+        assert_eq!(partial_trie_unwind_marker(Some(marker), None).unwrap(), Some(marker));
+    }
+
+    #[test]
+    fn partial_trie_unwind_marker_ignores_non_lagging_or_missing_partial_checkpoint() {
         let matching_finish_checkpoint = StageCheckpoint::new(42)
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: Some(42) });
         let ahead_finish_checkpoint = StageCheckpoint::new(42)
@@ -1468,22 +1548,34 @@ mod tests {
         let missing_partial_finish_checkpoint = StageCheckpoint::new(42)
             .with_finish_stage_checkpoint(FinishCheckpoint { partial_state_trie: None });
 
-        assert_eq!(partial_trie_unwind_target(Some(matching_finish_checkpoint)).unwrap(), None);
         assert_eq!(
-            partial_trie_unwind_target(Some(missing_partial_finish_checkpoint)).unwrap(),
+            partial_trie_unwind_marker(None, Some(matching_finish_checkpoint)).unwrap(),
             None
         );
-        assert_eq!(partial_trie_unwind_target(None).unwrap(), None);
+        assert_eq!(
+            partial_trie_unwind_marker(None, Some(missing_partial_finish_checkpoint)).unwrap(),
+            None
+        );
+        assert_eq!(partial_trie_unwind_marker(None, None).unwrap(), None);
 
         let partial_frontier = ahead_finish_checkpoint
             .finish_stage_checkpoint()
             .and_then(|finish| finish.partial_state_trie());
-        let result = partial_trie_unwind_target(Some(ahead_finish_checkpoint));
+        let result = partial_trie_unwind_marker(None, Some(ahead_finish_checkpoint));
         if partial_frontier.is_some() {
             let error = result.unwrap_err();
             assert!(error.to_string().contains("ahead of Finish"), "unexpected error: {error}");
         } else {
             assert_eq!(result.unwrap(), None);
         }
+    }
+
+    #[test]
+    fn partial_trie_unwind_marker_rejects_invalid_persisted_marker() {
+        let marker =
+            PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 42 };
+        let error = partial_trie_unwind_marker(Some(marker), None).unwrap_err();
+
+        assert!(error.to_string().contains("is not below original Finish"));
     }
 }

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -402,7 +402,11 @@ where
             info!(target: "sync::stages::merkle::unwind", "Nothing to unwind");
         } else {
             let (block_root, updates) = reth_trie_db::with_adapter!(provider, |A| {
-                DbStateRoot::<_, A>::incremental_root_with_updates(provider, range)
+                DbStateRoot::<_, A>::incremental_root_calculator(provider, range).and_then(
+                    |calculator| {
+                        calculator.with_walk_all_changed_branch_children(true).root_with_updates()
+                    },
+                )
             })
             .map_err(|e| StageError::Fatal(Box::new(e)))?;
 

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -90,10 +90,9 @@ pub enum MerkleStage {
         incremental_threshold: u64,
     },
     /// The unwind portion of the merkle stage.
-    Unwind {
-        /// Whether every child of a changed branch path should be walked.
-        walk_all_changed_branch_children: bool,
-    },
+    Unwind,
+    /// The unwind portion that walks every child of a changed branch path.
+    UnwindWithChangedBranchChildren,
     /// Able to execute and unwind. Used for tests
     #[cfg(any(test, feature = "test-utils"))]
     Both {
@@ -118,12 +117,12 @@ impl MerkleStage {
 
     /// Stage default for the [`MerkleStage::Unwind`].
     pub const fn default_unwind() -> Self {
-        Self::new_unwind(false)
+        Self::Unwind
     }
 
-    /// Create a new instance of [`MerkleStage::Unwind`].
-    pub const fn new_unwind(walk_all_changed_branch_children: bool) -> Self {
-        Self::Unwind { walk_all_changed_branch_children }
+    /// Stage unwind that visits every child of changed branch paths.
+    pub const fn unwind_with_changed_branch_children() -> Self {
+        Self::UnwindWithChangedBranchChildren
     }
 
     /// Create new instance of [`MerkleStage::Execution`].
@@ -182,7 +181,7 @@ where
     fn id(&self) -> StageId {
         match self {
             Self::Execution { .. } => StageId::MerkleExecute,
-            Self::Unwind { .. } => StageId::MerkleUnwind,
+            Self::Unwind | Self::UnwindWithChangedBranchChildren => StageId::MerkleUnwind,
             #[cfg(any(test, feature = "test-utils"))]
             Self::Both { .. } => StageId::Other("MerkleBoth"),
         }
@@ -191,7 +190,7 @@ where
     /// Execute the stage.
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         let (threshold, incremental_threshold) = match self {
-            Self::Unwind { .. } => {
+            Self::Unwind | Self::UnwindWithChangedBranchChildren => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
                 return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
             }
@@ -385,12 +384,8 @@ where
             info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
             return Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
         }
-        let walk_all_changed_branch_children = match self {
-            Self::Unwind { walk_all_changed_branch_children } => *walk_all_changed_branch_children,
-            #[cfg(any(test, feature = "test-utils"))]
-            Self::Both { .. } => false,
-            Self::Execution { .. } => unreachable!(),
-        };
+        let walk_all_changed_branch_children =
+            matches!(self, Self::UnwindWithChangedBranchChildren);
 
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -90,9 +90,10 @@ pub enum MerkleStage {
         incremental_threshold: u64,
     },
     /// The unwind portion of the merkle stage.
-    Unwind,
-    /// The unwind portion that walks every child of a changed branch path.
-    UnwindWithChangedBranchChildren,
+    Unwind {
+        /// Whether every child of a changed branch path should be walked.
+        walk_all_changed_branch_children: bool,
+    },
     /// Able to execute and unwind. Used for tests
     #[cfg(any(test, feature = "test-utils"))]
     Both {
@@ -117,12 +118,12 @@ impl MerkleStage {
 
     /// Stage default for the [`MerkleStage::Unwind`].
     pub const fn default_unwind() -> Self {
-        Self::Unwind
+        Self::new_unwind(false)
     }
 
-    /// Stage unwind that visits every child of changed branch paths.
-    pub const fn unwind_with_changed_branch_children() -> Self {
-        Self::UnwindWithChangedBranchChildren
+    /// Create a new instance of [`MerkleStage::Unwind`].
+    pub const fn new_unwind(walk_all_changed_branch_children: bool) -> Self {
+        Self::Unwind { walk_all_changed_branch_children }
     }
 
     /// Create new instance of [`MerkleStage::Execution`].
@@ -181,7 +182,7 @@ where
     fn id(&self) -> StageId {
         match self {
             Self::Execution { .. } => StageId::MerkleExecute,
-            Self::Unwind | Self::UnwindWithChangedBranchChildren => StageId::MerkleUnwind,
+            Self::Unwind { .. } => StageId::MerkleUnwind,
             #[cfg(any(test, feature = "test-utils"))]
             Self::Both { .. } => StageId::Other("MerkleBoth"),
         }
@@ -190,7 +191,7 @@ where
     /// Execute the stage.
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         let (threshold, incremental_threshold) = match self {
-            Self::Unwind | Self::UnwindWithChangedBranchChildren => {
+            Self::Unwind { .. } => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
                 return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
             }
@@ -384,8 +385,12 @@ where
             info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
             return Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
         }
-        let walk_all_changed_branch_children =
-            matches!(self, Self::UnwindWithChangedBranchChildren);
+        let walk_all_changed_branch_children = match self {
+            Self::Unwind { walk_all_changed_branch_children } => *walk_all_changed_branch_children,
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Both { .. } => false,
+            Self::Execution { .. } => unreachable!(),
+        };
 
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -90,7 +90,10 @@ pub enum MerkleStage {
         incremental_threshold: u64,
     },
     /// The unwind portion of the merkle stage.
-    Unwind,
+    Unwind {
+        /// Whether every child of a changed branch path should be walked.
+        walk_all_changed_branch_children: bool,
+    },
     /// Able to execute and unwind. Used for tests
     #[cfg(any(test, feature = "test-utils"))]
     Both {
@@ -115,7 +118,12 @@ impl MerkleStage {
 
     /// Stage default for the [`MerkleStage::Unwind`].
     pub const fn default_unwind() -> Self {
-        Self::Unwind
+        Self::new_unwind(false)
+    }
+
+    /// Create a new instance of [`MerkleStage::Unwind`].
+    pub const fn new_unwind(walk_all_changed_branch_children: bool) -> Self {
+        Self::Unwind { walk_all_changed_branch_children }
     }
 
     /// Create new instance of [`MerkleStage::Execution`].
@@ -174,7 +182,7 @@ where
     fn id(&self) -> StageId {
         match self {
             Self::Execution { .. } => StageId::MerkleExecute,
-            Self::Unwind => StageId::MerkleUnwind,
+            Self::Unwind { .. } => StageId::MerkleUnwind,
             #[cfg(any(test, feature = "test-utils"))]
             Self::Both { .. } => StageId::Other("MerkleBoth"),
         }
@@ -183,7 +191,7 @@ where
     /// Execute the stage.
     fn execute(&mut self, provider: &Provider, input: ExecInput) -> Result<ExecOutput, StageError> {
         let (threshold, incremental_threshold) = match self {
-            Self::Unwind => {
+            Self::Unwind { .. } => {
                 info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
                 return Ok(ExecOutput::done(StageCheckpoint::new(input.target())))
             }
@@ -377,6 +385,12 @@ where
             info!(target: "sync::stages::merkle::unwind", "Stage is always skipped");
             return Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })
         }
+        let walk_all_changed_branch_children = match self {
+            Self::Unwind { walk_all_changed_branch_children } => *walk_all_changed_branch_children,
+            #[cfg(any(test, feature = "test-utils"))]
+            Self::Both { .. } => false,
+            Self::Execution { .. } => unreachable!(),
+        };
 
         let mut entities_checkpoint =
             input.checkpoint.entities_stage_checkpoint().unwrap_or(EntitiesCheckpoint {
@@ -404,7 +418,9 @@ where
             let (block_root, updates) = reth_trie_db::with_adapter!(provider, |A| {
                 DbStateRoot::<_, A>::incremental_root_calculator(provider, range).and_then(
                     |calculator| {
-                        calculator.with_walk_all_changed_branch_children(true).root_with_updates()
+                        calculator
+                            .with_walk_all_changed_branch_children(walk_all_changed_branch_children)
+                            .root_with_updates()
                     },
                 )
             })

--- a/crates/storage/db-api/src/models/metadata.rs
+++ b/crates/storage/db-api/src/models/metadata.rs
@@ -91,3 +91,12 @@ impl StorageSettings {
         self.storage_v2
     }
 }
+
+/// Marker for an in-progress partial state trie unwind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartialStateTrieUnwindMarker {
+    /// The Finish stage block number before the unwind started.
+    pub finish_block_number: u64,
+    /// The partial state trie frontier the pipeline is unwinding to.
+    pub partial_state_trie: u64,
+}

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4083,11 +4083,11 @@ mod tests {
     #[cfg(feature = "partial-persistence")]
     use reth_chain_state::test_utils::TestBlockBuilder;
     use reth_chain_state::ExecutedBlock;
-    use reth_db_api::models::{PartialStateTrieUnwindMarker, StorageSettings};
+    use reth_db_api::models::StorageSettings;
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::{AccountRevertInit, BlockExecutionOutput, BlockExecutionResult};
     use reth_primitives_traits::SealedBlock;
-    use reth_storage_api::{metadata::keys, MetadataProvider, MetadataWriter};
+    use reth_storage_api::{MetadataProvider, MetadataWriter};
     use reth_testing_utils::generators::{self, random_block, BlockParams};
     use reth_trie::{
         HashedPostState, KeccakKeyHasher, Nibbles, SortedTrieData, StoredNibbles,
@@ -4129,25 +4129,19 @@ mod tests {
     }
 
     #[test]
-    fn partial_state_trie_unwind_metadata_lifecycle() {
+    fn metadata_can_be_deleted() {
         let factory = create_test_provider_factory();
-        let marker =
-            PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 21 };
+        let key = "metadata-delete-test";
 
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.write_partial_state_trie_unwind(marker).unwrap();
+        provider_rw.write_metadata(key, vec![1]).unwrap();
         provider_rw.commit().unwrap();
-        assert_eq!(factory.provider().unwrap().partial_state_trie_unwind().unwrap(), Some(marker));
+        assert_eq!(factory.provider().unwrap().get_metadata(key).unwrap(), Some(vec![1]));
 
         let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.delete_partial_state_trie_unwind().unwrap();
+        provider_rw.delete_metadata(key).unwrap();
         provider_rw.commit().unwrap();
-        assert_eq!(factory.provider().unwrap().partial_state_trie_unwind().unwrap(), None);
-
-        let provider_rw = factory.provider_rw().unwrap();
-        provider_rw.write_metadata(keys::PARTIAL_STATE_TRIE_UNWIND, vec![0xff]).unwrap();
-        provider_rw.commit().unwrap();
-        assert!(factory.provider().unwrap().partial_state_trie_unwind().is_err());
+        assert_eq!(factory.provider().unwrap().get_metadata(key).unwrap(), None);
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4045,6 +4045,11 @@ impl<TX: DbTxMut, N: NodeTypes> MetadataWriter for DatabaseProvider<TX, N> {
     fn write_metadata(&self, key: &str, value: Vec<u8>) -> ProviderResult<()> {
         self.tx.put::<tables::Metadata>(key.to_string(), value).map_err(Into::into)
     }
+
+    fn delete_metadata(&self, key: &str) -> ProviderResult<()> {
+        self.tx.delete::<tables::Metadata>(key.to_string(), None)?;
+        Ok(())
+    }
 }
 
 impl<TX: Send, N: NodeTypes> StorageSettingsCache for DatabaseProvider<TX, N> {
@@ -4078,11 +4083,11 @@ mod tests {
     #[cfg(feature = "partial-persistence")]
     use reth_chain_state::test_utils::TestBlockBuilder;
     use reth_chain_state::ExecutedBlock;
-    use reth_db_api::models::StorageSettings;
+    use reth_db_api::models::{PartialStateTrieUnwindMarker, StorageSettings};
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::{AccountRevertInit, BlockExecutionOutput, BlockExecutionResult};
     use reth_primitives_traits::SealedBlock;
-    use reth_storage_api::MetadataWriter;
+    use reth_storage_api::{metadata::keys, MetadataProvider, MetadataWriter};
     use reth_testing_utils::generators::{self, random_block, BlockParams};
     use reth_trie::{
         HashedPostState, KeccakKeyHasher, Nibbles, SortedTrieData, StoredNibbles,
@@ -4121,6 +4126,28 @@ mod tests {
         let end = 9u64;
         let result = provider.receipts_by_block_range(start..=end).unwrap();
         assert_eq!(result, Vec::<Vec<reth_ethereum_primitives::Receipt>>::new());
+    }
+
+    #[test]
+    fn partial_state_trie_unwind_metadata_lifecycle() {
+        let factory = create_test_provider_factory();
+        let marker =
+            PartialStateTrieUnwindMarker { finish_block_number: 42, partial_state_trie: 21 };
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.write_partial_state_trie_unwind(marker).unwrap();
+        provider_rw.commit().unwrap();
+        assert_eq!(factory.provider().unwrap().partial_state_trie_unwind().unwrap(), Some(marker));
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.delete_partial_state_trie_unwind().unwrap();
+        provider_rw.commit().unwrap();
+        assert_eq!(factory.provider().unwrap().partial_state_trie_unwind().unwrap(), None);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.write_metadata(keys::PARTIAL_STATE_TRIE_UNWIND, vec![0xff]).unwrap();
+        provider_rw.commit().unwrap();
+        assert!(factory.provider().unwrap().partial_state_trie_unwind().is_err());
     }
 
     #[test]

--- a/crates/storage/storage-api/src/metadata.rs
+++ b/crates/storage/storage-api/src/metadata.rs
@@ -1,13 +1,11 @@
 //! Metadata provider trait for reading and writing node metadata.
 
 use alloc::vec::Vec;
-use reth_db_api::models::{PartialStateTrieUnwindMarker, StorageSettings};
+use reth_db_api::models::StorageSettings;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 
 /// Metadata keys.
 pub mod keys {
-    /// Marker for an in-progress partial state trie unwind.
-    pub const PARTIAL_STATE_TRIE_UNWIND: &str = "partial_state_trie_unwind";
     /// Storage configuration settings for this node.
     pub const STORAGE_SETTINGS: &str = "storage_settings";
 }
@@ -17,13 +15,6 @@ pub mod keys {
 pub trait MetadataProvider: Send {
     /// Get a metadata value by key
     fn get_metadata(&self, key: &str) -> ProviderResult<Option<Vec<u8>>>;
-
-    /// Get the marker for an in-progress partial state trie unwind.
-    fn partial_state_trie_unwind(&self) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
-        self.get_metadata(keys::PARTIAL_STATE_TRIE_UNWIND)?
-            .map(|bytes| serde_json::from_slice(&bytes).map_err(ProviderError::other))
-            .transpose()
-    }
 
     /// Get storage settings for this node.
     ///
@@ -45,22 +36,6 @@ pub trait MetadataWriter: Send {
     /// Delete a metadata value.
     fn delete_metadata(&self, _key: &str) -> ProviderResult<()> {
         Err(ProviderError::UnsupportedProvider)
-    }
-
-    /// Write the marker for an in-progress partial state trie unwind.
-    fn write_partial_state_trie_unwind(
-        &self,
-        marker: PartialStateTrieUnwindMarker,
-    ) -> ProviderResult<()> {
-        self.write_metadata(
-            keys::PARTIAL_STATE_TRIE_UNWIND,
-            serde_json::to_vec(&marker).map_err(ProviderError::other)?,
-        )
-    }
-
-    /// Delete the marker for an in-progress partial state trie unwind.
-    fn delete_partial_state_trie_unwind(&self) -> ProviderResult<()> {
-        self.delete_metadata(keys::PARTIAL_STATE_TRIE_UNWIND)
     }
 
     /// Write storage settings for this node

--- a/crates/storage/storage-api/src/metadata.rs
+++ b/crates/storage/storage-api/src/metadata.rs
@@ -1,11 +1,13 @@
 //! Metadata provider trait for reading and writing node metadata.
 
 use alloc::vec::Vec;
-use reth_db_api::models::StorageSettings;
+use reth_db_api::models::{PartialStateTrieUnwindMarker, StorageSettings};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 
 /// Metadata keys.
 pub mod keys {
+    /// Marker for an in-progress partial state trie unwind.
+    pub const PARTIAL_STATE_TRIE_UNWIND: &str = "partial_state_trie_unwind";
     /// Storage configuration settings for this node.
     pub const STORAGE_SETTINGS: &str = "storage_settings";
 }
@@ -15,6 +17,13 @@ pub mod keys {
 pub trait MetadataProvider: Send {
     /// Get a metadata value by key
     fn get_metadata(&self, key: &str) -> ProviderResult<Option<Vec<u8>>>;
+
+    /// Get the marker for an in-progress partial state trie unwind.
+    fn partial_state_trie_unwind(&self) -> ProviderResult<Option<PartialStateTrieUnwindMarker>> {
+        self.get_metadata(keys::PARTIAL_STATE_TRIE_UNWIND)?
+            .map(|bytes| serde_json::from_slice(&bytes).map_err(ProviderError::other))
+            .transpose()
+    }
 
     /// Get storage settings for this node.
     ///
@@ -32,6 +41,27 @@ pub trait MetadataProvider: Send {
 pub trait MetadataWriter: Send {
     /// Write a metadata value
     fn write_metadata(&self, key: &str, value: Vec<u8>) -> ProviderResult<()>;
+
+    /// Delete a metadata value.
+    fn delete_metadata(&self, _key: &str) -> ProviderResult<()> {
+        Err(ProviderError::UnsupportedProvider)
+    }
+
+    /// Write the marker for an in-progress partial state trie unwind.
+    fn write_partial_state_trie_unwind(
+        &self,
+        marker: PartialStateTrieUnwindMarker,
+    ) -> ProviderResult<()> {
+        self.write_metadata(
+            keys::PARTIAL_STATE_TRIE_UNWIND,
+            serde_json::to_vec(&marker).map_err(ProviderError::other)?,
+        )
+    }
+
+    /// Delete the marker for an in-progress partial state trie unwind.
+    fn delete_partial_state_trie_unwind(&self) -> ProviderResult<()> {
+        self.delete_metadata(keys::PARTIAL_STATE_TRIE_UNWIND)
+    }
 
     /// Write storage settings for this node
     ///

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -36,6 +36,8 @@ pub struct StateRoot<T, H> {
     pub hashed_cursor_factory: H,
     /// A set of prefix sets that have changed.
     pub prefix_sets: TriePrefixSets,
+    /// Whether every child under a branch whose path matches the prefix set should be walked.
+    walk_all_changed_branch_children: bool,
     /// Previous intermediate state.
     previous_state: Option<IntermediateStateRootState>,
     /// The number of updates after which the intermediate progress should be returned.
@@ -56,6 +58,7 @@ impl<T, H> StateRoot<T, H> {
             trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets: TriePrefixSets::default(),
+            walk_all_changed_branch_children: false,
             previous_state: None,
             threshold: DEFAULT_INTERMEDIATE_THRESHOLD,
             #[cfg(feature = "metrics")]
@@ -66,6 +69,12 @@ impl<T, H> StateRoot<T, H> {
     /// Set the prefix sets.
     pub fn with_prefix_sets(mut self, prefix_sets: TriePrefixSets) -> Self {
         self.prefix_sets = prefix_sets;
+        self
+    }
+
+    /// Configures the state root walker to visit all children of changed branch paths.
+    pub const fn with_walk_all_changed_branch_children(mut self, enabled: bool) -> Self {
+        self.walk_all_changed_branch_children = enabled;
         self
     }
 
@@ -93,6 +102,7 @@ impl<T, H> StateRoot<T, H> {
             trie_cursor_factory: self.trie_cursor_factory,
             hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
+            walk_all_changed_branch_children: self.walk_all_changed_branch_children,
             threshold: self.threshold,
             previous_state: self.previous_state,
             #[cfg(feature = "metrics")]
@@ -106,6 +116,7 @@ impl<T, H> StateRoot<T, H> {
             trie_cursor_factory,
             hashed_cursor_factory: self.hashed_cursor_factory,
             prefix_sets: self.prefix_sets,
+            walk_all_changed_branch_children: self.walk_all_changed_branch_children,
             threshold: self.threshold,
             previous_state: self.previous_state,
             #[cfg(feature = "metrics")]
@@ -183,6 +194,7 @@ where
                 account_root_state.walker_stack,
                 self.prefix_sets.account_prefix_set,
             )
+            .with_walk_all_changed_branch_children(self.walk_all_changed_branch_children)
             .with_deletions_retained(retain_updates);
             let account_node_iter = TrieNodeIter::state_trie(walker, hashed_account_cursor)
                 .with_last_hashed_key(account_root_state.last_hashed_key);
@@ -223,6 +235,7 @@ where
                             .cloned()
                             .unwrap_or_default(),
                         previous_state: Some(storage_state.state),
+                        walk_all_changed_branch_children: self.walk_all_changed_branch_children,
                         threshold: remaining_threshold,
                         retain_updates,
                     },
@@ -254,6 +267,7 @@ where
             // calculation
             let hash_builder = HashBuilder::default().with_updates(retain_updates);
             let walker = TrieWalker::state_trie(trie_cursor, self.prefix_sets.account_prefix_set)
+                .with_walk_all_changed_branch_children(self.walk_all_changed_branch_children)
                 .with_deletions_retained(retain_updates);
             let node_iter = TrieNodeIter::state_trie(walker, hashed_account_cursor);
             (hash_builder, node_iter)
@@ -294,6 +308,7 @@ where
                                 .cloned()
                                 .unwrap_or_default(),
                             previous_state: None,
+                            walk_all_changed_branch_children: self.walk_all_changed_branch_children,
                             threshold: remaining_threshold,
                             retain_updates,
                         },
@@ -494,6 +509,8 @@ pub struct StorageRoot<T, H> {
     pub hashed_address: B256,
     /// The set of storage slot prefixes that have changed.
     pub prefix_set: PrefixSet,
+    /// Whether every child under a branch whose path matches the prefix set should be walked.
+    walk_all_changed_branch_children: bool,
     /// Previous intermediate state.
     previous_state: Option<IntermediateRootState>,
     /// The number of updates after which the intermediate progress should be returned.
@@ -535,6 +552,7 @@ impl<T, H> StorageRoot<T, H> {
             hashed_cursor_factory,
             hashed_address,
             prefix_set,
+            walk_all_changed_branch_children: false,
             previous_state: None,
             threshold: DEFAULT_INTERMEDIATE_THRESHOLD,
             #[cfg(feature = "metrics")]
@@ -545,6 +563,12 @@ impl<T, H> StorageRoot<T, H> {
     /// Set the changed prefixes.
     pub fn with_prefix_set(mut self, prefix_set: PrefixSet) -> Self {
         self.prefix_set = prefix_set;
+        self
+    }
+
+    /// Configures the storage root walker to visit all children of changed branch paths.
+    pub const fn with_walk_all_changed_branch_children(mut self, enabled: bool) -> Self {
+        self.walk_all_changed_branch_children = enabled;
         self
     }
 
@@ -573,6 +597,7 @@ impl<T, H> StorageRoot<T, H> {
             hashed_cursor_factory,
             hashed_address: self.hashed_address,
             prefix_set: self.prefix_set,
+            walk_all_changed_branch_children: self.walk_all_changed_branch_children,
             previous_state: self.previous_state,
             threshold: self.threshold,
             #[cfg(feature = "metrics")]
@@ -587,6 +612,7 @@ impl<T, H> StorageRoot<T, H> {
             hashed_cursor_factory: self.hashed_cursor_factory,
             hashed_address: self.hashed_address,
             prefix_set: self.prefix_set,
+            walk_all_changed_branch_children: self.walk_all_changed_branch_children,
             previous_state: self.previous_state,
             threshold: self.threshold,
             #[cfg(feature = "metrics")]
@@ -649,6 +675,7 @@ where
             hashed_cursor_factory,
             hashed_address,
             prefix_set,
+            walk_all_changed_branch_children,
             previous_state,
             threshold,
             #[cfg(feature = "metrics")]
@@ -664,6 +691,7 @@ where
                 hashed_address,
                 prefix_set,
                 previous_state,
+                walk_all_changed_branch_children,
                 threshold,
                 retain_updates,
             },
@@ -691,6 +719,7 @@ where
             trie_cursor_factory,
             hashed_address,
             prefix_set,
+            walk_all_changed_branch_children,
             previous_state,
             threshold,
             #[cfg(feature = "metrics")]
@@ -705,6 +734,7 @@ where
                 hashed_address,
                 prefix_set,
                 previous_state,
+                walk_all_changed_branch_children,
                 threshold,
                 retain_updates,
             },
@@ -731,6 +761,7 @@ where
             hashed_address,
             prefix_set,
             previous_state,
+            walk_all_changed_branch_children,
             threshold,
             retain_updates,
         } = calculation;
@@ -762,6 +793,7 @@ where
                     state.walker_stack,
                     prefix_set,
                 )
+                .with_walk_all_changed_branch_children(walk_all_changed_branch_children)
                 .with_deletions_retained(retain_updates);
                 let node_iter = TrieNodeIter::storage_trie(walker, hashed_storage_cursor)
                     .with_last_hashed_key(state.last_hashed_key);
@@ -770,6 +802,7 @@ where
             None => {
                 let hash_builder = HashBuilder::default().with_updates(retain_updates);
                 let walker = TrieWalker::storage_trie(trie_cursor, prefix_set)
+                    .with_walk_all_changed_branch_children(walk_all_changed_branch_children)
                     .with_deletions_retained(retain_updates);
                 let node_iter = TrieNodeIter::storage_trie(walker, hashed_storage_cursor);
                 (hash_builder, node_iter)
@@ -847,6 +880,7 @@ struct StorageRootCalculation {
     hashed_address: B256,
     prefix_set: PrefixSet,
     previous_state: Option<IntermediateRootState>,
+    walk_all_changed_branch_children: bool,
     threshold: u64,
     retain_updates: bool,
 }

--- a/crates/trie/trie/src/walker.rs
+++ b/crates/trie/trie/src/walker.rs
@@ -8,6 +8,18 @@ use alloy_trie::proof::AddedRemovedKeys;
 use reth_storage_errors::db::DatabaseError;
 use tracing::{instrument, trace};
 
+#[cfg(test)]
+use crate::trie_cursor::{mock::MockTrieCursorFactory, TrieCursorFactory};
+
+#[cfg(test)]
+use alloy_primitives::map::B256Map;
+
+#[cfg(test)]
+use alloy_trie::TrieMask;
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+
 #[cfg(feature = "metrics")]
 use crate::metrics::WalkerMetrics;
 
@@ -26,6 +38,9 @@ pub struct TrieWalker<C, K = AddedRemovedKeys> {
     pub can_skip_current_node: bool,
     /// A `PrefixSet` representing the changes to be applied to the trie.
     pub changes: PrefixSet,
+    /// When enabled, all children of a branch become unskippable if the branch path itself
+    /// matches the prefix set, even if a given child path does not.
+    walk_all_changed_branch_children: bool,
     /// The retained trie node keys that need to be removed.
     removed_keys: Option<HashSet<Nibbles>>,
     /// Provided when it's necessary not to skip certain nodes during proof generation.
@@ -76,6 +91,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
             changes,
             stack,
             can_skip_current_node: false,
+            walk_all_changed_branch_children: false,
             removed_keys: None,
             added_removed_keys: None,
             #[cfg(feature = "metrics")]
@@ -101,11 +117,18 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
             stack: self.stack,
             can_skip_current_node: self.can_skip_current_node,
             changes: self.changes,
+            walk_all_changed_branch_children: self.walk_all_changed_branch_children,
             removed_keys: self.removed_keys,
             added_removed_keys,
             #[cfg(feature = "metrics")]
             metrics: self.metrics,
         }
+    }
+
+    /// Configures the walker to treat every child of a matching branch path as unskippable.
+    pub const fn with_walk_all_changed_branch_children(mut self, enabled: bool) -> Self {
+        self.walk_all_changed_branch_children = enabled;
+        self
     }
 
     /// Split the walker into stack and trie updates.
@@ -188,7 +211,12 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
                 "Checked for only non-removed child",
             );
 
+            let branch_path_matches_prefix_set = self.walk_all_changed_branch_children &&
+                node.position().is_child() &&
+                self.changes.contains(&node.key);
+
             !self.changes.contains(node.full_key()) &&
+                !branch_path_matches_prefix_set &&
                 node.hash_flag() &&
                 !key_is_only_nonremoved_child
         });
@@ -233,6 +261,7 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
             changes,
             stack: vec![CursorSubNode::default()],
             can_skip_current_node: false,
+            walk_all_changed_branch_children: false,
             removed_keys: None,
             added_removed_keys: Default::default(),
             #[cfg(feature = "metrics")]
@@ -385,5 +414,85 @@ impl<C: TrieCursor, K: AsRef<AddedRemovedKeys>> TrieWalker<C, K> {
         self.move_to_next_sibling(false)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prefix_set::PrefixSetMut;
+    use alloy_primitives::B256;
+
+    fn branch_node(state_mask: u16, tree_mask: u16, hash_mask: u16) -> BranchNodeCompact {
+        let hash_count = hash_mask.count_ones() as usize;
+        BranchNodeCompact::new(
+            TrieMask::new(state_mask),
+            TrieMask::new(tree_mask),
+            TrieMask::new(hash_mask),
+            vec![B256::ZERO; hash_count],
+            None,
+        )
+    }
+
+    fn root_branch_node(state_mask: u16, tree_mask: u16, hash_mask: u16) -> BranchNodeCompact {
+        let hash_count = hash_mask.count_ones() as usize;
+        BranchNodeCompact::new(
+            TrieMask::new(state_mask),
+            TrieMask::new(tree_mask),
+            TrieMask::new(hash_mask),
+            vec![B256::ZERO; hash_count],
+            Some(B256::ZERO),
+        )
+    }
+
+    fn walker_for_matching_branch_children_test(
+        walk_all_changed_branch_children: bool,
+    ) -> TrieWalker<crate::trie_cursor::mock::MockTrieCursor> {
+        let trie_nodes = BTreeMap::from([
+            (Nibbles::default(), root_branch_node(1 << 2, 1 << 2, 1 << 2)),
+            (
+                Nibbles::from_nibbles([0x2]),
+                branch_node((1 << 3) | (1 << 4), 0, (1 << 3) | (1 << 4)),
+            ),
+        ]);
+        let factory = MockTrieCursorFactory::new(trie_nodes, B256Map::default());
+
+        let mut prefix_set = PrefixSetMut::default();
+        prefix_set.insert(Nibbles::from_nibbles([0x2, 0x3, 0x1]));
+
+        TrieWalker::state_trie(factory.account_trie_cursor().unwrap(), prefix_set.freeze())
+            .with_walk_all_changed_branch_children(walk_all_changed_branch_children)
+    }
+
+    #[test]
+    fn branch_siblings_remain_skippable_by_default() {
+        let mut walker = walker_for_matching_branch_children_test(false);
+
+        assert_eq!(walker.key().copied(), Some(Nibbles::default()));
+        assert!(!walker.can_skip_current_node);
+
+        walker.advance().unwrap();
+        assert_eq!(walker.key().copied(), Some(Nibbles::from_nibbles([0x2])));
+        assert!(!walker.can_skip_current_node);
+
+        walker.advance().unwrap();
+        assert_eq!(walker.key().copied(), Some(Nibbles::from_nibbles([0x2, 0x3])));
+        assert_eq!(walker.stack.last().unwrap().position(), SubNodePosition::Child(0x3));
+        assert!(!walker.can_skip_current_node);
+
+        walker.advance().unwrap();
+        assert_eq!(walker.key().copied(), Some(Nibbles::from_nibbles([0x2, 0x4])));
+        assert!(walker.can_skip_current_node);
+    }
+
+    #[test]
+    fn matching_branch_path_can_make_all_children_unskippable() {
+        let mut walker = walker_for_matching_branch_children_test(true);
+
+        walker.advance().unwrap();
+        walker.advance().unwrap();
+        walker.advance().unwrap();
+        assert_eq!(walker.key().copied(), Some(Nibbles::from_nibbles([0x2, 0x4])));
+        assert!(!walker.can_skip_current_node);
     }
 }


### PR DESCRIPTION
Extracts the staged pipeline unwind handling from #24100.

On startup, a lagging `partial_state_trie` frontier first unwinds to the durable trie tip with full changed-branch walks. A lower RocksDB/static-file target then runs as a separate normal unwind.

## walk_all_changed_branch_children

This new flag is required when unwinding to partial_state_trie in order to handle the following scenario:

* Block 10: hash of child 2 of trie node N is updated
* Block 14: hash of child 4 of trie node N is updated
* Block 10->12 is persisted, 13->14 masking
    * trie node N is not persisted, because it is masked
* kill -9

In this situation we would unwind 14->12. However when doing the unwind only N's child 4 will be in the prefix set which is used; 2 will not be in the prefix set because it was only updated in block 10. Because of this a stale hash for 2 would get used, and any ancestor cached hashes would end up incorrect as well.

The fix is to enable this `walk_all_changed_branch_children` mode, under which the TrieWalker will visit all children of a branch when just one child of the branch is in the prefix set. This way any stale sibling hashes are also refreshed.

A durable metadata marker records the original Finish and partial-state-trie frontiers before recovery starts. Interrupted recovery resumes from this marker, which is deleted only after the special unwind completes successfully.