### PR TITLE
feat(engine): build payloads on canonical ancestors above finality

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
@@ -55,8 +55,6 @@ pub struct SendForkchoiceUpdate<Engine> {
     pub head: BlockReference,
     /// Expected payload status (None means accept any non-error)
     pub expected_status: Option<PayloadStatusEnum>,
-    /// Expected RPC error code (the FCU must fail with this error)
-    pub expected_error_code: Option<i32>,
     /// Node index to send to (None means active node)
     pub node_idx: Option<usize>,
     /// Tracks engine type
@@ -70,26 +68,12 @@ impl<Engine> SendForkchoiceUpdate<Engine> {
         safe: BlockReference,
         head: BlockReference,
     ) -> Self {
-        Self {
-            finalized,
-            safe,
-            head,
-            expected_status: None,
-            expected_error_code: None,
-            node_idx: None,
-            _phantom: PhantomData,
-        }
+        Self { finalized, safe, head, expected_status: None, node_idx: None, _phantom: PhantomData }
     }
 
     /// Set expected status for the FCU response
     pub fn with_expected_status(mut self, status: PayloadStatusEnum) -> Self {
         self.expected_status = Some(status);
-        self
-    }
-
-    /// Expect the FCU to fail with the given RPC error code
-    pub const fn with_expected_error(mut self, code: i32) -> Self {
-        self.expected_error_code = Some(code);
         self
     }
 
@@ -126,26 +110,9 @@ where
             }
 
             let engine = env.node_clients[node_idx].engine.http_client();
-            let fcu_result =
+            let fcu_response =
                 EngineApiClient::<Engine>::fork_choice_updated_v3(&engine, fork_choice_state, None)
