### PR TITLE
refactor: centralize in-memory state anchors

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -127,18 +127,11 @@ where
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
-        if self.overlay_manager.contains_block(self.parent_hash) {
-            let db_tip_number = self.provider_factory.last_block_number()?;
-            let db_tip = self
-                .provider_factory
-                .block_hash(db_tip_number)?
-                .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
-            if let Some((anchor_hash, overlay)) =
-                self.overlay_manager.state_provider_blocks(self.parent_hash, db_tip)
-            {
-                let historical = self.provider_factory.state_by_block_hash(anchor_hash)?;
-                return Ok(Box::new(MemoryOverlayStateProvider::new(historical, overlay)))
-            }
+        if let Some((anchor_hash, overlay)) =
+            self.overlay_manager.state_provider_blocks(&self.provider_factory, self.parent_hash)?
+        {
+            let historical = self.provider_factory.state_by_block_hash(anchor_hash)?;
+            return Ok(Box::new(MemoryOverlayStateProvider::new(historical, overlay)))
         }
         self.provider_factory.state_by_block_hash(self.parent_hash)
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -29,9 +29,9 @@ use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 use reth_provider::{
-    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockReader, ChangeSetReader,
-    DatabaseProviderFactory, HashedPostStateProvider, ProviderError, SaveBlocksInput,
-    StageCheckpointReader, StateProviderBox, StateProviderFactory, StateReader,
+    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockHashReader, BlockReader,
+    ChangeSetReader, DatabaseProviderFactory, HashedPostStateProvider, ProviderError,
+    SaveBlocksInput, StageCheckpointReader, StateProviderBox, StateProviderFactory, StateReader,
     StorageChangeSetReader, StorageSettingsCache, TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
@@ -108,35 +108,39 @@ const CHANGESET_CACHE_RETENTION_BLOCKS: u64 = 64;
 pub struct StateProviderBuilder<N: NodePrimitives, P> {
     /// The provider factory used to create providers.
     provider_factory: P,
-    /// The historical block hash to fetch state from.
-    historical: B256,
-    /// The blocks that form the chain from historical to target and are in memory.
-    overlay: Option<Vec<ExecutedBlock<N>>>,
+    /// The block hash whose state should be provided.
+    parent_hash: B256,
+    /// Shared in-memory overlay state.
+    overlay_manager: OverlayManager<N>,
 }
 
 impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
-    /// Creates a new state provider from the provider factory, historical block hash and optional
-    /// overlaid blocks.
-    pub const fn new(
-        provider_factory: P,
-        historical: B256,
-        overlay: Option<Vec<ExecutedBlock<N>>>,
-    ) -> Self {
-        Self { provider_factory, historical, overlay }
+    /// Creates a new state provider from the provider factory and target block hash.
+    pub fn new(provider_factory: P, parent_hash: B256, overlay_manager: OverlayManager<N>) -> Self {
+        Self { provider_factory, parent_hash, overlay_manager }
     }
 }
 
 impl<N: NodePrimitives, P> StateProviderBuilder<N, P>
 where
-    P: BlockReader + StateProviderFactory + StateReader + Clone,
+    P: BlockHashReader + BlockReader + StateProviderFactory + StateReader + Clone,
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
-        let mut provider = self.provider_factory.state_by_block_hash(self.historical)?;
-        if let Some(overlay) = self.overlay.clone() {
-            provider = Box::new(MemoryOverlayStateProvider::new(provider, overlay))
+        if self.overlay_manager.contains_block(self.parent_hash) {
+            let db_tip_number = self.provider_factory.last_block_number()?;
+            let db_tip = self
+                .provider_factory
+                .block_hash(db_tip_number)?
+                .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
+            if let Some((anchor_hash, overlay)) =
+                self.overlay_manager.state_provider_blocks(self.parent_hash, db_tip)
+            {
+                let historical = self.provider_factory.state_by_block_hash(anchor_hash)?;
+                return Ok(Box::new(MemoryOverlayStateProvider::new(historical, overlay)))
+            }
         }
-        Ok(provider)
+        self.provider_factory.state_by_block_hash(self.parent_hash)
     }
 }
 
@@ -3409,15 +3413,15 @@ where
         hash: B256,
     ) -> ProviderResult<Option<StateProviderBuilder<N, P>>>
     where
