### PR TITLE
perf(rpc): reuse a single EVM across transaction replay in tracing RPCs

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -22,7 +22,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
-    EvmEnvFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
+    EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
@@ -796,6 +796,29 @@ pub trait Call:
         I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
         let mut evm = self.evm_config().evm_with_env(db, evm_env);
+        self.replay_transactions_until_with_evm(&mut evm, transactions, target_tx_hash)
+    }
+
+    /// Replays all the transactions until the target transaction is found, on the given EVM.
+    ///
+    /// Unlike [`Self::replay_transactions_until`], this executes on a caller provided EVM, so the
+    /// target transaction can then be run on the same EVM, keeping any block-scoped EVM state
+    /// intact. The EVM's inspector configuration is left untouched; see
+    /// [`Self::inspect_transaction_in_block`] to replay without inspection and trace the target.
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator.
+    fn replay_transactions_until_with_evm<'a, DB, I, Txs>(
+        &self,
+        evm: &mut EvmFor<Self::Evm, DB, I>,
+        transactions: Txs,
+        target_tx_hash: B256,
+    ) -> Result<usize, Self::Error>
+    where
+        DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
+        I: InspectorFor<Self::Evm, DB>,
+        Txs: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
+    {
         let mut index = 0;
         for tx in transactions {
             if *tx.tx_hash() == target_tx_hash {
@@ -808,6 +831,33 @@ pub trait Call:
             index += 1;
         }
         Ok(index)
+    }
+
+    /// Replays all transactions before the target transaction without inspection, then executes
+    /// the target transaction with the configured inspector, all on the given EVM.
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator and its execution
+    /// result.
+    #[expect(clippy::type_complexity)]
+    fn inspect_transaction_in_block<'a, DB, I, Txs>(
+        &self,
+        evm: &mut EvmFor<Self::Evm, DB, I>,
+        transactions: Txs,
+        target_tx_hash: B256,
+        target_tx_env: TxEnvFor<Self::Evm>,
+    ) -> Result<(usize, ResultAndState<HaltReasonFor<Self::Evm>>), Self::Error>
+    where
+        DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
+        I: InspectorFor<Self::Evm, DB>,
+        Txs: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
+    {
+        evm.disable_inspector();
+        let index = self.replay_transactions_until_with_evm(evm, transactions, target_tx_hash)?;
+        evm.enable_inspector();
+
+        let res = evm.transact(target_tx_env).map_err(Self::Error::from_evm_err)?;
+        Ok((index, res))
     }
 
     ///

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -181,11 +181,15 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
 
                 this.apply_pre_execution_changes(&block, &mut db)?;
 
-                // replay all transactions prior to the targeted transaction
-                this.replay_transactions_until(&mut db, evm_env.clone(), block_txs, *tx.tx_hash())?;
-
+                let target_hash = *tx.tx_hash();
                 let tx_env = this.evm_config().tx_env(tx);
-                let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
+
+                let mut evm =
+                    this.evm_config().evm_with_env_and_inspector(&mut db, evm_env, &mut inspector);
+                let (_, res) =
+                    this.inspect_transaction_in_block(&mut evm, block_txs, target_hash, tx_env)?;
+                drop(evm);
+
                 f(tx_info, inspector, res, db)
             })
             .await

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -123,29 +123,33 @@ where
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
+                let block_hash = block.hash();
+                let block_env = evm_env.block_env.clone();
+
+                let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
+                // single EVM for the whole block so that block-scoped EVM state stays intact
+                let mut evm =
+                    eth_api.evm_config().evm_with_env_and_inspector(&mut db, evm_env, inspector);
+
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
-                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
                 while let Some((index, tx)) = transactions.next() {
                     let tx_hash = *tx.tx_hash();
                     let tx_env = eth_api.evm_config().tx_env(tx);
 
-                    let res = eth_api.inspect(
-                        &mut db,
-                        evm_env.clone(),
-                        tx_env.clone(),
-                        &mut inspector,
-                    )?;
+                    let res = evm.transact(tx_env.clone()).map_err(Eth::Error::from_evm_err)?;
+
+                    let (evm_db, inspector, _) = evm.components_mut();
                     let result = inspector
                         .get_result(
                             Some(TransactionContext {
-                                block_hash: Some(block.hash()),
+                                block_hash: Some(block_hash),
                                 tx_hash: Some(tx_hash),
                                 tx_index: Some(index),
                             }),
                             &tx_env,
-                            &evm_env.block_env,
+                            &block_env,
                             &res,
-                            &mut db,
+                            evm_db,
                         )
                         .map_err(Eth::Error::from_eth_err)?;
 
@@ -154,7 +158,7 @@ where
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit(res.state)
+                        evm_db.commit(res.state)
                     }
                 }
 