-                    .await;
-
-            if let Some(expected_code) = self.expected_error_code {
-                return match fcu_result {
-                    Err(jsonrpsee::core::client::Error::Call(err)) if err.code() == expected_code => {
-                        debug!("Node {node_idx}: FCU failed with error {expected_code} as expected");
-                        Ok(())
-                    }
-                    Err(err) => Err(eyre::eyre!(
-                        "Node {node_idx}: expected FCU to fail with error code {expected_code}, got {err:?}"
-                    )),
-                    Ok(response) => Err(eyre::eyre!(
-                        "Node {node_idx}: expected FCU to fail with error code {expected_code}, got response {response:?}"
-                    )),
-                };
-            }
-
-            let fcu_response = fcu_result?;
+                    .await?;
 
             debug!(
                 "Node {node_idx}: FCU response - status: {:?}, latest_valid_hash: {:?}",

--- a/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/custom_fcu.rs
@@ -55,6 +55,8 @@ pub struct SendForkchoiceUpdate<Engine> {
     pub head: BlockReference,
     /// Expected payload status (None means accept any non-error)
     pub expected_status: Option<PayloadStatusEnum>,
+    /// Expected RPC error code (the FCU must fail with this error)
+    pub expected_error_code: Option<i32>,
     /// Node index to send to (None means active node)
     pub node_idx: Option<usize>,
     /// Tracks engine type
@@ -68,12 +70,26 @@ impl<Engine> SendForkchoiceUpdate<Engine> {
         safe: BlockReference,
         head: BlockReference,
     ) -> Self {
-        Self { finalized, safe, head, expected_status: None, node_idx: None, _phantom: PhantomData }
+        Self {
+            finalized,
+            safe,
+            head,
+            expected_status: None,
+            expected_error_code: None,
+            node_idx: None,
+            _phantom: PhantomData,
+        }
     }
 
     /// Set expected status for the FCU response
     pub fn with_expected_status(mut self, status: PayloadStatusEnum) -> Self {
         self.expected_status = Some(status);
+        self
+    }
+
+    /// Expect the FCU to fail with the given RPC error code
+    pub const fn with_expected_error(mut self, code: i32) -> Self {
+        self.expected_error_code = Some(code);
         self
     }
 
@@ -110,9 +126,26 @@ where
             }
 
             let engine = env.node_clients[node_idx].engine.http_client();
-            let fcu_response =
+            let fcu_result =
                 EngineApiClient::<Engine>::fork_choice_updated_v3(&engine, fork_choice_state, None)
-                    .await?;
+                    .await;
+
+            if let Some(expected_code) = self.expected_error_code {
+                return match fcu_result {
+                    Err(jsonrpsee::core::client::Error::Call(err)) if err.code() == expected_code => {
+                        debug!("Node {node_idx}: FCU failed with error {expected_code} as expected");
+                        Ok(())
+                    }
+                    Err(err) => Err(eyre::eyre!(
+                        "Node {node_idx}: expected FCU to fail with error code {expected_code}, got {err:?}"
+                    )),
+                    Ok(response) => Err(eyre::eyre!(
+                        "Node {node_idx}: expected FCU to fail with error code {expected_code}, got response {response:?}"
+                    )),
+                };
+            }
+
+            let fcu_response = fcu_result?;
 
             debug!(
                 "Node {node_idx}: FCU response - status: {:?}, latest_valid_hash: {:?}",

--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -1,6 +1,7 @@
 //! Actions that can be performed in tests.
 
 use crate::testsuite::Environment;
+use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatusEnum};
 use eyre::Result;
 use futures_util::future::BoxFuture;

--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -145,7 +145,10 @@ where
                 let fork_choice_state = ForkchoiceState {
                     head_block_hash: latest_block.hash,
                     safe_block_hash: latest_block.hash,
-                    finalized_block_hash: latest_block.hash,
+                    // Making a block canonical does not imply finality: tests advance the
+                    // finalized block explicitly via `FinalizeBlock`, and a finalized tip would
+                    // reject any later forkchoice update below it as a too deep reorg.
+                    finalized_block_hash: B256::ZERO,
                 };
 
                 let active_idx = env.active_node_idx;

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -402,7 +402,10 @@ where
             let fork_choice_state = ForkchoiceState {
                 head_block_hash: head_hash,
                 safe_block_hash: head_hash,
-                finalized_block_hash: head_hash,
+                // Making a block canonical does not imply finality: tests advance the finalized
+                // block explicitly via `FinalizeBlock`, and a finalized tip would reject any
+                // later forkchoice update below it as a too deep reorg.
+                finalized_block_hash: B256::ZERO,
             };
             debug!(
                 "Broadcasting forkchoice update to {} clients. Head: {:?}",

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -83,6 +83,15 @@ impl OnForkChoiceUpdated {
         }
     }
 
+    /// Creates a new instance of `OnForkChoiceUpdated` if the forkchoice update failed because the
+    /// requested reorg to the head block exceeds the supported reorg depth.
+    pub fn too_deep_reorg() -> Self {
+        Self {
+            forkchoice_status: ForkchoiceStatus::Invalid,
+            fut: Either::Left(futures::future::ready(Err(ForkchoiceUpdateError::TooDeepReorg))),
+        }
+    }
+
     /// Creates a new instance of `OnForkChoiceUpdated` if the forkchoice update was successful but
     /// payload attributes were invalid.
     pub fn invalid_payload_attributes() -> Self {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1310,34 +1310,46 @@ where
 
             // For OpStack, or if explicitly configured, the proposers are allowed to reorg their
             // own chain at will, so we need to always trigger a new payload job if requested.
-            if self.engine_kind.is_opstack() ||
-                self.config.always_process_payload_attributes_on_canonical_head()
-            {
-                // We need to effectively unwind the _canonical_ chain to the FCU's head, which is
-                // part of the canonical chain. We need to update the latest block state to reflect
-                // the canonical ancestor. This ensures that state providers and the transaction
-                // pool operate with the correct chain state after forkchoice update processing, and
-                // new payloads built on the reorg'd head will be added to the tree immediately.
-                if self.config.unwind_canonical_header() {
-                    self.update_latest_block_to_canonical_ancestor(&canonical_header)?;
-                }
+            let always_trigger_payload_job = self.engine_kind.is_opstack() ||
+                self.config.always_process_payload_attributes_on_canonical_head();
 
-                if let Some(attr) = attrs {
-                    debug!(target: "engine::tree", head = canonical_header.number(), "handling payload attributes for canonical head");
-                    // Clone only when we actually need to process the attributes
-                    let updated =
-                        self.process_payload_attributes(attr.clone(), &canonical_header, state);
-                    return Ok(Some(TreeOutcome::new(updated)));
-                }
+            // A canonical ancestor below the latest known finalized block can never become the
+            // head again, because this would reorg out the finalized block. Such a forkchoice
+            // update exceeds the supported reorg depth and is rejected regardless of the payload
+            // attributes:
+            // <https://github.com/ethereum/execution-apis/blob/bf20b4083284e677db19e7f3871bd669b88354a6/src/engine/paris.md?plain=1#L221>
+            //
+            // The stored finalized block is used because a forkchoice update MAY carry a zero
+            // finalized hash without clearing previously established finality.
+            if !always_trigger_payload_job &&
+                self.canonical_in_memory_state
+                    .get_finalized_num_hash()
+                    .is_some_and(|finalized| canonical_header.number() < finalized.number)
+            {
+                debug!(target: "engine::tree", head = canonical_header.number(), "rejecting canonical ancestor fcu below the finalized block");
+                return Ok(Some(TreeOutcome::new(OnForkChoiceUpdated::too_deep_reorg())));
             }
 
-            // According to the Engine API specification, client software MAY skip an update of the
-            // forkchoice state and MUST NOT begin a payload build process if
-            // `forkchoiceState.headBlockHash` references a `VALID` ancestor of the head
-            // of canonical chain, i.e. the ancestor passed payload validation process
-            // and deemed `VALID`. In the case of such an event, client software MUST
-            // return `{payloadStatus: {status: VALID, latestValidHash:
-            // forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`
+            // We need to effectively unwind the _canonical_ chain to the FCU's head, which is
+            // part of the canonical chain. We need to update the latest block state to reflect
+            // the canonical ancestor. This ensures that state providers and the transaction
+            // pool operate with the correct chain state after forkchoice update processing, and
+            // new payloads built on the reorg'd head will be added to the tree immediately.
+            if always_trigger_payload_job && self.config.unwind_canonical_header() {
+                self.update_latest_block_to_canonical_ancestor(&canonical_header)?;
+            }
+
+            // A canonical ancestor at or above the latest known finalized block can become the
+            // parent of the next block, e.g. when the CL wants to reorg out the current head.
+            // The canonical chain remains untouched here; the block built on the ancestor
+            // triggers the actual reorg once it is inserted via newPayload and FCU'd.
+            if let Some(attr) = attrs {
+                debug!(target: "engine::tree", head = canonical_header.number(), "handling payload attributes for canonical head");
+                // Clone only when we actually need to process the attributes
+                let updated =
+                    self.process_payload_attributes(attr.clone(), &canonical_header, state);
+                return Ok(Some(TreeOutcome::new(updated)));
+            }
 
             // The head block is already canonical and we're not processing payload attributes,
             // so we're not triggering a payload job and can return right away

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -17,6 +17,7 @@ use alloy_primitives::{
 use alloy_rlp::Decodable;
 use alloy_rpc_types_engine::{
     ExecutionData, ExecutionPayloadSidecar, ExecutionPayloadV1, ForkchoiceState,
+    ForkchoiceUpdateError,
 };
 use assert_matches::assert_matches;
 use reth_chain_state::{test_utils::TestBlockBuilder, BlockState};
@@ -1428,6 +1429,137 @@ async fn test_fcu_with_canonical_ancestor_updates_latest_block() {
         test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
         ancestor_block.hash(),
         "In-memory state: Latest block hash should be updated to canonical ancestor"
+    );
+}
+
+#[tokio::test]
+async fn test_fcu_with_canonical_ancestor_below_finalized_is_rejected() {
+    reth_tracing::init_test_tracing();
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+
+    let current_head = blocks[3].recovered_block();
+    let finalized = blocks[2].recovered_block();
+    let ancestor = blocks[1].recovered_block();
+    test_harness.tree.canonical_in_memory_state.set_finalized(finalized.clone_sealed_header());
+
+    // An FCU to an ancestor below the latest known finalized block would reorg out the
+    // finalized block and is rejected, with or without payload attributes.
+    let payload_attributes = EthPayloadAttributes {
+        timestamp: ancestor.timestamp() + 1,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Default::default(),
+        withdrawals: None,
+        parent_beacon_block_root: None,
+        slot_number: None,
+        target_gas_limit: None,
+    };
+    for attrs in [Some(payload_attributes), None] {
+        let err = test_harness
+            .tree
+            .on_forkchoice_updated(
+                ForkchoiceState {
+                    head_block_hash: ancestor.hash(),
+                    safe_block_hash: B256::ZERO,
+                    finalized_block_hash: B256::ZERO,
+                },
+                attrs,
+            )
+            .unwrap()
+            .outcome
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, ForkchoiceUpdateError::TooDeepReorg);
+    }
+
+    // no payload build is started and the canonical head remains untouched
+    assert!(test_harness.payload_command_rx.try_recv().is_err());
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), current_head.hash());
+
+    // the finalized block itself is not below finality and can become the parent of the next
+    // block
+    let payload_attributes = EthPayloadAttributes {
+        timestamp: finalized.timestamp() + 1,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Default::default(),
+        withdrawals: None,
+        parent_beacon_block_root: None,
+        slot_number: None,
+        target_gas_limit: None,
+    };
+    let outcome = test_harness
+        .tree
+        .on_forkchoice_updated(
+            ForkchoiceState {
+                head_block_hash: finalized.hash(),
+                safe_block_hash: B256::ZERO,
+                finalized_block_hash: B256::ZERO,
+            },
+            Some(payload_attributes),
+        )
+        .unwrap();
+
+    assert_eq!(outcome.outcome.forkchoice_status(), ForkchoiceStatus::Valid);
+    let command = test_harness.payload_command_rx.try_recv().unwrap();
+    let PayloadServiceCommand::BuildNewPayload(input, _, _) = command else {
+        panic!("expected build new payload command")
+    };
+    assert_eq!(input.parent_hash, finalized.hash());
+}
+
+#[tokio::test]
+async fn test_fcu_with_canonical_ancestor_above_finalized_starts_payload_build() {
+    reth_tracing::init_test_tracing();
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..5).collect();
+    test_harness = test_harness.with_blocks(blocks.clone());
+
+    let current_head = blocks[3].recovered_block();
+    let finalized = blocks[0].recovered_block();
+    let ancestor = blocks[2].recovered_block();
+    test_harness.tree.canonical_in_memory_state.set_finalized(finalized.clone_sealed_header());
+
+    let payload_attributes = EthPayloadAttributes {
+        timestamp: ancestor.timestamp() + 1,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Default::default(),
+        withdrawals: None,
+        parent_beacon_block_root: None,
+        slot_number: None,
+        target_gas_limit: None,
+    };
+    let outcome = test_harness
+        .tree
+        .on_forkchoice_updated(
+            ForkchoiceState {
+                head_block_hash: ancestor.hash(),
+                safe_block_hash: B256::ZERO,
+                finalized_block_hash: B256::ZERO,
+            },
+            Some(payload_attributes),
+        )
+        .unwrap();
+
+    assert_eq!(outcome.outcome.forkchoice_status(), ForkchoiceStatus::Valid);
+
+    // a payload build is started on top of the ancestor
+    let command = test_harness.payload_command_rx.try_recv().unwrap();
+    let PayloadServiceCommand::BuildNewPayload(input, _, _) = command else {
+        panic!("expected build new payload command")
+    };
+    assert_eq!(input.parent_hash, ancestor.hash());
+
+    // the canonical chain remains untouched, only the built block reorgs it eventually
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), current_head.hash());
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
+        current_head.hash()
     );
 }
 

