### PR TITLE
refactor(storage): share state-trie overlay anchoring

### DIFF
--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -21,9 +21,12 @@ pub struct MemoryOverlayStateProviderRef<
     'a,
     N: NodePrimitives = reth_ethereum_primitives::EthPrimitives,
 > {
-    /// Historical state provider for state lookups that are not found in memory blocks.
+    /// Database state provider for lookups that are not found in overlay blocks.
     pub(crate) historical: Box<dyn StateProvider + 'a>,
-    /// The collection of executed parent blocks. Expected order is newest to oldest.
+    /// Executed blocks forming the forward state/trie overlay, ordered newest to oldest.
+    ///
+    /// When a partial-persistence chain covers the database Finish tip, this can include the
+    /// masking suffix through that tip even though the base provider is already indexed there.
     pub(crate) in_memory: Cow<'a, [ExecutedBlock<N>]>,
     /// Lazy-loaded in-memory trie data.
     pub(crate) trie_input: OnceLock<TrieInput>,
@@ -34,9 +37,8 @@ impl<'a, N: NodePrimitives> MemoryOverlayStateProviderRef<'a, N> {
     ///
     /// ## Arguments
     ///
-    /// - `in_memory` - the collection of executed ancestor blocks in reverse.
-    /// - `historical` - a historical state provider for the latest ancestor block stored in the
-    ///   database.
+    /// - `in_memory` - executed blocks forming the forward overlay, newest to oldest.
+    /// - `historical` - the database state provider used as the overlay base.
     pub fn new(historical: Box<dyn StateProvider + 'a>, in_memory: Vec<ExecutedBlock<N>>) -> Self {
         Self { historical, in_memory: Cow::Owned(in_memory), trie_input: OnceLock::new() }
     }
@@ -246,9 +248,12 @@ impl<N: NodePrimitives> BytecodeReader for MemoryOverlayStateProviderRef<'_, N> 
 /// well as a reference of the historical state provider for fallback lookups.
 #[expect(missing_debug_implementations)]
 pub struct MemoryOverlayStateProvider<N: NodePrimitives = reth_ethereum_primitives::EthPrimitives> {
-    /// Historical state provider for state lookups that are not found in memory blocks.
+    /// Database state provider for lookups that are not found in overlay blocks.
     pub(crate) historical: StateProviderBox,
-    /// The collection of executed parent blocks. Expected order is newest to oldest.
+    /// Executed blocks forming the forward state/trie overlay, ordered newest to oldest.
+    ///
+    /// When a partial-persistence chain covers the database Finish tip, this can include the
+    /// masking suffix through that tip even though the base provider is already indexed there.
     pub(crate) in_memory: Vec<ExecutedBlock<N>>,
     /// Lazy-loaded in-memory trie data.
     pub(crate) trie_input: OnceLock<TrieInput>,
@@ -259,9 +264,8 @@ impl<N: NodePrimitives> MemoryOverlayStateProvider<N> {
     ///
     /// ## Arguments
     ///
-    /// - `in_memory` - the collection of executed ancestor blocks in reverse.
-    /// - `historical` - a historical state provider for the latest ancestor block stored in the
-    ///   database.
+    /// - `in_memory` - executed blocks forming the forward overlay, newest to oldest.
+    /// - `historical` - the database state provider used as the overlay base.
     pub fn new(historical: StateProviderBox, in_memory: Vec<ExecutedBlock<N>>) -> Self {
         Self { historical, in_memory, trie_input: OnceLock::new() }
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -108,21 +108,21 @@ const CHANGESET_CACHE_RETENTION_BLOCKS: u64 = 64;
 pub struct StateProviderBuilder<N: NodePrimitives, P> {
     /// The provider factory used to create providers.
     provider_factory: P,
-    /// The historical block hash to fetch state from.
-    historical: B256,
-    /// The blocks that form the chain from historical to target and are in memory.
+    /// Hash of the post-state to build.
+    parent_hash: B256,
+    /// In-memory blocks that may be required to build the parent state.
     overlay: Option<Vec<ExecutedBlock<N>>>,
 }
 
 impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
-    /// Creates a new state provider from the provider factory, historical block hash and optional
+    /// Creates a new state provider from the provider factory, post-state hash, and optional
     /// overlaid blocks.
     pub const fn new(
         provider_factory: P,
-        historical: B256,
+        parent_hash: B256,
         overlay: Option<Vec<ExecutedBlock<N>>>,
     ) -> Self {
-        Self { provider_factory, historical, overlay }
+        Self { provider_factory, parent_hash, overlay }
     }
 }
 
@@ -134,12 +134,12 @@ where
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
         let Some(overlay) = self.overlay.clone() else {
-            return self.provider_factory.state_by_block_hash(self.historical)
+            return self.provider_factory.state_by_block_hash(self.parent_hash)
         };
 
         let database_provider = self.provider_factory.database_provider_ro()?;
         let (historical, overlay) =
-            get_anchored_overlay(&database_provider, self.historical, overlay)?;
+            get_anchored_overlay(&database_provider, self.parent_hash, overlay)?;
         let provider = self.provider_factory.state_by_block_hash(historical)?;
         Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }
@@ -3419,11 +3419,7 @@ where
         if let Some((historical, blocks)) = self.state.tree_state.blocks_by_hash(hash) {
             debug!(target: "engine::tree", %hash, %historical, "found canonical state for block in memory, creating provider builder");
             // the block leads back to the canonical chain
-            return Ok(Some(StateProviderBuilder::new(
-                self.provider.clone(),
-                historical,
-                Some(blocks),
-            )))
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, Some(blocks))))
         }
 
         // Check if the block is persisted

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -29,8 +29,8 @@ use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 use reth_provider::{
-    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockHashReader, BlockNumReader,
-    BlockReader, ChangeSetReader, DatabaseProviderFactory, HashedPostStateProvider, ProviderError,
+    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockNumReader, BlockReader,
+    ChangeSetReader, DatabaseProviderFactory, HashedPostStateProvider, ProviderError,
     SaveBlocksInput, StageCheckpointReader, StateProviderBox, StateProviderFactory, StateReader,
     StorageChangeSetReader, StorageSettingsCache, TransactionVariant,
     TryIntoHistoricalStateProvider,
@@ -144,9 +144,6 @@ where
         let anchor_number = database_provider
             .block_number(anchor_hash)?
             .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
-        if database_provider.block_hash(anchor_number)? != Some(anchor_hash) {
-            return Err(ProviderError::BlockHashNotFound(anchor_hash))
-        }
         let provider = database_provider.try_into_history_at_block(anchor_number)?;
         Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -36,7 +36,7 @@ use reth_provider::{
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_storage_overlay::OverlayManager;
+use reth_storage_overlay::{select_historical_anchor, OverlayManager};
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie::ComputedTrieData;
 use revm::interpreter::debug_unreachable;
@@ -132,11 +132,14 @@ where
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
-        let mut provider = self.provider_factory.state_by_block_hash(self.historical)?;
-        if let Some(overlay) = self.overlay.clone() {
-            provider = Box::new(MemoryOverlayStateProvider::new(provider, overlay))
-        }
-        Ok(provider)
+        let Some(overlay) = self.overlay.clone() else {
+            return self.provider_factory.state_by_block_hash(self.historical)
+        };
+
+        let (historical, overlay) =
+            select_historical_anchor(&self.provider_factory, self.historical, overlay)?;
+        let provider = self.provider_factory.state_by_block_hash(historical)?;
+        Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }
 }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -29,14 +29,14 @@ use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 use reth_provider::{
-    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockReader, ChangeSetReader,
-    DatabaseProviderFactory, HashedPostStateProvider, ProviderError, SaveBlocksInput,
-    StageCheckpointReader, StateProviderBox, StateProviderFactory, StateReader,
+    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockNumReader, BlockReader,
+    ChangeSetReader, DatabaseProviderFactory, HashedPostStateProvider, ProviderError,
+    SaveBlocksInput, StageCheckpointReader, StateProviderBox, StateProviderFactory, StateReader,
     StorageChangeSetReader, StorageSettingsCache, TransactionVariant,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_storage_overlay::{get_anchored_overlay, OverlayManager};
+use reth_storage_overlay::{get_anchored_overlay, OverlayAnchor, OverlayManager};
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie::ComputedTrieData;
 use revm::interpreter::debug_unreachable;
@@ -128,7 +128,8 @@ impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
 
 impl<N: NodePrimitives, P> StateProviderBuilder<N, P>
 where
-    P: BlockReader + StateProviderFactory + StateReader + Clone,
+    P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
+    P::Provider: BlockNumReader,
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
@@ -136,8 +137,13 @@ where
             return self.provider_factory.state_by_block_hash(self.historical)
         };
 
-        let (historical, overlay) =
-            get_anchored_overlay(&self.provider_factory, self.historical, overlay)?;
+        let database_provider = self.provider_factory.database_provider_ro()?;
+        let (historical, overlay) = get_anchored_overlay(
+            &database_provider,
+            self.historical,
+            overlay,
+            OverlayAnchor::DatabaseTip,
+        )?;
         let provider = self.provider_factory.state_by_block_hash(historical)?;
         Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -218,12 +218,7 @@ impl<N: NodePrimitives> EngineApiTreeState<N> {
         }
 
         self.pending_sparse_trie_prune = false;
-        Some(
-            self.tree_state
-                .blocks_by_hash(parent_hash)
-                .map(|(_, blocks)| blocks)
-                .unwrap_or_default(),
-        )
+        Some(self.tree_state.blocks_by_hash(parent_hash).unwrap_or_default())
     }
 
     /// Returns true if the block has been marked as invalid.
@@ -3420,18 +3415,9 @@ where
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone,
     {
-        if let Some((historical, blocks)) = self.state.tree_state.blocks_by_hash(hash) {
-            debug!(target: "engine::tree", %hash, %historical, "found canonical state for block in memory, creating provider builder");
-            // the block leads back to the canonical chain
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, Some(blocks))))
-        }
-
-        // Check if the block is persisted
-        if let Some(header) = self.provider.header(hash)? {
-            debug!(target: "engine::tree", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
-            // For persisted blocks, we create a builder that will fetch state directly from the
-            // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+        let overlay = self.state.tree_state.blocks_by_hash(hash);
+        if overlay.is_some() || self.provider.header(hash)?.is_some() {
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, overlay)))
         }
 
         debug!(target: "engine::tree", %hash, "no canonical state found for block");

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -36,7 +36,7 @@ use reth_provider::{
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_storage_overlay::{select_historical_anchor, OverlayManager};
+use reth_storage_overlay::{get_anchored_overlay, OverlayManager};
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie::ComputedTrieData;
 use revm::interpreter::debug_unreachable;
@@ -137,7 +137,7 @@ where
         };
 
         let (historical, overlay) =
-            select_historical_anchor(&self.provider_factory, self.historical, overlay)?;
+            get_anchored_overlay(&self.provider_factory, self.historical, overlay)?;
         let provider = self.provider_factory.state_by_block_hash(historical)?;
         Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -29,10 +29,11 @@ use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 use reth_provider::{
-    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockNumReader, BlockReader,
-    ChangeSetReader, DatabaseProviderFactory, HashedPostStateProvider, ProviderError,
+    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockHashReader, BlockNumReader,
+    BlockReader, ChangeSetReader, DatabaseProviderFactory, HashedPostStateProvider, ProviderError,
     SaveBlocksInput, StageCheckpointReader, StateProviderBox, StateProviderFactory, StateReader,
     StorageChangeSetReader, StorageSettingsCache, TransactionVariant,
+    TryIntoHistoricalStateProvider,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
@@ -129,7 +130,7 @@ impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
 impl<N: NodePrimitives, P> StateProviderBuilder<N, P>
 where
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
@@ -138,9 +139,15 @@ where
         };
 
         let database_provider = self.provider_factory.database_provider_ro()?;
