### PR TITLE
test: fix e2e testsuite flows building below finalized blocks

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/mod.rs
@@ -1,7 +1,6 @@
 //! Actions that can be performed in tests.
 
 use crate::testsuite::Environment;
-use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatusEnum};
 use eyre::Result;
 use futures_util::future::BoxFuture;
@@ -146,10 +145,7 @@ where
                 let fork_choice_state = ForkchoiceState {
                     head_block_hash: latest_block.hash,
                     safe_block_hash: latest_block.hash,
-                    // Making a block canonical does not imply finality: tests advance the
-                    // finalized block explicitly via `FinalizeBlock`, and a finalized tip would
-                    // reject any later forkchoice update below it as a too deep reorg.
-                    finalized_block_hash: B256::ZERO,
+                    finalized_block_hash: latest_block.hash,
                 };
 
                 let active_idx = env.active_node_idx;

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -402,10 +402,7 @@ where
             let fork_choice_state = ForkchoiceState {
                 head_block_hash: head_hash,
                 safe_block_hash: head_hash,
-                // Making a block canonical does not imply finality: tests advance the finalized
-                // block explicitly via `FinalizeBlock`, and a finalized tip would reject any
-                // later forkchoice update below it as a too deep reorg.
-                finalized_block_hash: B256::ZERO,
+                finalized_block_hash: head_hash,
             };
             debug!(
                 "Broadcasting forkchoice update to {} clients. Head: {:?}",

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -357,9 +357,7 @@ pub struct BroadcastLatestForkchoice {}
 
 impl<Engine> Action<Engine> for BroadcastLatestForkchoice
 where
-    Engine: EngineTypes + PayloadTypes,
-    Engine::PayloadAttributes: From<PayloadAttributes> + Clone,
-    Engine::ExecutionPayloadEnvelopeV3: Into<ExecutionPayloadEnvelopeV3>,
+    Engine: EngineTypes,
 {
     fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {
@@ -367,37 +365,10 @@ where
                 return Err(eyre::eyre!("No node clients available"));
             }
 
-            // use the hash of the newly executed payload if available
-            let head_hash = if let Some(payload_envelope) =
-                &env.active_node_state()?.latest_payload_envelope
-            {
-                let execution_payload_envelope: ExecutionPayloadEnvelopeV3 =
-                    payload_envelope.clone().into();
-                let new_block_hash = execution_payload_envelope
-                    .execution_payload
-                    .payload_inner
-                    .payload_inner
-                    .block_hash;
-                debug!("Using newly executed block hash as head: {new_block_hash}");
-                new_block_hash
-            } else {
-                // fallback to RPC query
-                let rpc_client = &env.node_clients[0].rpc;
-                let current_head_block = EthApiClient::<
-                    TransactionRequest,
-                    Transaction,
-                    Block,
-                    Receipt,
-                    Header,
-                    TransactionSigned,
-                >::block_by_number(
-                    rpc_client, alloy_eips::BlockNumberOrTag::Latest, false
-                )
-                .await?
-                .ok_or_else(|| eyre::eyre!("No latest block found from RPC"))?;
-                debug!("Using RPC latest block hash as head: {}", current_head_block.header.hash);
-                current_head_block.header.hash
-            };
+            let head_hash = env
+                .current_block_info()
+                .ok_or_else(|| eyre::eyre!("No current block information available"))?
+                .hash;
 
             let fork_choice_state = ForkchoiceState {
                 head_block_hash: head_hash,

--- a/crates/e2e-test-utils/src/testsuite/actions/reorg.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/reorg.rs
@@ -5,10 +5,10 @@ use crate::testsuite::{
     BlockInfo, Environment,
 };
 use alloy_primitives::B256;
-use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
+use alloy_rpc_types_engine::ForkchoiceState;
 use eyre::Result;
 use futures_util::future::BoxFuture;
-use reth_node_api::{EngineTypes, PayloadTypes};
+use reth_node_api::EngineTypes;
 use std::marker::PhantomData;
 use tracing::debug;
 
@@ -44,10 +44,7 @@ impl<Engine> ReorgTo<Engine> {
 
 impl<Engine> Action<Engine> for ReorgTo<Engine>
 where
-    Engine: EngineTypes + PayloadTypes,
-    Engine::PayloadAttributes: From<PayloadAttributes> + Clone,
-    Engine::ExecutionPayloadEnvelopeV3:
-        Into<alloy_rpc_types_engine::payload::ExecutionPayloadEnvelopeV3>,
+    Engine: EngineTypes,
 {
     fn execute<'a>(&'a mut self, env: &'a mut Environment<Engine>) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -8,9 +8,9 @@ use reth_e2e_test_utils::{
     test_rlp_utils::{generate_test_blocks, write_blocks_to_rlp},
     testsuite::{
         actions::{
-            Action, AssertChainTip, AssertMineBlock, CaptureBlock, CaptureBlockOnNode,
-            CompareNodeChainTips, CreateFork, MakeCanonical, ProduceBlocks, ReorgTo,
-            SelectActiveNode, UpdateBlockInfo,
+            Action, AssertChainTip, AssertMineBlock, BlockReference, CaptureBlock,
+            CaptureBlockOnNode, CompareNodeChainTips, CreateFork, FinalizeBlock, MakeCanonical,
+            ProduceBlocks, ReorgTo, SelectActiveNode, UpdateBlockInfo,
         },
         setup::{NetworkSetup, Setup},
         Environment, TestBuilder,
@@ -220,9 +220,16 @@ async fn test_testsuite_create_fork() -> Result<()> {
 
     let test = TestBuilder::new()
         .with_setup(setup)
-        .with_action(ProduceBlocks::<EthEngineTypes>::new(2))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(1))
+        .with_action(CaptureBlock::new("fork_base"))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(1))
+        .with_action(CaptureBlock::new("main_tip"))
         .with_action(MakeCanonical::new())
-        .with_action(CreateFork::<EthEngineTypes>::new(1, 3));
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("fork_base".to_string()))
+                .with_head(BlockReference::Tag("main_tip".to_string())),
+        )
+        .with_action(CreateFork::<EthEngineTypes>::new_from_tag("fork_base", 3));
 
     test.run::<EthereumNode>().await?;
 
@@ -250,9 +257,16 @@ async fn test_testsuite_reorg_with_tagging() -> Result<()> {
 
     let test = TestBuilder::new()
         .with_setup(setup)
-        .with_action(ProduceBlocks::<EthEngineTypes>::new(3)) // produce blocks 1, 2, 3
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(1))
+        .with_action(CaptureBlock::new("fork_base"))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(2)) // produce blocks 2 and 3
+        .with_action(CaptureBlock::new("main_tip"))
         .with_action(MakeCanonical::new()) // make main chain tip canonical
-        .with_action(CreateFork::<EthEngineTypes>::new(1, 2)) // fork from block 1, produce blocks 2', 3'
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("fork_base".to_string()))
+                .with_head(BlockReference::Tag("main_tip".to_string())),
+        )
+        .with_action(CreateFork::<EthEngineTypes>::new_from_tag("fork_base", 2)) // fork from block 1, produce blocks 2', 3'
         .with_action(CaptureBlock::new("fork_tip")) // tag fork tip
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("fork_tip")); // reorg to fork tip
 
