### PR TITLE
fix: support chains with a non-zero genesis block across static files, pruning, consistency checks and rpc

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -223,11 +223,14 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
             }
 
             // Highly unlikely to happen, and given its destructive nature, it's better to panic
-            // instead.
-            assert_ne!(
-                unwind_target,
-                PipelineTarget::Unwind(0),
-                "A static file <> database inconsistency was found that would trigger an unwind to block 0"
+            // instead. The genesis block is the floor on chains with a non-zero genesis.
+            assert!(
+                !matches!(
+                    unwind_target,
+                    PipelineTarget::Unwind(block)
+                        if block <= factory.static_file_provider().genesis_block_number()
+                ),
+                "A static file <> database inconsistency was found that would trigger an unwind to the genesis block ({unwind_target})"
             );
 
             info!(target: "reth::cli", unwind_target = %unwind_target, "Executing an unwind after a failed storage consistency check.");

--- a/crates/cli/commands/src/db/migrate_v2.rs
+++ b/crates/cli/commands/src/db/migrate_v2.rs
@@ -59,12 +59,21 @@ impl Command {
             return Ok(());
         }
 
-        let tip =
-            provider.get_stage_checkpoint(StageId::Execution)?.map(|c| c.block_number).unwrap_or(0);
-
-        info!(target: "reth::cli", tip, "Chain tip block number");
-
         let sf_provider = provider_factory.static_file_provider();
+        let genesis = sf_provider.genesis_block_number();
+
+        let tip = provider
+            .get_stage_checkpoint(StageId::Execution)?
+            .map(|c| c.block_number)
+            .unwrap_or(genesis);
+
+        info!(target: "reth::cli", tip, genesis, "Chain tip block number");
+
+        if tip < genesis {
+            eyre::bail!(
+                "Invalid chain state: execution checkpoint {tip} is before genesis block {genesis}"
+            );
+        }
 
         for segment in [StaticFileSegment::AccountChangeSets, StaticFileSegment::StorageChangeSets]
         {
@@ -130,15 +139,20 @@ impl Command {
 
         let mut cursor = provider.tx_ref().cursor_read::<tables::AccountChangeSets>()?;
 
+        // Static file segments are genesis-aligned: on chains with a non-zero genesis block
+        // there is no data before the genesis block and the segment's `expected_block_start`
+        // is the genesis block, so migration must not start at 0.
+        let genesis = sf_provider.genesis_block_number();
         let first_block = provider
             .get_prune_checkpoint(PruneSegment::AccountHistory)?
             .and_then(|cp| cp.block_number)
-            .map_or(0, |b| b + 1);
+            .map_or(genesis, |b| b + 1)
+            .max(genesis);
 
         // The writer always starts at the fixed range boundary (e.g. 2500000) which may be
         // earlier than first_block (e.g. 2603897 from prune checkpoint).
         let mut writer = sf_provider.latest_writer(StaticFileSegment::AccountChangeSets)?;
-        if first_block > 0 {
+        if first_block > genesis {
             writer.ensure_at_block(first_block - 1)?;
         }
 
@@ -176,15 +190,18 @@ impl Command {
 
         let mut cursor = provider.tx_ref().cursor_read::<tables::StorageChangeSets>()?;
 
+        // See `migrate_account_changesets`: never start before the genesis block.
+        let genesis = sf_provider.genesis_block_number();
         let first_block = provider
             .get_prune_checkpoint(PruneSegment::StorageHistory)?
             .and_then(|cp| cp.block_number)
-            .map_or(0, |b| b + 1);
+            .map_or(genesis, |b| b + 1)
+            .max(genesis);
 
         // The writer always starts at the fixed range boundary (e.g. 2500000) which may be
         // earlier than first_block (e.g. 2603897 from prune checkpoint).
         let mut writer = sf_provider.latest_writer(StaticFileSegment::StorageChangeSets)?;
-        if first_block > 0 {
+        if first_block > genesis {
             writer.ensure_at_block(first_block - 1)?;
         }
 
@@ -243,15 +260,17 @@ impl Command {
         info!(target: "reth::cli", "Migrating Receipts → static files");
 
         let provider = factory.provider()?.disable_long_read_transaction_safety();
+        // See `migrate_account_changesets`: never start before the genesis block.
+        let genesis = sf_provider.genesis_block_number();
         let prune_start = provider
             .get_prune_checkpoint(PruneSegment::Receipts)?
             .and_then(|cp| cp.block_number)
-            .map_or(0, |b| b + 1);
-        let first_block = prune_start.max(existing.map_or(0, |b| b + 1));
+            .map_or(genesis, |b| b + 1);
+        let first_block = prune_start.max(existing.map_or(genesis, |b| b + 1)).max(genesis);
 
         // The writer always starts at the fixed range boundary (e.g. 2500000) which may be
         // earlier than first_block (e.g. 2603897 from prune checkpoint).
-        if first_block > 0 {
+        if first_block > genesis {
             let mut writer = sf_provider.latest_writer(StaticFileSegment::Receipts)?;
             writer.ensure_at_block(first_block - 1)?;
             writer.commit()?;
@@ -339,30 +358,32 @@ impl Command {
         clear_table!(tables::AccountsTrie);
         clear_table!(tables::StoragesTrie);
 
-        // Reset stage checkpoints so the pipeline rebuilds everything
+        // Reset stage checkpoints so the pipeline rebuilds everything. The lowest valid
+        // checkpoint is the genesis block (non-zero on some chains), matching `init_genesis`.
         info!(target: "reth::cli", "Resetting stage checkpoints");
         let provider_rw = factory.database_provider_rw()?;
+        let genesis = factory.static_file_provider().genesis_block_number();
         for stage in [StageId::SenderRecovery, StageId::MerkleExecute, StageId::MerkleUnwind] {
-            provider_rw.save_stage_checkpoint(stage, StageCheckpoint::new(0))?;
-            info!(target: "reth::cli", %stage, "Checkpoint reset to 0");
+            provider_rw.save_stage_checkpoint(stage, StageCheckpoint::new(genesis))?;
+            info!(target: "reth::cli", %stage, genesis, "Checkpoint reset to genesis");
         }
         provider_rw.save_stage_checkpoint_progress(StageId::MerkleExecute, vec![])?;
 
-        if provider_rw.last_block_number()? > 0 {
+        if provider_rw.last_block_number()? > genesis {
             let first_indices_entry = provider_rw
                 .tx_ref()
                 .cursor_read::<tables::BlockBodyIndices>()?
-                .seek(1)?
+                .seek(genesis + 1)?
                 .map(|(block, _)| block)
                 .ok_or_else(|| eyre::eyre!("no block body indices found"))?;
 
-            // If the first block body indices entry is not block 1, it means that the v1 database
-            // was likely initialized with dummy blocks coming from a dummy chain generated by
-            // `setup_without_evm`.
+            // If the first block body indices entry past genesis is not genesis + 1, it means
+            // that the v1 database was likely initialized with dummy blocks coming from a dummy
+            // chain generated by `setup_without_evm`.
             //
             // In that case, sender recovery starts from the first block that has a corresponding
             // block body indices entry.
-            if first_indices_entry > 1 {
+            if first_indices_entry > genesis + 1 {
                 provider_rw.save_stage_checkpoint(
                     StageId::SenderRecovery,
                     StageCheckpoint::new(first_indices_entry - 1),

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -97,7 +97,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
 
         let components = components(provider_factory.chain_spec());
 
-        let min_block = self.from;
+        // Blocks at or below the genesis block (non-zero on some chains) cannot be
+        // re-executed; the default `--from 1` means "from the start of the chain".
+        let min_block =
+            self.from.max(provider_factory.static_file_provider().genesis_block_number() + 1);
         let best_block = DatabaseProviderFactory::database_provider_ro(&provider_factory)?
             .best_block_number()?;
         let mut max_block = best_block;

--- a/crates/cli/commands/src/stage/drop.rs
+++ b/crates/cli/commands/src/stage/drop.rs
@@ -22,7 +22,7 @@ use reth_provider::{
     StorageSettingsCache,
 };
 use reth_prune::PruneSegment;
-use reth_stages::StageId;
+use reth_stages::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use std::sync::Arc;
 
@@ -63,6 +63,10 @@ impl<C: ChainSpecParser> Command<C> {
         // have deleted them, BUT before we have committed the checkpoints to the database, we'd
         // lose essential data.
         let static_file_provider = tool.provider_factory.static_file_provider();
+        // Dropping a stage truncates its static file segment back to the genesis block, which
+        // is non-zero on some chains: block counts are relative to it and it is the lowest
+        // valid truncation target.
+        let genesis_block = static_file_provider.genesis_block_number();
         for segment in static_file_segments {
             if let Some(highest_block) = static_file_provider.get_highest_static_file_block(segment)
             {
@@ -70,34 +74,34 @@ impl<C: ChainSpecParser> Command<C> {
 
                 match segment {
                     StaticFileSegment::Headers => {
-                        writer.prune_headers(highest_block)?;
+                        writer.prune_headers(highest_block.saturating_sub(genesis_block))?;
                     }
                     StaticFileSegment::Transactions => {
                         let to_delete = static_file_provider
                             .get_highest_static_file_tx(segment)
                             .map(|tx_num| tx_num + 1)
                             .unwrap_or_default();
-                        writer.prune_transactions(to_delete, 0)?;
+                        writer.prune_transactions(to_delete, genesis_block)?;
                     }
                     StaticFileSegment::Receipts => {
                         let to_delete = static_file_provider
                             .get_highest_static_file_tx(segment)
                             .map(|tx_num| tx_num + 1)
                             .unwrap_or_default();
-                        writer.prune_receipts(to_delete, 0)?;
+                        writer.prune_receipts(to_delete, genesis_block)?;
                     }
                     StaticFileSegment::TransactionSenders => {
                         let to_delete = static_file_provider
                             .get_highest_static_file_tx(segment)
                             .map(|tx_num| tx_num + 1)
                             .unwrap_or_default();
-                        writer.prune_transaction_senders(to_delete, 0)?;
+                        writer.prune_transaction_senders(to_delete, genesis_block)?;
                     }
                     StaticFileSegment::AccountChangeSets => {
-                        writer.prune_account_changesets(highest_block)?;
+                        writer.prune_account_changesets(genesis_block)?;
                     }
                     StaticFileSegment::StorageChangeSets => {
-                        writer.prune_storage_changesets(highest_block)?;
+                        writer.prune_storage_changesets(genesis_block)?;
                     }
                 }
             }
@@ -111,7 +115,7 @@ impl<C: ChainSpecParser> Command<C> {
                 tx.clear::<tables::CanonicalHeaders>()?;
                 tx.clear::<tables::Headers<HeaderTy<N>>>()?;
                 tx.clear::<tables::HeaderNumbers>()?;
-                reset_stage_checkpoint(tx, StageId::Headers)?;
+                reset_stage_checkpoint(tx, StageId::Headers, genesis_block)?;
 
                 insert_genesis_header(&provider_rw, &self.env.chain)?;
             }
@@ -122,7 +126,7 @@ impl<C: ChainSpecParser> Command<C> {
                 tx.clear::<tables::TransactionBlocks>()?;
                 tx.clear::<tables::BlockOmmers<HeaderTy<N>>>()?;
                 tx.clear::<tables::BlockWithdrawals>()?;
-                reset_stage_checkpoint(tx, StageId::Bodies)?;
+                reset_stage_checkpoint(tx, StageId::Bodies, genesis_block)?;
 
                 insert_genesis_header(&provider_rw, &self.env.chain)?;
             }
@@ -130,14 +134,14 @@ impl<C: ChainSpecParser> Command<C> {
                 tx.clear::<tables::TransactionSenders>()?;
                 // Reset pruned numbers to not count them in the next rerun's stage progress
                 reset_prune_checkpoint(tx, PruneSegment::SenderRecovery)?;
-                reset_stage_checkpoint(tx, StageId::SenderRecovery)?;
+                reset_stage_checkpoint(tx, StageId::SenderRecovery, genesis_block)?;
             }
             StageEnum::Execution => {
                 if provider_rw.cached_storage_settings().use_hashed_state() {
                     tx.clear::<tables::HashedAccounts>()?;
                     tx.clear::<tables::HashedStorages>()?;
-                    reset_stage_checkpoint(tx, StageId::AccountHashing)?;
-                    reset_stage_checkpoint(tx, StageId::StorageHashing)?;
+                    reset_stage_checkpoint(tx, StageId::AccountHashing, genesis_block)?;
+                    reset_stage_checkpoint(tx, StageId::StorageHashing, genesis_block)?;
                 } else {
                     tx.clear::<tables::PlainAccountState>()?;
                     tx.clear::<tables::PlainStorageState>()?;
@@ -149,34 +153,34 @@ impl<C: ChainSpecParser> Command<C> {
 
                 reset_prune_checkpoint(tx, PruneSegment::Receipts)?;
                 reset_prune_checkpoint(tx, PruneSegment::ContractLogs)?;
-                reset_stage_checkpoint(tx, StageId::Execution)?;
+                reset_stage_checkpoint(tx, StageId::Execution, genesis_block)?;
 
                 let alloc = &self.env.chain.genesis().alloc;
                 insert_genesis_state(&provider_rw, alloc.iter())?;
             }
             StageEnum::AccountHashing => {
                 tx.clear::<tables::HashedAccounts>()?;
-                reset_stage_checkpoint(tx, StageId::AccountHashing)?;
+                reset_stage_checkpoint(tx, StageId::AccountHashing, genesis_block)?;
             }
             StageEnum::StorageHashing => {
                 tx.clear::<tables::HashedStorages>()?;
-                reset_stage_checkpoint(tx, StageId::StorageHashing)?;
+                reset_stage_checkpoint(tx, StageId::StorageHashing, genesis_block)?;
             }
             StageEnum::Hashing => {
                 // Clear hashed accounts
                 tx.clear::<tables::HashedAccounts>()?;
-                reset_stage_checkpoint(tx, StageId::AccountHashing)?;
+                reset_stage_checkpoint(tx, StageId::AccountHashing, genesis_block)?;
 
                 // Clear hashed storages
                 tx.clear::<tables::HashedStorages>()?;
-                reset_stage_checkpoint(tx, StageId::StorageHashing)?;
+                reset_stage_checkpoint(tx, StageId::StorageHashing, genesis_block)?;
             }
             StageEnum::Merkle => {
                 tx.clear::<tables::AccountsTrie>()?;
                 tx.clear::<tables::StoragesTrie>()?;
 
-                reset_stage_checkpoint(tx, StageId::MerkleExecute)?;
-                reset_stage_checkpoint(tx, StageId::MerkleUnwind)?;
+                reset_stage_checkpoint(tx, StageId::MerkleExecute, genesis_block)?;
+                reset_stage_checkpoint(tx, StageId::MerkleUnwind, genesis_block)?;
 
                 tx.delete::<tables::StageCheckpointProgresses>(
                     StageId::MerkleExecute.to_string(),
@@ -193,7 +197,7 @@ impl<C: ChainSpecParser> Command<C> {
                     tx.clear::<tables::AccountsHistory>()?;
                 }
 
-                reset_stage_checkpoint(tx, StageId::IndexAccountHistory)?;
+                reset_stage_checkpoint(tx, StageId::IndexAccountHistory, genesis_block)?;
 
                 insert_genesis_account_history(
                     &provider_rw,
@@ -210,7 +214,7 @@ impl<C: ChainSpecParser> Command<C> {
                     tx.clear::<tables::StoragesHistory>()?;
                 }
 
-                reset_stage_checkpoint(tx, StageId::IndexStorageHistory)?;
+                reset_stage_checkpoint(tx, StageId::IndexStorageHistory, genesis_block)?;
 
                 insert_genesis_storage_history(
                     &provider_rw,
@@ -228,12 +232,15 @@ impl<C: ChainSpecParser> Command<C> {
 
                 reset_prune_checkpoint(tx, PruneSegment::TransactionLookup)?;
 
-                reset_stage_checkpoint(tx, StageId::TransactionLookup)?;
+                reset_stage_checkpoint(tx, StageId::TransactionLookup, genesis_block)?;
                 insert_genesis_header(&provider_rw, &self.env.chain)?;
             }
         }
 
-        tx.put::<tables::StageCheckpoints>(StageId::Finish.to_string(), Default::default())?;
+        tx.put::<tables::StageCheckpoints>(
+            StageId::Finish.to_string(),
+            StageCheckpoint::new(genesis_block),
+        )?;
 
         provider_rw.commit()?;
 
@@ -261,8 +268,12 @@ fn reset_prune_checkpoint(
 fn reset_stage_checkpoint(
     tx: &Tx<reth_db::mdbx::RW>,
     stage_id: StageId,
+    genesis_block: u64,
 ) -> Result<(), DatabaseError> {
-    tx.put::<tables::StageCheckpoints>(stage_id.to_string(), Default::default())?;
+    // Checkpoints reset to the genesis block, matching what `init_genesis` writes on a fresh
+    // datadir — a 0 checkpoint on a non-zero genesis chain trips the startup consistency
+    // check into pre-genesis unwind targets.
+    tx.put::<tables::StageCheckpoints>(stage_id.to_string(), StageCheckpoint::new(genesis_block))?;
 
     Ok(())
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -550,16 +550,17 @@ where
 
         if let Some(unwind_block) = unwind_target {
             // Highly unlikely to happen, and given its destructive nature, it's better to panic
-            // instead. Unwinding to 0 would leave MDBX with a huge free list size.
+            // instead. Unwinding the whole chain would leave MDBX with a huge free list size.
+            // The genesis block is the floor on chains with a non-zero genesis.
             let inconsistency_source = match (rocksdb_unwind, static_file_unwind) {
                 (Some(_), Some(_)) => "RocksDB and static file",
                 (Some(_), None) => "RocksDB",
                 (None, Some(_)) => "static file",
                 (None, None) => unreachable!(),
             };
-            assert_ne!(
-                unwind_block, 0,
-                "A {} inconsistency was found that would trigger an unwind to block 0",
+            assert!(
+                unwind_block > factory.static_file_provider().genesis_block_number(),
+                "A {} inconsistency was found that would trigger an unwind to the genesis block ({unwind_block})",
                 inconsistency_source
             );
 

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -99,6 +99,7 @@ impl PrunerBuilder {
                 Primitives = <PF::ProviderRW as NodePrimitivesProvider>::Primitives,
             >,
     {
+        let genesis_block_number = provider_factory.static_file_provider().genesis_block_number();
         let segments =
             SegmentSet::from_components(provider_factory.static_file_provider(), self.segments);
 
@@ -109,7 +110,8 @@ impl PrunerBuilder {
             self.delete_limit,
             self.timeout,
             self.finished_exex_height,
-        );
+        )
+        .with_genesis_block_number(genesis_block_number);
         if let Some(distance) = self.minimum_pruning_distance {
             pruner = pruner.with_minimum_pruning_distance(distance);
         }
@@ -135,6 +137,7 @@ impl PrunerBuilder {
             + StorageChangeSetReader
             + RocksDBProviderFactory,
     {
+        let genesis_block_number = static_file_provider.genesis_block_number();
         let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);
 
         let mut pruner = Pruner::new(
@@ -143,7 +146,8 @@ impl PrunerBuilder {
             self.delete_limit,
             self.timeout,
             self.finished_exex_height,
-        );
+        )
+        .with_genesis_block_number(genesis_block_number);
         if let Some(distance) = self.minimum_pruning_distance {
             pruner = pruner.with_minimum_pruning_distance(distance);
         }

--- a/crates/prune/prune/src/pruner.rs
+++ b/crates/prune/prune/src/pruner.rs
@@ -16,7 +16,7 @@ use reth_stages_types::StageId;
 use reth_tokio_util::{EventSender, EventStream};
 use std::time::Duration;
 use tokio::sync::watch;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 /// Result of [`Pruner::run`] execution.
 pub type PrunerResult = Result<PrunerOutput, PrunerError>;
@@ -47,6 +47,9 @@ pub struct Pruner<Provider, PF> {
     /// Optional override for the minimum pruning distance. When set, this replaces the
     /// per-segment hardcoded minimums (e.g. `MINIMUM_UNWIND_SAFE_DISTANCE`).
     minimum_pruning_distance: Option<u64>,
+    /// The genesis block number of the chain. No data exists below it, so it is the floor for
+    /// every prune target and range start (non-zero on some chains).
+    genesis_block_number: BlockNumber,
     /// The finished height of all `ExEx`'s.
     finished_exex_height: watch::Receiver<FinishedExExHeight>,
     #[doc(hidden)]
@@ -71,6 +74,7 @@ impl<Provider> Pruner<Provider, ()> {
             delete_limit,
             timeout,
             minimum_pruning_distance: None,
+            genesis_block_number: 0,
             finished_exex_height,
             metrics: Metrics::default(),
             event_sender: Default::default(),
@@ -99,6 +103,7 @@ where
             delete_limit,
             timeout,
             minimum_pruning_distance: None,
+            genesis_block_number: 0,
             finished_exex_height,
             metrics: Metrics::default(),
             event_sender: Default::default(),
@@ -110,6 +115,12 @@ impl<Provider, S> Pruner<Provider, S> {
     /// Sets the minimum pruning distance, overriding per-segment hardcoded minimums.
     pub const fn with_minimum_pruning_distance(mut self, distance: u64) -> Self {
         self.minimum_pruning_distance = Some(distance);
+        self
+    }
+
+    /// Sets the genesis block number, the floor for every prune target and range start.
+    pub const fn with_genesis_block_number(mut self, genesis_block_number: BlockNumber) -> Self {
+        self.genesis_block_number = genesis_block_number;
         self
     }
 }
@@ -144,7 +155,9 @@ where
         else {
             return Ok(PruneProgress::Finished.into())
         };
-        if tip_block_number == 0 {
+        // Only the genesis block exists at (or below) the genesis height, which is non-zero on
+        // some chains — there is nothing to prune yet.
+        if tip_block_number <= self.genesis_block_number {
             self.previous_tip_block_number = Some(tip_block_number);
 
             debug!(target: "pruner", %tip_block_number, "Nothing to prune yet");
@@ -216,6 +229,20 @@ where
                 .transpose()?
                 .flatten()
             {
+                // A target below genesis (e.g. `Distance` larger than the chain's height above
+                // a non-zero genesis) has no data to prune, and a checkpoint must never be
+                // written for a block that does not exist.
+                if to_block < self.genesis_block_number {
+                    warn!(
+                        target: "pruner",
+                        segment = ?segment.segment(),
+                        %to_block,
+                        genesis = self.genesis_block_number,
+                        "Prune target below genesis, skipping"
+                    );
+                    continue
+                }
+
                 // Check if segment has a required stage that must be finished first
                 if let Some(required_stage) = segment.required_stage() &&
                     !is_stage_finished(provider, required_stage)?
@@ -242,7 +269,12 @@ where
                 let previous_checkpoint = provider.get_prune_checkpoint(segment.segment())?;
                 let segment_output = segment.prune(
                     provider,
-                    PruneInput { previous_checkpoint, to_block, limiter: limiter.clone() },
+                    PruneInput {
+                        previous_checkpoint,
+                        to_block,
+                        limiter: limiter.clone(),
+                        genesis_block_number: self.genesis_block_number,
+                    },
                 )?;
                 if let Some(checkpoint) = segment_output.checkpoint {
                     segment

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -153,6 +153,9 @@ pub struct PruneInput {
     pub(crate) to_block: BlockNumber,
     /// Limits pruning of a segment.
     pub(crate) limiter: PruneLimiter,
+    /// The genesis block number: without a checkpoint, pruning ranges start here since no data
+    /// exists below it (non-zero on some chains).
+    pub(crate) genesis_block_number: BlockNumber,
 }
 
 impl PruneInput {
@@ -223,14 +226,14 @@ impl PruneInput {
     /// Returns the start of the next block range.
     ///
     /// 1. If checkpoint exists, use next block.
-    /// 2. If checkpoint doesn't exist, use block 0.
+    /// 2. If checkpoint doesn't exist, use the genesis block.
     pub(crate) fn get_start_next_block_range(&self) -> u64 {
         self.previous_checkpoint
             .and_then(|checkpoint| checkpoint.block_number)
             // Checkpoint exists, prune from the next block after the highest pruned one
             .map(|block_number| block_number + 1)
             // No checkpoint exists, prune from genesis
-            .unwrap_or(0)
+            .unwrap_or(self.genesis_block_number)
     }
 }
 
@@ -248,6 +251,7 @@ mod tests {
     #[test]
     fn test_prune_input_get_next_tx_num_range_no_to_block() {
         let input = PruneInput {
+            genesis_block_number: 0,
             previous_checkpoint: None,
             to_block: 10,
             limiter: PruneLimiter::default(),
@@ -264,6 +268,7 @@ mod tests {
     #[test]
     fn test_prune_input_get_next_tx_num_range_no_tx() {
         let input = PruneInput {
+            genesis_block_number: 0,
             previous_checkpoint: None,
             to_block: 10,
             limiter: PruneLimiter::default(),
@@ -302,6 +307,7 @@ mod tests {
     fn test_prune_input_get_next_tx_num_range_valid() {
         // Create a new prune input
         let input = PruneInput {
+            genesis_block_number: 0,
             previous_checkpoint: None,
             to_block: 10,
             limiter: PruneLimiter::default(),
@@ -344,6 +350,7 @@ mod tests {
     fn test_prune_input_get_next_tx_checkpoint_without_tx_number() {
         // Create a prune input with a previous checkpoint without a tx number (unexpected)
         let input = PruneInput {
+            genesis_block_number: 0,
             previous_checkpoint: Some(PruneCheckpoint {
                 block_number: Some(5),
                 tx_number: None,
@@ -420,6 +427,7 @@ mod tests {
 
         // Create a prune input with a previous checkpoint that is the last tx number
         let input = PruneInput {
+            genesis_block_number: 0,
             previous_checkpoint: Some(PruneCheckpoint {
                 block_number: Some(5),
                 tx_number: Some(max_range),

--- a/crates/prune/prune/src/segments/receipts.rs
+++ b/crates/prune/prune/src/segments/receipts.rs
@@ -156,6 +156,7 @@ mod tests {
             let prune_mode = PruneMode::Before(to_block);
             let mut limiter = PruneLimiter::default().set_deleted_entries_limit(10);
             let input = PruneInput {
+                genesis_block_number: 0,
                 previous_checkpoint: db
                     .factory
                     .provider()

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -217,12 +217,13 @@ impl AccountHistory {
         trace!(target: "pruner", pruned = %pruned_changesets, %done, "Pruned account history (changesets from database)");
 
         // The table walk can stop in the middle of a block, so the interrupted block has to be
-        // pruned again on the next run.
+        // pruned again on the next run. Floor at the genesis block: on chains with a non-zero
+        // genesis block, an interruption on it must not report a checkpoint below genesis.
         let last_pruned_block = last_changeset_pruned_block.map(|block_number| {
             if done {
                 block_number
             } else {
-                block_number.saturating_sub(1)
+                block_number.saturating_sub(1).max(input.genesis_block_number)
             }
         });
 
@@ -411,6 +412,7 @@ mod tests {
                 let mut limiter =
                     PruneLimiter::default().set_deleted_entries_limit(deleted_entries_limit);
                 let input = PruneInput {
+                    genesis_block_number: 0,
                     previous_checkpoint: db
                         .factory
                         .provider()
@@ -577,8 +579,12 @@ mod tests {
 
         let to_block: BlockNumber = 50;
         let prune_mode = PruneMode::Before(to_block);
-        let input =
-            PruneInput { previous_checkpoint: None, to_block, limiter: PruneLimiter::default() };
+        let input = PruneInput {
+            previous_checkpoint: None,
+            to_block,
+            limiter: PruneLimiter::default(),
+            genesis_block_number: 0,
+        };
         let segment = AccountHistory::new(prune_mode);
 
         db.factory.set_storage_settings_cache(StorageSettings::v2());
@@ -691,7 +697,12 @@ mod tests {
         let deleted_entries_limit = 14; // 14/2 = 7 changeset entries before limit
         let limiter = PruneLimiter::default().set_deleted_entries_limit(deleted_entries_limit);
 
-        let input = PruneInput { previous_checkpoint: None, to_block: 10, limiter };
+        let input = PruneInput {
+            previous_checkpoint: None,
+            to_block: 10,
+            limiter,
+            genesis_block_number: 0,
+        };
         let segment = AccountHistory::new(prune_mode);
 
         let provider = db.factory.database_provider_rw().unwrap();
@@ -747,6 +758,7 @@ mod tests {
 
         // Run prune again to complete - should finish processing block 5 and 6
         let input2 = PruneInput {
+            genesis_block_number: 0,
             previous_checkpoint: Some(checkpoint),
             to_block: 10,
             limiter: PruneLimiter::default().set_deleted_entries_limit(100), // high limit
@@ -844,6 +856,7 @@ mod tests {
 
         let run_prune = |checkpoint: PruneCheckpoint, limit: usize| {
             let input = PruneInput {
+                genesis_block_number: 0,
                 previous_checkpoint: Some(checkpoint),
                 to_block,
                 limiter: PruneLimiter::default().set_deleted_entries_limit(limit),
@@ -936,6 +949,7 @@ mod tests {
         for _ in 0..3 {
             let previous = checkpoint.block_number;
             let input = PruneInput {
+                genesis_block_number: 0,
                 previous_checkpoint: Some(checkpoint),
                 to_block,
                 // Halved internally by ACCOUNT_HISTORY_TABLES_TO_PRUNE, so 4 == one dense block.

--- a/crates/prune/prune/src/segments/user/receipts_by_logs.rs
+++ b/crates/prune/prune/src/segments/user/receipts_by_logs.rs
@@ -312,6 +312,7 @@ mod tests {
             let result = ReceiptsByLogs::new(receipts_log_filter).prune(
                 &provider,
                 PruneInput {
+                    genesis_block_number: 0,
                     previous_checkpoint: db
                         .factory
                         .provider()

--- a/crates/prune/prune/src/segments/user/sender_recovery.rs
+++ b/crates/prune/prune/src/segments/user/sender_recovery.rs
@@ -188,6 +188,7 @@ mod tests {
             let segment = SenderRecovery::new(prune_mode);
             let mut limiter = PruneLimiter::default().set_deleted_entries_limit(10);
             let input = PruneInput {
+                genesis_block_number: 0,
                 previous_checkpoint: db
                     .factory
                     .provider()

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -219,12 +219,13 @@ impl StorageHistory {
         trace!(target: "pruner", deleted = %pruned_changesets, %done, "Pruned storage history (changesets)");
 
         // The table walk can stop in the middle of a block, so the interrupted block has to be
-        // pruned again on the next run.
+        // pruned again on the next run. Floor at the genesis block: on chains with a non-zero
+        // genesis block, an interruption on it must not report a checkpoint below genesis.
         let last_pruned_block = last_changeset_pruned_block.map(|block_number| {
             if done {
                 block_number
             } else {
-                block_number.saturating_sub(1)
+                block_number.saturating_sub(1).max(input.genesis_block_number)
             }
         });
 
@@ -419,6 +420,7 @@ mod tests {
             let mut limiter =
                 PruneLimiter::default().set_deleted_entries_limit(deleted_entries_limit);
             let input = PruneInput {
+                genesis_block_number: 0,
                 previous_checkpoint: db
                     .factory
                     .provider()
@@ -600,7 +602,12 @@ mod tests {
         let deleted_entries_limit = 14; // 14/2 = 7 storage entries before limit
         let limiter = PruneLimiter::default().set_deleted_entries_limit(deleted_entries_limit);
 
-        let input = PruneInput { previous_checkpoint: None, to_block: 10, limiter };
+        let input = PruneInput {
+            previous_checkpoint: None,
+            to_block: 10,
+            limiter,
+            genesis_block_number: 0,
+        };
         let segment = StorageHistory::new(prune_mode);
 
         let provider = db.factory.database_provider_rw().unwrap();
@@ -650,6 +657,7 @@ mod tests {
 
         // Run prune again to complete - should finish processing block 5 and 6
         let input2 = PruneInput {
+            genesis_block_number: 0,
             previous_checkpoint: Some(checkpoint),
             to_block: 10,
             limiter: PruneLimiter::default().set_deleted_entries_limit(100), // high limit
@@ -750,8 +758,12 @@ mod tests {
 
         let to_block = 50u64;
         let prune_mode = PruneMode::Before(to_block);
-        let input =
-            PruneInput { previous_checkpoint: None, to_block, limiter: PruneLimiter::default() };
+        let input = PruneInput {
+            previous_checkpoint: None,
+            to_block,
+            limiter: PruneLimiter::default(),
+            genesis_block_number: 0,
+        };
         let segment = StorageHistory::new(prune_mode);
 
         let provider = db.factory.database_provider_rw().unwrap();
@@ -855,6 +867,7 @@ mod tests {
 
         let run_prune = |checkpoint: PruneCheckpoint, limit: usize| {
             let input = PruneInput {
+                genesis_block_number: 0,
                 previous_checkpoint: Some(checkpoint),
                 to_block,
                 limiter: PruneLimiter::default().set_deleted_entries_limit(limit),

--- a/crates/prune/prune/src/segments/user/transaction_lookup.rs
+++ b/crates/prune/prune/src/segments/user/transaction_lookup.rs
@@ -353,6 +353,7 @@ mod tests {
             let segment = TransactionLookup::new(prune_mode);
             let mut limiter = PruneLimiter::default().set_deleted_entries_limit(10);
             let input = PruneInput {
+                genesis_block_number: 0,
                 previous_checkpoint: db
                     .factory
                     .provider()
@@ -492,8 +493,12 @@ mod tests {
 
         let to_block: BlockNumber = 6;
         let prune_mode = PruneMode::Before(to_block);
-        let input =
-            PruneInput { previous_checkpoint: None, to_block, limiter: PruneLimiter::default() };
+        let input = PruneInput {
+            previous_checkpoint: None,
+            to_block,
+            limiter: PruneLimiter::default(),
+            genesis_block_number: 0,
+        };
         let segment = TransactionLookup::new(prune_mode);
 
         // Enable RocksDB storage for transaction hash numbers
@@ -595,7 +600,7 @@ mod tests {
         let mut limiter = PruneLimiter::default().set_deleted_entries_limit(1);
         limiter.increment_deleted_entries_count(); // Exhaust the limit
 
-        let input = PruneInput { previous_checkpoint, to_block, limiter };
+        let input = PruneInput { previous_checkpoint, to_block, limiter, genesis_block_number: 0 };
         let segment = TransactionLookup::new(prune_mode);
 
         let provider = db.factory.database_provider_rw().unwrap();

--- a/crates/rpc/rpc-eth-api/src/helpers/fee.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/fee.rs
@@ -132,9 +132,13 @@ pub trait EthFees:
 
             // need to add 1 to the end block to get the correct (inclusive) range
             let end_block_plus = end_block + 1;
-            // Ensure that we would not be querying outside of genesis
-            if end_block_plus < block_count {
-                block_count = end_block_plus;
+            // Ensure that we would not be querying outside of the available chain: the earliest
+            // block is the genesis block, which is non-zero on some chains.
+            let earliest_block =
+                self.provider().earliest_block_number().map_err(Self::Error::from_eth_err)?;
+            let available_blocks = end_block_plus.saturating_sub(earliest_block);
+            if available_blocks < block_count {
+                block_count = available_blocks;
             }
 
             // Fetch the headers and ensure we got all of them

--- a/crates/rpc/rpc-eth-types/src/gas_oracle.rs
+++ b/crates/rpc/rpc-eth-types/src/gas_oracle.rs
@@ -15,7 +15,7 @@ use reth_rpc_server_types::{
         DEFAULT_MAX_GAS_PRICE, MAX_HEADER_HISTORY, MAX_REWARD_PERCENTILE_COUNT, SAMPLE_NUMBER,
     },
 };
-use reth_storage_api::{BlockReaderIdExt, NodePrimitivesProvider};
+use reth_storage_api::{BlockNumReader, BlockReaderIdExt, NodePrimitivesProvider};
 use schnellru::{ByLength, LruMap};
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
@@ -154,8 +154,12 @@ where
         let mut results = Vec::new();
         let mut populated_blocks = 0;
 
-        // we only check a maximum of 2 * max_block_history, or the number of blocks in the chain
-        let max_blocks = header.number().min(self.oracle_config.max_block_history * 2);
+        // we only check a maximum of 2 * max_block_history, or the number of blocks in the
+        // chain — counted from the earliest available block, since the chain does not
+        // necessarily start at block 0 and walking past its start yields HeaderNotFound.
+        let earliest = self.provider.earliest_block_number()?;
+        let max_blocks =
+            header.number().saturating_sub(earliest).min(self.oracle_config.max_block_history * 2);
 
         for _ in 0..max_blocks {
             // Check if current hash is in cache

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -354,7 +354,11 @@ where
         // We'll reuse the matcher across multiple blocks that are traced in parallel
         let matcher = Arc::new(filter.matcher());
         let TraceFilter { from_block, to_block, mut after, count, .. } = filter;
-        let start = from_block.unwrap_or(0);
+        // Omitting `fromBlock` means "from the start of the available chain": the earliest
+        // block is the genesis block, which is non-zero on some chains.
+        let earliest_block =
+            self.provider().earliest_block_number().map_err(Eth::Error::from_eth_err)?;
+        let start = from_block.unwrap_or(earliest_block);
 
         let latest_block = self.provider().best_block_number().map_err(Eth::Error::from_eth_err)?;
         if start > latest_block {
@@ -367,8 +371,6 @@ where
         }
 
         // Check if the requested range overlaps with pruned history (EIP-4444)
-        let earliest_block =
-            self.provider().earliest_block_number().map_err(Eth::Error::from_eth_err)?;
         if start < earliest_block {
             return Err(EthApiError::PrunedHistoryUnavailable.into());
         }

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -9,7 +9,8 @@ use reth_primitives_traits::constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH;
 use reth_provider::{
     providers::ProviderNodeTypes, BlockHashReader, BlockNumReader, ChainStateBlockReader,
     ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory,
-    PruneCheckpointReader, StageCheckpointReader, StageCheckpointWriter, StorageSettingsCache,
+    PruneCheckpointReader, StageCheckpointReader, StageCheckpointWriter, StaticFileProviderFactory,
+    StorageSettingsCache,
 };
 use reth_prune::PrunerBuilder;
 use reth_static_file::StaticFileProducer;
@@ -305,6 +306,9 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
         to: BlockNumber,
         bad_block: Option<BlockNumber>,
     ) -> Result<(), PipelineError> {
+        // Never unwind below the genesis block, which is non-zero on some chains.
+        let to = to.max(self.provider_factory.static_file_provider().genesis_block_number());
+
         // Add validation before starting unwind
         let (latest_block, prune_modes, checkpoints) = {
             let provider = self.provider_factory.provider()?;

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -97,7 +97,15 @@ where
         // the database commit in a previous stage run. So, our only solution is to unwind the
         // static files and proceed from the database expected height.
         Ordering::Greater => {
-            let highest_db_block = provider.tx_ref().entries::<tables::BlockBodyIndices>()? as u64;
+            // The truncation target is the highest block present in the database, NOT the
+            // table's row count: on chains with a non-zero genesis block the count is far
+            // smaller than the block number and would corrupt the segment's block range.
+            let highest_db_block = provider
+                .tx_ref()
+                .cursor_read::<tables::BlockBodyIndices>()?
+                .last()?
+                .map(|(block, _)| block)
+                .unwrap_or_else(|| static_file_provider.genesis_block_number());
             let mut static_file_producer =
                 static_file_provider.latest_writer(StaticFileSegment::Transactions)?;
             static_file_producer

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -173,9 +173,14 @@ where
                 .get_prune_checkpoint(PruneSegment::SenderRecovery)?
                 .ok_or(StageError::MissingPruneCheckpoint(PruneSegment::SenderRecovery))?;
 
-            // `unwrap_or_default` is safe because we know that genesis block doesn't have any
-            // transactions and senders
-            result.checkpoint = StageCheckpoint::new(checkpoint.block_number.unwrap_or_default());
+            // Falling back to the genesis block is safe because it has no transactions and
+            // senders. A 0 fallback would push the stage checkpoint below genesis on chains
+            // with a non-zero genesis block, stalling every downstream stage.
+            result.checkpoint = StageCheckpoint::new(
+                checkpoint
+                    .block_number
+                    .unwrap_or_else(|| provider.static_file_provider().genesis_block_number()),
+            );
         }
 
         Ok(result)

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -132,12 +132,14 @@ where
             input.next_block_range_with_transaction_threshold(provider, self.commit_threshold)?
         else {
             info!(target: "sync::stages::sender_recovery", "No transaction senders to recover");
+            // An empty segment opens at the genesis block — opening at 0 on a chain with a
+            // non-zero genesis block would create a file with an inverted block range.
             EitherWriter::new_senders(
                 provider,
                 provider
                     .static_file_provider()
                     .get_highest_static_file_block(StaticFileSegment::TransactionSenders)
-                    .unwrap_or_default(),
+                    .unwrap_or_else(|| provider.static_file_provider().genesis_block_number()),
             )?
             .ensure_at_block(input.target())?;
             return Ok(ExecOutput {

--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -408,8 +408,9 @@ pub(crate) fn missing_static_data_error<Provider>(
 where
     Provider: BlockReader + StaticFileProviderFactory,
 {
+    let genesis_block = static_file_provider.genesis_block_number();
     let mut last_block =
-        static_file_provider.get_highest_static_file_block(segment).unwrap_or_default();
+        static_file_provider.get_highest_static_file_block(segment).unwrap_or(genesis_block);
 
     // To be extra safe, we make sure that the last tx num matches the last block from its indices.
     // If not, get it.
@@ -419,7 +420,9 @@ where
         {
             break
         }
-        if last_block == 0 {
+        // No data exists below the genesis block, which is non-zero on some chains; walking
+        // further would scan non-existent blocks.
+        if last_block <= genesis_block {
             break
         }
         last_block -= 1;

--- a/crates/static-file/static-file/src/static_file_producer.rs
+++ b/crates/static-file/static-file/src/static_file_producer.rs
@@ -120,7 +120,8 @@ where
         }
 
         debug_assert!(targets.is_contiguous_to_highest_static_files(
-            self.provider.static_file_provider().get_highest_static_files()
+            self.provider.static_file_provider().get_highest_static_files(),
+            self.provider.static_file_provider().genesis_block_number()
         ));
 
         self.event_sender.notify(StaticFileProducerEvent::Started { targets: targets.clone() });
@@ -224,7 +225,13 @@ where
         highest_static_file: Option<BlockNumber>,
         finalized_block_number: BlockNumber,
     ) -> Option<RangeInclusive<BlockNumber>> {
-        let range = highest_static_file.map_or(0, |block| block + 1)..=finalized_block_number;
+        // An empty segment starts producing at the genesis block, which is non-zero on some
+        // chains — starting at 0 would fail the writer's genesis-aligned first append.
+        let first_block = highest_static_file.map_or_else(
+            || self.provider.static_file_provider().genesis_block_number(),
+            |block| block + 1,
+        );
+        let range = first_block..=finalized_block_number;
         (!range.is_empty()).then_some(range)
     }
 }

--- a/crates/static-file/types/src/lib.rs
+++ b/crates/static-file/types/src/lib.rs
@@ -74,13 +74,21 @@ impl StaticFileTargets {
 
     /// Returns `true` if all targets are either [`None`] or has beginning of the range equal to the
     /// highest static file.
-    pub fn is_contiguous_to_highest_static_files(&self, static_files: HighestStaticFiles) -> bool {
+    ///
+    /// An empty segment's first block is the genesis block, which is non-zero on some chains.
+    pub fn is_contiguous_to_highest_static_files(
+        &self,
+        static_files: HighestStaticFiles,
+        genesis_block: BlockNumber,
+    ) -> bool {
         core::iter::once(&(self.receipts.as_ref(), static_files.receipts)).all(
             |(target_block_range, highest_static_file_block)| {
                 target_block_range.is_none_or(|target_block_range| {
                     *target_block_range.start() ==
                         highest_static_file_block
-                            .map_or(0, |highest_static_file_block| highest_static_file_block + 1)
+                            .map_or(genesis_block, |highest_static_file_block| {
+                                highest_static_file_block + 1
+                            })
                 })
             },
         )

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -615,6 +615,12 @@ impl<N: ProviderNodeTypes> BlockNumReader for ConsistentProvider<N> {
         self.storage_provider.last_block_number()
     }
 
+    fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
+        // The trait default returns 0, which does not exist on chains with a non-zero
+        // genesis; delegate to the storage provider's genesis-aware implementation.
+        self.storage_provider.earliest_block_number()
+    }
+
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
         self.get_in_memory_or_storage_by_block(
             hash.into(),

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1896,6 +1896,12 @@ impl<TX: DbTx + 'static, N: NodeTypes> BlockNumReader for DatabaseProvider<TX, N
         self.static_file_provider.last_block_number()
     }
 
+    fn earliest_block_number(&self) -> ProviderResult<BlockNumber> {
+        // The trait default returns 0, which does not exist on chains with a non-zero
+        // genesis; the earliest available block is the lowest non-expired one.
+        Ok(self.static_file_provider.earliest_history_height())
+    }
+
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.tx.get::<tables::HeaderNumbers>(hash)?)
     }

--- a/crates/storage/provider/src/providers/rocksdb/invariants.rs
+++ b/crates/storage/provider/src/providers/rocksdb/invariants.rs
@@ -90,7 +90,7 @@ impl RocksDBProvider {
 
     /// Heals the `TransactionHashNumbers` table.
     ///
-    /// - Fast path: if checkpoint == 0, clear any stale data and return
+    /// - Fast path: if checkpoint is at the genesis block, clear any stale data and return
     /// - If `sf_tip` < checkpoint, return unwind target (static files behind)
     /// - If `sf_tip` == checkpoint, nothing to do
     /// - If `sf_tip` > checkpoint, heal via transaction ranges in batches
@@ -106,22 +106,27 @@ impl RocksDBProvider {
                 Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
             >,
     {
+        // The chain starts at the genesis block, which is non-zero on some chains: it is both
+        // the "nothing indexed yet" checkpoint value and the floor for static file tips.
+        let genesis_block = provider.static_file_provider().genesis_block_number();
+
         let checkpoint = provider
             .get_stage_checkpoint(StageId::TransactionLookup)?
             .map(|cp| cp.block_number)
-            .unwrap_or(0);
+            .unwrap_or(genesis_block);
 
         let sf_tip = provider
             .static_file_provider()
             .get_highest_static_file_block(StaticFileSegment::Transactions)
-            .unwrap_or(0);
+            .unwrap_or(genesis_block);
 
-        // Fast path: clear any stale data and return.
-        if checkpoint == 0 {
+        // Fast path: nothing indexed yet (genesis has no transactions) — clear any stale data
+        // and return.
+        if checkpoint == genesis_block {
             if self.first::<tables::TransactionHashNumbers>()?.is_some() {
                 tracing::info!(
                     target: "reth::providers::rocksdb",
-                    "TransactionHashNumbers: checkpoint is 0, clearing stale data"
+                    "TransactionHashNumbers: checkpoint is at genesis, clearing stale data"
                 );
                 self.clear::<tables::TransactionHashNumbers>()?;
             }
@@ -268,15 +273,20 @@ impl RocksDBProvider {
             + StorageChangeSetReader
             + ChainSpecProvider,
     {
+        // See `heal_transaction_hash_numbers`: the genesis block (non-zero on some chains) is
+        // the "nothing indexed yet" checkpoint value and the floor for static file tips —
+        // defaulting the tip to 0 would produce a spurious unwind-to-0 signal below.
+        let genesis_block = provider.static_file_provider().genesis_block_number();
+
         let checkpoint = provider
             .get_stage_checkpoint(StageId::IndexStorageHistory)?
             .map(|cp| cp.block_number)
-            .unwrap_or(0);
+            .unwrap_or(genesis_block);
 
         let sf_tip = provider
             .static_file_provider()
             .get_highest_static_file_block(StaticFileSegment::StorageChangeSets)
-            .unwrap_or(0);
+            .unwrap_or(genesis_block);
 
         if sf_tip < checkpoint {
             // This should never happen in normal operation - static files are always
@@ -296,16 +306,17 @@ impl RocksDBProvider {
         }
 
         // Fast path: clear and re-insert genesis history.
-        if checkpoint == 0 {
+        if checkpoint == genesis_block {
             tracing::info!(
                 target: "reth::providers::rocksdb",
-                "StoragesHistory: checkpoint is 0, clearing stale data"
+                "StoragesHistory: checkpoint is at genesis, clearing stale data"
             );
             self.clear::<tables::StoragesHistory>()?;
 
             let chain_spec = provider.chain_spec();
             let genesis = chain_spec.genesis();
-            let list = tables::BlockNumberList::new([0]).expect("single block always fits");
+            let list =
+                tables::BlockNumberList::new([genesis_block]).expect("single block always fits");
             for (addr, account) in &genesis.alloc {
                 if let Some(storage) = &account.storage {
                     for key in storage.keys() {
@@ -381,15 +392,18 @@ impl RocksDBProvider {
             + ChangeSetReader
             + ChainSpecProvider,
     {
+        // See `heal_storages_history` for why these default to the genesis block.
+        let genesis_block = provider.static_file_provider().genesis_block_number();
+
         let checkpoint = provider
             .get_stage_checkpoint(StageId::IndexAccountHistory)?
             .map(|cp| cp.block_number)
-            .unwrap_or(0);
+            .unwrap_or(genesis_block);
 
         let sf_tip = provider
             .static_file_provider()
             .get_highest_static_file_block(StaticFileSegment::AccountChangeSets)
-            .unwrap_or(0);
+            .unwrap_or(genesis_block);
 
         if sf_tip < checkpoint {
             // This should never happen in normal operation - static files are always
@@ -409,16 +423,17 @@ impl RocksDBProvider {
         }
 
         // Fast path: clear and re-insert genesis history.
-        if checkpoint == 0 {
+        if checkpoint == genesis_block {
             tracing::info!(
                 target: "reth::providers::rocksdb",
-                "AccountsHistory: checkpoint is 0, clearing stale data"
+                "AccountsHistory: checkpoint is at genesis, clearing stale data"
             );
             self.clear::<tables::AccountsHistory>()?;
 
             let chain_spec = provider.chain_spec();
             let genesis = chain_spec.genesis();
-            let list = tables::BlockNumberList::new([0]).expect("single block always fits");
+            let list =
+                tables::BlockNumberList::new([genesis_block]).expect("single block always fits");
             for addr in genesis.alloc.keys() {
                 self.put::<tables::AccountsHistory>(ShardedKey::last(*addr), &list)?;
             }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1056,11 +1056,30 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
 
         match segment_max_block {
             Some(segment_max_block) => {
-                let fixed_range = self.find_fixed_range_with_block_index(
+                let mut fixed_range = self.find_fixed_range_with_block_index(
                     segment,
                     indexes.get(segment).map(|index| &index.expected_block_ranges_by_max_block),
                     segment_max_block,
                 );
+
+                // True when `fixed_range` came from an existing on-disk file (vs. a
+                // freshly derived range that has no file yet).
+                let from_existing_file = indexes.get(segment).is_some_and(|index| {
+                    index
+                        .expected_block_ranges_by_max_block
+                        .values()
+                        .any(|range| *range == fixed_range)
+                });
+
+                // Genesis-align only when creating a new first-segment file: on chains with a
+                // non-zero genesis, `StaticFileProviderRW::open` names it starting at genesis.
+                // Legacy data (pre genesis-aligned naming) names that file by the bucket floor,
+                // so bumping an existing range would load a non-existent filename.
+                let genesis = self.genesis_block_number();
+                if !from_existing_file && fixed_range.start() < genesis {
+                    info!(target: "providers::static_file", ?fixed_range, "Adjusting static file range start to genesis block");
+                    fixed_range = SegmentRangeInclusive::new(genesis, fixed_range.end());
+                }
 
                 let jar = NippyJar::<SegmentHeader>::load(
                     &self.path.join(segment.filename(&fixed_range)),
@@ -1228,6 +1247,12 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             // the earliest height is the lowest available block number
             self.earliest_history_height
                 .store(lowest_range.start(), std::sync::atomic::Ordering::Relaxed);
+        } else {
+            // No transaction static files yet: the earliest available block is the genesis
+            // block, which is non-zero on some chains. Without this, a freshly initialized
+            // node would report an earliest height of 0 until the first file is created.
+            self.earliest_history_height
+                .store(self.genesis_block_number, std::sync::atomic::Ordering::Relaxed);
         }
 
         Ok(())
@@ -1326,7 +1351,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                     unwind_target = highest_block,
                     "Setting unwind target."
                 );
-                update_unwind_target(highest_block.unwrap_or_default());
+                update_unwind_target(highest_block.unwrap_or(self.genesis_block_number()));
             }
 
             // Only applies to transaction-based static files. (Receipts & Transactions)
@@ -1339,7 +1364,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             debug!(target: "reth::providers::static_file", "Checking tx index segment");
 
             if let Some(highest_tx) = highest_tx {
-                let mut last_block = highest_block.unwrap_or_default();
+                let mut last_block = highest_block.unwrap_or(self.genesis_block_number());
                 debug!(target: "reth::providers::static_file", last_block, highest_tx, "Verifying last transaction matches last block indices");
                 loop {
                     let Some(indices) = provider.block_body_indices(last_block)? else {
@@ -1356,8 +1381,9 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                         break
                     }
 
-                    if last_block == 0 {
-                        debug!(target: "reth::providers::static_file", "Reached block 0 in verification loop");
+                    // Never walk (or publish an unwind target) below the genesis block.
+                    if last_block <= self.genesis_block_number() {
+                        debug!(target: "reth::providers::static_file", "Reached genesis block in verification loop");
                         break
                     }
 
@@ -1682,13 +1708,19 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         }
 
         let highest_static_file_entry = highest_static_file_entry.unwrap_or_default();
-        let highest_static_file_block = highest_static_file_block.unwrap_or_default();
+        // Missing data or checkpoints floor at the genesis block: no data exists below it on
+        // chains with a non-zero genesis, so 0 would produce a pre-genesis unwind/prune target.
+        let highest_static_file_block =
+            highest_static_file_block.unwrap_or(self.genesis_block_number());
 
         // If static file entry is ahead of the database entries, then ensure the checkpoint block
         // number matches.
         let stage_id = segment.to_stage_id();
-        let checkpoint_block_number =
-            provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
+        let checkpoint_block_number = provider
+            .get_stage_checkpoint(stage_id)?
+            .unwrap_or_default()
+            .block_number
+            .max(self.genesis_block_number());
         debug!(target: "reth::providers::static_file", ?stage_id, checkpoint_block_number, "Retrieved stage checkpoint");
 
         // If the checkpoint is ahead, then we lost static file data. May be data corruption.
@@ -1822,11 +1854,16 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             debug!(target: "reth::providers::static_file", ?segment, "No database entries found");
         }
 
-        let highest_static_file_block = highest_static_file_block.unwrap_or_default();
+        // See `ensure_invariants`: missing data or checkpoints floor at the genesis block.
+        let highest_static_file_block =
+            highest_static_file_block.unwrap_or(self.genesis_block_number());
 
         let stage_id = segment.to_stage_id();
-        let checkpoint_block_number =
-            provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
+        let checkpoint_block_number = provider
+            .get_stage_checkpoint(stage_id)?
+            .unwrap_or_default()
+            .block_number
+            .max(self.genesis_block_number());
 
         if checkpoint_block_number > highest_static_file_block {
             info!(

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -303,6 +303,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
 
         let static_file_provider = Self::upgrade_provider_to_strong_reference(&reader);
 
+        let genesis = static_file_provider.genesis_block_number();
         let block_range = static_file_provider.find_fixed_range(segment, block);
         let (jar, path) = match static_file_provider.get_segment_provider_for_block(
             segment,
@@ -314,6 +315,17 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 provider.data_path().into(),
             ),
             Err(ProviderError::MissingStaticFileBlock(_, _)) => {
+                // New files never start before genesis. If the requested block's bucket lies
+                // entirely below genesis, fall back to the genesis bucket — otherwise clamping
+                // only the start would produce an inverted range (start > end).
+                let block_range = if block_range.end() < genesis {
+                    let genesis_range = static_file_provider.find_fixed_range(segment, genesis);
+                    SegmentRangeInclusive::new(genesis, genesis_range.end())
+                } else if block_range.start() < genesis {
+                    SegmentRangeInclusive::new(genesis, block_range.end())
+                } else {
+                    block_range
+                };
                 let path = static_file_provider.directory().join(segment.filename(&block_range));
                 (create_jar(segment, &path, block_range), path)
             }
@@ -748,8 +760,27 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         let current_block = if let Some(current_block_number) = self.current_block_number() {
             current_block_number
         } else {
-            self.increment_block(0)?;
-            0
+            // Empty segment: the next appendable block is `expected_block_start`, which is
+            // genesis-aligned and not necessarily 0. The writer is logically positioned one
+            // block before it, so advance from there without materializing block 0.
+            let next_block = self.next_block_number();
+            if advance_to.checked_add(1) == Some(next_block) {
+                // Already positioned: the next append will be at `advance_to + 1`.
+                return Ok(());
+            }
+            if advance_to < next_block {
+                return Err(ProviderError::UnexpectedStaticFileBlockNumber(
+                    self.writer.user_header().segment(),
+                    next_block,
+                    advance_to,
+                ));
+            }
+            // Register the gap as empty blocks (e.g. data pruned below `advance_to`) —
+            // block coverage must stay contiguous for later appends to line up.
+            for block in next_block..=advance_to {
+                self.increment_block(block)?;
+            }
+            return Ok(());
         };
 
         match current_block.cmp(&advance_to) {
@@ -875,6 +906,11 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         let segment = self.writer.user_header().segment();
         debug_assert!(segment.is_change_based());
 
+        // No data exists before the genesis block, so a lower target means "truncate
+        // everything above genesis" — otherwise the backwards file walk below would try to
+        // delete the first file and `set_block_range` would store an inverted range.
+        let last_block = last_block.max(self.reader().genesis_block_number());
+
         // Get the current block range
         let current_block_end = self
             .writer
@@ -976,6 +1012,11 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     fn truncate(&mut self, num_rows: u64, last_block: Option<u64>) -> ProviderResult<()> {
         let mut remaining_rows = num_rows;
         let segment = self.writer.user_header().segment();
+        let genesis = self.reader().genesis_block_number();
+        // No data exists before the genesis block, so a lower target means "truncate
+        // everything above genesis" — otherwise the backwards file walk below would try to
+        // delete the first file and `set_block_range` would store an inverted range.
+        let last_block = last_block.map(|b| b.max(genesis));
         while remaining_rows > 0 {
             let len = if segment.is_block_based() {
                 self.writer.user_header().block_len().unwrap_or_default()
@@ -993,7 +1034,10 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
                 // * it's a tx-based segment AND `last_block` is lower than the first block of this
                 //   file's block range. Otherwise, having no rows simply means that this block
                 //   range has no transactions, but the file should remain.
-                if block_start != 0 &&
+                //
+                // The first file is the one whose range contains genesis: it starts at genesis
+                // for genesis-aligned files, or below it (bucket floor) for legacy files.
+                if block_start > genesis &&
                     (segment.is_headers() || last_block.is_some_and(|b| b < block_start))
                 {
                     self.delete_current_and_open_previous()?;
@@ -1042,6 +1086,16 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
     fn delete_current_and_open_previous(&mut self) -> Result<(), ProviderError> {
         let segment = self.user_header().segment();
         let current_path = self.data_path.clone();
+
+        // The first file (its range contains genesis) has no previous file. Worse, with a
+        // non-zero genesis, `open(expected_block_start - 1)` would resolve back to this very
+        // file and we would delete the file we just re-opened.
+        if self.writer.user_header().expected_block_start() <= self.reader().genesis_block_number()
+        {
+            return Err(ProviderError::other(std::io::Error::other(format!(
+                "refusing to delete the first static file of segment {segment}"
+            ))));
+        }
         let (previous_writer, data_path) = Self::open(
             segment,
             self.writer.user_header().expected_block_start() - 1,

--- a/crates/storage/provider/src/providers/static_file/writer_tests.rs
+++ b/crates/storage/provider/src/providers/static_file/writer_tests.rs
@@ -12,7 +12,9 @@ mod tests {
     use alloy_primitives::{Address, U256};
     use reth_db::{models::AccountBeforeTx, test_utils::create_test_static_files_dir};
     use reth_primitives_traits::Account;
-    use reth_static_file_types::{ChangesetOffset, ChangesetOffsetReader, StaticFileSegment};
+    use reth_static_file_types::{
+        ChangesetOffset, ChangesetOffsetReader, SegmentRangeInclusive, StaticFileSegment,
+    };
     use std::{fs::OpenOptions, io::Write as _, path::PathBuf};
 
     use crate::providers::{
@@ -882,5 +884,119 @@ mod tests {
         );
 
         drop(writer);
+    }
+
+    /// Regression: with a non-zero genesis (e.g. 250), an empty segment's first
+    /// appendable block is the genesis block, not 0. `ensure_at_block` used to
+    /// call `increment_block(0)` on empty segments, failing with
+    /// "trying to append data to ... as block #0 but expected block #250".
+    #[test]
+    fn test_ensure_at_block_with_non_zero_genesis() {
+        let (static_dir, _) = create_test_static_files_dir();
+        let segment = StaticFileSegment::AccountChangeSets;
+
+        let provider: StaticFileProvider<EthPrimitives> =
+            StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(100)
+                .with_genesis_block_number(250)
+                .build()
+                .unwrap();
+
+        {
+            let mut writer = provider.latest_writer(segment).unwrap();
+
+            // Positioning at genesis - 1 on an empty segment is a no-op: the next
+            // append is already expected at the genesis block.
+            writer.ensure_at_block(249).unwrap();
+
+            // Positioning before that is impossible.
+            assert!(writer.ensure_at_block(248).is_err());
+
+            // Appending the genesis block right after must succeed.
+            writer.append_account_changeset(generate_test_changeset(250, 1), 250).unwrap();
+            writer.commit().unwrap();
+        }
+
+        assert_eq!(provider.get_highest_static_file_block(segment), Some(250));
+
+        // Advancing an empty segment past genesis fills empty blocks from genesis.
+        let segment = StaticFileSegment::StorageChangeSets;
+        let mut writer = provider.latest_writer(segment).unwrap();
+        writer.ensure_at_block(260).unwrap();
+        writer.commit().unwrap();
+        drop(writer);
+
+        assert_eq!(provider.get_highest_static_file_block(segment), Some(260));
+    }
+
+    /// Regression: truncating below a non-zero genesis must clamp at the first file
+    /// instead of deleting it. The old `block_start != 0` guard never matched a
+    /// genesis-aligned first file, and `delete_current_and_open_previous` on the first
+    /// file resolves back to the same file — deleting the data it just re-opened.
+    #[test]
+    fn test_truncate_below_genesis_keeps_first_file() {
+        use alloy_consensus::Header;
+        use alloy_primitives::B256;
+
+        let (static_dir, _) = create_test_static_files_dir();
+
+        let provider: StaticFileProvider<EthPrimitives> =
+            StaticFileProviderBuilder::read_write(&static_dir)
+                .with_blocks_per_file(100)
+                .with_genesis_block_number(250)
+                .build()
+                .unwrap();
+
+        // Changesets across three files (250-299, 300-399, 400-499).
+        let segment = StaticFileSegment::AccountChangeSets;
+        {
+            let mut writer = provider.latest_writer(segment).unwrap();
+            for block in 250..=450 {
+                writer.append_account_changeset(generate_test_changeset(block, 1), block).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        // A target below genesis clamps to genesis: later files are deleted, the first
+        // file survives holding only the genesis block, and appends continue from there.
+        // Pruning is queued and applied on commit.
+        {
+            let mut writer = provider.latest_writer(segment).unwrap();
+            writer.prune_account_changesets(0).unwrap();
+            writer.commit().unwrap();
+        }
+        assert_eq!(provider.get_highest_static_file_block(segment), Some(250));
+
+        {
+            let mut writer = provider.latest_writer(segment).unwrap();
+            writer.append_account_changeset(generate_test_changeset(251, 1), 251).unwrap();
+            writer.commit().unwrap();
+        }
+        assert_eq!(provider.get_highest_static_file_block(segment), Some(251));
+
+        // Headers: pruning more rows than the segment holds (e.g. `stage drop` passing an
+        // absolute block height as a row count) must empty the first file, not delete it.
+        let segment = StaticFileSegment::Headers;
+        {
+            let mut writer = provider.latest_writer(segment).unwrap();
+            for block in 250..=450 {
+                let header = Header { number: block, ..Default::default() };
+                writer.append_header(&header, &B256::ZERO).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+        {
+            let mut writer = provider.latest_writer(segment).unwrap();
+            writer.prune_headers(451).unwrap();
+            writer.commit().unwrap();
+        }
+        assert_eq!(provider.get_highest_static_file_block(segment), None);
+        assert!(
+            static_dir
+                .path()
+                .join(segment.filename(&SegmentRangeInclusive::new(250, 299)))
+                .exists(),
+            "first headers file must survive over-pruning"
+        );
     }
 }


### PR DESCRIPTION
We run reth on X Layer, an OP-stack L2 whose genesis block number is 42810021
(the datadir is initialized at that height via init-state after a chain
migration). The static file provider already carries a `genesis_block_number`,
but many code paths still hardcode block 0 as the chain start, which on such a
chain ranges from broken commands to silent data loss:

- the static file writer opens empty segments at block 0 (`ensure_at_block`
  fails with "trying to append data to ... as block #0 but expected block
  #42810021"), and the "first file" checks in truncation compare against 0 —
  so truncating past the first (genesis-aligned) file deletes it, with
  `delete_current_and_open_previous` resolving `start - 1` back to the same
  file it is about to delete
- startup consistency checks default missing checkpoints and static file
  heights to 0, producing pre-genesis unwind/prune targets (e.g. pruning
  ~42.8M header rows); the computed target is genesis-1, not 0, so the
  existing unwind-to-0 panic guards never fire
- `Pipeline::unwind` accepts targets below genesis and walks millions of
  non-existent blocks
- the pruner starts ranges at block 0 without a checkpoint, can persist prune
  checkpoints below genesis, and `earliest_history_height` reports 0 until the
  first Transactions file exists
- `stage drop` passes absolute block heights as row counts and 0 as the
  truncation floor; `db migrate-v2` and `re-execute` have the same 0-based
  assumptions
- `earliest_block_number` falls through to the trait default of 0 on
  `DatabaseProvider`/`ConsistentProvider`, so `trace_filter` without a
  `fromBlock` always returns `PrunedHistoryUnavailable`, and `eth_feeHistory` /
  the gas price oracle compute availability from block 0

This clamps all of these to `genesis_block_number()`. On chains with genesis 0
every change is an identity (`max(0)` / `unwrap_or(0)`), so behavior there is
unchanged — the existing static file test suite passes as-is, and two
regression tests cover the non-zero-genesis writer paths.