--- a/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
@@ -1,7 +1,5 @@
 //! E2E tests for forkchoice updates to canonical ancestors around the finalized block.
 
-use alloy_primitives::B256;
-use alloy_rpc_types_engine::TOO_DEEP_REORG_ERROR;
 use eyre::Result;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::testsuite::{
@@ -36,9 +34,8 @@ fn default_engine_tree_setup() -> Setup<EthEngineTypes> {
         .with_tree_config(TreeConfig::default().with_has_enough_parallelism(true))
 }
 
-/// Verifies that an FCU to a canonical ancestor below the latest known finalized block is
-/// rejected with `-38006: Too deep reorg`, while an FCU to an ancestor above finality can start
-/// a payload build on top of the ancestor whose block eventually reorgs out the current head.
+/// Verifies that an FCU to a canonical ancestor above finality can start a payload build on top
+/// of the ancestor whose block eventually reorgs out the current head.
 #[tokio::test]
 async fn test_fcu_to_canonical_ancestor_around_finalized() -> Result<()> {
     reth_tracing::init_test_tracing();
@@ -46,9 +43,7 @@ async fn test_fcu_to_canonical_ancestor_around_finalized() -> Result<()> {
     let test = TestBuilder::new()
         .with_setup(default_engine_tree_setup())
         // Build and tag canonical ancestors on the way to block 10.
-        .with_action(ProduceBlocks::<EthEngineTypes>::new(5))
-        .with_action(CaptureBlock::new("block_5"))
-        .with_action(ProduceBlocks::<EthEngineTypes>::new(2))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(7))
         .with_action(CaptureBlock::new("block_7"))
         .with_action(ProduceBlocks::<EthEngineTypes>::new(1))
         .with_action(CaptureBlock::new("block_8"))
@@ -60,19 +55,6 @@ async fn test_fcu_to_canonical_ancestor_around_finalized() -> Result<()> {
             FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("block_7".to_string()))
                 .with_head(BlockReference::Tag("block_10".to_string())),
         )
-        // A reorg to block 5 below the latest known finalized block would reorg out the
-        // finalized block and is rejected. The stored finalized block is used, even when the
-        // FCU carries zero hashes.
-        .with_action(
-            SendForkchoiceUpdate::<EthEngineTypes>::new(
-                BlockReference::Hash(B256::ZERO),
-                BlockReference::Hash(B256::ZERO),
-                BlockReference::Tag("block_5".to_string()),
-            )
-            .with_expected_error(TOO_DEEP_REORG_ERROR),
-        )
-        .with_action(UpdateBlockInfo::default())
-        .with_action(AssertChainTip::new(10))
         // Block 8 is above finality: without payload attributes the FCU is acknowledged, but the
         // canonical head does not move.
         .with_action(

--- a/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/fcu_finalized_blocks.rs
@@ -1,13 +1,13 @@
-//! E2E test for forkchoice update with finalized blocks.
-//!
-//! This test verifies the behavior when attempting to reorg behind a finalized block.
+//! E2E tests for forkchoice updates to canonical ancestors around the finalized block.
 
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::TOO_DEEP_REORG_ERROR;
 use eyre::Result;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::testsuite::{
     actions::{
-        BlockReference, CaptureBlock, CreateFork, FinalizeBlock, MakeCanonical, ProduceBlocks,
-        SendForkchoiceUpdate,
+        AssertChainTip, BlockReference, CaptureBlock, CreateFork, FinalizeBlock, MakeCanonical,
+        ProduceBlocks, SendForkchoiceUpdate, UpdateBlockInfo,
     },
     setup::{NetworkSetup, Setup},
     TestBuilder,
@@ -36,40 +36,61 @@ fn default_engine_tree_setup() -> Setup<EthEngineTypes> {
         .with_tree_config(TreeConfig::default().with_has_enough_parallelism(true))
 }
 
-/// This test:
-/// 1. Creates a main chain and finalizes a block
-/// 2. Creates a fork that branches BEFORE the finalized block
-/// 3. Attempts to switch to that fork (which would require changing history behind finalized)
+/// Verifies that an FCU to a canonical ancestor below the latest known finalized block is
+/// rejected with `-38006: Too deep reorg`, while an FCU to an ancestor above finality can start
+/// a payload build on top of the ancestor whose block eventually reorgs out the current head.
 #[tokio::test]
-async fn test_reorg_to_fork_behind_finalized() -> Result<()> {
+async fn test_fcu_to_canonical_ancestor_around_finalized() -> Result<()> {
     reth_tracing::init_test_tracing();
 
     let test = TestBuilder::new()
         .with_setup(default_engine_tree_setup())
-        // Build main chain: blocks 1-10
-        .with_action(ProduceBlocks::<EthEngineTypes>::new(10))
+        // Build and tag canonical ancestors on the way to block 10.
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(5))
+        .with_action(CaptureBlock::new("block_5"))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(2))
+        .with_action(CaptureBlock::new("block_7"))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(1))
+        .with_action(CaptureBlock::new("block_8"))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(2))
+        .with_action(CaptureBlock::new("block_10"))
         .with_action(MakeCanonical::new())
-        // Capture blocks for the test
-        .with_action(CaptureBlock::new("block_5")) // Will be fork point
-        .with_action(CaptureBlock::new("block_7")) // Will be finalized
-        .with_action(CaptureBlock::new("block_10")) // Current head
-        // Create a fork from block 5 (before block 7 which will be finalized)
-        .with_action(CreateFork::<EthEngineTypes>::new(5, 5)) // Fork from block 5, add 5 blocks
-        .with_action(CaptureBlock::new("fork_tip"))
-        // Step 1: Finalize block 7 with head at block 10
+        // Establish block 7 as the latest known finalized block.
         .with_action(
             FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("block_7".to_string()))
                 .with_head(BlockReference::Tag("block_10".to_string())),
         )