-        P: BlockReader + StateProviderFactory + StateReader + Clone,
+        P: BlockHashReader + BlockReader + StateProviderFactory + StateReader + Clone,
     {
-        if let Some((historical, blocks)) = self.state.tree_state.blocks_by_hash(hash) {
-            debug!(target: "engine::tree", %hash, %historical, "found canonical state for block in memory, creating provider builder");
+        if self.state.tree_state.blocks_by_hash.contains_key(&hash) {
+            debug!(target: "engine::tree", %hash, "found canonical state for block in memory, creating provider builder");
             // the block leads back to the canonical chain
             return Ok(Some(StateProviderBuilder::new(
                 self.provider.clone(),
-                historical,
-                Some(blocks),
+                hash,
+                self.state.tree_state.overlay_manager.clone(),
             )))
         }
 
@@ -3426,7 +3430,11 @@ where
             debug!(target: "engine::tree", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+            return Ok(Some(StateProviderBuilder::new(
+                self.provider.clone(),
+                hash,
+                self.state.tree_state.overlay_manager.clone(),
+            )))
         }
 
         debug!(target: "engine::tree", %hash, "no canonical state found for block");

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1403,13 +1403,13 @@ where
         hash: B256,
         state: &EngineApiTreeState<N>,
     ) -> ProviderResult<Option<StateProviderBuilder<N, P>>> {
-        if let Some((historical, blocks)) = state.tree_state.blocks_by_hash(hash) {
-            debug!(target: "engine::tree::payload_validator", %hash, %historical, "found canonical state for block in memory, creating provider builder");
+        if state.tree_state.blocks_by_hash.contains_key(&hash) {
+            debug!(target: "engine::tree::payload_validator", %hash, "found canonical state for block in memory, creating provider builder");
             // the block leads back to the canonical chain
             return Ok(Some(StateProviderBuilder::new(
                 self.provider.clone(),
-                historical,
-                Some(blocks),
+                hash,
+                state.tree_state.overlay_manager.clone(),
             )))
         }
 
@@ -1418,7 +1418,11 @@ where
             debug!(target: "engine::tree::payload_validator", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
             // For persisted blocks, we create a builder that will fetch state directly from the
             // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+            return Ok(Some(StateProviderBuilder::new(
+                self.provider.clone(),
+                hash,
+                state.tree_state.overlay_manager.clone(),
+            )))
         }
 
         debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");

--- a/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
@@ -10,6 +10,8 @@ use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{BlockReader, StateProviderFactory, StateReader};
 use reth_revm::{cached::CachedReads, db::State};
+#[cfg(test)]
+use reth_storage_overlay::OverlayManager;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -365,7 +367,7 @@ mod tests {
                 provider_builder: StateProviderBuilder::new(
                     MockEthProvider::default(),
                     parent_hash,
-                    None,
+                    OverlayManager::default(),
                 ),
             };
             self.commands.send(Command::Start { parent_hash, job }).unwrap();

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -154,13 +154,8 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         &self,
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
-        let db_tip_number = self.database.last_block_number()?;
-        let db_tip = self
-            .database
-            .block_hash(db_tip_number)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
         if let Some((anchor_hash, in_memory)) =
-            self.database.overlay_manager().state_provider_blocks(state.hash(), db_tip)
+            self.database.overlay_manager().state_provider_blocks(&self.database, state.hash())?
         {
             let historical = self.database.history_by_block_hash(anchor_hash)?;
             return Ok(MemoryOverlayStateProvider::new(historical, in_memory))

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -161,10 +161,12 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
             return Ok(MemoryOverlayStateProvider::new(historical, in_memory))
         }
 
-        // The manager only tracks blocks inserted through `TreeState`. The canonical in-memory
-        // state can also retain an already-persisted block during canonical recovery, or briefly
-        // outlive its manager entry while persistence removes the two views. Use its parent chain
-        // as the overlay in either case.
+        // The manager only tracks blocks inserted through `TreeState::insert_executed`. The
+        // canonical in-memory state can contain blocks absent from the manager in two cases:
+        // `ensure_block_in_memory` loads an already-persisted canonical block directly into the
+        // canonical state, and `on_new_persisted_block` removes manager entries through
+        // `TreeState::remove_until` before removing those blocks from the canonical state. Use the
+        // captured state's parent chain as the overlay in both cases.
         let anchor_hash = state.anchor().hash;
         let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
         Ok(state.state_provider(latest_historical))

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -161,6 +161,10 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
             return Ok(MemoryOverlayStateProvider::new(historical, in_memory))
         }
 
