### PR TITLE
fix(engine): keep API responsive during persistence backpressure

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -41,7 +41,7 @@ use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie::ComputedTrieData;
 use revm::interpreter::debug_unreachable;
 use state::TreeState;
-use std::{fmt::Debug, ops, sync::Arc, time::Duration};
+use std::{collections::VecDeque, fmt::Debug, ops, sync::Arc, time::Duration};
 
 use crossbeam_channel::{Receiver, Sender};
 use tokio::sync::{
@@ -327,6 +327,8 @@ where
     incoming_tx: Sender<FromEngine<EngineApiRequest<T, N>, N::Block>>,
     /// Incoming engine API requests.
     incoming: Receiver<FromEngine<EngineApiRequest<T, N>, N::Block>>,
+    /// Messages deferred while persistence backpressure is active.
+    deferred_engine_messages: VecDeque<FromEngine<EngineApiRequest<T, N>, N::Block>>,
     /// Outgoing events that are emitted to the handler.
     outgoing: UnboundedSender<EngineApiEvent<N>>,
     /// Channels to the persistence layer.
@@ -373,6 +375,7 @@ where
             .field("payload_validator", &self.payload_validator)
             .field("state", &self.state)
             .field("incoming_tx", &self.incoming_tx)
+            .field("deferred_engine_messages", &self.deferred_engine_messages.len())
             .field("persistence", &self.persistence)
             .field("persistence_state", &self.persistence_state)
             .field("backfill_sync_state", &self.backfill_sync_state)
@@ -432,6 +435,7 @@ where
             consensus,
             payload_validator,
             incoming,
+            deferred_engine_messages: VecDeque::new(),
             outgoing,
             persistence,
             persistence_state,
@@ -539,7 +543,8 @@ where
         self.persistence_gap().saturating_sub(self.config.memory_block_buffer_target())
     }
 
-    /// Returns `true` when the main loop should stop draining the tree input channel.
+    /// Returns `true` when the main loop should stop processing messages that can add more work to
+    /// the persistence queue.
     ///
     /// This is the case when persistence is already running and the number of blocks beyond the
     /// configured in-memory buffer has reached the configured threshold.
@@ -559,25 +564,17 @@ where
             // 1. Non-blocking poll for persistence completion. If the background flush already
             //    landed, absorb the result now so the gap calculation below is fresh.
             // 2. Decide how to wait for the next event. When the canonical-to-persisted gap beyond
-            //    the in-memory buffer reaches the backpressure threshold we only block on the
-            //    persistence receiver, leaving new engine requests sitting in the unbounded
-            //    upstream channel.
+            //    the in-memory buffer reaches the backpressure threshold, keep answering standard
+            //    consensus requests with SYNCING while waiting for persistence. Messages that can
+            //    add more work are deferred until persistence catches up.
             // 3. Handle the event (engine message or persistence completion) and kick off a new
             //    persistence cycle if the threshold is met again.
             //
             // The net effect: when the unbuffered persistence gap reaches the threshold, we stop
