### PR TITLE
feat(provider): return header with transaction metadata

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -7,7 +7,7 @@ use crate::{
     BlockReader, BlockReaderIdExt, BlockSource, CanonChainTracker, CanonStateNotifications,
     CanonStateSubscriptions, ChainSpecProvider, ChainStateBlockReader, ChangeSetReader,
     DatabaseProviderFactory, HashedPostStateProvider, HeaderProvider, ProviderError,
-    ProviderFactory, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
+    ProviderFactory, ProviderHeader, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
     RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateProviderFactory,
     StateReader, StaticFileProviderFactory, TransactionVariant, TransactionsProvider,
 };
@@ -605,6 +605,15 @@ impl<N: ProviderNodeTypes> TransactionsProvider for BlockchainProvider<N> {
         self.consistent_provider()?.transaction_by_hash_with_meta(tx_hash)
     }
 
+    fn transaction_by_hash_with_meta_and_header(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<
+        Option<(Self::Transaction, TransactionMeta, SealedHeader<ProviderHeader<Self>>)>,
+    > {
+        self.consistent_provider()?.transaction_by_hash_with_meta_and_header(tx_hash)
+    }
+
     fn transactions_by_block(
         &self,
         id: BlockHashOrNumber,
@@ -1017,7 +1026,7 @@ mod tests {
         },
         BlockWriter, CanonChainTracker, ProviderFactory, SaveBlocksInput,
     };
-    use alloy_consensus::constants::EMPTY_ROOT_HASH;
+    use alloy_consensus::{constants::EMPTY_ROOT_HASH, transaction::TransactionMeta, BlockHeader};
     use alloy_eips::{BlockHashOrNumber, BlockNumHash, BlockNumberOrTag};
     use alloy_primitives::{keccak256, Address, BlockNumber, TxNumber, B256, U256};
     use itertools::Itertools;
@@ -2682,6 +2691,27 @@ mod tests {
                 |block: &SealedBlock<Block>, _: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
                     tx_hash,
                     Some(block.body().transactions[test_tx_index].clone())
+                ),
+                B256::random()
+            ),
+            (
+                ONE,
+                transaction_by_hash_with_meta_and_header,
+                |block: &SealedBlock<Block>, _: TxNumber, tx_hash: B256, _: &Vec<Vec<Receipt>>| (
+                    tx_hash,
+                    Some((
+                        block.body().transactions[test_tx_index].clone(),
+                        TransactionMeta {
+                            tx_hash,
+                            index: test_tx_index as u64,
+                            block_hash: block.hash(),
+                            block_number: block.number,
+                            base_fee: block.base_fee_per_gas(),
+                            excess_blob_gas: block.excess_blob_gas(),
+                            timestamp: block.timestamp(),
+                        },
+                        block.clone_sealed_header(),
+                    ))
                 ),
                 B256::random()
             ),

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -3,7 +3,7 @@ use crate::{
     providers::{StaticFileProvider, StaticFileProviderRWRefMut},
     to_range, AccountReader, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
     BlockReaderIdExt, BlockSource, ChainSpecProvider, ChangeSetReader, HeaderProvider,
-    ProviderError, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
+    ProviderError, ProviderHeader, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
     StageCheckpointReader, StateReader, StaticFileProviderFactory, TransactionVariant,
     TransactionsProvider,
 };
@@ -855,6 +855,29 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ConsistentProvider<N> {
         }
 
         self.storage_provider.transaction_by_hash_with_meta(tx_hash)
