### PR TITLE
feat(config): add bootnodes to reth.toml

### DIFF
--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-network-peers = { workspace = true, features = ["secp256k1"] }
+reth-network-peers.workspace = true
 reth-network-types.workspace = true
 reth-prune-types.workspace = true
 reth-stages-types.workspace = true
@@ -34,6 +34,7 @@ serde = [
     "dep:serde",
     "dep:toml",
     "dep:humantime-serde",
+    "reth-network-peers/secp256k1",
     "reth-network-types/serde",
     "reth-prune-types/serde",
     "reth-stages-types/serde",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # reth
+reth-network-peers = { workspace = true, features = ["secp256k1"] }
 reth-network-types.workspace = true
 reth-prune-types.workspace = true
 reth-stages-types.workspace = true
@@ -42,5 +43,4 @@ serde = [
 
 [dev-dependencies]
 tempfile.workspace = true
-reth-network-peers.workspace = true
 alloy-primitives = { workspace = true, features = ["getrandom"] }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,4 +1,5 @@
 //! Configuration files.
+use reth_network_peers::TrustedPeer;
 use reth_network_types::{PeersConfig, SessionsConfig};
 use reth_prune_types::{PruneModes, MINIMUM_UNWIND_SAFE_DISTANCE};
 use reth_stages_types::ExecutionStageThresholds;
@@ -20,6 +21,10 @@ pub const DEFAULT_BLOCK_INTERVAL: usize = 5;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(default))]
 pub struct Config {
+    /// Nodes to bootstrap P2P discovery with, as `enode://` URLs or `enr:` records.
+    ///
+    /// Takes precedence over the chain spec bootnodes, and is overridden by `--bootnodes`.
+    pub bootnodes: Vec<TrustedPeer>,
     /// Configuration for each stage in the pipeline.
     pub stages: StageConfig,
     /// Configuration for pruning.
@@ -1199,5 +1204,38 @@ connect_trusted_nodes_only = true
             let node = TrustedPeer::from_str(enode).unwrap();
             assert!(conf.peers.trusted_nodes.contains(&node));
         }