-        // Step 2: Attempt to reorg to a fork that doesn't contain the finalized block
+        // A reorg to block 5 below the latest known finalized block would reorg out the
+        // finalized block and is rejected. The stored finalized block is used, even when the
+        // FCU carries zero hashes.
         .with_action(
             SendForkchoiceUpdate::<EthEngineTypes>::new(
-                BlockReference::Tag("block_7".to_string()), // Keep finalized
-                BlockReference::Tag("fork_tip".to_string()), // New safe
-                BlockReference::Tag("fork_tip".to_string()), // New head
+                BlockReference::Hash(B256::ZERO),
+                BlockReference::Hash(B256::ZERO),
+                BlockReference::Tag("block_5".to_string()),
+            )
+            .with_expected_error(TOO_DEEP_REORG_ERROR),
+        )
+        .with_action(UpdateBlockInfo::default())
+        .with_action(AssertChainTip::new(10))
+        // Block 8 is above finality: without payload attributes the FCU is acknowledged, but the
+        // canonical head does not move.
+        .with_action(
+            SendForkchoiceUpdate::<EthEngineTypes>::new(
+                BlockReference::Tag("block_7".to_string()),
+                BlockReference::Tag("block_7".to_string()),
+                BlockReference::Tag("block_8".to_string()),
             )
             .with_expected_status(alloy_rpc_types_engine::PayloadStatusEnum::Valid),
-        );
+        )
+        .with_action(UpdateBlockInfo::default())
+        .with_action(AssertChainTip::new(10))
+        // With payload attributes, an FCU to block 8 starts a payload build on top of it:
+        // `CreateFork` drives the full fcu(attrs) -> getPayload -> newPayload flow. Making the
+        // built block canonical reorgs out the previous blocks 9 and 10.
+        .with_action(CreateFork::<EthEngineTypes>::new_from_tag("block_8", 1))
+        .with_action(MakeCanonical::new())
+        .with_action(AssertChainTip::new(9));
 
     test.run::<EthereumNode>().await?;
 

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -1,7 +1,8 @@
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::{
     ForkchoiceUpdateError, INVALID_FORK_CHOICE_STATE_ERROR, INVALID_FORK_CHOICE_STATE_ERROR_MSG,
-    INVALID_PAYLOAD_ATTRIBUTES_ERROR, INVALID_PAYLOAD_ATTRIBUTES_ERROR_MSG,
+    INVALID_PAYLOAD_ATTRIBUTES_ERROR, INVALID_PAYLOAD_ATTRIBUTES_ERROR_MSG, TOO_DEEP_REORG_ERROR,
+    TOO_DEEP_REORG_ERROR_MSG,
 };
 use jsonrpsee_types::error::{
     INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE, INVALID_PARAMS_MSG, SERVER_ERROR_MSG,
@@ -195,6 +196,13 @@ impl From<EngineApiError> for jsonrpsee_types::error::ErrorObject<'static> {
                             None::<()>,
                         )
                     }