@@ -244,25 +248,30 @@ where
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
-                // replay all transactions prior to the targeted transaction
-                let index = eth_api.replay_transactions_until(
-                    &mut db,
-                    evm_env.clone(),
-                    block_txs,
-                    *tx.tx_hash(),
-                )?;
-
-                let tx_env = eth_api.evm_config().tx_env(&tx);
+                let target_hash = *tx.tx_hash();
 
                 let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                let res =
-                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
+                let mut evm = eth_api.evm_config().evm_with_env_and_inspector(
+                    &mut db,
+                    evm_env,
+                    &mut inspector,
+                );
+
+                let tx_env = eth_api.evm_config().tx_env(&tx);
+                let (index, res) = eth_api.inspect_transaction_in_block(
+                    &mut evm,
+                    block_txs,
+                    target_hash,
+                    tx_env.clone(),
+                )?;
+                let (_, evm_env) = evm.finish();
+
                 let trace = inspector
                     .get_result(
                         Some(TransactionContext {
                             block_hash: Some(block_hash),
                             tx_index: Some(index),
-                            tx_hash: Some(*tx.tx_hash()),
+                            tx_hash: Some(target_hash),
                         }),
                         &tx_env,
                         &evm_env.block_env,
@@ -446,10 +455,10 @@ where
                     let transactions = block.transactions_recovered().take(num_txs);
 
                     // Execute all transactions until index
+                    let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
                     for tx in transactions {
                         let tx_env = eth_api.evm_config().tx_env(tx);
-                        let res = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit(res.state);
+                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
                     }
                 }
 
@@ -727,18 +736,21 @@ where
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
                 let mut roots = Vec::with_capacity(block.body().transactions().len());