-            // processing incoming messages and let them queue in the channel. This is only a soft
-            // form of backpressure: it delays replies and, more importantly, prevents executing
-            // further blocks that would pile up in the persistence queue - where each block
-            // carries heavier state (eg. trie updates) than the raw payload sitting in the engine
-            // channel.
-            //
-            // Standard Ethereum CLs won't truly back off - the engine API has no
-            // backpressure semantics, and CLs typically timeout after ≈8s and resend - so
-            // this cannot prevent the incoming channel from growing under sustained load.
-            // But it shifts the bottleneck to the lighter-weight incoming queue rather than
-            // the costlier persistence pipeline. Other clients that respect reply latency
-            // can treat the delayed responses as a signal to chill out.
+            // executing new blocks that would pile up heavier state such as trie updates in the
+            // persistence queue. Standard newPayload and forkchoiceUpdated calls still get prompt
+            // SYNCING responses, which avoids consensus-layer timeouts and duplicate retries while
+            // making it explicit that the execution layer has not applied the request.
             match self.try_poll_persistence() {
                 Ok(true) => {
                     if let Err(err) = self.advance_persistence() {
@@ -639,21 +636,97 @@ where
         }
     }
 
-    /// Blocks until the in-flight persistence task completes, used when we are under
-    /// backpressure.
+    /// Blocks until the in-flight persistence task completes while keeping standard consensus
+    /// requests responsive.
     ///
-    /// Unlike `wait_for_event`, this deliberately does not read from the tree input channel. Any
-    /// requests sent to the tree remain queued upstream until persistence catches up.
+    /// newPayload and forkchoiceUpdated receive an immediate SYNCING response because applying
+    /// either request could add more unpersisted state. Other messages are deferred in arrival
+    /// order and processed once persistence catches up.
     fn wait_for_persistence_event(&mut self) -> LoopEvent<T, N> {
         let maybe_persistence = self.persistence_state.rx.take();
 
         if let Some((persistence_rx, start_time, _action)) = maybe_persistence {
-            match persistence_rx.recv() {
-                Ok(result) => LoopEvent::PersistenceComplete { result, start_time },
-                Err(_) => LoopEvent::Disconnected,
+            loop {
+                crossbeam_channel::select_biased! {
+                    recv(persistence_rx) -> result => {
+                        return match result {
+                            Ok(result) => LoopEvent::PersistenceComplete { result, start_time },
+                            Err(_) => LoopEvent::Disconnected,
+                        }
+                    },
+                    recv(self.incoming) -> msg => {
+                        match msg {
+                            Ok(msg) => {
+                                if let Some(msg) = self.respond_to_backpressured_message(msg) {
+                                    self.deferred_engine_messages.push_back(msg);
+                                }
+                            }
+                            Err(_) => return LoopEvent::Disconnected,
+                        }
+                    },
+                }
             }
         } else {
             self.wait_for_event()
+        }
+    }
+
+    /// Responds to standard consensus requests without applying them while persistence
+    /// backpressure is active. Returns messages that must be processed later.
+    fn respond_to_backpressured_message(
+        &mut self,
+        msg: FromEngine<EngineApiRequest<T, N>, N::Block>,
+    ) -> Option<FromEngine<EngineApiRequest<T, N>, N::Block>> {
+        match msg {
+            FromEngine::Request(EngineApiRequest::Beacon(
+                BeaconEngineMessage::ForkchoiceUpdated { state, payload_attrs, tx },
+            )) => {
+                let start = Instant::now();
+                let has_attrs = payload_attrs.is_some();
+                let output: Result<TreeOutcome<OnForkChoiceUpdated>, ProviderError> =
+                    Ok(TreeOutcome::new(OnForkChoiceUpdated::syncing()));
+
+                self.metrics.engine.forkchoice_updated.update_response_metrics(
+                    start,
+                    &mut self.metrics.engine.new_payload.latest_finish_at,
+                    has_attrs,
+                    &output,
+                );
+
+                if let Err(err) = tx.send(output.map(|o| o.outcome).map_err(Into::into)) {
+                    self.metrics.engine.failed_forkchoice_updated_response_deliveries.increment(1);
+                    warn!(target: "engine::tree", ?state, elapsed=?start.elapsed(), "Failed to deliver forkchoiceUpdated backpressure response, receiver dropped (request cancelled): {err:?}");
+                }
+                None
+            }
+            FromEngine::Request(EngineApiRequest::Beacon(BeaconEngineMessage::NewPayload {
+                payload,
+                tx,
+            })) => {
+                let start = Instant::now();
+                let gas_used = payload.gas_used();
+                let num_hash = payload.num_hash();
+                let output: Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> =
+                    Ok(TreeOutcome::new(PayloadStatus::from_status(PayloadStatusEnum::Syncing)));
+
+                self.metrics.engine.new_payload.update_response_metrics(
+                    start,
+                    &mut self.metrics.engine.forkchoice_updated.latest_finish_at,
+                    &output,
+                    gas_used,
+                );
+
+                if let Err(err) = tx.send(
+                    output
+                        .map(|o| o.outcome)
+                        .map_err(|err| BeaconOnNewPayloadError::Internal(Box::new(err))),
+                ) {
+                    self.metrics.engine.failed_new_payload_response_deliveries.increment(1);
+                    warn!(target: "engine::tree", payload=?num_hash, elapsed=?start.elapsed(), "Failed to deliver newPayload backpressure response, receiver dropped (request cancelled): {err:?}");
+                }
+                None
+            }
+            msg => Some(msg),
         }
     }
 
@@ -663,6 +736,10 @@ where
     /// Uses biased selection to prioritize persistence completion to update in-memory state and
     /// unblock further writes.
     fn wait_for_event(&mut self) -> LoopEvent<T, N> {
+        if let Some(msg) = self.deferred_engine_messages.pop_front() {
+            return LoopEvent::EngineMessage(msg)
+        }
+
         // Take ownership of persistence rx if present
         let maybe_persistence = self.persistence_state.rx.take();
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -857,7 +857,7 @@ async fn test_holesky_payload() {
 }
 
 #[test]
-fn test_backpressure_waits_for_persistence_before_reading_incoming() {
+fn test_backpressure_returns_syncing_and_defers_non_consensus_messages() {
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
     let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
     test_harness.tree.config = test_harness
@@ -872,7 +872,7 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
     test_harness.tree.persistence_state.start_save(persisted, persist_rx);
     assert!(test_harness.tree.should_backpressure());
 
-    let (tx, mut rx) = oneshot::channel();
+    let (tx, rx) = oneshot::channel();
     test_harness
         .to_tree_tx
         .send(FromEngine::Request(
@@ -888,11 +888,35 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
             .into(),
         ))
         .unwrap();
-    test_harness.to_tree_tx.send(FromEngine::DownloadedBlocks(vec![])).unwrap();
-    assert_eq!(test_harness.tree.incoming.len(), 2);
 
-    std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(10));
+    let data = Bytes::from_str(include_str!("../../test-data/holesky/1.rlp")).unwrap();
+    let block: Block = Block::decode(&mut data.as_ref()).unwrap();
+    let sealed = block.seal_slow();
+    let hash = sealed.hash();
+    let block = sealed.into_block();
+    let payload = ExecutionPayloadV1::from_block_unchecked(hash, &block);
+    let (payload_tx, payload_rx) = oneshot::channel();
+    test_harness
+        .to_tree_tx
+        .send(FromEngine::Request(
+            BeaconEngineMessage::NewPayload {
+                payload: ExecutionData {
+                    payload: payload.into(),
+                    sidecar: ExecutionPayloadSidecar::none(),
+                },
+                tx: payload_tx,
+            }
+            .into(),
+        ))
+        .unwrap();
+    test_harness.to_tree_tx.send(FromEngine::DownloadedBlocks(vec![])).unwrap();
+    assert_eq!(test_harness.tree.incoming.len(), 3);
+
+    let response_thread = std::thread::spawn(move || {
+        let response = rx.blocking_recv().unwrap().unwrap();
+        assert!(response.forkchoice_status().is_syncing());
+        let payload_response = payload_rx.blocking_recv().unwrap().unwrap();
+        assert!(payload_response.is_syncing());
         persist_tx
             .send(PersistenceResult {
                 last_block: persisted,
@@ -903,8 +927,10 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
     });
 
     let event = test_harness.tree.wait_for_persistence_event();
+    response_thread.join().unwrap();
     assert!(matches!(event, super::LoopEvent::PersistenceComplete { .. }));
-    assert_eq!(test_harness.tree.incoming.len(), 2);
+    assert_eq!(test_harness.tree.incoming.len(), 0);
+    assert_eq!(test_harness.tree.deferred_engine_messages.len(), 1);
 
     let super::LoopEvent::PersistenceComplete { result, start_time } = event else {
         unreachable!()
@@ -915,14 +941,7 @@ fn test_backpressure_waits_for_persistence_before_reading_incoming() {
         panic!("expected queued engine message")
     };
     let _ = test_harness.tree.on_engine_message(message).unwrap();
-    let msg = rx.try_recv();
-    assert!(msg.is_ok());
-    assert_eq!(test_harness.tree.incoming.len(), 1);
-
-    let super::LoopEvent::EngineMessage(message) = test_harness.tree.wait_for_event() else {
-        panic!("expected queued engine message")
-    };
-    let _ = test_harness.tree.on_engine_message(message).unwrap();
+    assert_eq!(test_harness.tree.deferred_engine_messages.len(), 0);
     assert_eq!(test_harness.tree.incoming.len(), 0);
 }
 


### PR DESCRIPTION
## Summary

Persistence backpressure currently blocks the engine loop exclusively on the persistence result. During a slow archive write, the loop stops reading `newPayload` and `forkchoiceUpdated` requests. Consensus clients then time out, retry the same requests, and leave response receivers behind, which makes the Engine API appear frozen even though the process and persistence worker remain alive.

This change keeps the existing backpressure limit while making the Engine API responsive:

- Standard `newPayload` and `forkchoiceUpdated` calls receive an immediate `SYNCING` response while backpressure is active. The requests are not applied, so no additional executed state enters the persistence pipeline.
- Persistence completion remains the highest priority event.
- Downloaded blocks, inserted executed blocks, orchestrator events, and `reth_newPayload` timing requests are deferred in FIFO order and processed before newer channel work after persistence catches up.
- Existing Engine API response metrics record the synthetic `SYNCING` results, including failed response delivery counters if a caller has already disconnected.

This avoids consensus client timeouts and retry bursts without removing the memory protection provided by persistence backpressure. A slow persistence operation remains visible through the existing backpressure and persistence duration metrics.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo +1.95.0 test -p reth-engine-tree test_backpressure --lib`
- `cargo +1.95.0 test -p reth-engine-tree --lib`
- `cargo +1.95.0 clippy -p reth-engine-tree --lib --tests -- -D warnings`

The backpressure regression test verifies that both standard consensus methods return `SYNCING` before persistence completes and that non-consensus work remains deferred until persistence is available again.

Closes #26445