+    }
+
+    fn transaction_by_hash_with_meta_and_header(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<
+        Option<(Self::Transaction, TransactionMeta, SealedHeader<ProviderHeader<Self>>)>,
+    > {
+        if let Some((tx, meta, header)) = self.head_block.as_ref().and_then(|head| {
+            head.chain().find_map(|block_state| {
+                block_state.find_indexed(tx_hash).map(|indexed| {
+                    (
+                        indexed.tx().clone(),
+                        indexed.meta(),
+                        block_state.block_ref().recovered_block().clone_sealed_header(),
+                    )
+                })
+            })
+        }) {
+            return Ok(Some((tx, meta, header)))
+        }
+
+        self.storage_provider.transaction_by_hash_with_meta_and_header(tx_hash)
     }
 
     fn transactions_by_block(

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     traits::{BlockSource, ReceiptProvider},
     BalProvider, BalStoreHandle, BlockHashReader, BlockNumReader, BlockReader, ChainSpecProvider,
     DatabaseProviderFactory, EitherWriterDestination, HashedPostStateProvider, HeaderProvider,
-    HeaderSyncGapProvider, InMemoryBalStore, MetadataProvider, ProviderError,
+    HeaderSyncGapProvider, InMemoryBalStore, MetadataProvider, ProviderError, ProviderHeader,
     PruneCheckpointReader, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox,
     StaticFileProviderFactory, StaticFileWriter, TransactionVariant, TransactionsProvider,
 };
@@ -823,6 +823,15 @@ impl<N: ProviderNodeTypes> TransactionsProvider for ProviderFactory<N> {
         tx_hash: TxHash,
     ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
         self.provider()?.transaction_by_hash_with_meta(tx_hash)
+    }
+
+    fn transaction_by_hash_with_meta_and_header(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<
+        Option<(Self::Transaction, TransactionMeta, SealedHeader<ProviderHeader<Self>>)>,
+    > {
+        self.provider()?.transaction_by_hash_with_meta_and_header(tx_hash)
     }
 
     fn transactions_by_block(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -16,10 +16,10 @@ use crate::{
     DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
     HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
     LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, PersistenceFrontiers,
-    ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit,
-    RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
-    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
-    TransactionsProvider, TransactionsProviderExt, TrieWriter,
+    ProviderError, ProviderHeader, PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch,
+    RevertsInit, RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox,
+    StateWriter, StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter,
+    TransactionVariant, TransactionsProvider, TransactionsProviderExt, TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -2107,31 +2107,40 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> TransactionsProvider for Datab
         &self,
         tx_hash: TxHash,
     ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>> {
+        Ok(self
+            .transaction_by_hash_with_meta_and_header(tx_hash)?
+            .map(|(transaction, meta, _)| (transaction, meta)))
+    }
+
+    fn transaction_by_hash_with_meta_and_header(
+        &self,
+        tx_hash: TxHash,
+    ) -> ProviderResult<
+        Option<(Self::Transaction, TransactionMeta, SealedHeader<ProviderHeader<Self>>)>,
+    > {
         if let Some(transaction_id) = self.transaction_id(tx_hash)? &&
             let Some(transaction) = self.transaction_by_id_unhashed(transaction_id)? &&
             let Some(block_number) = self.block_by_transaction_id(transaction_id)? &&
-            let Some(sealed_header) = self.sealed_header(block_number)?
+            let Some(sealed_header) = self.sealed_header(block_number)? &&
+            let Some(block_body) = self.block_body_indices(block_number)?
         {
-            let (header, block_hash) = sealed_header.split();
-            if let Some(block_body) = self.block_body_indices(block_number)? {
-                // the index of the tx in the block is the offset:
-                // len([start..tx_id])
-                // NOTE: `transaction_id` is always `>=` the block's first
-                // index
-                let index = transaction_id - block_body.first_tx_num();
+            // the index of the tx in the block is the offset:
+            // len([start..tx_id])
+            // NOTE: `transaction_id` is always `>=` the block's first
+            // index
+            let index = transaction_id - block_body.first_tx_num();
 
-                let meta = TransactionMeta {
-                    tx_hash,
-                    index,
-                    block_hash,
-                    block_number,
-                    base_fee: header.base_fee_per_gas(),
-                    excess_blob_gas: header.excess_blob_gas(),
-                    timestamp: header.timestamp(),
-                };
+            let meta = TransactionMeta {
+                tx_hash,
+                index,
+                block_hash: sealed_header.hash(),
+                block_number,
+                base_fee: sealed_header.base_fee_per_gas(),
+                excess_blob_gas: sealed_header.excess_blob_gas(),
+                timestamp: sealed_header.timestamp(),
+            };
 
-                return Ok(Some((transaction, meta)))
-            }
+            return Ok(Some((transaction, meta, sealed_header)))
         }
 
         Ok(None)

--- a/crates/storage/storage-api/src/transactions.rs
+++ b/crates/storage/storage-api/src/transactions.rs
@@ -1,10 +1,10 @@
-use crate::{BlockNumReader, BlockReader};
+use crate::{BlockNumReader, BlockReader, HeaderProvider};
 use alloc::vec::Vec;
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockNumber, TxHash, TxNumber};
 use core::ops::{Range, RangeBounds, RangeInclusive};
-use reth_primitives_traits::SignedTransaction;
+use reth_primitives_traits::{SealedHeader, SignedTransaction};
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 
 /// Enum to control transaction hash inclusion.
@@ -48,6 +48,33 @@ pub trait TransactionsProvider: BlockNumReader + Send {
         &self,
         hash: TxHash,
     ) -> ProviderResult<Option<(Self::Transaction, TransactionMeta)>>;
+
+    /// Get transaction by transaction hash, additional metadata, and the sealed block header.
+    ///
+    /// Implementers that already load the header while constructing [`TransactionMeta`] should
+    /// override this method to return it without another lookup.
+    #[auto_impl(keep_default_for(&, Arc))]
+    #[expect(clippy::type_complexity)]
+    fn transaction_by_hash_with_meta_and_header(
+        &self,
+        hash: TxHash,
+    ) -> ProviderResult<
+        Option<(
+            Self::Transaction,
+            TransactionMeta,
+            SealedHeader<<Self as HeaderProvider>::Header>,
+        )>,
+    >
+    where
+        Self: HeaderProvider,
+    {
+        let Some((transaction, meta)) = self.transaction_by_hash_with_meta(hash)? else {
+            return Ok(None)
+        };
+        let Some(header) = self.sealed_header_by_hash(meta.block_hash)? else { return Ok(None) };
+
+        Ok(Some((transaction, meta, header)))
+    }
 
     /// Get transactions by block id.
     fn transactions_by_block(


### PR DESCRIPTION
Adds a transaction provider helper that returns the sealed header already loaded while constructing `TransactionMeta`, with optimized database and canonical in-memory implementations. This lets receipt conversion introduced in #26491 avoid a second block/header lookup on cache misses.

Validated with `cargo check -p reth-storage-api -p reth-provider --all-features`, `cargo nextest run -p reth-provider test_non_range_methods`, and `cargo +nightly clippy -p reth-storage-api -p reth-provider --all-targets --all-features -- -D warnings`.