-        let (historical, overlay) =
+        let (anchor_hash, overlay) =
             get_anchored_overlay(&database_provider, self.parent_hash, overlay)?;
-        let provider = self.provider_factory.state_by_block_hash(historical)?;
+        let anchor_number = database_provider
+            .block_number(anchor_hash)?
+            .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
+        if database_provider.block_hash(anchor_number)? != Some(anchor_hash) {
+            return Err(ProviderError::BlockHashNotFound(anchor_hash))
+        }
+        let provider = database_provider.try_into_history_at_block(anchor_number)?;
         Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -36,7 +36,7 @@ use reth_provider::{
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_storage_overlay::{get_anchored_overlay, OverlayAnchor, OverlayManager};
+use reth_storage_overlay::{get_anchored_overlay, OverlayManager};
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie::ComputedTrieData;
 use revm::interpreter::debug_unreachable;
@@ -129,7 +129,7 @@ impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
 impl<N: NodePrimitives, P> StateProviderBuilder<N, P>
 where
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
 {
     /// Creates a new state provider from this builder.
     pub fn build(&self) -> ProviderResult<StateProviderBox> {
@@ -138,12 +138,8 @@ where
         };
 
         let database_provider = self.provider_factory.database_provider_ro()?;
-        let (historical, overlay) = get_anchored_overlay(
-            &database_provider,
-            self.historical,
-            overlay,
-            OverlayAnchor::DatabaseTip,
-        )?;
+        let (historical, overlay) =
+            get_anchored_overlay(&database_provider, self.historical, overlay)?;
         let provider = self.provider_factory.state_by_block_hash(historical)?;
         Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -19,7 +19,7 @@ use reth_evm::{
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     BlockExecutionOutput, BlockNumReader, BlockReader, DatabaseProviderFactory,
-    StageCheckpointReader, StateProviderFactory, StateReader,
+    StageCheckpointReader, StateProviderFactory, StateReader, TryIntoHistoricalStateProvider,
 };
 use reth_revm::db::BundleState;
 use reth_tasks::Runtime;
@@ -181,7 +181,7 @@ where
             + StateReader
             + Clone
             + 'static,
-        P::Provider: BlockNumReader + StageCheckpointReader,
+        P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count, parallel_bal_execution);
@@ -351,7 +351,7 @@ where
             + StateReader
             + Clone
             + 'static,
-        P::Provider: BlockNumReader + StageCheckpointReader,
+        P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     {
         // Each mode carries the capability its producers use; the rest is dropped here, so
         // unused capabilities do not keep the state-root task's update channel open.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -19,7 +19,7 @@ use reth_evm::{
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     BlockExecutionOutput, BlockNumReader, BlockReader, DatabaseProviderFactory,
-    StateProviderFactory, StateReader,
+    StageCheckpointReader, StateProviderFactory, StateReader,
 };
 use reth_revm::db::BundleState;
 use reth_tasks::Runtime;
@@ -181,7 +181,7 @@ where
             + StateReader
             + Clone
             + 'static,
-        P::Provider: BlockNumReader,
+        P::Provider: BlockNumReader + StageCheckpointReader,
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count, parallel_bal_execution);
@@ -351,7 +351,7 @@ where
             + StateReader
             + Clone
             + 'static,
