### PR TITLE
fix(db): no-op changeset pruning in stage drop and row-count-as-block-number in bodies stage

### DIFF
--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -94,10 +94,13 @@ impl<C: ChainSpecParser> Command<C> {
                         writer.prune_transaction_senders(to_delete, 0)?;
                     }
                     StaticFileSegment::AccountChangeSets => {
-                        writer.prune_account_changesets(highest_block)?;
+                        // The argument is the last block to KEEP, so passing the segment's
+                        // own tip is a no-op. Keep only the genesis changesets.
+                        writer.prune_account_changesets(0)?;
                     }
                     StaticFileSegment::StorageChangeSets => {
-                        writer.prune_storage_changesets(highest_block)?;
+                        // See `AccountChangeSets` above.
+                        writer.prune_storage_changesets(0)?;
                     }
                 }
             }

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -97,7 +97,15 @@ where
         // the database commit in a previous stage run. So, our only solution is to unwind the
         // static files and proceed from the database expected height.
         Ordering::Greater => {
-            let highest_db_block = provider.tx_ref().entries::<tables::BlockBodyIndices>()? as u64;
+            // The truncation target is the highest block number present in the database, NOT
+            // the table's row count: the two only coincide when the table is contiguous from
+            // block 0, and a wrong target corrupts the segment's block range.
+            let highest_db_block = provider
+                .tx_ref()
+                .cursor_read::<tables::BlockBodyIndices>()?
+                .last()?
+                .map(|(block, _)| block)
+                .unwrap_or_default();
             let mut static_file_producer =
                 static_file_provider.latest_writer(StaticFileSegment::Transactions)?;
             static_file_producer


### PR DESCRIPTION
`stage drop` passes each changeset segment's own tip to `prune_account_changesets`/`prune_storage_changesets`, whose argument is the last block to *keep* — a silent no-op that leaves stale changesets behind for the next
startup's consistency check to prune. Truncate to genesis directly, matching the other segment arms and the checkpoint the command resets to.

The bodies stage's `ensure_consistency` uses the `BlockBodyIndices` row count as the highest database block when unwinding transaction static files; the two only coincide when the table is contiguous from block 0. Use the table's last key
instead.