### PR TITLE
fix(rpc): stop cancelled payload body range requests

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -650,6 +650,10 @@ where
             // Check if the requested range starts before the earliest available block due to pruning/expiry
             let earliest_block = inner.provider.earliest_block_number().unwrap_or(0);
             for num in start..=end {
+                if tx.is_closed() {
+                    return;
+                }
+
                 if num < earliest_block {
                     result.push(None);
                     continue;


### PR DESCRIPTION
Related to #26531

Stops payload-body range workers between block reads when their response receiver has closed. Previously the detached blocking task kept reading the rest of the range after a consensus-layer timeout or disconnect, consuming blocking executor capacity without a caller.