-        P::Provider: BlockNumReader,
+        P::Provider: BlockNumReader + StageCheckpointReader,
     {
         // Each mode carries the capability its producers use; the rest is dropped here, so
         // unused capabilities do not keep the state-root task's update channel open.

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -17,7 +17,10 @@ use reth_evm::{
     ConfigureEvm, ConvertTx, ExecutableTxIterator, ExecutableTxTuple, SpecFor, TxEnvFor,
 };
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
-use reth_provider::{BlockExecutionOutput, BlockReader, StateProviderFactory, StateReader};
+use reth_provider::{
+    BlockExecutionOutput, BlockNumReader, BlockReader, DatabaseProviderFactory,
+    StateProviderFactory, StateReader,
+};
 use reth_revm::db::BundleState;
 use reth_tasks::Runtime;
 pub use reth_trie_parallel::{
@@ -172,7 +175,13 @@ where
         parallel_bal_execution: bool,
     ) -> IteratorPayloadHandle<Evm, I>
     where
-        P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
+        P: BlockReader
+            + DatabaseProviderFactory
+            + StateProviderFactory
+            + StateReader
+            + Clone
+            + 'static,
+        P::Provider: BlockNumReader,
     {
         let (prewarm_rx, execution_rx) =
             self.spawn_tx_iterator(transactions, env.transaction_count, parallel_bal_execution);
@@ -336,7 +345,13 @@ where
         parallel_bal_execution: bool,
     ) -> CacheTaskHandle<<Evm::Primitives as NodePrimitives>::Receipt>
     where
-        P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
+        P: BlockReader
+            + DatabaseProviderFactory
+            + StateProviderFactory
+            + StateReader
+            + Clone
+            + 'static,
+        P::Provider: BlockNumReader,
     {
         // Each mode carries the capability its producers use; the rest is dropped here, so
         // unused capabilities do not keep the state-root task's update channel open.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -28,7 +28,7 @@ use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     AccountReader, BlockExecutionOutput, BlockNumReader, BlockReader, DatabaseProviderFactory,
-    StageCheckpointReader, StateProviderFactory, StateReader,
+    StageCheckpointReader, StateProviderFactory, StateReader, TryIntoHistoricalStateProvider,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_tasks::{pool::WorkerPool, Runtime};
@@ -92,7 +92,7 @@ impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone + 'static,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Initializes the task with the given transactions pending execution
@@ -564,7 +564,7 @@ impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone + 'static,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Creates a per-thread EVM for prewarming.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -27,7 +27,8 @@ use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, RecoveredTx,
 use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
-    AccountReader, BlockExecutionOutput, BlockReader, StateProviderFactory, StateReader,
+    AccountReader, BlockExecutionOutput, BlockNumReader, BlockReader, DatabaseProviderFactory,
+    StateProviderFactory, StateReader,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_tasks::{pool::WorkerPool, Runtime};
@@ -90,7 +91,8 @@ where
 impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
 where
     N: NodePrimitives,
-    P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
+    P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone + 'static,
+    P::Provider: BlockNumReader,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Initializes the task with the given transactions pending execution
@@ -561,7 +563,8 @@ type PrewarmEvmState<Evm> =
 impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
     N: NodePrimitives,
-    P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
+    P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone + 'static,
+    P::Provider: BlockNumReader,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Creates a per-thread EVM for prewarming.

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -28,7 +28,7 @@ use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     AccountReader, BlockExecutionOutput, BlockNumReader, BlockReader, DatabaseProviderFactory,
-    StateProviderFactory, StateReader,
+    StageCheckpointReader, StateProviderFactory, StateReader,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_tasks::{pool::WorkerPool, Runtime};
@@ -92,7 +92,7 @@ impl<N, P, Evm> PrewarmCacheTask<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone + 'static,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Initializes the task with the given transactions pending execution
@@ -564,7 +564,7 @@ impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone + 'static,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Creates a per-thread EVM for prewarming.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1405,18 +1405,9 @@ where
         hash: B256,
         state: &EngineApiTreeState<N>,
     ) -> ProviderResult<Option<StateProviderBuilder<N, P>>> {
-        if let Some((historical, blocks)) = state.tree_state.blocks_by_hash(hash) {
-            debug!(target: "engine::tree::payload_validator", %hash, %historical, "found canonical state for block in memory, creating provider builder");
-            // the block leads back to the canonical chain
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, Some(blocks))))
-        }
-
-        // Check if the block is persisted
-        if let Some(header) = self.provider.header(hash)? {
-            debug!(target: "engine::tree::payload_validator", %hash, number = %header.number(), "found canonical state for block in database, creating provider builder");
-            // For persisted blocks, we create a builder that will fetch state directly from the
-            // database
-            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, None)))
+        let overlay = state.tree_state.blocks_by_hash(hash);
+        if overlay.is_some() || self.provider.header(hash)?.is_some() {
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, overlay)))
         }
 
         debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1406,11 +1406,7 @@ where
         if let Some((historical, blocks)) = state.tree_state.blocks_by_hash(hash) {
             debug!(target: "engine::tree::payload_validator", %hash, %historical, "found canonical state for block in memory, creating provider builder");
             // the block leads back to the canonical chain
-            return Ok(Some(StateProviderBuilder::new(
-                self.provider.clone(),
-                historical,
-                Some(blocks),
-            )))
+            return Ok(Some(StateProviderBuilder::new(self.provider.clone(), hash, Some(blocks))))
         }
 
         // Check if the block is persisted

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -150,6 +150,7 @@ use reth_provider::{
     ChangeSetReader, DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider,
     ProviderError, PruneCheckpointReader, StageCheckpointReader, StateProvider, StateProviderBox,
     StateProviderFactory, StateReader, StorageChangeSetReader, StorageSettingsCache,
+    TryIntoHistoricalStateProvider,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
 use reth_storage_overlay::OverlayManager;
@@ -304,6 +305,7 @@ where
     P: DatabaseProviderFactory<
             Provider: BlockReader
                           + StageCheckpointReader
+                          + TryIntoHistoricalStateProvider
                           + PruneCheckpointReader
                           + ChangeSetReader
                           + StorageChangeSetReader
@@ -1786,6 +1788,7 @@ where
     P: DatabaseProviderFactory<
             Provider: BlockReader
                           + StageCheckpointReader
+                          + TryIntoHistoricalStateProvider
                           + PruneCheckpointReader
                           + ChangeSetReader
                           + StorageChangeSetReader

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -95,11 +95,10 @@ impl<N: NodePrimitives> TreeState<N> {
     }
 
     /// Returns all available blocks for the given hash that lead back to the canonical chain, from
-    /// newest to oldest, and the parent hash of the oldest returned block. This parent hash is the
-    /// highest persisted block connected to this chain.
+    /// newest to oldest.
     ///
     /// Returns `None` if the block for the given hash is not found.
-    pub fn blocks_by_hash(&self, hash: B256) -> Option<(B256, Vec<ExecutedBlock<N>>)> {
+    pub fn blocks_by_hash(&self, hash: B256) -> Option<Vec<ExecutedBlock<N>>> {
         let block = self.blocks_by_hash.get(&hash).cloned()?;
         let mut parent_hash = block.recovered_block().parent_hash();
         let mut blocks = vec![block];
@@ -108,7 +107,7 @@ impl<N: NodePrimitives> TreeState<N> {
             blocks.push(executed.clone());
         }
 
-        Some((parent_hash, blocks))
+        Some(blocks)
     }
 
     /// Insert executed block into the state.

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -71,7 +71,7 @@ use reth_primitives_traits::{
 use reth_provider::{
     providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockNumReader, BlockReader,
     DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider, ProviderError,
-    StateProviderFactory, StateReader, StateRootProvider,
+    StageCheckpointReader, StateProviderFactory, StateReader, StateRootProvider,
 };
 use reth_storage_overlay::OverlayManager;
 use reth_tasks::utils::increase_thread_priority;
@@ -825,7 +825,7 @@ where
         + StateReader
         + Clone
         + 'static,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1000,7 +1000,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
 {
     fn name(&self) -> &'static str {
         "synchronous"
@@ -1041,7 +1041,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1155,7 +1155,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1257,7 +1257,7 @@ fn compare_trie_updates_with_serial<N, P>(
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     OverlayStateProviderFactory<P, N>:
         DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>,
 {

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -72,6 +72,7 @@ use reth_provider::{
     providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockNumReader, BlockReader,
     DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider, ProviderError,
     StageCheckpointReader, StateProviderFactory, StateReader, StateRootProvider,
+    TryIntoHistoricalStateProvider,
 };
 use reth_storage_overlay::OverlayManager;
 use reth_tasks::utils::increase_thread_priority;
@@ -825,7 +826,7 @@ where
         + StateReader
         + Clone
         + 'static,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1000,7 +1001,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
 {
     fn name(&self) -> &'static str {
         "synchronous"
@@ -1041,7 +1042,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1155,7 +1156,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1257,7 +1258,7 @@ fn compare_trie_updates_with_serial<N, P>(
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     OverlayStateProviderFactory<P, N>:
         DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>,
 {

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -69,7 +69,7 @@ use reth_primitives_traits::{
     AlloyBlockHeader, FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedHeader,
 };
 use reth_provider::{
-    providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockReader,
+    providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockNumReader, BlockReader,
     DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider, ProviderError,
     StateProviderFactory, StateReader, StateRootProvider,
 };
@@ -825,6 +825,7 @@ where
         + StateReader
         + Clone
         + 'static,
+    P::Provider: BlockNumReader,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -991,7 +992,15 @@ struct SynchronousStateRootJob<N: NodePrimitives, P> {
 impl<N, P> StateRootJob<N> for SynchronousStateRootJob<N, P>
 where
     N: NodePrimitives,
-    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+    P: BlockReader
+        + DatabaseProviderFactory
+        + StateProviderFactory
+        + StateReader
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    P::Provider: BlockNumReader,
 {
     fn name(&self) -> &'static str {
         "synchronous"
@@ -1024,8 +1033,15 @@ struct SparseTrieStateRootJob<N: NodePrimitives, P> {
 impl<N, P> SparseTrieStateRootJob<N, P>
 where
     N: NodePrimitives,
-    P: StateProviderFactory + Clone + Send + Sync + 'static,
-    P: BlockReader + StateReader,
+    P: BlockReader
+        + DatabaseProviderFactory
+        + StateProviderFactory
+        + StateReader
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    P::Provider: BlockNumReader,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1131,7 +1147,15 @@ where
 impl<N, P> StateRootJob<N> for SparseTrieStateRootJob<N, P>
 where
     N: NodePrimitives,
-    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+    P: BlockReader
+        + DatabaseProviderFactory
+        + StateProviderFactory
+        + StateReader
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    P::Provider: BlockNumReader,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
         + Clone
         + Send
@@ -1232,7 +1256,8 @@ fn compare_trie_updates_with_serial<N, P>(
 ) -> bool
 where
     N: NodePrimitives,
-    P: BlockReader + StateProviderFactory + StateReader + Clone,
+    P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
+    P::Provider: BlockNumReader,
     OverlayStateProviderFactory<P, N>:
         DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>,
 {

--- a/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
@@ -9,7 +9,9 @@ use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{Address, B256};
 use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::{NodePrimitives, TxTy};
-use reth_provider::{BlockReader, StateProviderFactory, StateReader};
+use reth_provider::{
+    BlockNumReader, BlockReader, DatabaseProviderFactory, StateProviderFactory, StateReader,
+};
 use std::{fmt::Debug, sync::Arc};
 
 /// Coordinates a long-lived worker and the latest completed immutable snapshot.
@@ -34,7 +36,15 @@ where
 impl<N, P, Evm> Handle<N, P, Evm>
 where
     N: NodePrimitives,
-    P: BlockReader + StateProviderFactory + StateReader + Clone + Send + Sync + 'static,
+    P: BlockReader
+        + DatabaseProviderFactory
+        + StateProviderFactory
+        + StateReader
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    P::Provider: BlockNumReader,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Spawns the long-lived worker, which owns its mutable read cache and starts a fresh one for

--- a/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
@@ -11,7 +11,7 @@ use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::{NodePrimitives, TxTy};
 use reth_provider::{
     BlockNumReader, BlockReader, DatabaseProviderFactory, StageCheckpointReader,
-    StateProviderFactory, StateReader,
+    StateProviderFactory, StateReader, TryIntoHistoricalStateProvider,
 };
 use std::{fmt::Debug, sync::Arc};
 
@@ -45,7 +45,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Spawns the long-lived worker, which owns its mutable read cache and starts a fresh one for

--- a/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
@@ -10,7 +10,8 @@ use alloy_primitives::{Address, B256};
 use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::{NodePrimitives, TxTy};
 use reth_provider::{
-    BlockNumReader, BlockReader, DatabaseProviderFactory, StateProviderFactory, StateReader,
+    BlockNumReader, BlockReader, DatabaseProviderFactory, StageCheckpointReader,
+    StateProviderFactory, StateReader,
 };
 use std::{fmt::Debug, sync::Arc};
 
@@ -44,7 +45,7 @@ where
         + Send
         + Sync
         + 'static,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     Evm: ConfigureEvm<Primitives = N> + 'static,
 {
     /// Spawns the long-lived worker, which owns its mutable read cache and starts a fresh one for

--- a/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
@@ -9,7 +9,8 @@ use crossbeam_channel::{Receiver, RecvTimeoutError, TryRecvError};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    BlockNumReader, BlockReader, DatabaseProviderFactory, StateProviderFactory, StateReader,
+    BlockNumReader, BlockReader, DatabaseProviderFactory, StageCheckpointReader,
+    StateProviderFactory, StateReader,
 };
 use reth_revm::{cached::CachedReads, db::State};
 use std::{
@@ -66,7 +67,7 @@ impl<N, P, Evm> Worker<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
-    P::Provider: BlockNumReader,
+    P::Provider: BlockNumReader + StageCheckpointReader,
     Evm: ConfigureEvm<Primitives = N>,
 {
     pub(super) fn new(

--- a/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
@@ -8,7 +8,9 @@ use alloy_primitives::B256;
 use crossbeam_channel::{Receiver, RecvTimeoutError, TryRecvError};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
-use reth_provider::{BlockReader, StateProviderFactory, StateReader};
+use reth_provider::{
+    BlockNumReader, BlockReader, DatabaseProviderFactory, StateProviderFactory, StateReader,
+};
 use reth_revm::{cached::CachedReads, db::State};
 use std::{
     sync::Arc,
@@ -63,7 +65,8 @@ where
 impl<N, P, Evm> Worker<N, P, Evm>
 where
     N: NodePrimitives,
-    P: BlockReader + StateProviderFactory + StateReader + Clone,
+    P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
+    P::Provider: BlockNumReader,
     Evm: ConfigureEvm<Primitives = N>,
 {
     pub(super) fn new(

--- a/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
@@ -10,7 +10,7 @@ use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     BlockNumReader, BlockReader, DatabaseProviderFactory, StageCheckpointReader,
-    StateProviderFactory, StateReader,
+    StateProviderFactory, StateReader, TryIntoHistoricalStateProvider,
 };
 use reth_revm::{cached::CachedReads, db::State};
 use std::{
@@ -67,7 +67,7 @@ impl<N, P, Evm> Worker<N, P, Evm>
 where
     N: NodePrimitives,
     P: BlockReader + DatabaseProviderFactory + StateProviderFactory + StateReader + Clone,
-    P::Provider: BlockNumReader + StageCheckpointReader,
+    P::Provider: BlockNumReader + StageCheckpointReader + TryIntoHistoricalStateProvider,
     Evm: ConfigureEvm<Primitives = N>,
 {
     pub(super) fn new(

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -35,7 +35,7 @@ use reth_storage_api::{
     StorageRangeResult,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{get_anchored_overlay, OverlayAnchor};
+use reth_storage_overlay::get_anchored_overlay;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,
@@ -156,12 +156,9 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
-        let (anchor_hash, in_memory) = get_anchored_overlay(
-            &self.database,
-            state.anchor().hash,
-            in_memory,
-            OverlayAnchor::DatabaseTip,
-        )?;
+        let database_provider = self.database.database_provider_ro()?;
+        let (anchor_hash, in_memory) =
+            get_anchored_overlay(&database_provider, state.anchor().hash, in_memory)?;
         let historical = self.database.history_by_block_hash(anchor_hash)?;
         Ok(MemoryOverlayStateProvider::new(historical, in_memory))
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -35,7 +35,7 @@ use reth_storage_api::{
     StorageRangeResult,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::get_anchored_overlay;
+use reth_storage_overlay::{get_anchored_overlay, OverlayAnchor};
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,
@@ -156,8 +156,12 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
-        let (anchor_hash, in_memory) =
-            get_anchored_overlay(&self.database, state.anchor().hash, in_memory)?;
+        let (anchor_hash, in_memory) = get_anchored_overlay(
+            &self.database,
+            state.anchor().hash,
+            in_memory,
+            OverlayAnchor::DatabaseTip,
+        )?;
         let historical = self.database.history_by_block_hash(anchor_hash)?;
         Ok(MemoryOverlayStateProvider::new(historical, in_memory))
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -35,7 +35,7 @@ use reth_storage_api::{
     StorageRangeResult,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::select_historical_anchor;
+use reth_storage_overlay::get_anchored_overlay;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,
@@ -157,7 +157,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
         let (anchor_hash, in_memory) =
-            select_historical_anchor(&self.database, state.anchor().hash, in_memory)?;
+            get_anchored_overlay(&self.database, state.anchor().hash, in_memory)?;
         let historical = self.database.history_by_block_hash(anchor_hash)?;
         Ok(MemoryOverlayStateProvider::new(historical, in_memory))
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -158,7 +158,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
         let database_provider = self.database.database_provider_ro()?;
         let (anchor_hash, in_memory) =
-            get_anchored_overlay(&database_provider, state.anchor().hash, in_memory)?;
+            get_anchored_overlay(&database_provider, state.hash(), in_memory)?;
         let historical = self.database.history_by_block_hash(anchor_hash)?;
         Ok(MemoryOverlayStateProvider::new(historical, in_memory))
     }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -35,6 +35,7 @@ use reth_storage_api::{
     StorageRangeResult,
 };
 use reth_storage_errors::provider::ProviderResult;
+use reth_storage_overlay::select_historical_anchor;
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,
@@ -154,9 +155,11 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         &self,
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
-        let anchor_hash = state.anchor().hash;
-        let latest_historical = self.database.history_by_block_hash(anchor_hash)?;
-        Ok(state.state_provider(latest_historical))
+        let in_memory = state.chain().map(|block_state| block_state.block()).collect();
+        let (anchor_hash, in_memory) =
+            select_historical_anchor(&self.database, state.anchor().hash, in_memory)?;
+        let historical = self.database.history_by_block_hash(anchor_hash)?;
+        Ok(MemoryOverlayStateProvider::new(historical, in_memory))
     }
 
     /// Returns a cursor-backed state view for a state root still only in canonical in-memory

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -31,7 +31,7 @@ use reth_storage_api::{
     StateProviderBox, StorageChangeSetReader, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::select_historical_anchor;
+use reth_storage_overlay::get_anchored_overlay;
 use revm::database::states::PlainStorageRevert;
 use std::{
     ops::{Add, Bound, RangeBounds, RangeInclusive, Sub},
@@ -236,7 +236,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
         let (anchor_hash, in_memory) =
-            select_historical_anchor(&self.storage_provider, state.anchor().hash, in_memory)?;
+            get_anchored_overlay(&self.storage_provider, state.anchor().hash, in_memory)?;
 
         // The selected anchor can be a retained block that also exists in the database. Looking
         // it up through this consistent view would resolve the same in-memory chain again.
@@ -448,7 +448,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         {
             let in_memory = block_state.chain().map(|block_state| block_state.block()).collect();
             let (anchor_hash, in_memory) =
-                select_historical_anchor(&storage_provider, block_state.anchor().hash, in_memory)?;
+                get_anchored_overlay(&storage_provider, block_state.anchor().hash, in_memory)?;
             let block_number = storage_provider
                 .block_number(anchor_hash)?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -31,7 +31,7 @@ use reth_storage_api::{
     StateProviderBox, StorageChangeSetReader, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::get_anchored_overlay;
+use reth_storage_overlay::{get_anchored_overlay, OverlayAnchor};
 use revm::database::states::PlainStorageRevert;
 use std::{
     ops::{Add, Bound, RangeBounds, RangeInclusive, Sub},
@@ -235,8 +235,12 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
-        let (anchor_hash, in_memory) =
-            get_anchored_overlay(&self.storage_provider, state.anchor().hash, in_memory)?;
+        let (anchor_hash, in_memory) = get_anchored_overlay(
+            &self.storage_provider,
+            state.anchor().hash,
+            in_memory,
+            OverlayAnchor::DatabaseTip,
+        )?;
 
         // The selected anchor can be a retained block that also exists in the database. Looking
         // it up through this consistent view would resolve the same in-memory chain again.
@@ -447,8 +451,12 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
             let in_memory = block_state.chain().map(|block_state| block_state.block()).collect();
-            let (anchor_hash, in_memory) =
-                get_anchored_overlay(&storage_provider, block_state.anchor().hash, in_memory)?;
+            let (anchor_hash, in_memory) = get_anchored_overlay(
+                &storage_provider,
+                block_state.anchor().hash,
+                in_memory,
+                OverlayAnchor::DatabaseTip,
+            )?;
             let block_number = storage_provider
                 .block_number(anchor_hash)?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -13,7 +13,9 @@ use alloy_consensus::{
 };
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, HashOrNumber};
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
-use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStateProviderRef};
+use reth_chain_state::{
+    BlockState, CanonicalInMemoryState, MemoryOverlayStateProvider, MemoryOverlayStateProviderRef,
+};
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::ExecutionOutcome;
@@ -29,6 +31,7 @@ use reth_storage_api::{
     StateProviderBox, StorageChangeSetReader, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
+use reth_storage_overlay::select_historical_anchor;
 use revm::database::states::PlainStorageRevert;
 use std::{
     ops::{Add, Bound, RangeBounds, RangeInclusive, Sub},
@@ -111,22 +114,6 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             trace!(target: "providers::blockchain", "Using database state for latest state provider");
             Ok(self.storage_provider.latest())
         }
-    }
-
-    fn history_by_block_hash_ref<'a>(
-        &'a self,
-        block_hash: BlockHash,
-    ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
-        trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
-
-        self.get_in_memory_or_storage_by_block(
-            block_hash.into(),
-            |_| self.storage_provider.history_by_block_hash(block_hash),
-            |block_state| {
-                let state_provider = self.block_state_provider_ref(block_state)?;
-                Ok(Box::new(state_provider))
-            },
-        )
     }
 
     /// Fetches a range of data from both in-memory state and persistent storage while a predicate
@@ -247,10 +234,14 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         &self,
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
-        let anchor_hash = state.anchor().hash;
-        let latest_historical = self.history_by_block_hash_ref(anchor_hash)?;
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
-        Ok(MemoryOverlayStateProviderRef::new(latest_historical, in_memory))
+        let (anchor_hash, in_memory) =
+            select_historical_anchor(&self.storage_provider, state.anchor().hash, in_memory)?;
+
+        // The selected anchor can be a retained block that also exists in the database. Looking
+        // it up through this consistent view would resolve the same in-memory chain again.
+        let historical = self.storage_provider.history_by_block_hash(anchor_hash)?;
+        Ok(MemoryOverlayStateProviderRef::new(historical, in_memory))
     }
 
     /// Fetches data from either in-memory state or persistent storage for a range of transactions.
@@ -455,12 +446,14 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         if let Some(Some(block_state)) =
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
-            let anchor_hash = block_state.anchor().hash;
+            let in_memory = block_state.chain().map(|block_state| block_state.block()).collect();
+            let (anchor_hash, in_memory) =
+                select_historical_anchor(&storage_provider, block_state.anchor().hash, in_memory)?;
             let block_number = storage_provider
                 .block_number(anchor_hash)?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
             let latest_historical = storage_provider.try_into_history_at_block(block_number)?;
-            return Ok(Box::new(block_state.state_provider(latest_historical)));
+            return Ok(Box::new(MemoryOverlayStateProvider::new(latest_historical, in_memory)));
         }
         storage_provider.try_into_history_at_block(block_number)
     }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -236,7 +236,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
         let (anchor_hash, in_memory) =
-            get_anchored_overlay(&self.storage_provider, state.anchor().hash, in_memory)?;
+            get_anchored_overlay(&self.storage_provider, state.hash(), in_memory)?;
 
         // The selected anchor can be a retained block that also exists in the database. Looking
         // it up through this consistent view would resolve the same in-memory chain again.
@@ -448,7 +448,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         {
             let in_memory = block_state.chain().map(|block_state| block_state.block()).collect();
             let (anchor_hash, in_memory) =
-                get_anchored_overlay(&storage_provider, block_state.anchor().hash, in_memory)?;
+                get_anchored_overlay(&storage_provider, block_hash, in_memory)?;
             let block_number = storage_provider
                 .block_number(anchor_hash)?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -31,7 +31,7 @@ use reth_storage_api::{
     StateProviderBox, StorageChangeSetReader, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{get_anchored_overlay, OverlayAnchor};
+use reth_storage_overlay::get_anchored_overlay;
 use revm::database::states::PlainStorageRevert;
 use std::{
     ops::{Add, Bound, RangeBounds, RangeInclusive, Sub},
@@ -235,12 +235,8 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<MemoryOverlayStateProviderRef<'_, N::Primitives>> {
         let in_memory = state.chain().map(|block_state| block_state.block()).collect();
-        let (anchor_hash, in_memory) = get_anchored_overlay(
-            &self.storage_provider,
-            state.anchor().hash,
-            in_memory,
-            OverlayAnchor::DatabaseTip,
-        )?;
+        let (anchor_hash, in_memory) =
+            get_anchored_overlay(&self.storage_provider, state.anchor().hash, in_memory)?;
 
         // The selected anchor can be a retained block that also exists in the database. Looking
         // it up through this consistent view would resolve the same in-memory chain again.
@@ -451,12 +447,8 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
             head_block.as_ref().map(|b| b.block_on_chain(block_hash.into()))
         {
             let in_memory = block_state.chain().map(|block_state| block_state.block()).collect();
-            let (anchor_hash, in_memory) = get_anchored_overlay(
-                &storage_provider,
-                block_state.anchor().hash,
-                in_memory,
-                OverlayAnchor::DatabaseTip,
-            )?;
+            let (anchor_hash, in_memory) =
+                get_anchored_overlay(&storage_provider, block_state.anchor().hash, in_memory)?;
             let block_number = storage_provider
                 .block_number(anchor_hash)?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -38,6 +38,7 @@ use reth_storage_api::{
     BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory,
     HashedPostStateProvider, NodePrimitivesProvider, StageCheckpointReader, StateProofProvider,
     StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
+    TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
 use reth_trie::{
@@ -1194,6 +1195,17 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> StatePr
 
     fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>> {
         Ok(Some(Box::new(self.clone())))
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static>
+    TryIntoHistoricalStateProvider for MockEthProvider<T, ChainSpec>
+{
+    fn try_into_history_at_block(
+        self,
+        _block_number: BlockNumber,
+    ) -> ProviderResult<StateProviderBox> {
+        Ok(Box::new(self))
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -475,7 +475,7 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProvi
     type ProviderRW = Self;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
-        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
+        Ok(self.clone())
     }
 
     fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -475,7 +475,7 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProvi
     type ProviderRW = Self;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
-        Ok(self.clone())
+        Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())
     }
 
     fn database_provider_rw(&self) -> ProviderResult<Self::ProviderRW> {

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -4,7 +4,7 @@ use crate::{
     AccountReader, BalProvider, BlockReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader,
     DatabaseProviderFactory, HashedPostStateProvider, PruneCheckpointReader,
     RocksDBProviderFactory, StageCheckpointReader, StateProviderFactory, StateRangeProviderFactory,
-    StateReader, StaticFileProviderFactory,
+    StateReader, StaticFileProviderFactory, TryIntoHistoricalStateProvider,
 };
 use reth_chain_state::{
     CanonStateSubscriptions, ForkChoiceSubscriptions, PersistedBlockSubscriptions,
@@ -22,7 +22,8 @@ pub trait FullProvider<N: NodeTypesWithDB>:
                       + PruneCheckpointReader
                       + ChangeSetReader
                       + StorageChangeSetReader
-                      + StorageSettingsCache,
+                      + StorageSettingsCache
+                      + TryIntoHistoricalStateProvider,
     > + NodePrimitivesProvider<Primitives = N::Primitives>
     + StaticFileProviderFactory<Primitives = N::Primitives>
     + RocksDBProviderFactory
@@ -60,7 +61,8 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
                           + PruneCheckpointReader
                           + ChangeSetReader
                           + StorageChangeSetReader
-                          + StorageSettingsCache,
+                          + StorageSettingsCache
+                          + TryIntoHistoricalStateProvider,
         > + NodePrimitivesProvider<Primitives = N::Primitives>
         + StaticFileProviderFactory<Primitives = N::Primitives>
         + RocksDBProviderFactory

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -15,7 +15,6 @@ use reth_storage_api::{
 };
 use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted};
 use std::{
-    collections::HashMap,
     ops::RangeInclusive,
     sync::Arc,
     time::{Duration, Instant},
@@ -463,9 +462,9 @@ where
 
 /// Selects the database anchor and in-memory blocks for a state provider.
 ///
-/// `parent_hash` identifies the post-state being built. `blocks` must contain its complete
-/// in-memory ancestry back to a database anchor, but may also contain unrelated blocks. Only the
-/// chain beginning at `parent_hash` is returned, ordered from newest to oldest. During partial
+/// `parent_hash` identifies the post-state being built. `blocks` must be ordered from newest to
+/// oldest and contain its complete in-memory ancestry back to a database anchor. It may start with
+/// blocks newer than `parent_hash`; only the suffix beginning there is returned. During partial
 /// persistence, using the Finish tip as that anchor requires `blocks` to cover the complete
 /// masking segment back through the state/trie tip.
 ///
@@ -498,12 +497,13 @@ where
         return Ok((parent_hash, Vec::new()))
     }
 
-    let mut blocks_by_hash = blocks
-        .into_iter()
-        .map(|block| (block.recovered_block().hash(), block))
-        .collect::<HashMap<_, _>>();
+    let mut blocks = blocks.into_iter();
+    let parent = blocks
+        .find(|block| block.recovered_block().hash() == parent_hash)
+        .ok_or(ProviderError::BlockHashNotFound(parent_hash))?;
+    let mut blocks = std::iter::once(parent).chain(blocks);
     let mut anchor_hash = parent_hash;
-    let mut overlay = Vec::new();
+    let mut overlay = Vec::with_capacity(blocks.size_hint().0);
     let mut covers_finish_tip = state_trie_tip.hash == finish_tip.hash;
 
     loop {
@@ -513,7 +513,9 @@ where
             return Ok((database_anchor, overlay))
         }
 
-        let Some(block) = blocks_by_hash.remove(&anchor_hash) else {
+        let Some(block) =
+            blocks.next().filter(|block| block.recovered_block().hash() == anchor_hash)
+        else {
             // A database block above the state/trie frontier is not a usable base unless the
             // complete masking suffix back to that frontier is available.
             if state_trie_tip.hash != finish_tip.hash &&

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -159,13 +159,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         let anchor_hash = match &self.overlay_source {
             Some(OverlaySource::Managed) => {
                 let blocks = self.overlay_manager.blocks_for_parent(self.parent_hash);
-                get_anchored_overlay_at_state_trie_tip(
-                    provider,
-                    self.parent_hash,
-                    blocks,
-                    state_trie_tip_block,
-                )?
-                .0
+                get_anchored_overlay(provider, self.parent_hash, blocks)?.0
             }
             _ => self.parent_hash,
         };
@@ -481,24 +475,6 @@ where
     N: NodePrimitives,
 {
     let (state_trie_tip, _) = database_state_frontiers(provider)?;
-
-    get_anchored_overlay_at_state_trie_tip(provider, parent_hash, blocks, state_trie_tip)
-}
-
-/// Selects the historical anchor and in-memory blocks using a previously read state/trie tip.
-///
-/// This lets [`OverlayBuilder::build_overlay_at_frontiers`] reuse the selector without re-reading
-/// the frontier that keys its cache and reverts.
-fn get_anchored_overlay_at_state_trie_tip<P, N>(
-    provider: &P,
-    parent_hash: B256,
-    blocks: Vec<ExecutedBlock<N>>,
-    state_trie_tip: BlockNumHash,
-) -> ProviderResult<(B256, Vec<ExecutedBlock<N>>)>
-where
-    P: BlockNumReader,
-    N: NodePrimitives,
-{
     let parent_is_persisted = match provider.block_number(parent_hash)? {
         Some(parent_number) if parent_number <= state_trie_tip.number => {
             provider.block_hash(parent_number)? == Some(parent_hash)

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -2,6 +2,7 @@ use crate::OverlayManager;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, BlockNumber, B256};
 use metrics::{Counter, Histogram};
+use reth_chain_state::ExecutedBlock;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_metrics::Metrics;
@@ -463,6 +464,40 @@ where
     ))
 }
 
+/// Selects the historical anchor and in-memory blocks for a state provider.
+///
+/// `blocks` must be ordered from newest to oldest. If the durable database tip is present in
+/// `blocks`, that tip becomes the historical anchor and only blocks newer than it are retained.
+/// Otherwise, the original `historical` anchor and all blocks are retained. Matching the tip hash,
+/// rather than only its number, preserves the correct state across same-height forks.
+pub fn select_historical_anchor<P, N>(
+    provider: &P,
+    historical: B256,
+    mut blocks: Vec<ExecutedBlock<N>>,
+) -> ProviderResult<(B256, Vec<ExecutedBlock<N>>)>
+where
+    P: BlockNumReader,
+    N: NodePrimitives,
+{
+    if blocks.is_empty() {
+        return Ok((historical, blocks))
+    }
+
+    let tip_number = provider.last_block_number()?;
+    let tip_hash = provider
+        .block_hash(tip_number)?
+        .ok_or_else(|| ProviderError::HeaderNotFound(tip_number.into()))?;
+
+    if let Some(tip_index) =
+        blocks.iter().position(|block| block.recovered_block().hash() == tip_hash)
+    {
+        blocks.truncate(tip_index);
+        return Ok((tip_hash, blocks))
+    }
+
+    Ok((historical, blocks))
+}
+
 /// Metrics for overlay construction.
 #[derive(Clone, Metrics)]
 #[metrics(scope = "storage.overlay.builder")]
@@ -483,9 +518,11 @@ struct OverlayBuilderMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::BlockHeader;
     use alloy_primitives::U256;
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
+    use reth_provider::test_utils::MockEthProvider;
     #[cfg(feature = "partial-persistence")]
     use reth_provider::{
         test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
@@ -533,6 +570,48 @@ mod tests {
             .enumerate()
             .map(|(index, block)| with_unique_trie_data(&block, index as u8 + 1))
             .collect()
+    }
+
+    #[test]
+    fn select_historical_anchor_uses_durable_tip_overlap() {
+        let mut block_builder = TestBlockBuilder::eth();
+        let blocks = block_builder.get_executed_blocks(1..4).collect::<Vec<_>>();
+        let in_memory = vec![blocks[2].clone(), blocks[1].clone(), blocks[0].clone()];
+        let historical = blocks[0].recovered_block().parent_hash();
+
+        let provider = MockEthProvider::default();
+        provider.add_header(
+            blocks[1].recovered_block().hash(),
+            blocks[1].recovered_block().header().clone(),
+        );
+        let (anchor, selected) =
+            select_historical_anchor(&provider, historical, in_memory.clone()).unwrap();
+        assert_eq!(anchor, blocks[1].recovered_block().hash());
+        assert_eq!(selected, vec![blocks[2].clone()]);
+
+        let provider = MockEthProvider::default();
+        provider.add_header(
+            blocks[2].recovered_block().hash(),
+            blocks[2].recovered_block().header().clone(),
+        );
+        let (anchor, selected) =
+            select_historical_anchor(&provider, historical, in_memory.clone()).unwrap();
+        assert_eq!(anchor, blocks[2].recovered_block().hash());
+        assert!(selected.is_empty());
+
+        let alternate_tip = block_builder.get_executed_block_with_number(
+            blocks[2].block_number(),
+            blocks[1].recovered_block().hash(),
+        );
+        let provider = MockEthProvider::default();
+        provider.add_header(
+            alternate_tip.recovered_block().hash(),
+            alternate_tip.recovered_block().header().clone(),
+        );
+        let (anchor, selected) =
+            select_historical_anchor(&provider, historical, in_memory.clone()).unwrap();
+        assert_eq!(anchor, historical);
+        assert_eq!(selected, in_memory);
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -470,7 +470,7 @@ where
 /// `blocks`, that tip becomes the historical anchor and only blocks newer than it are retained.
 /// Otherwise, the original `historical` anchor and all blocks are retained. Matching the tip hash,
 /// rather than only its number, preserves the correct state across same-height forks.
-pub fn select_historical_anchor<P, N>(
+pub fn get_anchored_overlay<P, N>(
     provider: &P,
     historical: B256,
     mut blocks: Vec<ExecutedBlock<N>>,
@@ -573,7 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn select_historical_anchor_uses_durable_tip_overlap() {
+    fn get_anchored_overlay_uses_durable_tip_overlap() {
         let mut block_builder = TestBlockBuilder::eth();
         let blocks = block_builder.get_executed_blocks(1..4).collect::<Vec<_>>();
         let in_memory = vec![blocks[2].clone(), blocks[1].clone(), blocks[0].clone()];
@@ -585,7 +585,7 @@ mod tests {
             blocks[1].recovered_block().header().clone(),
         );
         let (anchor, selected) =
-            select_historical_anchor(&provider, historical, in_memory.clone()).unwrap();
+            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
         assert_eq!(anchor, blocks[1].recovered_block().hash());
         assert_eq!(selected, vec![blocks[2].clone()]);
 
@@ -595,7 +595,7 @@ mod tests {
             blocks[2].recovered_block().header().clone(),
         );
         let (anchor, selected) =
-            select_historical_anchor(&provider, historical, in_memory.clone()).unwrap();
+            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
         assert_eq!(anchor, blocks[2].recovered_block().hash());
         assert!(selected.is_empty());
 
@@ -609,7 +609,7 @@ mod tests {
             alternate_tip.recovered_block().header().clone(),
         );
         let (anchor, selected) =
-            select_historical_anchor(&provider, historical, in_memory.clone()).unwrap();
+            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
         assert_eq!(anchor, historical);
         assert_eq!(selected, in_memory);
     }

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -56,15 +56,6 @@ pub enum OverlaySource {
     Managed,
 }
 
-/// Selects the durable frontier used to anchor an in-memory overlay.
-#[derive(Debug, Clone, Copy)]
-pub enum OverlayAnchor {
-    /// Use the Finish tip from a provider that reads the durable database.
-    DatabaseTip,
-    /// Use the partial state/trie persistence frontier.
-    StateTrieTip(BlockNumHash),
-}
-
 /// Builder for calculating trie and hashed-state overlays.
 ///
 /// This stores the overlay manager, overlay configuration, and the logic for resolving overlays
@@ -167,11 +158,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         let anchor_hash = match &self.overlay_source {
             Some(OverlaySource::Managed) => {
                 let (historical, blocks) = self.overlay_manager.blocks_for_parent(self.parent_hash);
-                get_anchored_overlay(
+                get_anchored_overlay_at_state_trie_tip(
                     provider,
                     historical,
                     blocks,
-                    OverlayAnchor::StateTrieTip(state_trie_tip_block),
+                    state_trie_tip_block,
                 )?
                 .0
             }
@@ -473,39 +464,44 @@ where
 
 /// Selects the historical anchor and in-memory blocks for a state provider.
 ///
-/// `blocks` must be ordered from newest to oldest. If the selected durable frontier is present in
-/// `blocks`, that frontier becomes the historical anchor and only blocks newer than it are
-/// retained. Otherwise, the original `historical` anchor and all blocks are retained. A target
-/// that is already persisted at or below the selected frontier needs no overlay. Matching hashes,
-/// rather than only numbers, preserves the correct state across same-height forks.
-///
-/// For [`OverlayAnchor::DatabaseTip`], `provider` must read the durable database rather than an
-/// in-memory view.
+/// `blocks` must be ordered from newest to oldest. The state/trie persistence frontier is read
+/// from `provider`. If it is present in `blocks`, it becomes the historical anchor and only blocks
+/// newer than it are retained. Otherwise, the original `historical` anchor and all blocks are
+/// retained. A target that is already persisted at or below that frontier needs no overlay.
+/// Matching hashes, rather than only numbers, preserves the correct state across same-height
+/// forks.
 pub fn get_anchored_overlay<P, N>(
     provider: &P,
     historical: B256,
+    blocks: Vec<ExecutedBlock<N>>,
+) -> ProviderResult<(B256, Vec<ExecutedBlock<N>>)>
+where
+    P: BlockNumReader + StageCheckpointReader,
+    N: NodePrimitives,
+{
+    let (state_trie_tip, _) = database_state_frontiers(provider)?;
+
+    get_anchored_overlay_at_state_trie_tip(provider, historical, blocks, state_trie_tip)
+}
+
+/// Selects the historical anchor and in-memory blocks using a previously read state/trie tip.
+///
+/// This lets [`OverlayBuilder::build_overlay_at_frontiers`] reuse the selector without re-reading
+/// the frontier that keys its cache and reverts.
+fn get_anchored_overlay_at_state_trie_tip<P, N>(
+    provider: &P,
+    historical: B256,
     mut blocks: Vec<ExecutedBlock<N>>,
-    anchor: OverlayAnchor,
+    state_trie_tip: BlockNumHash,
 ) -> ProviderResult<(B256, Vec<ExecutedBlock<N>>)>
 where
     P: BlockNumReader,
     N: NodePrimitives,
 {
-    let anchor = match anchor {
-        OverlayAnchor::DatabaseTip => {
-            let number = provider.best_block_number()?;
-            let hash = provider
-                .block_hash(number)?
-                .ok_or_else(|| ProviderError::HeaderNotFound(number.into()))?;
-            BlockNumHash::new(number, hash)
-        }
-        OverlayAnchor::StateTrieTip(anchor) => anchor,
-    };
-
     let target_hash =
         blocks.first().map(|block| block.recovered_block().hash()).unwrap_or(historical);
     let target_is_persisted = match provider.block_number(target_hash)? {
-        Some(number) if number <= anchor.number => {
+        Some(number) if number <= state_trie_tip.number => {
             provider.block_hash(number)? == Some(target_hash)
         }
         _ => false,
@@ -519,10 +515,10 @@ where
     }
 
     if let Some(anchor_index) =
-        blocks.iter().position(|block| block.recovered_block().hash() == anchor.hash)
+        blocks.iter().position(|block| block.recovered_block().hash() == state_trie_tip.hash)
     {
         blocks.truncate(anchor_index);
-        return Ok((anchor.hash, blocks))
+        return Ok((state_trie_tip.hash, blocks))
     }
 
     Ok((historical, blocks))
@@ -548,11 +544,11 @@ struct OverlayBuilderMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "partial-persistence")]
     use alloy_consensus::BlockHeader;
     use alloy_primitives::U256;
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
-    use reth_provider::test_utils::MockEthProvider;
     #[cfg(feature = "partial-persistence")]
     use reth_provider::{
         test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
@@ -602,63 +598,6 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn get_anchored_overlay_uses_durable_tip_overlap() {
-        let mut block_builder = TestBlockBuilder::eth();
-        let blocks = block_builder.get_executed_blocks(1..4).collect::<Vec<_>>();
-        let in_memory = vec![blocks[2].clone(), blocks[1].clone(), blocks[0].clone()];
-        let historical = blocks[0].recovered_block().parent_hash();
-
-        let provider = MockEthProvider::default();
-        provider.add_header(
-            blocks[1].recovered_block().hash(),
-            blocks[1].recovered_block().header().clone(),
-        );
-        let (anchor, selected) = get_anchored_overlay(
-            &provider,
-            historical,
-            in_memory.clone(),
-            OverlayAnchor::DatabaseTip,
-        )
-        .unwrap();
-        assert_eq!(anchor, blocks[1].recovered_block().hash());
-        assert_eq!(selected, vec![blocks[2].clone()]);
-
-        let provider = MockEthProvider::default();
-        provider.add_header(
-            blocks[2].recovered_block().hash(),
-            blocks[2].recovered_block().header().clone(),
-        );
-        let (anchor, selected) = get_anchored_overlay(
-            &provider,
-            historical,
-            in_memory.clone(),
-            OverlayAnchor::DatabaseTip,
-        )
-        .unwrap();
-        assert_eq!(anchor, blocks[2].recovered_block().hash());
-        assert!(selected.is_empty());
-
-        let alternate_tip = block_builder.get_executed_block_with_number(
-            blocks[2].block_number(),
-            blocks[1].recovered_block().hash(),
-        );
-        let provider = MockEthProvider::default();
-        provider.add_header(
-            alternate_tip.recovered_block().hash(),
-            alternate_tip.recovered_block().header().clone(),
-        );
-        let (anchor, selected) = get_anchored_overlay(
-            &provider,
-            historical,
-            in_memory.clone(),
-            OverlayAnchor::DatabaseTip,
-        )
-        .unwrap();
-        assert_eq!(anchor, historical);
-        assert_eq!(selected, in_memory);
-    }
-
     #[cfg(feature = "partial-persistence")]
     fn setup_frontiers(
         state_trie_tip_index: usize,
@@ -686,33 +625,52 @@ mod tests {
 
     #[cfg(feature = "partial-persistence")]
     #[test]
-    fn get_anchored_overlay_uses_the_selected_partial_persistence_frontier() {
+    fn get_anchored_overlay_uses_state_trie_tip_overlap() {
         let (factory, blocks) = setup_frontiers(1, 3);
         let provider = factory.provider().unwrap();
         let historical = blocks[1].recovered_block().parent_hash();
         let in_memory =
             vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone(), blocks[1].clone()];
 
-        let (anchor, selected) = get_anchored_overlay(
-            &provider,
-            historical,
-            in_memory.clone(),
-            OverlayAnchor::DatabaseTip,
-        )
-        .unwrap();
-        assert_eq!(anchor, blocks[3].recovered_block().hash());
-        assert_eq!(selected, vec![blocks[4].clone()]);
-
-        let (state_trie_tip, _) = database_state_frontiers(&provider).unwrap();
-        let (anchor, selected) = get_anchored_overlay(
-            &provider,
-            historical,
-            in_memory,
-            OverlayAnchor::StateTrieTip(state_trie_tip),
-        )
-        .unwrap();
+        let (anchor, selected) = get_anchored_overlay(&provider, historical, in_memory).unwrap();
         assert_eq!(anchor, blocks[1].recovered_block().hash());
         assert_eq!(selected, vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone()]);
+
+        let (anchor, selected) =
+            get_anchored_overlay(&provider, historical, vec![blocks[1].clone()]).unwrap();
+        assert_eq!(anchor, blocks[1].recovered_block().hash());
+        assert!(selected.is_empty());
+
+        let in_memory = vec![blocks[4].clone()];
+        let historical = blocks[3].recovered_block().hash();
+        let (anchor, selected) =
+            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
+        assert_eq!(anchor, historical);
+        assert_eq!(selected, in_memory);
+
+        let mut block_builder = TestBlockBuilder::eth();
+        let alternate_state_trie_tip = block_builder.get_executed_block_with_number(
+            blocks[1].block_number(),
+            blocks[0].recovered_block().hash(),
+        );
+        assert_ne!(
+            alternate_state_trie_tip.recovered_block().hash(),
+            blocks[1].recovered_block().hash()
+        );
+        let alternate_child = block_builder.get_executed_block_with_number(
+            blocks[2].block_number(),
+            alternate_state_trie_tip.recovered_block().hash(),
+        );
+        let alternate_tip = block_builder.get_executed_block_with_number(
+            blocks[3].block_number(),
+            alternate_child.recovered_block().hash(),
+        );
+        let in_memory = vec![alternate_tip, alternate_child, alternate_state_trie_tip];
+        let historical = blocks[0].recovered_block().hash();
+        let (anchor, selected) =
+            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
+        assert_eq!(anchor, historical);
+        assert_eq!(selected, in_memory);
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -56,6 +56,15 @@ pub enum OverlaySource {
     Managed,
 }
 
+/// Selects the durable frontier used to anchor an in-memory overlay.
+#[derive(Debug, Clone, Copy)]
+pub enum OverlayAnchor {
+    /// Use the Finish tip from a provider that reads the durable database.
+    DatabaseTip,
+    /// Use the partial state/trie persistence frontier.
+    StateTrieTip(BlockNumHash),
+}
+
 /// Builder for calculating trie and hashed-state overlays.
 ///
 /// This stores the overlay manager, overlay configuration, and the logic for resolving overlays
@@ -157,16 +166,14 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         let hashed_state_updates_total_len;
         let anchor_hash = match &self.overlay_source {
             Some(OverlaySource::Managed) => {
-                let parent_is_persisted = provider
-                    .convert_hash_or_number(self.parent_hash.into())?
-                    .is_some_and(|parent_number| parent_number <= state_trie_tip_block.number);
-                if parent_is_persisted {
-                    self.parent_hash
-                } else {
-                    self.overlay_manager
-                        .anchor_for_parent(self.parent_hash, state_trie_tip_block.hash)
-                        .ok_or(ProviderError::BlockHashNotFound(self.parent_hash))?
-                }
+                let (historical, blocks) = self.overlay_manager.blocks_for_parent(self.parent_hash);
+                get_anchored_overlay(
+                    provider,
+                    historical,
+                    blocks,
+                    OverlayAnchor::StateTrieTip(state_trie_tip_block),
+                )?
+                .0
             }
             _ => self.parent_hash,
         };
@@ -466,33 +473,56 @@ where
 
 /// Selects the historical anchor and in-memory blocks for a state provider.
 ///
-/// `blocks` must be ordered from newest to oldest. If the durable database tip is present in
-/// `blocks`, that tip becomes the historical anchor and only blocks newer than it are retained.
-/// Otherwise, the original `historical` anchor and all blocks are retained. Matching the tip hash,
-/// rather than only its number, preserves the correct state across same-height forks.
+/// `blocks` must be ordered from newest to oldest. If the selected durable frontier is present in
+/// `blocks`, that frontier becomes the historical anchor and only blocks newer than it are
+/// retained. Otherwise, the original `historical` anchor and all blocks are retained. A target
+/// that is already persisted at or below the selected frontier needs no overlay. Matching hashes,
+/// rather than only numbers, preserves the correct state across same-height forks.
+///
+/// For [`OverlayAnchor::DatabaseTip`], `provider` must read the durable database rather than an
+/// in-memory view.
 pub fn get_anchored_overlay<P, N>(
     provider: &P,
     historical: B256,
     mut blocks: Vec<ExecutedBlock<N>>,
+    anchor: OverlayAnchor,
 ) -> ProviderResult<(B256, Vec<ExecutedBlock<N>>)>
 where
     P: BlockNumReader,
     N: NodePrimitives,
 {
-    if blocks.is_empty() {
-        return Ok((historical, blocks))
+    let anchor = match anchor {
+        OverlayAnchor::DatabaseTip => {
+            let number = provider.best_block_number()?;
+            let hash = provider
+                .block_hash(number)?
+                .ok_or_else(|| ProviderError::HeaderNotFound(number.into()))?;
+            BlockNumHash::new(number, hash)
+        }
+        OverlayAnchor::StateTrieTip(anchor) => anchor,
+    };
+
+    let target_hash =
+        blocks.first().map(|block| block.recovered_block().hash()).unwrap_or(historical);
+    let target_is_persisted = match provider.block_number(target_hash)? {
+        Some(number) if number <= anchor.number => {
+            provider.block_hash(number)? == Some(target_hash)
+        }
+        _ => false,
+    };
+    if target_is_persisted {
+        return Ok((target_hash, Vec::new()))
     }
 
-    let tip_number = provider.last_block_number()?;
-    let tip_hash = provider
-        .block_hash(tip_number)?
-        .ok_or_else(|| ProviderError::HeaderNotFound(tip_number.into()))?;
+    if blocks.is_empty() {
+        return Err(ProviderError::BlockHashNotFound(target_hash))
+    }
 
-    if let Some(tip_index) =
-        blocks.iter().position(|block| block.recovered_block().hash() == tip_hash)
+    if let Some(anchor_index) =
+        blocks.iter().position(|block| block.recovered_block().hash() == anchor.hash)
     {
-        blocks.truncate(tip_index);
-        return Ok((tip_hash, blocks))
+        blocks.truncate(anchor_index);
+        return Ok((anchor.hash, blocks))
     }
 
     Ok((historical, blocks))
@@ -584,8 +614,13 @@ mod tests {
             blocks[1].recovered_block().hash(),
             blocks[1].recovered_block().header().clone(),
         );
-        let (anchor, selected) =
-            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
+        let (anchor, selected) = get_anchored_overlay(
+            &provider,
+            historical,
+            in_memory.clone(),
+            OverlayAnchor::DatabaseTip,
+        )
+        .unwrap();
         assert_eq!(anchor, blocks[1].recovered_block().hash());
         assert_eq!(selected, vec![blocks[2].clone()]);
 
@@ -594,8 +629,13 @@ mod tests {
             blocks[2].recovered_block().hash(),
             blocks[2].recovered_block().header().clone(),
         );
-        let (anchor, selected) =
-            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
+        let (anchor, selected) = get_anchored_overlay(
+            &provider,
+            historical,
+            in_memory.clone(),
+            OverlayAnchor::DatabaseTip,
+        )
+        .unwrap();
         assert_eq!(anchor, blocks[2].recovered_block().hash());
         assert!(selected.is_empty());
 
@@ -608,8 +648,13 @@ mod tests {
             alternate_tip.recovered_block().hash(),
             alternate_tip.recovered_block().header().clone(),
         );
-        let (anchor, selected) =
-            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
+        let (anchor, selected) = get_anchored_overlay(
+            &provider,
+            historical,
+            in_memory.clone(),
+            OverlayAnchor::DatabaseTip,
+        )
+        .unwrap();
         assert_eq!(anchor, historical);
         assert_eq!(selected, in_memory);
     }
@@ -637,6 +682,37 @@ mod tests {
         provider_rw.commit().unwrap();
 
         (factory, blocks)
+    }
+
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn get_anchored_overlay_uses_the_selected_partial_persistence_frontier() {
+        let (factory, blocks) = setup_frontiers(1, 3);
+        let provider = factory.provider().unwrap();
+        let historical = blocks[1].recovered_block().parent_hash();
+        let in_memory =
+            vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone(), blocks[1].clone()];
+
+        let (anchor, selected) = get_anchored_overlay(
+            &provider,
+            historical,
+            in_memory.clone(),
+            OverlayAnchor::DatabaseTip,
+        )
+        .unwrap();
+        assert_eq!(anchor, blocks[3].recovered_block().hash());
+        assert_eq!(selected, vec![blocks[4].clone()]);
+
+        let (state_trie_tip, _) = database_state_frontiers(&provider).unwrap();
+        let (anchor, selected) = get_anchored_overlay(
+            &provider,
+            historical,
+            in_memory,
+            OverlayAnchor::StateTrieTip(state_trie_tip),
+        )
+        .unwrap();
+        assert_eq!(anchor, blocks[1].recovered_block().hash());
+        assert_eq!(selected, vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone()]);
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -6,7 +6,7 @@ use reth_chain_state::ExecutedBlock;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_metrics::Metrics;
-use reth_primitives_traits::NodePrimitives;
+use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives};
 use reth_prune_types::PruneSegment;
 use reth_stages_types::StageId;
 use reth_storage_api::{
@@ -15,6 +15,7 @@ use reth_storage_api::{
 };
 use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted};
 use std::{
+    collections::HashMap,
     ops::RangeInclusive,
     sync::Arc,
     time::{Duration, Instant},
@@ -157,10 +158,10 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         let hashed_state_updates_total_len;
         let anchor_hash = match &self.overlay_source {
             Some(OverlaySource::Managed) => {
-                let (historical, blocks) = self.overlay_manager.blocks_for_parent(self.parent_hash);
+                let blocks = self.overlay_manager.blocks_for_parent(self.parent_hash);
                 get_anchored_overlay_at_state_trie_tip(
                     provider,
-                    historical,
+                    self.parent_hash,
                     blocks,
                     state_trie_tip_block,
                 )?
@@ -464,15 +465,15 @@ where
 
 /// Selects the historical anchor and in-memory blocks for a state provider.
 ///
-/// `blocks` must be ordered from newest to oldest. The state/trie persistence frontier is read
-/// from `provider`. If it is present in `blocks`, it becomes the historical anchor and only blocks
-/// newer than it are retained. Otherwise, the original `historical` anchor and all blocks are
-/// retained. A target that is already persisted at or below that frontier needs no overlay.
-/// Matching hashes, rather than only numbers, preserves the correct state across same-height
-/// forks.
+/// `parent_hash` identifies the post-state being built. `blocks` must contain its complete
+/// in-memory ancestry back to a database anchor, but may also contain unrelated blocks. Only the
+/// chain beginning at `parent_hash` is returned, ordered from newest to oldest. The state/trie
+/// persistence frontier is read from `provider`. If it overlaps that chain, it becomes the
+/// historical anchor and only blocks newer than it are retained. A parent already persisted at or
+/// below that frontier needs no overlay.
 pub fn get_anchored_overlay<P, N>(
     provider: &P,
-    historical: B256,
+    parent_hash: B256,
     blocks: Vec<ExecutedBlock<N>>,
 ) -> ProviderResult<(B256, Vec<ExecutedBlock<N>>)>
 where
@@ -481,7 +482,7 @@ where
 {
     let (state_trie_tip, _) = database_state_frontiers(provider)?;
 
-    get_anchored_overlay_at_state_trie_tip(provider, historical, blocks, state_trie_tip)
+    get_anchored_overlay_at_state_trie_tip(provider, parent_hash, blocks, state_trie_tip)
 }
 
 /// Selects the historical anchor and in-memory blocks using a previously read state/trie tip.
@@ -490,38 +491,47 @@ where
 /// the frontier that keys its cache and reverts.
 fn get_anchored_overlay_at_state_trie_tip<P, N>(
     provider: &P,
-    historical: B256,
-    mut blocks: Vec<ExecutedBlock<N>>,
+    parent_hash: B256,
+    blocks: Vec<ExecutedBlock<N>>,
     state_trie_tip: BlockNumHash,
 ) -> ProviderResult<(B256, Vec<ExecutedBlock<N>>)>
 where
     P: BlockNumReader,
     N: NodePrimitives,
 {
-    let target_hash =
-        blocks.first().map(|block| block.recovered_block().hash()).unwrap_or(historical);
-    let target_is_persisted = match provider.block_number(target_hash)? {
-        Some(number) if number <= state_trie_tip.number => {
-            provider.block_hash(number)? == Some(target_hash)
+    let parent_is_persisted = match provider.block_number(parent_hash)? {
+        Some(parent_number) if parent_number <= state_trie_tip.number => {
+            provider.block_hash(parent_number)? == Some(parent_hash)
         }
         _ => false,
     };
-    if target_is_persisted {
-        return Ok((target_hash, Vec::new()))
+    if parent_is_persisted {
+        return Ok((parent_hash, Vec::new()))
     }
 
-    if blocks.is_empty() {
-        return Err(ProviderError::BlockHashNotFound(target_hash))
-    }
+    let mut blocks_by_hash = blocks
+        .into_iter()
+        .map(|block| (block.recovered_block().hash(), block))
+        .collect::<HashMap<_, _>>();
+    let mut anchor_hash = parent_hash;
+    let mut overlay = Vec::new();
 
-    if let Some(anchor_index) =
-        blocks.iter().position(|block| block.recovered_block().hash() == state_trie_tip.hash)
-    {
-        blocks.truncate(anchor_index);
-        return Ok((state_trie_tip.hash, blocks))
-    }
+    loop {
+        if anchor_hash == state_trie_tip.hash {
+            return Ok((anchor_hash, overlay))
+        }
 
-    Ok((historical, blocks))
+        let Some(block) = blocks_by_hash.remove(&anchor_hash) else {
+            return if overlay.is_empty() {
+                Err(ProviderError::BlockHashNotFound(parent_hash))
+            } else {
+                Ok((anchor_hash, overlay))
+            }
+        };
+
+        anchor_hash = block.recovered_block().parent_hash();
+        overlay.push(block);
+    }
 }
 
 /// Metrics for overlay construction.
@@ -544,8 +554,6 @@ struct OverlayBuilderMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "partial-persistence")]
-    use alloy_consensus::BlockHeader;
     use alloy_primitives::U256;
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
@@ -628,24 +636,34 @@ mod tests {
     fn get_anchored_overlay_uses_state_trie_tip_overlap() {
         let (factory, blocks) = setup_frontiers(1, 3);
         let provider = factory.provider().unwrap();
-        let historical = blocks[1].recovered_block().parent_hash();
         let in_memory =
             vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone(), blocks[1].clone()];
 
-        let (anchor, selected) = get_anchored_overlay(&provider, historical, in_memory).unwrap();
+        let (anchor, selected) =
+            get_anchored_overlay(&provider, blocks[4].recovered_block().hash(), in_memory.clone())
+                .unwrap();
         assert_eq!(anchor, blocks[1].recovered_block().hash());
         assert_eq!(selected, vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone()]);
 
         let (anchor, selected) =
-            get_anchored_overlay(&provider, historical, vec![blocks[1].clone()]).unwrap();
+            get_anchored_overlay(&provider, blocks[2].recovered_block().hash(), in_memory).unwrap();
+        assert_eq!(anchor, blocks[1].recovered_block().hash());
+        assert_eq!(selected, vec![blocks[2].clone()]);
+
+        let (anchor, selected) = get_anchored_overlay(
+            &provider,
+            blocks[1].recovered_block().hash(),
+            vec![blocks[1].clone()],
+        )
+        .unwrap();
         assert_eq!(anchor, blocks[1].recovered_block().hash());
         assert!(selected.is_empty());
 
         let in_memory = vec![blocks[4].clone()];
-        let historical = blocks[3].recovered_block().hash();
         let (anchor, selected) =
-            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
-        assert_eq!(anchor, historical);
+            get_anchored_overlay(&provider, blocks[4].recovered_block().hash(), in_memory.clone())
+                .unwrap();
+        assert_eq!(anchor, blocks[3].recovered_block().hash());
         assert_eq!(selected, in_memory);
 
         let mut block_builder = TestBlockBuilder::eth();
@@ -666,10 +684,10 @@ mod tests {
             alternate_child.recovered_block().hash(),
         );
         let in_memory = vec![alternate_tip, alternate_child, alternate_state_trie_tip];
-        let historical = blocks[0].recovered_block().hash();
+        let parent_hash = in_memory[0].recovered_block().hash();
         let (anchor, selected) =
-            get_anchored_overlay(&provider, historical, in_memory.clone()).unwrap();
-        assert_eq!(anchor, historical);
+            get_anchored_overlay(&provider, parent_hash, in_memory.clone()).unwrap();
+        assert_eq!(anchor, blocks[0].recovered_block().hash());
         assert_eq!(selected, in_memory);
     }
 

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -159,7 +159,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         let anchor_hash = match &self.overlay_source {
             Some(OverlaySource::Managed) => {
                 let blocks = self.overlay_manager.blocks_for_parent(self.parent_hash);
-                get_anchored_overlay(provider, self.parent_hash, blocks)?.0
+                let (database_anchor, blocks) =
+                    get_anchored_overlay(provider, self.parent_hash, blocks)?;
+                // The database anchor can be Finish during partial persistence, but the managed
+                // overlay still begins before the oldest retained masking block.
+                blocks.last().map_or(database_anchor, |block| block.recovered_block().parent_hash())
             }
             _ => self.parent_hash,
         };
@@ -457,14 +461,20 @@ where
     ))
 }
 
-/// Selects the historical anchor and in-memory blocks for a state provider.
+/// Selects the database anchor and in-memory blocks for a state provider.
 ///
 /// `parent_hash` identifies the post-state being built. `blocks` must contain its complete
 /// in-memory ancestry back to a database anchor, but may also contain unrelated blocks. Only the
-/// chain beginning at `parent_hash` is returned, ordered from newest to oldest. The state/trie
-/// persistence frontier is read from `provider`. If it overlaps that chain, it becomes the
-/// historical anchor and only blocks newer than it are retained. A parent already persisted at or
-/// below that frontier needs no overlay.
+/// chain beginning at `parent_hash` is returned, ordered from newest to oldest. During partial
+/// persistence, using the Finish tip as that anchor requires `blocks` to cover the complete
+/// masking segment back through the state/trie tip.
+///
+/// The state/trie and Finish persistence frontiers are read from `provider`. If the chain covers
+/// both, the Finish tip is returned as the database anchor while every block newer than the
+/// state/trie tip is retained. These retained blocks include the masking suffix required to use
+/// the database during partial persistence. If only the state/trie tip overlaps, it is returned as
+/// the database anchor instead. A parent already persisted at or below the state/trie frontier
+/// needs no forward overlay; historical reconstruction, when needed, is handled by the provider.
 pub fn get_anchored_overlay<P, N>(
     provider: &P,
     parent_hash: B256,
@@ -474,14 +484,17 @@ where
     P: BlockNumReader + StageCheckpointReader,
     N: NodePrimitives,
 {
-    let (state_trie_tip, _) = database_state_frontiers(provider)?;
-    let parent_is_persisted = match provider.block_number(parent_hash)? {
+    let (state_trie_tip, finish_tip) = database_state_frontiers(provider)?;
+    let parent_is_at_or_before_state_trie_tip = match provider.block_number(parent_hash)? {
         Some(parent_number) if parent_number <= state_trie_tip.number => {
             provider.block_hash(parent_number)? == Some(parent_hash)
         }
         _ => false,
     };
-    if parent_is_persisted {
+    if parent_is_at_or_before_state_trie_tip {
+        // There is no forward suffix to apply to a target behind this frontier. Consumers that
+        // need trie state for the hybrid database view still perform their normal historical
+        // reconstruction from this anchor.
         return Ok((parent_hash, Vec::new()))
     }
 
@@ -491,13 +504,26 @@ where
         .collect::<HashMap<_, _>>();
     let mut anchor_hash = parent_hash;
     let mut overlay = Vec::new();
+    let mut covers_finish_tip = state_trie_tip.hash == finish_tip.hash;
 
     loop {
         if anchor_hash == state_trie_tip.hash {
-            return Ok((anchor_hash, overlay))
+            let database_anchor =
+                if covers_finish_tip { finish_tip.hash } else { state_trie_tip.hash };
+            return Ok((database_anchor, overlay))
         }
 
         let Some(block) = blocks_by_hash.remove(&anchor_hash) else {
+            // A database block above the state/trie frontier is not a usable base unless the
+            // complete masking suffix back to that frontier is available.
+            if state_trie_tip.hash != finish_tip.hash &&
+                provider
+                    .block_number(anchor_hash)?
+                    .is_some_and(|number| number > state_trie_tip.number)
+            {
+                return Err(ProviderError::BlockHashNotFound(parent_hash))
+            }
+
             return if overlay.is_empty() {
                 Err(ProviderError::BlockHashNotFound(parent_hash))
             } else {
@@ -505,6 +531,7 @@ where
             }
         };
 
+        covers_finish_tip |= anchor_hash == finish_tip.hash;
         anchor_hash = block.recovered_block().parent_hash();
         overlay.push(block);
     }
@@ -531,6 +558,8 @@ struct OverlayBuilderMetrics {
 mod tests {
     use super::*;
     use alloy_primitives::U256;
+    #[cfg(feature = "partial-persistence")]
+    use reth_chain_state::MemoryOverlayStateProvider;
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
     #[cfg(feature = "partial-persistence")]
@@ -543,7 +572,10 @@ mod tests {
     #[cfg(feature = "partial-persistence")]
     use reth_stages_types::{FinishCheckpoint, StageCheckpoint};
     #[cfg(feature = "partial-persistence")]
-    use reth_storage_api::{PruneCheckpointWriter, StageCheckpointWriter};
+    use reth_storage_api::{
+        PruneCheckpointWriter, StageCheckpointWriter, StateRootProvider,
+        TryIntoHistoricalStateProvider,
+    };
     use reth_trie::{BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, Nibbles};
 
     fn with_unique_trie_data(
@@ -583,6 +615,20 @@ mod tests {
     }
 
     #[cfg(feature = "partial-persistence")]
+    fn empty_trie_blocks() -> Vec<ExecutedBlock<EthPrimitives>> {
+        TestBlockBuilder::eth()
+            .get_executed_blocks(0..5)
+            .map(|block| {
+                ExecutedBlock::new(
+                    Arc::clone(&block.recovered_block),
+                    Arc::clone(&block.execution_output),
+                    ComputedTrieData::new(Default::default(), Default::default()),
+                )
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "partial-persistence")]
     fn setup_frontiers(
         state_trie_tip_index: usize,
         finish_tip_index: usize,
@@ -618,7 +664,7 @@ mod tests {
         let (anchor, selected) =
             get_anchored_overlay(&provider, blocks[4].recovered_block().hash(), in_memory.clone())
                 .unwrap();
-        assert_eq!(anchor, blocks[1].recovered_block().hash());
+        assert_eq!(anchor, blocks[3].recovered_block().hash());
         assert_eq!(selected, vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone()]);
 
         let (anchor, selected) =
@@ -635,12 +681,17 @@ mod tests {
         assert_eq!(anchor, blocks[1].recovered_block().hash());
         assert!(selected.is_empty());
 
-        let in_memory = vec![blocks[4].clone()];
-        let (anchor, selected) =
-            get_anchored_overlay(&provider, blocks[4].recovered_block().hash(), in_memory.clone())
-                .unwrap();
-        assert_eq!(anchor, blocks[3].recovered_block().hash());
-        assert_eq!(selected, in_memory);
+        let error = get_anchored_overlay(
+            &provider,
+            blocks[4].recovered_block().hash(),
+            vec![blocks[4].clone()],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ProviderError::BlockHashNotFound(hash)
+                if hash == blocks[4].recovered_block().hash()
+        ));
 
         let mut block_builder = TestBlockBuilder::eth();
         let alternate_state_trie_tip = block_builder.get_executed_block_with_number(
@@ -665,6 +716,51 @@ mod tests {
             get_anchored_overlay(&provider, parent_hash, in_memory.clone()).unwrap();
         assert_eq!(anchor, blocks[0].recovered_block().hash());
         assert_eq!(selected, in_memory);
+    }
+
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn get_anchored_overlay_uses_finish_without_history() {
+        let factory = create_test_provider_factory();
+        let blocks = empty_trie_blocks();
+        let provider_rw = factory.provider_rw().unwrap();
+        for block in &blocks[..=3] {
+            provider_rw.insert_block(block.recovered_block()).unwrap();
+        }
+        provider_rw
+            .save_stage_checkpoint(
+                StageId::Finish,
+                StageCheckpoint::new(blocks[3].block_number()).with_finish_stage_checkpoint(
+                    FinishCheckpoint { partial_state_trie: Some(blocks[1].block_number()) },
+                ),
+            )
+            .unwrap();
+        provider_rw
+            .save_prune_checkpoint(
+                PruneSegment::AccountHistory,
+                PruneCheckpoint {
+                    block_number: Some(blocks[2].block_number()),
+                    tx_number: None,
+                    prune_mode: PruneMode::Full,
+                },
+            )
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let (anchor, overlay) = get_anchored_overlay(
+            &provider,
+            blocks[4].recovered_block().hash(),
+            vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone()],
+        )
+        .unwrap();
+        assert_eq!(anchor, blocks[3].recovered_block().hash());
+        assert_eq!(overlay, vec![blocks[4].clone(), blocks[3].clone(), blocks[2].clone()]);
+
+        let anchor_number = provider.block_number(anchor).unwrap().unwrap();
+        let historical = provider.try_into_history_at_block(anchor_number).unwrap();
+        let state_provider = MemoryOverlayStateProvider::new(historical, overlay);
+        state_provider.state_root(HashedPostState::default()).unwrap();
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -402,6 +402,19 @@ impl<N: NodePrimitives> OverlayManager<N> {
         Self::anchor_for_parent_in(self.blocks.as_ref(), parent_hash, preferred_anchor)
     }
 
+    /// Returns the in-memory parent chain from newest to oldest and its first missing parent.
+    pub(crate) fn blocks_for_parent(&self, parent_hash: B256) -> (B256, Vec<ExecutedBlock<N>>) {
+        let mut historical = parent_hash;
+        let mut blocks = Vec::new();
+
+        while let Some(block) = self.blocks.get(&historical) {
+            historical = block.recovered_block().parent_hash();
+            blocks.push(block.clone());
+        }
+
+        (historical, blocks)
+    }
+
     /// Returns true if `hash` is in the parent chain segment from `anchor_hash` inclusive to
     /// `parent_hash` inclusive.
     pub fn contains_hash(&self, parent_hash: B256, anchor_hash: B256, hash: B256) -> bool {

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -402,17 +402,17 @@ impl<N: NodePrimitives> OverlayManager<N> {
         Self::anchor_for_parent_in(self.blocks.as_ref(), parent_hash, preferred_anchor)
     }
 
-    /// Returns the in-memory parent chain from newest to oldest and its first missing parent.
-    pub(crate) fn blocks_for_parent(&self, parent_hash: B256) -> (B256, Vec<ExecutedBlock<N>>) {
-        let mut historical = parent_hash;
+    /// Returns the in-memory parent chain from newest to oldest.
+    pub(crate) fn blocks_for_parent(&self, parent_hash: B256) -> Vec<ExecutedBlock<N>> {
+        let mut hash = parent_hash;
         let mut blocks = Vec::new();
 
-        while let Some(block) = self.blocks.get(&historical) {
-            historical = block.recovered_block().parent_hash();
+        while let Some(block) = self.blocks.get(&hash) {
+            hash = block.recovered_block().parent_hash();
             blocks.push(block.clone());
         }
 
-        (historical, blocks)
+        blocks
     }
 
     /// Returns true if `hash` is in the parent chain segment from `anchor_hash` inclusive to


### PR DESCRIPTION
Centralizes in-memory state anchoring across state providers and OverlayBuilder. When the requested ancestry covers both durable frontiers, it uses the Finish-tip database state with the complete masking suffix after StateTrieTip, avoiding historical changesets while leaving the existing revert fallback unchanged.