@@ -290,7 +304,10 @@ async fn test_testsuite_deep_reorg() -> Result<()> {
         // receive forkchoiceUpdated with block hash A as head (block A at height 2)
         .with_action(CreateFork::<EthEngineTypes>::new(1, 1))
         .with_action(CaptureBlock::new("blockA_height2"))
-        .with_action(MakeCanonical::new())
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("block1".to_string()))
+                .with_head(BlockReference::Tag("blockA_height2".to_string())),
+        )
         // receive newPayload with block hash B and height 2
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("block1"))
         .with_action(CreateFork::<EthEngineTypes>::new(1, 1))

--- a/crates/engine/tree/tests/e2e-testsuite/main.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/main.rs
@@ -7,10 +7,10 @@ use eyre::Result;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::testsuite::{
     actions::{
-        BlockReference, CaptureBlock, CompareNodeChainTips, CreateFork, ExpectFcuStatus,
-        MakeCanonical, ProduceBlocks, ProduceBlocksLocally, ProduceInvalidBlocks, ReorgTo,
-        SelectActiveNode, SendForkchoiceUpdate, SendNewPayloads, SetForkBase, UpdateBlockInfo,
-        ValidateCanonicalTag, WaitForSync,
+        AssertChainTip, BlockReference, CaptureBlock, CompareNodeChainTips, CreateFork,
+        ExpectFcuStatus, FinalizeBlock, MakeCanonical, ProduceBlocks, ProduceBlocksLocally,
+        ProduceInvalidBlocks, ReorgTo, SelectActiveNode, SendForkchoiceUpdate, SendNewPayloads,
+        SetForkBase, UpdateBlockInfo, ValidateCanonicalTag, WaitForSync,
     },
     setup::{NetworkSetup, Setup},
     TestBuilder,
@@ -76,10 +76,19 @@ async fn test_engine_tree_fcu_reorg_with_all_blocks_e2e() -> Result<()> {
     let test = TestBuilder::new()
         .with_setup(default_engine_tree_setup())
         // create a main chain with 5 blocks (blocks 0-4)
-        .with_action(ProduceBlocks::<EthEngineTypes>::new(5))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(2))
+        .with_action(CaptureBlock::new("fork_base"))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(3))
+        .with_action(CaptureBlock::new("main_tip"))
         .with_action(MakeCanonical::new())
