### PR TITLE
perf(provider): avoid collecting in-memory chain in tx lookup

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -698,6 +698,19 @@ impl<N: NodePrimitives> BlockState<N> {
         std::iter::successors(Some(self), |state| state.parent.as_deref())
     }
 
+    /// Returns an iterator over the entire in memory chain.
+    ///
+    /// The block state order is oldest to newest (lowest to highest), including self as the
+    /// last element.
+    ///
+    /// Note: this re-walks the parent links for every step and is quadratic in the chain
+    /// length; the in-memory chain is expected to be short, making this cheaper than
+    /// collecting the chain into a `Vec`.
+    pub fn chain_oldest_first(&self) -> impl Iterator<Item = &Self> {
+        let len = self.chain().count();
+        (0..len).rev().filter_map(move |i| self.chain().nth(i))
+    }
+
     /// Appends the parent chain of this [`BlockState`] to the given vector.
     ///
     /// Parents are appended in order from newest to oldest (highest to lowest).
@@ -1518,6 +1531,22 @@ mod tests {
         assert_eq!(block_state_chain[1].block().recovered_block().number, 1);
 
         let block_state_chain = chain[0].chain().collect::<Vec<_>>();
+        assert_eq!(block_state_chain.len(), 1);
+        assert_eq!(block_state_chain[0].block().recovered_block().number, 1);
+    }
+
+    #[test]
+    fn test_block_state_chain_oldest_first() {
+        let mut test_block_builder: TestBlockBuilder = TestBlockBuilder::default();
+        let chain = create_mock_state_chain(&mut test_block_builder, 3);
+
+        let block_state_chain = chain[2].chain_oldest_first().collect::<Vec<_>>();
+        assert_eq!(block_state_chain.len(), 3);
+        assert_eq!(block_state_chain[0].block().recovered_block().number, 1);
+        assert_eq!(block_state_chain[1].block().recovered_block().number, 2);
+        assert_eq!(block_state_chain[2].block().recovered_block().number, 3);
+
+        let block_state_chain = chain[0].chain_oldest_first().collect::<Vec<_>>();
         assert_eq!(block_state_chain.len(), 1);
         assert_eq!(block_state_chain[0].block().recovered_block().number, 1);
     }

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -368,13 +368,13 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         S: FnOnce(&DatabaseProviderRO<N::DB, N>) -> ProviderResult<Option<R>>,
         M: Fn(usize, TxNumber, &BlockState<N::Primitives>) -> ProviderResult<Option<R>>,
     {
-        let in_mem_chain = self.head_block.iter().flat_map(|b| b.chain()).collect::<Vec<_>>();
         let provider = &self.storage_provider;
 
         // Get the last block number stored in the database which does NOT overlap with in-memory
         // chain.
-        let last_database_block_number = in_mem_chain
-            .last()
+        let last_database_block_number = self
+            .head_block
+            .as_ref()
             .map(|b| Ok(b.anchor().number))
             .unwrap_or_else(|| provider.last_block_number())?;
 
@@ -394,7 +394,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         }
 
         // Iterate from the lowest block to the highest
-        for block_state in in_mem_chain.iter().rev() {
+        for block_state in self.head_block.iter().flat_map(|b| b.chain_oldest_first()) {
             let executed_block = block_state.block_ref();
             let block = executed_block.recovered_block();
 


### PR DESCRIPTION
Avoids collecting the in-memory chain into a `Vec` in `get_in_memory_or_storage_by_tx`. Adds `BlockState::chain_oldest_first`, an iterator yielding the chain oldest to newest by re-walking the parent links, so the lookup logic itself stays unchanged. The in-memory chain is expected to be short, making the repeated traversal cheaper than the allocation.