+        // The manager only tracks blocks inserted through `TreeState`. The canonical in-memory
+        // state can also retain an already-persisted block during canonical recovery, or briefly
+        // outlive its manager entry while persistence removes the two views. Use its parent chain
+        // as the overlay in either case.
         let anchor_hash = state.anchor().hash;
         let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
         Ok(state.state_provider(latest_historical))

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -154,6 +154,18 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         &self,
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
+        let db_tip_number = self.database.last_block_number()?;
+        let db_tip = self
+            .database
+            .block_hash(db_tip_number)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
+        if let Some((anchor_hash, in_memory)) =
+            self.database.overlay_manager().state_provider_blocks(state.hash(), db_tip)
+        {
+            let historical = self.database.history_by_block_hash(anchor_hash)?;
+            return Ok(MemoryOverlayStateProvider::new(historical, in_memory))
+        }
+
         let anchor_hash = state.anchor().hash;
         let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
         Ok(state.state_provider(latest_historical))

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -253,13 +253,8 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         &self,
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
-        let db_tip_number = self.storage_provider.last_block_number()?;
-        let db_tip = self
-            .storage_provider
-            .block_hash(db_tip_number)?
-            .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
         if let Some((anchor_hash, in_memory)) =
-            self.overlay_manager.state_provider_blocks(state.hash(), db_tip)
+            self.overlay_manager.state_provider_blocks(&self.storage_provider, state.hash())?
         {
             let historical = self.history_by_block_hash_ref(anchor_hash)?;
             return Ok(MemoryOverlayStateProviderRef::new(historical, in_memory))
@@ -473,12 +468,8 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         if let Some(Some(block_state)) =
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
-            let db_tip_number = storage_provider.last_block_number()?;
-            let db_tip = storage_provider
-                .block_hash(db_tip_number)?
-                .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
             if let Some((anchor_hash, in_memory)) =
-                overlay_manager.state_provider_blocks(block_state.hash(), db_tip)
+                overlay_manager.state_provider_blocks(&storage_provider, block_state.hash())?
             {
                 let anchor_number = storage_provider
                     .block_number(anchor_hash)?

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -13,7 +13,9 @@ use alloy_consensus::{
 };
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, HashOrNumber};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
-use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStateProviderRef};
+use reth_chain_state::{
+    BlockState, CanonicalInMemoryState, MemoryOverlayStateProvider, MemoryOverlayStateProviderRef,
+};
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::ExecutionOutcome;
@@ -29,6 +31,7 @@ use reth_storage_api::{
     StateProviderBox, StorageChangeSetReader, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
+use reth_storage_overlay::OverlayManager;
 use revm::database::states::PlainStorageRevert;
 use std::{
     ops::{Add, Bound, RangeBounds, RangeInclusive, Sub},
@@ -51,6 +54,8 @@ pub struct ConsistentProvider<N: ProviderNodeTypes> {
     head_block: Option<Arc<BlockState<N::Primitives>>>,
     /// In-memory canonical state. This is not a snapshot, and can change! Use with caution.
     canonical_in_memory_state: CanonicalInMemoryState<N::Primitives>,
+    /// Shared in-memory overlay state.
+    overlay_manager: OverlayManager<N::Primitives>,
 }
 
 impl<N: ProviderNodeTypes> ConsistentProvider<N> {
@@ -71,8 +76,9 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         // working under an older view), while the in-memory state may have deleted them
         // entirely. Resulting in gaps on the range.
         let head_block = state.head_state();
+        let overlay_manager = storage_provider_factory.overlay_manager().clone();
         let storage_provider = storage_provider_factory.database_provider_ro()?;
-        Ok(Self { storage_provider, head_block, canonical_in_memory_state: state })
+        Ok(Self { storage_provider, head_block, canonical_in_memory_state: state, overlay_manager })
     }
 
     // Helper function to convert range bounds
@@ -247,6 +253,18 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         &self,
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
+        let db_tip_number = self.storage_provider.last_block_number()?;
+        let db_tip = self
+            .storage_provider
+            .block_hash(db_tip_number)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
+        if let Some((anchor_hash, in_memory)) =
+            self.overlay_manager.state_provider_blocks(state.hash(), db_tip)
+        {
+            let historical = self.history_by_block_hash_ref(anchor_hash)?;
+            return Ok(MemoryOverlayStateProviderRef::new(historical, in_memory))
+        }
+
         let anchor_hash = state.anchor().hash;
         let latest_historical = self.history_by_block_hash_ref(anchor_hash)?;
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
@@ -451,10 +469,24 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
         self.ensure_canonical_block(block_number)?;
 
-        let Self { storage_provider, head_block, .. } = self;
+        let Self { storage_provider, head_block, overlay_manager, .. } = self;
         if let Some(Some(block_state)) =
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
+            let db_tip_number = storage_provider.last_block_number()?;
+            let db_tip = storage_provider
+                .block_hash(db_tip_number)?
+                .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
+            if let Some((anchor_hash, in_memory)) =
+                overlay_manager.state_provider_blocks(block_state.hash(), db_tip)
+            {
+                let anchor_number = storage_provider
+                    .block_number(anchor_hash)?
+                    .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
+                let historical = storage_provider.try_into_history_at_block(anchor_number)?;
+                return Ok(MemoryOverlayStateProvider::new(historical, in_memory).boxed())
+            }
+
             let anchor_hash = block_state.anchor().hash;
             let block_number = storage_provider
                 .block_number(anchor_hash)?

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -155,18 +155,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         let trie_updates_total_len;
         let hashed_state_updates_total_len;
         let anchor_hash = match &self.overlay_source {
-            Some(OverlaySource::Managed) => {
-                let parent_is_persisted = provider
-                    .convert_hash_or_number(self.parent_hash.into())?
-                    .is_some_and(|parent_number| parent_number <= state_trie_tip_block.number);
-                if parent_is_persisted {
-                    self.parent_hash
-                } else {
-                    self.overlay_manager
-                        .anchor_for_parent(self.parent_hash, state_trie_tip_block.hash)
-                        .ok_or(ProviderError::BlockHashNotFound(self.parent_hash))?
-                }
-            }
+            Some(OverlaySource::Managed) => self.overlay_manager.anchor_for_overlay_parent(
+                provider,
+                self.parent_hash,
+                state_trie_tip_block,
+            )?,
             _ => self.parent_hash,
         };
 

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -101,6 +101,11 @@ impl<N: NodePrimitives> OverlayManager<N> {
         OverlayBuilder::new(parent_hash, self.clone())
     }
 
+    /// Returns whether `hash` is tracked as an in-memory block.
+    pub fn contains_block(&self, hash: B256) -> bool {
+        self.blocks.contains_key(&hash)
+    }
+
     /// Gets or computes cached changesets for an inclusive block range.
     pub fn get_or_compute_cached_changesets_range<P>(
         &self,
@@ -399,7 +404,39 @@ impl<N: NodePrimitives> OverlayManager<N> {
     /// Returns `None` if `parent_hash` is not `preferred_anchor` and the manager does not contain a
     /// block for `parent_hash`, meaning there is no in-memory parent chain to inspect.
     pub fn anchor_for_parent(&self, parent_hash: B256, preferred_anchor: B256) -> Option<B256> {
-        Self::anchor_for_parent_in(self.blocks.as_ref(), parent_hash, preferred_anchor)
+        self.state_provider_blocks(parent_hash, preferred_anchor).map(|(anchor, _)| anchor)
+    }
+
+    /// Returns the historical anchor and in-memory blocks needed to provide state at `parent_hash`.
+    ///
+    /// If `preferred_anchor` is on the in-memory parent chain, only blocks after that anchor are
+    /// returned. Otherwise, all available in-memory blocks are returned and their first missing
+    /// parent is used as the anchor. Blocks are ordered newest to oldest.
+    pub fn state_provider_blocks(
+        &self,
+        parent_hash: B256,
+        preferred_anchor: B256,
+    ) -> Option<(B256, Vec<ExecutedBlock<N>>)> {
+        if parent_hash == preferred_anchor {
+            return Some((preferred_anchor, Vec::new()))
+        }
+
+        let mut hash = parent_hash;
+        let mut blocks = Vec::new();
+
+        loop {
+            let block = self.blocks.get(&hash)?;
+            let parent_hash = block.recovered_block().parent_hash();
+            blocks.push(block.clone());
+
+            if parent_hash == preferred_anchor {
+                return Some((preferred_anchor, blocks))
+            }
+            if !self.blocks.contains_key(&parent_hash) {
+                return Some((parent_hash, blocks))
+            }
+            hash = parent_hash;
+        }
     }
 
     /// Returns true if `hash` is in the parent chain segment from `anchor_hash` inclusive to
@@ -430,13 +467,9 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
 
         let mut hash = parent_hash;
-
         loop {
             let block_parent_hash = blocks.get(&hash)?.recovered_block().parent_hash();
-            if block_parent_hash == preferred_anchor {
-                return Some(block_parent_hash)
-            }
-            if !blocks.contains_key(&block_parent_hash) {
+            if block_parent_hash == preferred_anchor || !blocks.contains_key(&block_parent_hash) {
                 return Some(block_parent_hash)
             }
             hash = block_parent_hash;
@@ -768,6 +801,25 @@ mod tests {
             manager.anchor_for_parent(blocks[2].recovered_block().hash(), db_tip_hash),
             Some(db_tip_hash)
         );
+    }
+
+    #[test]
+    fn state_provider_blocks_uses_suffix_after_preferred_anchor() {
+        let manager = OverlayManager::default();
+        let blocks = test_blocks();
+        for block in &blocks {
+            manager.insert_block(block.clone());
+        }
+
+        let (anchor, suffix) = manager
+            .state_provider_blocks(
+                blocks[2].recovered_block().hash(),
+                blocks[1].recovered_block().hash(),
+            )
+            .unwrap();
+
+        assert_eq!(anchor, blocks[1].recovered_block().hash());
+        assert_eq!(suffix, vec![blocks[2].clone()]);
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -8,7 +8,7 @@ use crate::{changeset_cache::compute_block_trie_updates, ChangesetCache, Overlay
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
-use reth_errors::ProviderResult;
+use reth_errors::{ProviderError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_metrics::{
     metrics::{Counter, Histogram},
@@ -19,7 +19,8 @@ use reth_primitives_traits::{
     AlloyBlockHeader, FastInstant, NodePrimitives,
 };
 use reth_storage_api::{
-    BlockNumReader, ChangeSetReader, DBProvider, StorageChangeSetReader, StorageSettingsCache,
+    BlockHashReader, BlockNumReader, ChangeSetReader, DBProvider, StorageChangeSetReader,
+    StorageSettingsCache,
 };
 #[cfg(feature = "rayon")]
 use reth_tasks::WorkerPool;
@@ -404,7 +405,32 @@ impl<N: NodePrimitives> OverlayManager<N> {
     /// Returns `None` if `parent_hash` is not `preferred_anchor` and the manager does not contain a
     /// block for `parent_hash`, meaning there is no in-memory parent chain to inspect.
     pub fn anchor_for_parent(&self, parent_hash: B256, preferred_anchor: B256) -> Option<B256> {
-        self.state_provider_blocks(parent_hash, preferred_anchor).map(|(anchor, _)| anchor)
+        self.state_provider_blocks_from_anchor(parent_hash, preferred_anchor)
+            .map(|(anchor, _)| anchor)
+    }
+
+    /// Returns the historical anchor and in-memory blocks needed to provide state at `parent_hash`.
+    ///
+    /// Uses the current database tip as the preferred anchor. Returns `None` when `parent_hash` is
+    /// not an in-memory block managed by this instance.
+    pub fn state_provider_blocks<P>(
+        &self,
+        provider: &P,
+        parent_hash: B256,
+    ) -> ProviderResult<Option<(B256, Vec<ExecutedBlock<N>>)>>
+    where
+        P: BlockHashReader + BlockNumReader,
+    {
+        if !self.contains_block(parent_hash) {
+            return Ok(None)
+        }
+
+        let db_tip_number = provider.last_block_number()?;
+        let db_tip = provider
+            .block_hash(db_tip_number)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(db_tip_number.into()))?;
+
+        Ok(self.state_provider_blocks_from_anchor(parent_hash, db_tip))
     }
 
     /// Returns the historical anchor and in-memory blocks needed to provide state at `parent_hash`.
@@ -412,7 +438,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
     /// If `preferred_anchor` is on the in-memory parent chain, only blocks after that anchor are
     /// returned. Otherwise, all available in-memory blocks are returned and their first missing
     /// parent is used as the anchor. Blocks are ordered newest to oldest.
-    pub fn state_provider_blocks(
+    fn state_provider_blocks_from_anchor(
         &self,
         parent_hash: B256,
         preferred_anchor: B256,
@@ -812,7 +838,7 @@ mod tests {
         }
 
         let (anchor, suffix) = manager
-            .state_provider_blocks(
+            .state_provider_blocks_from_anchor(
                 blocks[2].recovered_block().hash(),
                 blocks[1].recovered_block().hash(),
             )

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -5,6 +5,7 @@
 //! builds reusable flattened state trie overlays on demand.
 
 use crate::{changeset_cache::compute_block_trie_updates, ChangesetCache, OverlayBuilder};
+use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
@@ -246,10 +247,10 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
         if removed_blocks > 0 {
             let overlays_before = self.overlays.len();
-            let blocks = Arc::clone(&self.blocks);
-            self.overlays.retain(|key, _| {
+            let manager = self.clone();
+            self.overlays.retain(move |key, _| {
                 key.tip_hash != key.anchor_hash &&
-                    Self::anchor_for_parent_in(blocks.as_ref(), key.tip_hash, key.anchor_hash) ==
+                    manager.anchor_for_parent(key.tip_hash, key.anchor_hash) ==
                         Some(key.anchor_hash)
             });
             pruned_overlays = overlays_before.saturating_sub(self.overlays.len());
@@ -409,6 +410,30 @@ impl<N: NodePrimitives> OverlayManager<N> {
             .map(|(anchor, _)| anchor)
     }
 
+    /// Returns the anchor for an overlay whose durable state trie tip is `state_trie_tip_block`.
+    ///
+    /// A persisted parent can be used directly. Otherwise, the manager prefers the durable tip
+    /// when it is on the in-memory parent chain, falling back to the first missing parent.
+    pub fn anchor_for_overlay_parent<P>(
+        &self,
+        provider: &P,
+        parent_hash: B256,
+        state_trie_tip_block: BlockNumHash,
+    ) -> ProviderResult<B256>
+    where
+        P: BlockNumReader,
+    {
+        let parent_is_persisted = provider
+            .convert_hash_or_number(parent_hash.into())?
+            .is_some_and(|parent_number| parent_number <= state_trie_tip_block.number);
+        if parent_is_persisted {
+            return Ok(parent_hash)
+        }
+
+        self.anchor_for_parent(parent_hash, state_trie_tip_block.hash)
+            .ok_or(ProviderError::BlockHashNotFound(parent_hash))
+    }
+
     /// Returns the historical anchor and in-memory blocks needed to provide state at `parent_hash`.
     ///
     /// Uses the current database tip as the preferred anchor. Returns `None` when `parent_hash` is
@@ -480,25 +505,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
             let Some(block) = self.blocks.get(&current_hash) else { return false };
             current_hash = block.recovered_block().parent_hash();
-        }
-    }
-
-    fn anchor_for_parent_in(
-        blocks: &DashMap<B256, ExecutedBlock<N>>,
-        parent_hash: B256,
-        preferred_anchor: B256,
-    ) -> Option<B256> {
-        if parent_hash == preferred_anchor {
-            return Some(preferred_anchor)
-        }
-
-        let mut hash = parent_hash;
-        loop {
-            let block_parent_hash = blocks.get(&hash)?.recovered_block().parent_hash();
-            if block_parent_hash == preferred_anchor || !blocks.contains_key(&block_parent_hash) {
-                return Some(block_parent_hash)
-            }
-            hash = block_parent_hash;
         }
     }
 


### PR DESCRIPTION
Moves in-memory state anchor and suffix selection into OverlayManager. ConsistentProvider, BlockchainProvider, and StateProviderBuilder now reuse the database tip when it overlaps the in-memory chain, avoiding historical changeset collection.