+        // block production finalizes the produced blocks, so re-establish finality at the fork
+        // base: building below the finalized block is rejected as a too deep reorg
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("fork_base".to_string()))
+                .with_head(BlockReference::Tag("main_tip".to_string())),
+        )
         // create a fork from block 2 with 3 additional blocks
-        .with_action(CreateFork::<EthEngineTypes>::new(2, 3))
+        .with_action(CreateFork::<EthEngineTypes>::new_from_tag("fork_base", 3))
         .with_action(CaptureBlock::new("fork_tip"))
         // perform FCU to the fork tip - this should make the fork canonical
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("fork_tip"));
@@ -113,6 +122,12 @@ async fn test_engine_tree_valid_forks_with_older_canonical_head_e2e() -> Result<
         // create first competing chain (chain A) from fork point with 10 blocks
         .with_action(CreateFork::<EthEngineTypes>::new_from_tag("fork_point", 10))
         .with_action(CaptureBlock::new("chain_a_tip"))
+        // producing chain A finalized its blocks, so re-establish finality at the fork point
+        // before building below it again
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("fork_point".to_string()))
+                .with_head(BlockReference::Tag("chain_a_tip".to_string())),
+        )
         // create second competing chain (chain B) from same fork point with 10 blocks
         .with_action(CreateFork::<EthEngineTypes>::new_from_tag("fork_point", 10))
         .with_action(CaptureBlock::new("chain_b_tip"))
@@ -149,14 +164,23 @@ async fn test_engine_tree_valid_and_invalid_forks_with_older_canonical_head_e2e(
         // create chain A (competing chain) - first produce valid blocks, then test invalid
         // scenario
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("fork_point"))
+        // producing chain B finalized its blocks, so re-establish finality at the fork point
+        // before building below it again
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("fork_point".to_string()))
+                .with_head(BlockReference::Tag("chain_b_tip".to_string())),
+        )
         .with_action(ProduceBlocks::<EthEngineTypes>::new(10))
         .with_action(CaptureBlock::new("chain_a_tip"))
         // test that FCU to chain A tip returns VALID status (it's a valid competing chain)
         .with_action(ExpectFcuStatus::valid("chain_a_tip"))
         // attempt to produce invalid blocks (which should be rejected)
         .with_action(ProduceInvalidBlocks::<EthEngineTypes>::with_invalid_at(3, 2))
-        // chain B remains the canonical chain
-        .with_action(ValidateCanonicalTag::new("chain_b_tip"));
+        // the invalid block is rejected and the chain remains on the last valid block built on
+        // chain A: the fork point at 6, ten chain A blocks and two valid blocks on top. Chain B
+        // was reorged out when chain A became canonical and its blocks were finalized.
+        .with_action(UpdateBlockInfo::default())
+        .with_action(AssertChainTip::new(18));
 
     test.run::<EthereumNode>().await?;
 
@@ -319,9 +343,11 @@ async fn test_engine_tree_live_sync_transition_eventually_canonical_e2e() -> Res
         .with_action(CaptureBlock::new("long_chain_tip"))
         // Verify Node 0's canonical tip is the long chain tip
         .with_action(ValidateCanonicalTag::new("long_chain_tip"))
-        // Verify Node 1's canonical tip is still the base chain tip
+        // Verify Node 1's canonical tip is still behind Node 0. `ValidateCanonicalTag` cannot
+        // be used here: it sends an FCU to node 0, for which the base chain tip is a canonical
+        // ancestor below its finalized block, which is rejected as a too deep reorg.
         .with_action(SelectActiveNode::new(1))
