### PR TITLE
feat(net): support bootnodes in reth.toml

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1200,4 +1200,12 @@ connect_trusted_nodes_only = true
             assert!(conf.peers.trusted_nodes.contains(&node));
         }
     }
+
+    #[test]
+    fn test_can_support_bootnodes() {
+        let enr = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+        let config: Config = toml::from_str(&format!("[peers]\nbootnodes = [\"{enr}\"]")).unwrap();
+
+        assert_eq!(config.peers.bootnodes, Some(vec![TrustedPeer::from_str(enr).unwrap()]));
+    }
 }

--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -129,6 +129,9 @@ pub struct PeersConfig {
     /// How often to recheck free slots for outbound connections.
     #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub refill_slots_interval: Duration,
+    /// Nodes used to bootstrap P2P discovery.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub bootnodes: Option<Vec<TrustedPeer>>,
     /// Trusted nodes to connect to or accept from
     pub trusted_nodes: Vec<TrustedPeer>,
     /// Connect to or accept from trusted nodes only?
@@ -193,6 +196,7 @@ impl Default for PeersConfig {
     fn default() -> Self {
         Self {
             refill_slots_interval: Duration::from_millis(5_000),
+            bootnodes: None,
             connection_info: Default::default(),
             reputation_weights: Default::default(),
             ban_list: Default::default(),

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -115,6 +115,7 @@ impl PeersManager {
             ban_list,
             ban_duration,
             backoff_durations,
+            bootnodes: _,
             trusted_nodes,
             trusted_nodes_only,
             trusted_nodes_resolution_interval,

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -543,11 +543,12 @@ impl NetworkArgs {
     /// The `default_peers_file` will be used as the default location to store the persistent peers
     /// file if `no_persist_peers` is false, and there is no provided `peers_file`.
     ///
-    /// Configured Bootnodes are prioritized, if unset, the chain spec bootnodes are used
+    /// Configured bootnodes are prioritized, if unset, the chain spec bootnodes are used
     /// Priority order for bootnodes configuration:
     /// 1. --bootnodes flag
-    /// 2. Network preset flags (e.g. --holesky)
-    /// 3. default to mainnet nodes
+    /// 2. `[peers].bootnodes` in reth.toml
+    /// 3. Network preset flags (e.g. --holesky)
+    /// 4. default to mainnet nodes
     pub fn network_config<N: NetworkPrimitives>(
         &self,
         config: &Config,
@@ -565,6 +566,11 @@ impl NetworkArgs {
         let discovery_addr = self.resolved_discovery_addr(listener_addr);
         let chain_bootnodes = self
             .resolved_bootnodes()
+            .or_else(|| {
+                config.peers.bootnodes.clone().map(|bootnodes| {
+                    bootnodes.into_iter().filter_map(|node| node.resolve_blocking().ok()).collect()
+                })
+            })
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 
@@ -1628,5 +1634,45 @@ mod tests {
 
         // Cleanup
         let _ = fs::remove_file(&peers_file);
+    }
+
+    #[test]
+    fn network_config_uses_toml_bootnodes_when_cli_is_unset() {
+        let bootnode = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301";
+        let bootnode: TrustedPeer = bootnode.parse().unwrap();
+        let mut config = Config::default();
+        config.peers.bootnodes = Some(vec![bootnode.clone()]);
+
+        let args = NetworkArgs::default();
+        let builder = args.network_config::<reth_network::EthNetworkPrimitives>(
+            &config,
+            MAINNET.clone(),
+            SecretKey::from_byte_array(&[1u8; 32]).unwrap(),
+            std::env::temp_dir().join("reth_bootnodes_test"),
+            Runtime::test(),
+        );
+
+        assert_eq!(builder.boot_nodes_iter().collect::<Vec<_>>(), vec![&bootnode]);
+    }
+
+    #[test]
+    fn cli_bootnodes_override_toml_bootnodes() {
+        let toml_bootnode = "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303?discport=30301";
+        let cli_bootnode = "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@10.3.58.7:30303?discport=30301";
+        let cli_bootnode: TrustedPeer = cli_bootnode.parse().unwrap();
+        let mut config = Config::default();
+        config.peers.bootnodes = Some(vec![toml_bootnode.parse().unwrap()]);
+        let args =
+            NetworkArgs { bootnodes: Some(vec![cli_bootnode.clone()]), ..Default::default() };
+
+        let builder = args.network_config::<reth_network::EthNetworkPrimitives>(
+            &config,
+            MAINNET.clone(),
+            SecretKey::from_byte_array(&[1u8; 32]).unwrap(),
+            std::env::temp_dir().join("reth_bootnodes_test"),
+            Runtime::test(),
+        );
+
+        assert_eq!(builder.boot_nodes_iter().collect::<Vec<_>>(), vec![&cli_bootnode]);
     }
 }

--- a/docs/vocs/docs/pages/run/configuration.mdx
+++ b/docs/vocs/docs/pages/run/configuration.mdx
@@ -282,6 +282,9 @@ In the top level of the section you can configure trusted nodes, and how often r
 # How often reth will attempt to make outgoing connections,
 # if there is room for more peers
 refill_slots_interval = '5s'
+# Optional enode URLs or ENRs for P2P discovery bootstrap.
+# If unset, the network-specific defaults are used.
+# bootnodes = ["enr:-..."]
 # A list of ENRs for trusted peers, which are peers reth will always try to connect to.
 trusted_nodes = []
 # Whether reth will only attempt to connect to the peers specified above,


### PR DESCRIPTION
Adds optional `[peers].bootnodes` support to `reth.toml` for discovery bootstrap nodes, including enode and ENR values. CLI `--bootnodes` remains higher priority, followed by TOML, network presets, and built-in defaults.

Tests: `cargo +nightly fmt --all --check` and `git diff --check` pass. Cargo tests could not start because the pinned `sigp/discv5` revision was unavailable through the configured proxy (401/503).

Prompted by: @rakita