+                // single EVM for the whole block so that block-scoped EVM state stays intact
+                let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
                 for tx in block.transactions_recovered() {
                     let tx_env = eth_api.evm_config().tx_env(tx);
-                    {
-                        let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
-                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
-                    }
+                    evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+
+                    let state = evm.db_mut();
                     // Merge transitions into cumulative bundle_state
-                    db.merge_transitions(BundleRetention::PlainState);
+                    state.merge_transitions(BundleRetention::PlainState);
                     // Compute state root from the accumulated state changes
-                    let hashed_state = db.database.hashed_post_state(&db.bundle_state);
-                    let root =
-                        db.database.state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;
+                    let hashed_state = state.database.hashed_post_state(&state.bundle_state);
+                    let root = state
+                        .database
+                        .state_root(hashed_state)
+                        .map_err(Eth::Error::from_eth_err)?;
                     roots.push(root);
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1286,3 +1286,377 @@ impl<B: BlockTrait> Default for BadBlockStore<B> {
         Self::new(64)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EthApi, EthApiBuilder};
+    use alloy_consensus::{BlockBody, Header, TxLegacy};
+    use alloy_evm::{
+        eth::EthEvmContext, precompiles::PrecompilesMap, Database, EthEvm, EvmEnv, EvmFactory,
+    };
+    use alloy_network::Ethereum;
+    use alloy_primitives::{address, Signature, TxKind, U256};
+    use alloy_rpc_types_trace::geth::GethDebugBuiltInTracerType;
+    use reth_chainspec::ChainSpec;
+    use reth_ethereum_primitives::{EthPrimitives, Transaction, TransactionSigned};
+    use reth_evm_ethereum::EthEvmConfig;
+    use reth_network_api::noop::NoopNetwork;
+    use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+    use reth_rpc_convert::RpcConverter;
+    use reth_rpc_eth_api::{helpers::Trace, node::RpcNodeCoreAdapter};
+    use reth_rpc_eth_types::receipt::EthReceiptConverter;
+    use reth_transaction_pool::test_utils::{testing_pool, TestPool};
+    use revm::{
+        context::{
+            result::{EVMError, HaltReason, ResultAndState},
+            BlockEnv, CfgEnv, DBErrorMarker, TxEnv,
+        },
+        inspector::NoOpInspector,
+        primitives::hardfork::SpecId,
+        Inspector,
+    };
+    use revm_inspectors::tracing::TracingInspectorConfig;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    };
+
+    const WRITER: Address = address!("00000000000000000000000000000000000000aa");
+    const OBSERVED_SLOT: U256 = U256::ZERO;
+    const BLOCK_START_VALUE: u64 = 1;
+    const WRITTEN_VALUE: u64 = 2;
+    const SELECTOR: [u8; 4] = [0x11, 0x22, 0x33, 0x44];
+
+    #[derive(Debug, Default, Clone)]
+    struct EvmObservations {
+        values: Arc<Mutex<Vec<U256>>>,
+        evms_created: Arc<AtomicUsize>,
+    }
+
+    impl EvmObservations {
+        fn take_values(&self) -> Vec<U256> {
+            std::mem::take(&mut *self.values.lock().unwrap())
+        }
+
+        fn take_evms_created(&self) -> usize {
+            self.evms_created.swap(0, Ordering::Relaxed)
+        }
+    }
+
+    /// An [`EthEvm`] that carries block-scoped state: [`OBSERVED_SLOT`] is loaded on the first
+    /// transaction and cached for the rest of the block. A fresh EVM per transaction re-loads it
+    /// from whatever mid-block state it is handed.
+    struct StatefulEthEvm<DB: Database, I> {
+        inner: EthEvm<DB, I, PrecompilesMap>,
+        cached: Option<(U256, U256)>,
+        observations: EvmObservations,
+    }
+
+    impl<DB, I> Evm for StatefulEthEvm<DB, I>
+    where
+        DB: Database,
+        I: Inspector<EthEvmContext<DB>>,
+    {
+        type DB = DB;
+        type Tx = TxEnv;
+        type Error = EVMError<DB::Error>;
+        type HaltReason = HaltReason;
+        type Spec = SpecId;
+        type BlockEnv = BlockEnv;
+        type Precompiles = PrecompilesMap;
+        type Inspector = I;
+
+        fn transact_raw(
+            &mut self,
+            tx: Self::Tx,
+        ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+            let block_number = self.inner.block().number;
+            if self.cached.map(|(number, _)| number) != Some(block_number) {
+                let value = self
+                    .inner
+                    .db_mut()
+                    .storage(WRITER, OBSERVED_SLOT)
+                    .map_err(EVMError::Database)?;
+                self.cached = Some((block_number, value));
+            }
+            self.observations.values.lock().unwrap().push(self.cached.expect("just loaded").1);
+            self.inner.transact_raw(tx)
+        }
+
+        /// Delegates without seeding the cache: system calls must not count as the block's first
+        /// transaction.
+        fn transact_system_call(
+            &mut self,
+            caller: Address,
+            contract: Address,
+            data: Bytes,
+        ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+            self.inner.transact_system_call(caller, contract, data)
+        }
+
+        fn block(&self) -> &Self::BlockEnv {
+            self.inner.block()
+        }
+
+        fn cfg_env(&self) -> &CfgEnv<Self::Spec> {
+            self.inner.cfg_env()
+        }
+
+        fn chain_id(&self) -> u64 {
+            self.inner.chain_id()
+        }
+
+        fn finish(self) -> (Self::DB, EvmEnv<Self::Spec, Self::BlockEnv>) {
+            self.inner.finish()
+        }
+
+        fn set_inspector_enabled(&mut self, enabled: bool) {
+            self.inner.set_inspector_enabled(enabled)
+        }
+
+        fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
+            self.inner.components()
+        }
+
+        fn components_mut(
+            &mut self,
+        ) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
+            self.inner.components_mut()
+        }
+    }
+
+    #[derive(Debug, Default, Clone)]
+    struct StatefulEvmFactory {
+        observations: EvmObservations,
+    }
+
+    impl EvmFactory for StatefulEvmFactory {
+        type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = StatefulEthEvm<DB, I>;
+        type Context<DB: Database> = EthEvmContext<DB>;
+        type Tx = TxEnv;
+        type Error<DBError: DBErrorMarker> = EVMError<DBError>;
+        type HaltReason = HaltReason;
+        type Spec = SpecId;
+        type BlockEnv = BlockEnv;
+        type Precompiles = PrecompilesMap;
+
+        fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
+            self.observations.evms_created.fetch_add(1, Ordering::Relaxed);
+            StatefulEthEvm {
+                inner: alloy_evm::EthEvmFactory::default().create_evm(db, input),
+                cached: None,
+                observations: self.observations.clone(),
+            }
+        }
+
+        fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
+            &self,
+            db: DB,
+            input: EvmEnv,
+            inspector: I,
+        ) -> Self::Evm<DB, I> {
+            self.observations.evms_created.fetch_add(1, Ordering::Relaxed);
+            StatefulEthEvm {
+                inner: alloy_evm::EthEvmFactory::default()
+                    .create_evm_with_inspector(db, input, inspector),
+                cached: None,
+                observations: self.observations.clone(),
+            }
+        }
+    }
+
+    type StatefulEvmConfig = EthEvmConfig<ChainSpec, StatefulEvmFactory>;
+    type StatefulEthApi = EthApi<
+        RpcNodeCoreAdapter<MockEthProvider, TestPool, NoopNetwork, StatefulEvmConfig>,
+        // the default `EthRpcConverter` pins `EthEvmConfig`'s default factory
+        RpcConverter<Ethereum, StatefulEvmConfig, EthReceiptConverter<ChainSpec>>,
+    >;
+
+    struct Fixture {
+        api: DebugApi<StatefulEthApi>,
+        observations: EvmObservations,
+        block_hash: B256,
+        tx_hashes: Vec<B256>,
+    }
+
+    /// Builds a `tx_count`-transaction block at height 1: transaction 0 calls [`WRITER`], which
+    /// overwrites [`OBSERVED_SLOT`], the rest are bare transfers.
+    fn fixture(tx_count: usize) -> Fixture {
+        let provider = MockEthProvider::default().with_recovered_blocks();
+
+        provider.add_account(
+            WRITER,
+            ExtendedAccount::new(0, U256::ZERO)
+                // PUSH1 WRITTEN_VALUE, PUSH1 0, SSTORE, STOP
+                .with_bytecode(Bytes::from(vec![0x60, WRITTEN_VALUE as u8, 0x60, 0x00, 0x55, 0x00]))
+                .extend_storage([(B256::ZERO, U256::from(BLOCK_START_VALUE))]),
+        );
+
+        let transactions: Vec<_> = (0..tx_count)
+            .map(|i| {
+                let (to, gas_limit, input) = if i == 0 {
+                    // the selector is what the 4byte tracer records, WRITER ignores calldata
+                    (TxKind::Call(WRITER), 100_000, Bytes::from_static(&SELECTOR))
+                } else {
+                    // distinct gas limits give distinct signing hashes, hence distinct senders
+                    (TxKind::Call(Address::ZERO), 21_000 + i as u64, Bytes::new())
+                };
+                TransactionSigned::new_unhashed(
+                    Transaction::Legacy(TxLegacy {
+                        gas_limit,
+                        gas_price: 0,
+                        to,
+                        input,
+                        ..Default::default()
+                    }),
+                    Signature::test_signature(),
+                )
+            })
+            .collect();
+        let tx_hashes = transactions.iter().map(|tx| *tx.tx_hash()).collect();
+
+        let parent = Header { number: 0, gas_limit: 30_000_000, ..Default::default() };
+        let parent_hash = parent.hash_slow();
+        let block = reth_ethereum_primitives::Block {
+            header: Header { number: 1, parent_hash, gas_limit: 30_000_000, ..Default::default() },
+            body: BlockBody { transactions, ..Default::default() },
+        };
+        let block_hash = block.header.hash_slow();
+        provider.add_header(parent_hash, parent);
+        provider.add_block(block_hash, block);
+
+        let observations = EvmObservations::default();
+        let evm_config = EthEvmConfig::new_with_evm_factory(
+            provider.chain_spec(),
+            StatefulEvmFactory { observations: observations.clone() },
+        );
+        let eth_api =
+            EthApiBuilder::new(provider, testing_pool(), NoopNetwork::default(), evm_config)
+                .build();
+        let api = DebugApi::new(
+            eth_api,
+            BlockingTaskGuard::new(1),
+            &Runtime::test(),
+            futures::stream::empty::<ConsensusEngineEvent<EthPrimitives>>(),
+        );
+
+        // reset counters so each test only observes its own call
+        observations.take_values();
+        observations.take_evms_created();
+
+        Fixture { api, observations, block_hash, tx_hashes }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_block_sees_block_start_context() {
+        let f = fixture(3);
+
+        let results =
+            f.api.debug_trace_block(f.block_hash.into(), Default::default()).await.unwrap();
+
+        // transaction 0 must have succeeded, otherwise it never overwrote the value
+        assert_eq!(results.len(), 3);
+        for result in &results {
+            let TraceResult::Success { result, .. } = result else { panic!("{result:?}") };
+            let GethTrace::Default(frame) = result else { panic!("{result:?}") };
+            assert!(!frame.failed, "{frame:?}");
+        }
+
+        assert_eq!(f.observations.take_values(), vec![U256::from(BLOCK_START_VALUE); 3]);
+        // one EVM for the pre-execution changes, one for the block's transactions
+        assert_eq!(f.observations.take_evms_created(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_transaction_sees_block_start_context() {
+        let f = fixture(3);
+
+        // target index 2, so the prefix contains the transaction that overwrote the value
+        f.api.debug_trace_transaction(f.tx_hashes[2], Default::default()).await.unwrap();
+
+        assert_eq!(f.observations.take_values(), vec![U256::from(BLOCK_START_VALUE); 3]);
+        assert_eq!(f.observations.take_evms_created(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_block_fuses_inspector_between_transactions() {
+        let f = fixture(3);
+
+        // the 4byte tracer accumulates a selector map, so without fusing between transactions
+        // transaction 0's selector leaks into the later traces
+        let opts = GethDebugTracingOptions::new_tracer(GethDebugBuiltInTracerType::FourByteTracer);
+        let results = f.api.debug_trace_block(f.block_hash.into(), opts).await.unwrap();
+
+        let selectors = |i: usize| {
+            let TraceResult::Success { result, .. } = &results[i] else { panic!() };
+            let GethTrace::FourByteTracer(frame) = result else { panic!("{result:?}") };
+            frame.0.clone()
+        };
+        assert_eq!(selectors(0).len(), 1);
+        assert!(selectors(1).is_empty(), "{:?}", selectors(1));
+        assert!(selectors(2).is_empty(), "{:?}", selectors(2));
+    }
+
+    /// Covers `Trace::spawn_trace_transaction_in_block_with_inspector`, which backs
+    /// `trace_transaction`, `trace_get`, `trace_replayTransaction` and the `ots_*` trace
+    /// endpoints.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_trace_transaction_in_block_sees_block_start_context() {
+        let f = fixture(3);
+
+        f.api
+            .eth_api()
+            .spawn_trace_transaction_in_block(
+                f.tx_hashes[2],
+                TracingInspectorConfig::default_parity(),
+                |_, _, _, _| Ok(()),
+            )
+            .await
+            .unwrap()
+            .expect("transaction should be found");
+
+        assert_eq!(f.observations.take_values(), vec![U256::from(BLOCK_START_VALUE); 3]);
+        assert_eq!(f.observations.take_evms_created(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_debug_trace_call_many_replays_prefix_on_one_evm() {
+        // a prefix shorter than the block, so the replay is not skipped in favour of the
+        // committed post-block state
+        let f = fixture(4);
+
+        let bundles = vec![Bundle { transactions: vec![Default::default()], block_override: None }];
+        let context = StateContext {
+            block_number: Some(f.block_hash.into()),
+            transaction_index: Some(alloy_rpc_types_eth::TransactionIndex::Index(3)),
+        };
+        f.api.debug_trace_call_many(bundles, Some(context), None).await.unwrap();
+
+        // one EVM for the pre-execution changes, one for the three prefix transactions, one for
+        // the bundle's call
+        assert_eq!(f.observations.take_evms_created(), 3);
+
+        // the simulated call runs on a fresh EVM and re-loads the value from mid-block state,
+        // see `debug_trace_call_many`
+        assert_eq!(
+            f.observations.take_values(),
+            vec![
+                U256::from(BLOCK_START_VALUE),
+                U256::from(BLOCK_START_VALUE),
+                U256::from(BLOCK_START_VALUE),
+                U256::from(WRITTEN_VALUE),
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_intermediate_roots_sees_block_start_context() {
+        let f = fixture(3);
+
+        f.api.intermediate_roots(f.block_hash).await.unwrap();
+
+        assert_eq!(f.observations.take_values(), vec![U256::from(BLOCK_START_VALUE); 3]);
+        assert_eq!(f.observations.take_evms_created(), 2);
+    }
+}

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -93,6 +93,8 @@ pub struct MockEthProvider<T: NodePrimitives = EthPrimitives, ChainSpec = reth_c
     snap_account_proof: Arc<Mutex<Option<Vec<Bytes>>>>,
     /// Storage proof returned to snap handler tests.
     snap_storage_proof: Arc<Mutex<Option<Vec<Bytes>>>>,
+    /// Whether recovered block lookups resolve against the local block store.
+    recover_block_senders: Arc<AtomicBool>,
     tx: TxMock,
     prune_modes: Arc<PruneModes>,
 }
@@ -135,6 +137,7 @@ where
             snap_storage_range_requests: self.snap_storage_range_requests.clone(),
             snap_account_proof: self.snap_account_proof.clone(),
             snap_storage_proof: self.snap_storage_proof.clone(),
+            recover_block_senders: self.recover_block_senders.clone(),
             tx: self.tx.clone(),
             prune_modes: self.prune_modes.clone(),
         }
@@ -162,6 +165,7 @@ impl<T: NodePrimitives> MockEthProvider<T, reth_chainspec::ChainSpec> {
             snap_storage_range_requests: Default::default(),
             snap_account_proof: Default::default(),
             snap_storage_proof: Default::default(),
+            recover_block_senders: Default::default(),
             tx: Default::default(),
             prune_modes: Default::default(),
         }
@@ -169,6 +173,16 @@ impl<T: NodePrimitives> MockEthProvider<T, reth_chainspec::ChainSpec> {
 }
 
 impl<T: NodePrimitives, ChainSpec> MockEthProvider<T, ChainSpec> {
+    /// Serves [`BlockReader::recovered_block`] and [`BlockReader::sealed_block_with_senders`]
+    /// from the local block store by recovering signers, instead of always reporting a miss.
+    ///
+    /// Off by default so that existing consumers keep their behavior. Like the rest of this
+    /// mock's state, the flag is shared with all clones, including ones taken before this call.
+    pub fn with_recovered_blocks(self) -> Self {
+        self.recover_block_senders.store(true, Ordering::Relaxed);
+        self
+    }
+
     /// Makes snap state reads return provider errors when `fail` is true.
     pub fn set_snap_state_reads_fail(&self, fail: bool) {
         self.snap_state_reads_fail.store(fail, Ordering::Relaxed);
@@ -321,6 +335,7 @@ impl<T: NodePrimitives, ChainSpec> MockEthProvider<T, ChainSpec> {
             snap_storage_range_requests: self.snap_storage_range_requests,
             snap_account_proof: self.snap_account_proof,
             snap_storage_proof: self.snap_storage_proof,
+            recover_block_senders: self.recover_block_senders,
             tx: self.tx,
             prune_modes: self.prune_modes,
         }
@@ -881,18 +896,27 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> BlockRe
 
     fn recovered_block(
         &self,
-        _id: BlockHashOrNumber,
+        id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        Ok(None)
+        if !self.recover_block_senders.load(Ordering::Relaxed) {
+            return Ok(None)
+        }
+        let Some(block) = self.block(id)? else { return Ok(None) };
+        let senders = block.body().recover_signers()?;
+        Ok(Some(match id {
+            // tests often insert blocks under a synthetic hash, so keep the lookup key
+            BlockHashOrNumber::Hash(hash) => RecoveredBlock::new(block, senders, hash),
+            BlockHashOrNumber::Number(_) => RecoveredBlock::new_unhashed(block, senders),
+        }))
     }
 
     fn sealed_block_with_senders(
         &self,
-        _id: BlockHashOrNumber,
-        _transaction_kind: TransactionVariant,
+        id: BlockHashOrNumber,
+        transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        Ok(None)
+        self.recovered_block(id, transaction_kind)
     }
 
     fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
@@ -1290,9 +1314,108 @@ impl<T: NodePrimitives, ChainSpec: Send + Sync> NodePrimitivesProvider
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::Header;
-    use alloy_primitives::BlockHash;
-    use reth_ethereum_primitives::Receipt;
+    use alloy_consensus::{Header, TxLegacy};
+    use alloy_primitives::{BlockHash, Signature, TxKind};
+    use reth_ethereum_primitives::{Receipt, Transaction, TransactionSigned};
+
+    /// Builds a one-transaction block at the given number, signed so senders can be recovered.
+    fn block_with_signed_tx(number: u64) -> reth_ethereum_primitives::Block {
+        let tx = TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                gas_limit: 21_000,
+                to: TxKind::Call(Address::ZERO),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        );
+        reth_ethereum_primitives::Block {
+            header: Header { number, ..Default::default() },
+            body: alloy_consensus::BlockBody { transactions: vec![tx], ..Default::default() },
+        }
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_opt_in() {
+        let provider = MockEthProvider::<EthPrimitives>::new();
+        let hash = BlockHash::random();
+        provider.add_block(hash, block_with_signed_tx(1));
+
+        assert!(provider.block(hash.into()).unwrap().is_some());
+        assert!(provider
+            .recovered_block(hash.into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .sealed_block_with_senders(hash.into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_by_hash() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        // deliberately not the header's own hash: the lookup key must be preserved
+        let synthetic_hash = BlockHash::random();
+        let block = block_with_signed_tx(1);
+        assert_ne!(synthetic_hash, block.header.hash_slow());
+        provider.add_block(synthetic_hash, block);
+
+        let recovered =
+            provider.recovered_block(synthetic_hash.into(), TransactionVariant::WithHash).unwrap();
+        let recovered = recovered.expect("block should resolve");
+        assert_eq!(recovered.hash(), synthetic_hash);
+        assert_eq!(recovered.senders().len(), 1);
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_by_number() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        let synthetic_hash = BlockHash::random();
+        let block = block_with_signed_tx(7);
+        let computed_hash = block.header.hash_slow();
+        provider.add_block(synthetic_hash, block);
+
+        let recovered =
+            provider.recovered_block(7u64.into(), TransactionVariant::WithHash).unwrap();
+        let recovered = recovered.expect("block should resolve");
+        // no lookup key to preserve, so the hash comes from the header
+        assert_eq!(recovered.hash(), computed_hash);
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_missing() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        provider.add_block(BlockHash::random(), block_with_signed_tx(1));
+
+        assert!(provider
+            .recovered_block(BlockHash::random().into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .recovered_block(99u64.into(), TransactionVariant::WithHash)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_mock_provider_recovered_block_recovery_failure() {
+        let provider = MockEthProvider::<EthPrimitives>::new().with_recovered_blocks();
+        let hash = BlockHash::random();
+        // r = s = 0 is not a recoverable signature
+        let tx = TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy { gas_limit: 21_000, ..Default::default() }),
+            Signature::new(U256::ZERO, U256::ZERO, false),
+        );
+        provider.add_block(
+            hash,
+            reth_ethereum_primitives::Block {
+                header: Header { number: 1, ..Default::default() },
+                body: alloy_consensus::BlockBody { transactions: vec![tx], ..Default::default() },
+            },
+        );
+
+        assert!(provider.recovered_block(hash.into(), TransactionVariant::WithHash).is_err());
+    }
 
     #[test]
     fn test_mock_provider_receipts() {


### PR DESCRIPTION
Closes #17045.

The debug replay endpoints (`debug_traceBlock`, `debug_traceTransaction`, the `debug_traceCallMany` prefix, `debug_intermediateRoots`) and `Trace::spawn_trace_transaction_in_block_with_inspector`, which backs `trace_transaction`, `trace_get`, `trace_replayTransaction` and the `ots_*` trace endpoints, built a fresh EVM for every replayed transaction. Besides the redundant constructions, this is incorrect for downstream EVMs that carry lazily initialized block-scoped state, such as Celo's fee-currency context or OP's `L1BlockInfo`: every new EVM re-initializes that state from mid-block state. The prefix and the target now run on a single EVM with the inspector disabled during the prefix, matching how the block executor and the `trace_block*` path already behave.

Call simulations (`debug_traceCall`, `trace_call`, `trace_callMany` and the bundle calls of `debug_traceCallMany`) intentionally keep one EVM per call: `prepare_call_env` produces a per-call env and an EVM's env cannot be replaced. Those sites are documented accordingly.

Stock Ethereum has no block-scoped EVM state, so the regression tests use a test EVM factory whose EVMs cache a storage value per block on first use. With the fix reverted, `debug_traceBlock` observes `[1, 2, 2]` where `[1, 1, 1]` is expected. `MockEthProvider` gains opt-in recovered block lookups to back these tests.

This is an alternative to #26523 by @palango with the same approach and functionality; the commits carry co-authorship credit.