-        .with_action(ValidateCanonicalTag::new("base_chain_tip"))
+        .with_action(CompareNodeChainTips::expect_different(0, 1))
         // Node 1: Send FCU pointing to Node 0's long chain tip
         // This should trigger Node 1 to sync the missing blocks from Node 0
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("long_chain_tip"))
@@ -365,9 +391,18 @@ async fn test_engine_tree_fcu_reorg_with_all_blocks_v2_e2e() -> Result<()> {
 
     let test = TestBuilder::new()
         .with_setup(v2_engine_tree_setup())
-        .with_action(ProduceBlocks::<EthEngineTypes>::new(5))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(2))
+        .with_action(CaptureBlock::new("fork_base"))
+        .with_action(ProduceBlocks::<EthEngineTypes>::new(3))
+        .with_action(CaptureBlock::new("main_tip"))
         .with_action(MakeCanonical::new())
-        .with_action(CreateFork::<EthEngineTypes>::new(2, 3))
+        // block production finalizes the produced blocks, so re-establish finality at the fork
+        // base: building below the finalized block is rejected as a too deep reorg
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("fork_base".to_string()))
+                .with_head(BlockReference::Tag("main_tip".to_string())),
+        )
+        .with_action(CreateFork::<EthEngineTypes>::new_from_tag("fork_base", 3))
         .with_action(CaptureBlock::new("fork_tip"))
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("fork_tip"));
 

--- a/crates/engine/tree/tests/e2e-testsuite/main.rs
+++ b/crates/engine/tree/tests/e2e-testsuite/main.rs
@@ -116,7 +116,10 @@ async fn test_engine_tree_valid_forks_with_older_canonical_head_e2e() -> Result<
         // extend base chain with 5 more blocks to establish a fork point
         .with_action(ProduceBlocks::<EthEngineTypes>::new(5))
         .with_action(CaptureBlock::new("fork_point"))
-        .with_action(MakeCanonical::new())
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("old_head".to_string()))
+                .with_head(BlockReference::Tag("fork_point".to_string())),
+        )
         // revert to old head to simulate scenario where canonical head is older
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("old_head"))
         // create first competing chain (chain A) from fork point with 10 blocks
@@ -153,7 +156,10 @@ async fn test_engine_tree_valid_and_invalid_forks_with_older_canonical_head_e2e(
         // extend base chain with 5 more blocks to establish fork point
         .with_action(ProduceBlocks::<EthEngineTypes>::new(5))
         .with_action(CaptureBlock::new("fork_point"))
-        .with_action(MakeCanonical::new())
+        .with_action(
+            FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("old_head".to_string()))
+                .with_head(BlockReference::Tag("fork_point".to_string())),
+        )
         // revert to old head to simulate older canonical head scenario
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("old_head"))
         // create chain B (the valid chain) from fork point with 10 blocks
@@ -163,13 +169,13 @@ async fn test_engine_tree_valid_and_invalid_forks_with_older_canonical_head_e2e(
         .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("chain_b_tip"))
         // create chain A (competing chain) - first produce valid blocks, then test invalid
         // scenario
-        .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("fork_point"))
         // producing chain B finalized its blocks, so re-establish finality at the fork point
         // before building below it again
         .with_action(
             FinalizeBlock::<EthEngineTypes>::new(BlockReference::Tag("fork_point".to_string()))
                 .with_head(BlockReference::Tag("chain_b_tip".to_string())),
         )
+        .with_action(ReorgTo::<EthEngineTypes>::new_from_tag("fork_point"))
         .with_action(ProduceBlocks::<EthEngineTypes>::new(10))
         .with_action(CaptureBlock::new("chain_a_tip"))
         // test that FCU to chain A tip returns VALID status (it's a valid competing chain)


### PR DESCRIPTION
Follow-up to #26567, which made forkchoice updates to canonical ancestors below the latest known finalized block reject with `-38006: Too deep reorg` and started real payload builds on ancestors above finality.

The testsuite change that stopped MakeCanonical from finalizing the tip is reverted: block production finalizes the produced blocks in several other places, so the partial change broke sync and fork tests. Instead the affected tests manage finality explicitly, re-establishing it at the fork base via `FinalizeBlock` before building below it, and FCU based canonicity probes targeting old blocks are replaced with RPC assertions.

The valid-and-invalid forks test previously passed vacuously: building on the canonical fork point was silently skipped, so chain A never existed and chain B trivially remained canonical. It now exercises the real flow and asserts the chain rests on the last valid block.