### PR TITLE
fix(trie): propagate proof worker startup failures

### DIFF
--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -61,7 +61,7 @@ use crate::tree::{
     TreeConfig,
 };
 use alloy_primitives::B256;
-use crossbeam_channel::Receiver as CrossbeamReceiver;
+use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
 use reth_errors::ProviderResult;
 use reth_evm::{ConfigureEvm, OnStateHook};
@@ -79,7 +79,7 @@ use reth_trie::{
     hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
     HashedPostState,
 };
-use reth_trie_parallel::proof_task::{ProofTaskCtx, ProofWorkerHandle};
+use reth_trie_parallel::proof_task::{ProofResultMessage, ProofTaskCtx, ProofWorkerHandle};
 pub use reth_trie_parallel::{
     error::StateRootTaskError,
     state_root_task::{
@@ -539,13 +539,16 @@ impl DefaultStateRootStrategy {
         } = options;
         let (updates_tx, from_multi_proof) = crossbeam_channel::unbounded();
         let (cancel_guard, cancel_rx) = StateRootTaskCancelGuard::channel();
+        let (proof_result_tx, proof_result_rx) =
+            crossbeam_channel::unbounded::<ProofResultMessage>();
 
         let task_ctx = ProofTaskCtx::new(multiproof_provider_factory);
         #[cfg(feature = "trie-debug")]
         let task_ctx = task_ctx.with_proof_jitter(config.proof_jitter());
         let halve_workers = transaction_count
             .is_some_and(|count| count <= Self::SMALL_BLOCK_PROOF_WORKER_TX_THRESHOLD);
-        let proof_handle = ProofWorkerHandle::new(executor, task_ctx, halve_workers);
+        let proof_handle =
+            ProofWorkerHandle::new(executor, task_ctx, halve_workers, proof_result_tx.clone());
 
         let (state_root_tx, state_root_rx) = mpsc::channel();
         let (hashed_state_tx, hashed_state_rx) = mpsc::channel();
@@ -555,6 +558,8 @@ impl DefaultStateRootStrategy {
             executor,
             overlay_manager,
             proof_handle,
+            proof_result_tx,
+            proof_result_rx,
             state_root_tx,
             hashed_state_tx,
             from_multi_proof,
@@ -587,6 +592,8 @@ impl DefaultStateRootStrategy {
         executor: &reth_tasks::Runtime,
         overlay_manager: &OverlayManager<N>,
         proof_worker_handle: ProofWorkerHandle,
+        proof_result_tx: CrossbeamSender<ProofResultMessage>,
+        proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, StateRootTaskError>>,
         hashed_state_tx: mpsc::Sender<Arc<HashedPostState>>,
         from_multi_proof: CrossbeamReceiver<StateRootMessage>,
@@ -666,6 +673,8 @@ impl DefaultStateRootStrategy {
                 cancel_rx,
                 hashed_state_tx,
                 proof_worker_handle,
+                proof_result_tx,
+                proof_result_rx,
                 trie_metrics.clone(),
                 sparse_state_trie,
                 parent_state_root,

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1120,13 +1120,19 @@ enum SparseTrieTaskMessage {
 mod tests {
     use super::*;
     use alloy_primitives::{keccak256, Address, B256, U256};
+    use reth_db_common::init::init_genesis;
     use reth_provider::{
         providers::OverlayStateProviderFactory, test_utils::create_test_provider_factory,
-        ChainSpecProvider,
     };
     use reth_storage_overlay::OverlayManager;
     use reth_trie_parallel::proof_task::ProofTaskCtx;
     use reth_trie_sparse::ArenaParallelSparseTrie;
+
+    fn drain_sparse_trie_tasks(runtime: &Runtime) {
+        for task_name in ["trie-hashing", "storage-workers", "account-workers"] {
+            runtime.spawn_blocking_named(task_name, || {}).get();
+        }
+    }
 
     #[test]
     fn test_run_hashing_task_hashed_state_update_forwards() {
@@ -1225,7 +1231,7 @@ mod tests {
     fn run_returns_parent_root_without_revealing_blind_trie_when_no_state_updates() {
         let runtime = reth_tasks::Runtime::test();
         let provider_factory = create_test_provider_factory();
-        let anchor_hash = provider_factory.chain_spec().genesis_hash();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
         let overlay_factory = OverlayStateProviderFactory::new(
             provider_factory,
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
@@ -1271,13 +1277,16 @@ mod tests {
         assert_eq!(outcome.state_root, parent_state_root);
         assert!(outcome.trie_updates.is_empty());
         assert!(task.trie.state_trie_ref().is_none(), "blind trie should not be revealed");
+
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
     }
 
     #[test]
     fn stall_check_waits_for_in_flight_proofs_then_reports_pending_updates() {
         let runtime = reth_tasks::Runtime::test();
         let provider_factory = create_test_provider_factory();
-        let anchor_hash = provider_factory.chain_spec().genesis_hash();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
         let overlay_factory = OverlayStateProviderFactory::new(
             provider_factory,
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
@@ -1356,13 +1365,16 @@ mod tests {
         assert!(!error.contains("pending_storage_leaves"));
         assert!(!error.contains("pending_account_updates"));
         assert!(!error.contains(&format!("{slot:?}")));
+
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
     }
 
     #[test]
     fn run_errors_when_cancel_guard_drops_before_updates_finish() {
         let runtime = reth_tasks::Runtime::test();
         let provider_factory = create_test_provider_factory();
-        let anchor_hash = provider_factory.chain_spec().genesis_hash();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
         let overlay_factory = OverlayStateProviderFactory::new(
             provider_factory,
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
@@ -1407,13 +1419,15 @@ mod tests {
         assert!(matches!(error, StateRootTaskError::Canceled));
 
         drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
     }
 
     #[test]
     fn run_ignores_hints_queued_after_updates_finish() {
         let runtime = reth_tasks::Runtime::test();
         let provider_factory = create_test_provider_factory();
-        let anchor_hash = provider_factory.chain_spec().genesis_hash();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
         let overlay_factory = OverlayStateProviderFactory::new(
             provider_factory,
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
@@ -1472,5 +1486,8 @@ mod tests {
         handle.join().unwrap();
 
         assert!(result.expect("state root task stalled on a late hint").is_ok());
+
+        drop(updates_tx);
+        drain_sparse_trie_tasks(&runtime);
     }
 }

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -22,7 +22,8 @@ use reth_trie_common::{MultiProofTargetsV2, ProofV2Target, ProofV2TargetParent};
 use reth_trie_parallel::{
     error::StateRootTaskError,
     proof_task::{
-        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
+        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofResultSender,
+        ProofWorkerHandle,
     },
 };
 use reth_trie_sparse::{
@@ -35,7 +36,7 @@ use tracing::{debug, debug_span, error, instrument, trace_span};
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaParallelSparseTrie> {
     /// Sender for proof results.
-    proof_result_tx: CrossbeamSender<ProofResultMessage>,
+    proof_result_tx: ProofResultSender,
     /// Receiver for proof results directly from workers.
     proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
     /// Receives updates from execution and prewarming.
@@ -136,7 +137,7 @@ where
         cancel_rx: CrossbeamReceiver<()>,
         final_hashed_state_tx: std::sync::mpsc::Sender<Arc<HashedPostState>>,
         proof_worker_handle: ProofWorkerHandle,
-        proof_result_tx: CrossbeamSender<ProofResultMessage>,
+        proof_result_tx: ProofResultSender,
         proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
         metrics: SparseTrieTaskMetrics,
         trie: SparseStateTrie<A, S>,

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -136,15 +136,15 @@ where
         updates: CrossbeamReceiver<StateRootMessage>,
         cancel_rx: CrossbeamReceiver<()>,
         final_hashed_state_tx: std::sync::mpsc::Sender<Arc<HashedPostState>>,
-        mut proof_worker_handle: ProofWorkerHandle,
+        proof_worker_handle: ProofWorkerHandle,
+        proof_result_tx: ProofResultSender,
+        proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
         metrics: SparseTrieTaskMetrics,
         trie: SparseStateTrie<A, S>,
         parent_state_root: B256,
         new_epoch: TrieNodeEpoch,
         chunk_size: usize,
     ) -> Self {
-        let proof_result_tx = proof_worker_handle.proof_result_sender();
-        let proof_result_rx = proof_worker_handle.take_proof_result_rx();
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
 
         let parent_span = tracing::Span::current();
@@ -1231,8 +1231,13 @@ mod tests {
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
                 .overlay_builder(anchor_hash),
         );
-        let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(overlay_factory),
+            false,
+            proof_result_tx.clone(),
+        );
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()
@@ -1249,6 +1254,8 @@ mod tests {
             cancel_rx,
             std::sync::mpsc::channel().0,
             proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
             SparseTrieTaskMetrics::default(),
             trie,
             parent_state_root,
@@ -1276,8 +1283,13 @@ mod tests {
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
                 .overlay_builder(anchor_hash),
         );
-        let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(overlay_factory),
+            false,
+            proof_result_tx.clone(),
+        );
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()
@@ -1293,6 +1305,8 @@ mod tests {
             cancel_rx,
             std::sync::mpsc::channel().0,
             proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
             SparseTrieTaskMetrics::default(),
             trie,
             B256::from([0x55; 32]),
@@ -1354,8 +1368,13 @@ mod tests {
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
                 .overlay_builder(anchor_hash),
         );
-        let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(overlay_factory),
+            false,
+            proof_result_tx.clone(),
+        );
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()
@@ -1371,6 +1390,8 @@ mod tests {
             cancel_rx,
             std::sync::mpsc::channel().0,
             proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
             SparseTrieTaskMetrics::default(),
             trie,
             B256::from([0x55; 32]),
@@ -1398,8 +1419,13 @@ mod tests {
             OverlayManager::<reth_chain_state::EthPrimitives>::default()
                 .overlay_builder(anchor_hash),
         );
-        let proof_worker_handle =
-            ProofWorkerHandle::new(&runtime, ProofTaskCtx::new(overlay_factory), false);
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(overlay_factory),
+            false,
+            proof_result_tx.clone(),
+        );
 
         let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
         let trie = SparseStateTrie::default()
@@ -1415,6 +1441,8 @@ mod tests {
             cancel_rx,
             std::sync::mpsc::channel().0,
             proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
             SparseTrieTaskMetrics::default(),
             trie,
             B256::from([0x55; 32]),

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -22,8 +22,7 @@ use reth_trie_common::{MultiProofTargetsV2, ProofV2Target, ProofV2TargetParent};
 use reth_trie_parallel::{
     error::StateRootTaskError,
     proof_task::{
-        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofResultSender,
-        ProofWorkerHandle,
+        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
     },
 };
 use reth_trie_sparse::{
@@ -36,7 +35,7 @@ use tracing::{debug, debug_span, error, instrument, trace_span};
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaParallelSparseTrie> {
     /// Sender for proof results.
-    proof_result_tx: ProofResultSender,
+    proof_result_tx: CrossbeamSender<ProofResultMessage>,
     /// Receiver for proof results directly from workers.
     proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
     /// Receives updates from execution and prewarming.
@@ -137,7 +136,7 @@ where
         cancel_rx: CrossbeamReceiver<()>,
         final_hashed_state_tx: std::sync::mpsc::Sender<Arc<HashedPostState>>,
         proof_worker_handle: ProofWorkerHandle,
-        proof_result_tx: ProofResultSender,
+        proof_result_tx: CrossbeamSender<ProofResultMessage>,
         proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
         metrics: SparseTrieTaskMetrics,
         trie: SparseStateTrie<A, S>,

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -22,7 +22,8 @@ use reth_trie_common::{MultiProofTargetsV2, ProofV2Target, ProofV2TargetParent};
 use reth_trie_parallel::{
     error::StateRootTaskError,
     proof_task::{
-        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofWorkerHandle,
+        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofResultSender,
+        ProofWorkerHandle,
     },
 };
 use reth_trie_sparse::{
@@ -35,11 +36,9 @@ use tracing::{debug, debug_span, error, instrument, trace_span};
 /// Sparse trie task implementation that uses in-memory sparse trie data to schedule proof fetching.
 pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaParallelSparseTrie> {
     /// Sender for proof results.
-    proof_result_tx: CrossbeamSender<ProofResultMessage>,
+    proof_result_tx: ProofResultSender,
     /// Receiver for proof results directly from workers.
     proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
-    /// Receives terminal worker initialization failures.
-    worker_failure_rx: CrossbeamReceiver<StateRootTaskError>,
     /// Receives updates from execution and prewarming.
     updates: CrossbeamReceiver<SparseTrieTaskMessage>,
     /// Fires (by disconnecting) when the consumer drops its cancel guard, meaning nobody is
@@ -144,8 +143,8 @@ where
         new_epoch: TrieNodeEpoch,
         chunk_size: usize,
     ) -> Self {
-        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
-        let worker_failure_rx = proof_worker_handle.take_worker_failure_rx();
+        let proof_result_tx = proof_worker_handle.proof_result_sender();
+        let proof_result_rx = proof_worker_handle.take_proof_result_rx();
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
 
         let parent_span = tracing::Span::current();
@@ -158,7 +157,6 @@ where
         Self {
             proof_result_tx,
             proof_result_rx,
-            worker_failure_rx,
             updates: hashed_state_rx,
             cancel_rx,
             proof_worker_handle,
@@ -302,9 +300,6 @@ where
                     };
                     self.on_proof_results(result, &mut t)?;
                 },
-                recv(self.worker_failure_rx) -> error => {
-                    return Err(error.expect("proof worker failure sender dropped"))
-                },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
 
@@ -331,9 +326,6 @@ where
                         unreachable!("we own the sender half")
                     };
                     self.on_proof_results(result, &mut t)?;
-                },
-                recv(self.worker_failure_rx) -> error => {
-                    return Err(error.expect("proof worker failure sender dropped"))
                 },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
@@ -567,12 +559,13 @@ where
         &mut self,
         message: ProofResultMessage,
     ) -> Result<DecodedMultiProofV2, StateRootTaskError> {
+        let result = message.result?;
         debug_assert!(
             self.in_flight_proof_batches > 0,
             "received proof result without an in-flight proof batch"
         );
         self.in_flight_proof_batches = self.in_flight_proof_batches.saturating_sub(1);
-        message.result
+        Ok(result)
     }
 
     fn process_new_updates(&mut self) -> SparseTrieResult<()> {

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -38,6 +38,8 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     proof_result_tx: CrossbeamSender<ProofResultMessage>,
     /// Receiver for proof results directly from workers.
     proof_result_rx: CrossbeamReceiver<ProofResultMessage>,
+    /// Receives terminal worker initialization failures.
+    worker_failure_rx: CrossbeamReceiver<StateRootTaskError>,
     /// Receives updates from execution and prewarming.
     updates: CrossbeamReceiver<SparseTrieTaskMessage>,
     /// Fires (by disconnecting) when the consumer drops its cancel guard, meaning nobody is
@@ -135,7 +137,7 @@ where
         updates: CrossbeamReceiver<StateRootMessage>,
         cancel_rx: CrossbeamReceiver<()>,
         final_hashed_state_tx: std::sync::mpsc::Sender<Arc<HashedPostState>>,
-        proof_worker_handle: ProofWorkerHandle,
+        mut proof_worker_handle: ProofWorkerHandle,
         metrics: SparseTrieTaskMetrics,
         trie: SparseStateTrie<A, S>,
         parent_state_root: B256,
@@ -143,6 +145,7 @@ where
         chunk_size: usize,
     ) -> Self {
         let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let worker_failure_rx = proof_worker_handle.take_worker_failure_rx();
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
 
         let parent_span = tracing::Span::current();
@@ -155,6 +158,7 @@ where
         Self {
             proof_result_tx,
             proof_result_rx,
+            worker_failure_rx,
             updates: hashed_state_rx,
             cancel_rx,
             proof_worker_handle,
@@ -298,6 +302,9 @@ where
                     };
                     self.on_proof_results(result, &mut t)?;
                 },
+                recv(self.worker_failure_rx) -> error => {
+                    return Err(error.expect("proof worker failure sender dropped"))
+                },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
 
@@ -324,6 +331,9 @@ where
                         unreachable!("we own the sender half")
                     };
                     self.on_proof_results(result, &mut t)?;
+                },
+                recv(self.worker_failure_rx) -> error => {
+                    return Err(error.expect("proof worker failure sender dropped"))
                 },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }

--- a/crates/trie/parallel/src/error.rs
+++ b/crates/trie/parallel/src/error.rs
@@ -11,6 +11,9 @@ pub enum StateRootTaskError {
     /// Proof dispatch error.
     #[error("proof dispatch failed: {_0}")]
     ProofDispatch(ProviderError),
+    /// A proof worker failed before it could process queued work.
+    #[error("proof worker failed: {_0}")]
+    ProofWorker(String),
     /// Sparse trie error.
     #[error(transparent)]
     SparseTrie(#[from] SparseTrieError),

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -16,7 +16,7 @@
 //!    `ProofWorkerHandle`. The job carries a `ProofResultContext` so the worker knows how to send
 //!    the result back.
 //! 2. A worker receives the job, runs the proof, and sends a `ProofResultMessage` through the
-//!    provided result sender.
+//!    provided `ProofResultSender`.
 //! 3. The `SparseTrieCacheTask` receives the message and proceeds with its state-root logic.
 //!
 //! Each job gets its own direct channel so results go straight back to the `SparseTrieCacheTask`.
@@ -26,7 +26,7 @@
 //! SparseTrieCacheTask -> ProofWorkerHandle -> Storage/Account Worker
 //!        ^                       |
 //!        |                       v
-//! ProofResultMessage <-- CrossbeamSender<ProofResultMessage>
+//! ProofResultMessage <-- ProofResultSender
 //! ```
 
 use crate::{
@@ -170,7 +170,7 @@ impl ProofWorkerHandle {
         runtime: &Runtime,
         task_ctx: ProofTaskCtx<Factory>,
         halve_workers: bool,
-        proof_result_tx: CrossbeamSender<ProofResultMessage>,
+        proof_result_tx: ProofResultSender,
     ) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -491,6 +491,13 @@ where
     }
 }
 
+/// Channel used by worker threads to deliver proof results back to
+/// `SparseTrieCacheTask`.
+///
+/// Workers use this sender to deliver proof results or terminal initialization errors directly to
+/// `SparseTrieCacheTask`.
+pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
+
 /// Message containing a completed proof result with metadata for direct delivery to
 /// `SparseTrieCacheTask`.
 ///
@@ -513,7 +520,7 @@ pub struct ProofResultMessage {
 #[derive(Debug, Clone)]
 pub struct ProofResultContext {
     /// Channel sender for result delivery
-    pub sender: CrossbeamSender<ProofResultMessage>,
+    pub sender: ProofResultSender,
     /// Original state update that triggered this proof
     pub state: HashedPostState,
     /// Calculation start time for measuring elapsed duration
@@ -523,7 +530,7 @@ pub struct ProofResultContext {
 impl ProofResultContext {
     /// Creates a new proof result context.
     pub const fn new(
-        sender: CrossbeamSender<ProofResultMessage>,
+        sender: ProofResultSender,
         state: HashedPostState,
         start_time: Instant,
     ) -> Self {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -138,8 +138,10 @@ pub struct ProofWorkerHandle {
     storage_work_tx: CrossbeamSender<StorageWorkerJob>,
     /// Direct sender to account worker pool
     account_work_tx: CrossbeamSender<AccountWorkerJob>,
-    /// Reports terminal worker failures to the sparse trie task.
-    worker_failure_rx: CrossbeamReceiver<StateRootTaskError>,
+    /// Sends proof results and terminal worker failures to the sparse trie task.
+    proof_result_tx: ProofResultSender,
+    /// Receiver for proof results and terminal worker failures.
+    proof_result_rx: Option<CrossbeamReceiver<ProofResultMessage>>,
     /// Per-worker availability flags for storage workers. Used to determine whether to chunk
     /// multiproofs.
     storage_availability: Arc<AvailabilitySheet>,
@@ -182,7 +184,7 @@ impl ProofWorkerHandle {
     {
         let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
         let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
-        let (worker_failure_tx, worker_failure_rx) = unbounded::<StateRootTaskError>();
+        let (proof_result_tx, proof_result_rx) = unbounded::<ProofResultMessage>();
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
@@ -209,7 +211,7 @@ impl ProofWorkerHandle {
         let storage_task_ctx = task_ctx.clone();
         let storage_avail = storage_availability.clone();
         let storage_roots = cached_storage_roots.clone();
-        let storage_failure_tx = worker_failure_tx.clone();
+        let storage_result_tx = proof_result_tx.clone();
         let storage_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -241,9 +243,13 @@ impl ProofWorkerHandle {
                         ?error,
                         "Storage worker failed"
                     );
-                    let _ = storage_failure_tx.send(StateRootTaskError::ProofWorker(format!(
-                        "storage worker {worker_id}: {error}"
-                    )));
+                    let _ = storage_result_tx.send(ProofResultMessage {
+                        result: Err(StateRootTaskError::ProofWorker(format!(
+                            "storage worker {worker_id}: {error}"
+                        ))),
+                        elapsed: Duration::ZERO,
+                        state: Default::default(),
+                    });
                 }
             });
         });
@@ -251,7 +257,7 @@ impl ProofWorkerHandle {
         let account_rt = runtime.clone();
         let account_tx = storage_work_tx.clone();
         let account_avail = account_availability.clone();
-        let account_failure_tx = worker_failure_tx;
+        let account_result_tx = proof_result_tx.clone();
         let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("account-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -284,9 +290,13 @@ impl ProofWorkerHandle {
                         ?error,
                         "Account worker failed"
                     );
-                    let _ = account_failure_tx.send(StateRootTaskError::ProofWorker(format!(
-                        "account worker {worker_id}: {error}"
-                    )));
+                    let _ = account_result_tx.send(ProofResultMessage {
+                        result: Err(StateRootTaskError::ProofWorker(format!(
+                            "account worker {worker_id}: {error}"
+                        ))),
+                        elapsed: Duration::ZERO,
+                        state: Default::default(),
+                    });
                 }
             });
         });
@@ -294,7 +304,8 @@ impl ProofWorkerHandle {
         Self {
             storage_work_tx,
             account_work_tx,
-            worker_failure_rx,
+            proof_result_tx,
+            proof_result_rx: Some(proof_result_rx),
             storage_availability,
             account_availability,
             storage_worker_count,
@@ -302,12 +313,17 @@ impl ProofWorkerHandle {
         }
     }
 
-    /// Takes the receiver used to report terminal worker failures.
+    /// Returns a sender for proof results.
+    pub fn proof_result_sender(&self) -> ProofResultSender {
+        self.proof_result_tx.clone()
+    }
+
+    /// Takes the receiver used for proof results and terminal worker failures.
     ///
     /// The sparse trie task must stop rather than wait for results once a worker fails during
     /// initialization, because jobs accepted while that worker was starting cannot be completed.
-    pub fn take_worker_failure_rx(&mut self) -> CrossbeamReceiver<StateRootTaskError> {
-        std::mem::replace(&mut self.worker_failure_rx, crossbeam_channel::never())
+    pub const fn take_proof_result_rx(&mut self) -> CrossbeamReceiver<ProofResultMessage> {
+        self.proof_result_rx.take().expect("proof result receiver already taken")
     }
 
     /// Returns `true` if more than one storage worker is currently idle.
@@ -495,10 +511,11 @@ where
     }
 }
 
-/// Channel used by worker threads to deliver `ProofResultMessage` items back to
+/// Channel used by worker threads to deliver proof results back to
 /// `SparseTrieCacheTask`.
 ///
-/// Workers use this sender to deliver proof results directly to `SparseTrieCacheTask`.
+/// Workers use this sender to deliver proof results or terminal initialization errors directly to
+/// `SparseTrieCacheTask`.
 pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
 
 /// Message containing a completed proof result with metadata for direct delivery to

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -138,6 +138,10 @@ pub struct ProofWorkerHandle {
     storage_work_tx: CrossbeamSender<StorageWorkerJob>,
     /// Direct sender to account worker pool
     account_work_tx: CrossbeamSender<AccountWorkerJob>,
+    /// Reports terminal worker failures to the sparse trie task.
+    worker_failure_rx: CrossbeamReceiver<StateRootTaskError>,
+    /// Set when a worker fails before it can process queued work.
+    worker_failed: Arc<AtomicBool>,
     /// Per-worker availability flags for storage workers. Used to determine whether to chunk
     /// multiproofs.
     storage_availability: Arc<AvailabilitySheet>,
@@ -180,6 +184,8 @@ impl ProofWorkerHandle {
     {
         let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
         let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
+        let (worker_failure_tx, worker_failure_rx) = unbounded::<StateRootTaskError>();
+        let worker_failed = Arc::new(AtomicBool::new(false));
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
@@ -206,6 +212,8 @@ impl ProofWorkerHandle {
         let storage_task_ctx = task_ctx.clone();
         let storage_avail = storage_availability.clone();
         let storage_roots = cached_storage_roots.clone();
+        let storage_failure_tx = worker_failure_tx.clone();
+        let storage_failed = worker_failed.clone();
         let storage_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -231,12 +239,16 @@ impl ProofWorkerHandle {
                     cursor_metrics,
                 );
                 if let Err(error) = worker.run() {
+                    storage_failed.store(true, Ordering::Release);
                     error!(
                         target: "trie::proof_task",
                         worker_id,
                         ?error,
                         "Storage worker failed"
                     );
+                    let _ = storage_failure_tx.send(StateRootTaskError::ProofWorker(format!(
+                        "storage worker {worker_id}: {error}"
+                    )));
                 }
             });
         });
@@ -244,6 +256,8 @@ impl ProofWorkerHandle {
         let account_rt = runtime.clone();
         let account_tx = storage_work_tx.clone();
         let account_avail = account_availability.clone();
+        let account_failure_tx = worker_failure_tx;
+        let account_failed = worker_failed.clone();
         let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("account-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -270,12 +284,16 @@ impl ProofWorkerHandle {
                     cursor_metrics,
                 );
                 if let Err(error) = worker.run() {
+                    account_failed.store(true, Ordering::Release);
                     error!(
                         target: "trie::proof_task",
                         worker_id,
                         ?error,
                         "Account worker failed"
                     );
+                    let _ = account_failure_tx.send(StateRootTaskError::ProofWorker(format!(
+                        "account worker {worker_id}: {error}"
+                    )));
                 }
             });
         });
@@ -283,11 +301,31 @@ impl ProofWorkerHandle {
         Self {
             storage_work_tx,
             account_work_tx,
+            worker_failure_rx,
+            worker_failed,
             storage_availability,
             account_availability,
             storage_worker_count,
             account_worker_count,
         }
+    }
+
+    /// Takes the receiver used to report terminal worker failures.
+    ///
+    /// The sparse trie task must stop rather than wait for results once a worker fails during
+    /// initialization, because jobs accepted while that worker was starting cannot be completed.
+    pub fn take_worker_failure_rx(&mut self) -> CrossbeamReceiver<StateRootTaskError> {
+        std::mem::replace(&mut self.worker_failure_rx, crossbeam_channel::never())
+    }
+
+    /// Returns an error if a worker failed before it could process queued work.
+    fn ensure_workers_healthy(&self) -> Result<(), ProviderError> {
+        if self.worker_failed.load(Ordering::Acquire) {
+            return Err(ProviderError::other(std::io::Error::other(
+                "proof worker pool failed during initialization",
+            )))
+        }
+        Ok(())
     }
 
     /// Returns `true` if more than one storage worker is currently idle.
@@ -329,6 +367,7 @@ impl ProofWorkerHandle {
         proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
     ) -> Result<(), ProviderError> {
         let hashed_address = input.hashed_address;
+        self.ensure_workers_healthy()?;
         self.storage_work_tx
             .send(StorageWorkerJob::StorageProof { input, proof_result_sender })
             .map_err(|err| {
@@ -351,6 +390,7 @@ impl ProofWorkerHandle {
         &self,
         input: AccountMultiproofInput,
     ) -> Result<(), ProviderError> {
+        self.ensure_workers_healthy()?;
         self.account_work_tx
             .send(AccountWorkerJob::AccountMultiproof { input: Box::new(input) })
             .map_err(|err| {
@@ -1190,5 +1230,25 @@ mod tests {
 
         // Workers shut down automatically when handle is dropped
         drop(proof_handle);
+    }
+
+    #[test]
+    fn failed_workers_reject_dispatch() {
+        let (storage_work_tx, _) = unbounded();
+        let (account_work_tx, _) = unbounded();
+        let (_, worker_failure_rx) = unbounded();
+        let handle = ProofWorkerHandle {
+            storage_work_tx,
+            account_work_tx,
+            worker_failure_rx,
+            worker_failed: Arc::new(AtomicBool::new(true)),
+            storage_availability: Arc::new(AvailabilitySheet::new(0)),
+            account_availability: Arc::new(AvailabilitySheet::new(0)),
+            storage_worker_count: 0,
+            account_worker_count: 0,
+        };
+
+        let error = handle.ensure_workers_healthy().expect_err("worker pool should be failed");
+        assert!(error.to_string().contains("proof worker pool failed during initialization"));
     }
 }

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -138,10 +138,6 @@ pub struct ProofWorkerHandle {
     storage_work_tx: CrossbeamSender<StorageWorkerJob>,
     /// Direct sender to account worker pool
     account_work_tx: CrossbeamSender<AccountWorkerJob>,
-    /// Sends proof results and terminal worker failures to the sparse trie task.
-    proof_result_tx: ProofResultSender,
-    /// Receiver for proof results and terminal worker failures.
-    proof_result_rx: Option<CrossbeamReceiver<ProofResultMessage>>,
     /// Per-worker availability flags for storage workers. Used to determine whether to chunk
     /// multiproofs.
     storage_availability: Arc<AvailabilitySheet>,
@@ -174,6 +170,7 @@ impl ProofWorkerHandle {
         runtime: &Runtime,
         task_ctx: ProofTaskCtx<Factory>,
         halve_workers: bool,
+        proof_result_tx: ProofResultSender,
     ) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -184,8 +181,6 @@ impl ProofWorkerHandle {
     {
         let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
         let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
-        let (proof_result_tx, proof_result_rx) = unbounded::<ProofResultMessage>();
-
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
         let divisor = if halve_workers { 2 } else { 1 };
@@ -257,7 +252,7 @@ impl ProofWorkerHandle {
         let account_rt = runtime.clone();
         let account_tx = storage_work_tx.clone();
         let account_avail = account_availability.clone();
-        let account_result_tx = proof_result_tx.clone();
+        let account_result_tx = proof_result_tx;
         let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("account-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -304,26 +299,11 @@ impl ProofWorkerHandle {
         Self {
             storage_work_tx,
             account_work_tx,
-            proof_result_tx,
-            proof_result_rx: Some(proof_result_rx),
             storage_availability,
             account_availability,
             storage_worker_count,
             account_worker_count,
         }
-    }
-
-    /// Returns a sender for proof results.
-    pub fn proof_result_sender(&self) -> ProofResultSender {
-        self.proof_result_tx.clone()
-    }
-
-    /// Takes the receiver used for proof results and terminal worker failures.
-    ///
-    /// The sparse trie task must stop rather than wait for results once a worker fails during
-    /// initialization, because jobs accepted while that worker was starting cannot be completed.
-    pub const fn take_proof_result_rx(&mut self) -> CrossbeamReceiver<ProofResultMessage> {
-        self.proof_result_rx.take().expect("proof result receiver already taken")
     }
 
     /// Returns `true` if more than one storage worker is currently idle.
@@ -1220,7 +1200,8 @@ mod tests {
         let ctx = test_ctx(factory);
 
         let runtime = reth_tasks::Runtime::test();
-        let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false);
+        let (proof_result_tx, _) = unbounded();
+        let proof_handle = ProofWorkerHandle::new(&runtime, ctx, false, proof_result_tx);
 
         // Verify handle can be cloned
         let _cloned_handle = proof_handle.clone();

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -16,7 +16,7 @@
 //!    `ProofWorkerHandle`. The job carries a `ProofResultContext` so the worker knows how to send
 //!    the result back.
 //! 2. A worker receives the job, runs the proof, and sends a `ProofResultMessage` through the
-//!    provided `ProofResultSender`.
+//!    provided result sender.
 //! 3. The `SparseTrieCacheTask` receives the message and proceeds with its state-root logic.
 //!
 //! Each job gets its own direct channel so results go straight back to the `SparseTrieCacheTask`.
@@ -26,7 +26,7 @@
 //! SparseTrieCacheTask -> ProofWorkerHandle -> Storage/Account Worker
 //!        ^                       |
 //!        |                       v
-//! ProofResultMessage <-- ProofResultSender
+//! ProofResultMessage <-- CrossbeamSender<ProofResultMessage>
 //! ```
 
 use crate::{
@@ -170,7 +170,7 @@ impl ProofWorkerHandle {
         runtime: &Runtime,
         task_ctx: ProofTaskCtx<Factory>,
         halve_workers: bool,
-        proof_result_tx: ProofResultSender,
+        proof_result_tx: CrossbeamSender<ProofResultMessage>,
     ) -> Self
     where
         Factory: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -491,13 +491,6 @@ where
     }
 }
 
-/// Channel used by worker threads to deliver proof results back to
-/// `SparseTrieCacheTask`.
-///
-/// Workers use this sender to deliver proof results or terminal initialization errors directly to
-/// `SparseTrieCacheTask`.
-pub type ProofResultSender = CrossbeamSender<ProofResultMessage>;
-
 /// Message containing a completed proof result with metadata for direct delivery to
 /// `SparseTrieCacheTask`.
 ///
@@ -520,7 +513,7 @@ pub struct ProofResultMessage {
 #[derive(Debug, Clone)]
 pub struct ProofResultContext {
     /// Channel sender for result delivery
-    pub sender: ProofResultSender,
+    pub sender: CrossbeamSender<ProofResultMessage>,
     /// Original state update that triggered this proof
     pub state: HashedPostState,
     /// Calculation start time for measuring elapsed duration
@@ -530,7 +523,7 @@ pub struct ProofResultContext {
 impl ProofResultContext {
     /// Creates a new proof result context.
     pub const fn new(
-        sender: ProofResultSender,
+        sender: CrossbeamSender<ProofResultMessage>,
         state: HashedPostState,
         start_time: Instant,
     ) -> Self {

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -140,8 +140,6 @@ pub struct ProofWorkerHandle {
     account_work_tx: CrossbeamSender<AccountWorkerJob>,
     /// Reports terminal worker failures to the sparse trie task.
     worker_failure_rx: CrossbeamReceiver<StateRootTaskError>,
-    /// Set when a worker fails before it can process queued work.
-    worker_failed: Arc<AtomicBool>,
     /// Per-worker availability flags for storage workers. Used to determine whether to chunk
     /// multiproofs.
     storage_availability: Arc<AvailabilitySheet>,
@@ -185,7 +183,6 @@ impl ProofWorkerHandle {
         let (storage_work_tx, storage_work_rx) = unbounded::<StorageWorkerJob>();
         let (account_work_tx, account_work_rx) = unbounded::<AccountWorkerJob>();
         let (worker_failure_tx, worker_failure_rx) = unbounded::<StateRootTaskError>();
-        let worker_failed = Arc::new(AtomicBool::new(false));
 
         let cached_storage_roots = Arc::<DashMap<_, _>>::default();
 
@@ -213,7 +210,6 @@ impl ProofWorkerHandle {
         let storage_avail = storage_availability.clone();
         let storage_roots = cached_storage_roots.clone();
         let storage_failure_tx = worker_failure_tx.clone();
-        let storage_failed = worker_failed.clone();
         let storage_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("storage-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -239,7 +235,6 @@ impl ProofWorkerHandle {
                     cursor_metrics,
                 );
                 if let Err(error) = worker.run() {
-                    storage_failed.store(true, Ordering::Release);
                     error!(
                         target: "trie::proof_task",
                         worker_id,
@@ -257,7 +252,6 @@ impl ProofWorkerHandle {
         let account_tx = storage_work_tx.clone();
         let account_avail = account_availability.clone();
         let account_failure_tx = worker_failure_tx;
-        let account_failed = worker_failed.clone();
         let account_parent_span = tracing::Span::current();
         runtime.spawn_blocking_named("account-workers", move || {
             let worker_id = AtomicUsize::new(0);
@@ -284,7 +278,6 @@ impl ProofWorkerHandle {
                     cursor_metrics,
                 );
                 if let Err(error) = worker.run() {
-                    account_failed.store(true, Ordering::Release);
                     error!(
                         target: "trie::proof_task",
                         worker_id,
@@ -302,7 +295,6 @@ impl ProofWorkerHandle {
             storage_work_tx,
             account_work_tx,
             worker_failure_rx,
-            worker_failed,
             storage_availability,
             account_availability,
             storage_worker_count,
@@ -316,16 +308,6 @@ impl ProofWorkerHandle {
     /// initialization, because jobs accepted while that worker was starting cannot be completed.
     pub fn take_worker_failure_rx(&mut self) -> CrossbeamReceiver<StateRootTaskError> {
         std::mem::replace(&mut self.worker_failure_rx, crossbeam_channel::never())
-    }
-
-    /// Returns an error if a worker failed before it could process queued work.
-    fn ensure_workers_healthy(&self) -> Result<(), ProviderError> {
-        if self.worker_failed.load(Ordering::Acquire) {
-            return Err(ProviderError::other(std::io::Error::other(
-                "proof worker pool failed during initialization",
-            )))
-        }
-        Ok(())
     }
 
     /// Returns `true` if more than one storage worker is currently idle.
@@ -367,7 +349,6 @@ impl ProofWorkerHandle {
         proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
     ) -> Result<(), ProviderError> {
         let hashed_address = input.hashed_address;
-        self.ensure_workers_healthy()?;
         self.storage_work_tx
             .send(StorageWorkerJob::StorageProof { input, proof_result_sender })
             .map_err(|err| {
@@ -390,7 +371,6 @@ impl ProofWorkerHandle {
         &self,
         input: AccountMultiproofInput,
     ) -> Result<(), ProviderError> {
-        self.ensure_workers_healthy()?;
         self.account_work_tx
             .send(AccountWorkerJob::AccountMultiproof { input: Box::new(input) })
             .map_err(|err| {
@@ -1230,25 +1210,5 @@ mod tests {
 
         // Workers shut down automatically when handle is dropped
         drop(proof_handle);
-    }
-
-    #[test]
-    fn failed_workers_reject_dispatch() {
-        let (storage_work_tx, _) = unbounded();
-        let (account_work_tx, _) = unbounded();
-        let (_, worker_failure_rx) = unbounded();
-        let handle = ProofWorkerHandle {
-            storage_work_tx,
-            account_work_tx,
-            worker_failure_rx,
-            worker_failed: Arc::new(AtomicBool::new(true)),
-            storage_availability: Arc::new(AvailabilitySheet::new(0)),
-            account_availability: Arc::new(AvailabilitySheet::new(0)),
-            storage_worker_count: 0,
-            account_worker_count: 0,
-        };
-
-        let error = handle.ensure_workers_healthy().expect_err("worker pool should be failed");
-        assert!(error.to_string().contains("proof worker pool failed during initialization"));
     }
 }


### PR DESCRIPTION
Reports proof-worker initialization failures to the sparse-trie task and stops dispatching work once a worker pool is terminally failed.

This lets the existing serial state-root fallback run instead of waiting indefinitely for a proof result that cannot arrive.