### PR TITLE
fix(rpc): stop cancelled payload body hash requests

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -786,6 +786,10 @@ where
         self.inner.task_spawner.spawn_blocking_task(async move {
             let mut result = Vec::with_capacity(hashes.len());
             for hash in hashes {
+                if tx.is_closed() {
+                    return;
+                }
+
                 let block_result = inner.provider.block(BlockHashOrNumber::Hash(hash));
                 match block_result {
                     Ok(block) => {
@@ -816,6 +820,10 @@ where
         let bal_store = self.inner.provider.bal_store().clone();
 
         self.inner.task_spawner.spawn_blocking_task(async move {
+            if tx.is_closed() {
+                return;
+            }
+
             tx.send(
                 bal_store
                     .get_by_hashes(&hashes)


### PR DESCRIPTION
Follow-up to #26546: apply the same early-exit for cancelled requests to get_payload_bodies_by_hash_with and get_block_access_lists_by_hashes, which kept running after the client disconnected.