+                    ForkchoiceUpdateError::TooDeepReorg => {
+                        jsonrpsee_types::error::ErrorObject::owned(
+                            TOO_DEEP_REORG_ERROR,
+                            TOO_DEEP_REORG_ERROR_MSG,
+                            None::<()>,
+                        )
+                    }
                     // Map future alloy forkchoice errors as internal until handled.
                     #[allow(unreachable_patterns, clippy::needless_return)]
                     _ => {
@@ -276,6 +284,14 @@ mod tests {
             "Invalid payload attributes",
             EngineApiError::ForkChoiceUpdate(BeaconForkChoiceUpdateError::ForkchoiceUpdateError(
                 ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes,
+            )),
+        );
+
+        ensure_engine_rpc_error(
+            -38006,
+            "Too deep reorg",
+            EngineApiError::ForkChoiceUpdate(BeaconForkChoiceUpdateError::ForkchoiceUpdateError(
+                ForkchoiceUpdateError::TooDeepReorg,
             )),
         );
 


### PR DESCRIPTION
Implements https://github.com/ethereum/execution-apis/pull/786, superseding #23784.

Forkchoice updates to a canonical ancestor are no longer unconditionally acknowledged as a VALID no-op: an FCU to an ancestor below the latest known finalized block would reorg out the finalized block and is rejected with `-38006: Too deep reorg`, regardless of payload attributes. For ancestors at or above finality, payload attributes are now processed so the CL can build a new block on top of the ancestor, e.g. to reorg out the current head. The canonical chain itself is not rewound: the built payload triggers the actual reorg through the regular newPayload + FCU flow once the CL delivers it.

The `-38006` error is now also mapped to its engine error code instead of the internal-error fallback.