+    }
+
+    #[test]
+    fn test_bootnodes() {
+        let reth_toml = r#"
+    bootnodes = [
+        "enode://0401e494dbd0c84c5c0f72adac5985d2f2525e08b68d448958aae218f5ac8198a80d1498e0ebec2ce38b1b18d6750f6e61a56b4614c5a6c6cf0981c39aed47dc@34.159.32.127:30303",
+        "enode://e9675164b5e17b9d9edf0cc2bd79e6b6f487200c74d1331c220abb5b8ee80c2eefbf18213989585e9d0960683e819542e11d4eefb5f2b4019e1e49f9fd8fff18@berav2-bootnode.staketab.org:30303",
+        "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
+    ]
+    "#;
+
+        let conf: Config = toml::from_str(reth_toml).unwrap();
+        assert_eq!(conf.bootnodes.len(), 3);
+        assert_eq!(
+            conf.bootnodes[1].host,
+            url::Host::<String>::Domain("berav2-bootnode.staketab.org".to_string())
+        );
+        // the ENR omits the tcp key, so the udp port is used for the RLPx dial guess
+        assert_eq!(
+            conf.bootnodes[2],
+            TrustedPeer::from_str("enode://ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f@127.0.0.1:30303").unwrap()
+        );
+
+        // bootnodes are written back as enode URLs, including the ones read as ENRs
+        let serialized = toml::to_string(&conf).unwrap();
+        assert_eq!(toml::from_str::<Config>(&serialized).unwrap(), conf);
+    }
+
+    #[test]
+    fn test_bootnodes_default_empty() {
+        let conf: Config = toml::from_str("").unwrap();
+        assert!(conf.bootnodes.is_empty());
     }
 }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -487,8 +487,8 @@ impl NetworkArgs {
 
     /// Returns the resolved bootnodes if any are provided.
     pub fn resolved_bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.bootnodes.clone().map(|bootnodes| {
-            bootnodes.into_iter().filter_map(|node| node.resolve_blocking().ok()).collect()
+        self.bootnodes.as_deref().map(|bootnodes| {
+            bootnodes.iter().filter_map(|node| node.resolve_blocking().ok()).collect()
         })
     }
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -487,9 +487,7 @@ impl NetworkArgs {
 
     /// Returns the resolved bootnodes if any are provided.
     pub fn resolved_bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.bootnodes.clone().map(|bootnodes| {
-            bootnodes.into_iter().filter_map(|node| node.resolve_blocking().ok()).collect()
-        })
+        self.bootnodes.as_deref().map(resolve_bootnodes)
     }
 
     /// Returns the max inbound peers (2:1 ratio).
@@ -546,8 +544,9 @@ impl NetworkArgs {
     /// Configured Bootnodes are prioritized, if unset, the chain spec bootnodes are used
     /// Priority order for bootnodes configuration:
     /// 1. --bootnodes flag
-    /// 2. Network preset flags (e.g. --holesky)
-    /// 3. default to mainnet nodes
+    /// 2. `bootnodes` in the config file
+    /// 3. Network preset flags (e.g. --holesky)
+    /// 4. default to mainnet nodes
     pub fn network_config<N: NetworkPrimitives>(
         &self,
         config: &Config,
@@ -565,6 +564,9 @@ impl NetworkArgs {
         let discovery_addr = self.resolved_discovery_addr(listener_addr);
         let chain_bootnodes = self
             .resolved_bootnodes()
+            .or_else(|| {
+                (!config.bootnodes.is_empty()).then(|| resolve_bootnodes(&config.bootnodes))
+            })
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 
@@ -1144,6 +1146,11 @@ impl Default for DiscoveryArgs {
     }
 }
 
+/// Resolves the hosts of the given peers, dropping the ones that fail to resolve.
+fn resolve_bootnodes(bootnodes: &[TrustedPeer]) -> Vec<NodeRecord> {
+    bootnodes.iter().filter_map(|node| node.resolve_blocking().ok()).collect()
+}
+
 /// Parse a block number=hash pair or just a hash into `BlockNumHash`
 fn parse_block_num_hash(s: &str) -> Result<BlockNumHash, String> {
     if let Some((num_str, hash_str)) = s.split_once('=') {
@@ -1628,5 +1635,32 @@ mod tests {
 
         // Cleanup
         let _ = fs::remove_file(&peers_file);
+    }
+
+    #[test]
+    fn network_config_prefers_cli_bootnodes_over_config_file() {
+        let enr = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+        let enode = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303";
+        let config = Config { bootnodes: vec![enr.parse().unwrap()], ..Default::default() };
+        let secret_key = SecretKey::from_byte_array(&[1u8; 32]).unwrap();
+
+        let boot_nodes = |args: &NetworkArgs| {
+            args.network_config::<reth_network::EthNetworkPrimitives>(
+                &config,
+                MAINNET.clone(),
+                secret_key,
+                PathBuf::from("peers.json"),
+                Runtime::test(),
+            )
+            .boot_nodes_iter()
+            .cloned()
+            .collect::<Vec<_>>()
+        };
+
+        let args = NetworkArgs { no_persist_peers: true, ..Default::default() };
+        assert_eq!(boot_nodes(&args), vec![enr.parse::<TrustedPeer>().unwrap()]);
+
+        let args = NetworkArgs { bootnodes: Some(vec![enode.parse().unwrap()]), ..args };
+        assert_eq!(boot_nodes(&args), vec![enode.parse::<TrustedPeer>().unwrap()]);
     }
 }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -487,7 +487,9 @@ impl NetworkArgs {
 
     /// Returns the resolved bootnodes if any are provided.
     pub fn resolved_bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.bootnodes.as_deref().map(resolve_bootnodes)
+        self.bootnodes.clone().map(|bootnodes| {
+            bootnodes.into_iter().filter_map(|node| node.resolve_blocking().ok()).collect()
+        })
     }
 
     /// Returns the max inbound peers (2:1 ratio).
@@ -565,7 +567,13 @@ impl NetworkArgs {
         let chain_bootnodes = self
             .resolved_bootnodes()
             .or_else(|| {
-                (!config.bootnodes.is_empty()).then(|| resolve_bootnodes(&config.bootnodes))
+                (!config.bootnodes.is_empty()).then(|| {
+                    config
+                        .bootnodes
+                        .iter()
+                        .filter_map(|node| node.resolve_blocking().ok())
+                        .collect()
+                })
             })
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
@@ -1144,11 +1152,6 @@ impl Default for DiscoveryArgs {
             discv5_bootstrap_lookup_countdown,
         }
     }
-}
-
-/// Resolves the hosts of the given peers, dropping the ones that fail to resolve.
-fn resolve_bootnodes(bootnodes: &[TrustedPeer]) -> Vec<NodeRecord> {
-    bootnodes.iter().filter_map(|node| node.resolve_blocking().ok()).collect()
 }
 
 /// Parse a block number=hash pair or just a hash into `BlockNumHash`

--- a/docs/vocs/docs/pages/run/configuration.mdx
+++ b/docs/vocs/docs/pages/run/configuration.mdx
@@ -14,6 +14,7 @@ The default data directory is platform dependent:
 
 The configuration file contains the following sections:
 
+-   [`bootnodes`](#the-bootnodes-key) -- Nodes to bootstrap P2P discovery with
 -   [`[stages]`](#the-stages-section) -- Configuration of the individual sync stages
     -   [`era`](#era)
     -   [`headers`](#headers)
@@ -35,6 +36,19 @@ The configuration file contains the following sections:
 -   [`[sessions]`](#the-sessions-section)
 -   [`[prune]`](#the-prune-section)
 -   [`[static_files]`](#the-static_files-section)
+
+## The `bootnodes` key
+
+The nodes reth bootstraps P2P discovery with, as `enode://` URLs or `enr:` records. Entries may use a domain name instead of an IP address, which is resolved on startup.
+
+This takes precedence over the bootnodes of the chain being run, and is overridden by `--bootnodes`.
+
+```toml
+bootnodes = [
+    "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303",
+    "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8",
+]
+```
 
 ## The `[stages]` section
 


### PR DESCRIPTION
reth.toml has no bootnodes key, so a node configured from a file still needs `--bootnodes` on the command line.

This adds a top-level `bootnodes` list accepting `enode://` URLs and `enr:` records, resolved between `--bootnodes` and the chain spec bootnodes (CLI wins). ENR parsing comes from `TrustedPeer::from_str` (#26448); `reth-config` now enables the `secp256k1` feature directly instead of relying on feature unification.

Note on round-tripping: ENR entries are reduced at parse time to the endpoint they advertise (pubkey + IP + ports), same as `--bootnodes` on the CLI, so a config file rewritten by reth (e.g. `save_pruning_config` at launch) renders them as `enode://` URLs. This is only notation — discovery still contacts them over discv5.