### PR TITLE
chore(net): share the snap/2 slim account codec between server and client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8658,6 +8658,7 @@ dependencies = [
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "arbitrary",
  "bytes",
  "derive_more",

--- a/crates/net/eth-wire-types/Cargo.toml
+++ b/crates/net/eth-wire-types/Cargo.toml
@@ -24,6 +24,7 @@ alloy-eip7928 = { workspace = true, features = ["rlp"], optional = true }
 alloy-eips.workspace = true
 alloy-primitives = { workspace = true, features = ["map"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
+alloy-trie.workspace = true
 alloy-consensus.workspace = true
 
 bytes.workspace = true
@@ -68,6 +69,7 @@ std = [
     "serde?/std",
     "thiserror/std",
     "reth-chainspec/std",
+    "alloy-trie/std",
 ]
 arbitrary = [
     "reth-ethereum-primitives/arbitrary",
@@ -82,6 +84,7 @@ arbitrary = [
     "alloy-eips/arbitrary",
     "alloy-primitives/arbitrary",
     "reth-primitives-traits/arbitrary",
+    "alloy-trie/arbitrary",
 ]
 serde = [
     "dep:serde",
@@ -95,4 +98,5 @@ serde = [
     "reth-ethereum-primitives/serde",
     "alloy-hardforks/serde",
     "alloy-eip7928?/serde",
+    "alloy-trie/serde",
 ]

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -7,8 +7,9 @@
 
 use crate::BlockAccessLists;
 use alloc::vec::Vec;
-use alloy_primitives::{Bytes, B256};
+use alloy_primitives::{Bytes, B256, KECCAK256_EMPTY, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable, RlpDecodable, RlpEncodable};
+use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH};
 use reth_codecs_derive::add_arbitrary_tests;
 
 /// Supported SNAP protocol versions.
@@ -113,6 +114,34 @@ pub struct AccountData {
     pub body: Bytes,
 }
 
+impl AccountData {
+    /// Encodes `account` in snap/2's slim format.
+    pub fn from_trie_account(hash: B256, account: &TrieAccount) -> Self {
+        let body = alloy_rlp::encode(SlimAccountBody {
+            nonce: account.nonce,
+            balance: account.balance,
+            storage_root: SlimAccountBody::shorten(account.storage_root, EMPTY_ROOT_HASH),
+            code_hash: SlimAccountBody::shorten(account.code_hash, KECCAK256_EMPTY),
+        });
+        Self { hash, body: body.into() }
+    }
+
+    /// Decodes the slim body into the account the trie leaf commits to.
+    ///
+    /// Range proofs are verified against the full encoding, so the omitted storage root and code
+    /// hash are restored to their defaults here.
+    pub fn trie_account(&self) -> alloy_rlp::Result<TrieAccount> {
+        let slim = alloy_rlp::decode_exact::<SlimAccountBody>(&self.body)?;
+
+        Ok(TrieAccount {
+            nonce: slim.nonce,
+            balance: slim.balance,
+            storage_root: SlimAccountBody::restore(&slim.storage_root, EMPTY_ROOT_HASH)?,
+            code_hash: SlimAccountBody::restore(&slim.code_hash, KECCAK256_EMPTY)?,
+        })
+    }
+}
+
 /// Response containing a number of consecutive accounts and the Merkle proofs for the entire range.
 // http://github.com/ethereum/devp2p/blob/master/caps/snap.md#accountrange-0x01
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
@@ -208,6 +237,18 @@ pub struct StorageData {
     pub hash: B256,
     /// Data content of the slot
     pub data: Bytes,
+}
+
+impl StorageData {
+    /// Encodes a slot value as the storage trie leaf commits to it.
+    pub fn from_value(hash: B256, value: U256) -> Self {
+        Self { hash, data: alloy_rlp::encode(value).into() }
+    }
+
+    /// Decodes the slot value.
+    pub fn value(&self) -> alloy_rlp::Result<U256> {
+        alloy_rlp::decode_exact(&self.data)
+    }
 }
 
 /// Response containing a number of consecutive storage slots for the requested account
@@ -476,6 +517,39 @@ impl SnapProtocolMessage {
             return Err(SnapProtocolError::Rlp(alloy_rlp::Error::UnexpectedLength));
         }
         Ok(msg)
+    }
+}
+
+/// Like a trie account, with empty code and storage hashes omitted to reduce transfer size.
+#[derive(RlpEncodable, RlpDecodable)]
+struct SlimAccountBody {
+    /// The account's nonce.
+    nonce: u64,
+    /// The account's balance.
+    balance: U256,
+    /// Empty when the account has no storage.
+    storage_root: Bytes,
+    /// Empty when the account has no code.
+    code_hash: Bytes,
+}
+
+impl SlimAccountBody {
+    /// Drops a field that holds its empty default, which is what makes the encoding slim.
+    fn shorten(value: B256, empty: B256) -> Bytes {
+        if value == empty {
+            Bytes::new()
+        } else {
+            Bytes::copy_from_slice(value.as_slice())
+        }
+    }
+
+    /// Restores a dropped field to `empty`, rejecting any length the encoding never produces.
+    fn restore(value: &Bytes, empty: B256) -> alloy_rlp::Result<B256> {
+        match value.len() {
+            0 => Ok(empty),
+            32 => Ok(B256::from_slice(value)),
+            _ => Err(alloy_rlp::Error::UnexpectedLength),
+        }
     }
 }
 
@@ -788,5 +862,68 @@ mod tests {
         };
         assert_eq!(msg.starting_hash.unwrap_or(B256::ZERO), B256::ZERO);
         assert_eq!(msg.limit_hash.unwrap_or(B256::repeat_byte(0xff)), B256::repeat_byte(0xff));
+    }
+
+    fn trie_account(storage_root: B256, code_hash: B256) -> TrieAccount {
+        TrieAccount { nonce: 7, balance: U256::from(42), storage_root, code_hash }
+    }
+
+    #[test]
+    fn slim_body_elides_empty_storage_and_code() {
+        let account = trie_account(EMPTY_ROOT_HASH, KECCAK256_EMPTY);
+        let encoded = AccountData::from_trie_account(B256::repeat_byte(1), &account);
+
+        let body = SlimAccountBody::decode(&mut encoded.body.as_ref()).unwrap();
+        assert!(body.storage_root.is_empty());
+        assert!(body.code_hash.is_empty());
+        assert_eq!(encoded.trie_account().unwrap(), account);
+    }
+
+    #[test]
+    fn slim_body_keeps_non_default_storage_and_code() {
+        let account = trie_account(B256::repeat_byte(2), B256::repeat_byte(3));
+        let encoded = AccountData::from_trie_account(B256::repeat_byte(1), &account);
+
+        let body = SlimAccountBody::decode(&mut encoded.body.as_ref()).unwrap();
+        assert_eq!(body.storage_root.len(), 32);
+        assert_eq!(body.code_hash.len(), 32);
+        assert_eq!(encoded.trie_account().unwrap(), account);
+    }
+
+    #[test]
+    fn slim_body_rejects_field_lengths_the_encoding_never_produces() {
+        // A 16-byte field is neither an elided default nor a hash, so accepting it would let a
+        // peer smuggle a value that hashes differently than the one it claims to serve.
+        let truncated = Bytes::from_static(&[0xaa; 16]);
+
+        assert!(SlimAccountBody::restore(&truncated, EMPTY_ROOT_HASH).is_err());
+    }
+
+    #[test]
+    fn slim_body_rejects_trailing_bytes() {
+        let account = trie_account(EMPTY_ROOT_HASH, KECCAK256_EMPTY);
+        let mut encoded = AccountData::from_trie_account(B256::repeat_byte(1), &account);
+        encoded.body = [encoded.body.as_ref(), &[0x00]].concat().into();
+
+        assert!(encoded.trie_account().is_err());
+    }
+
+    #[test]
+    fn storage_data_carries_the_trie_leaf_encoding() {
+        let value = U256::from(1234);
+        let slot = StorageData::from_value(B256::repeat_byte(4), value);
+
+        // Clients verify range proofs against the RLP-encoded trie leaf, so the wire bytes must be
+        // exactly that rather than a fixed-width word.
+        assert_eq!(slot.data.as_ref(), alloy_rlp::encode(value));
+        assert_eq!(slot.value().unwrap(), value);
+    }
+
+    #[test]
+    fn storage_data_rejects_trailing_bytes() {
+        let mut slot = StorageData::from_value(B256::repeat_byte(4), U256::from(1));
+        slot.data = [slot.data.as_ref(), &[0x00]].concat().into();
+
+        assert!(slot.value().is_err());
     }
 }

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -117,11 +117,11 @@ pub struct AccountData {
 impl AccountData {
     /// Encodes `account` in snap/2's slim format.
     pub fn from_trie_account(hash: B256, account: &TrieAccount) -> Self {
-        let body = alloy_rlp::encode(SlimAccountBody {
+        let body = alloy_rlp::encode(SlimAccountBodyRef {
             nonce: account.nonce,
             balance: account.balance,
-            storage_root: SlimAccountBody::shorten(account.storage_root, EMPTY_ROOT_HASH),
-            code_hash: SlimAccountBody::shorten(account.code_hash, KECCAK256_EMPTY),
+            storage_root: SlimAccountBodyRef::shorten(&account.storage_root, EMPTY_ROOT_HASH),
+            code_hash: SlimAccountBodyRef::shorten(&account.code_hash, KECCAK256_EMPTY),
         });
         Self { hash, body: body.into() }
     }
@@ -521,7 +521,7 @@ impl SnapProtocolMessage {
 }
 
 /// Like a trie account, with empty code and storage hashes omitted to reduce transfer size.
-#[derive(RlpEncodable, RlpDecodable)]
+#[derive(RlpDecodable)]
 struct SlimAccountBody {
     /// The account's nonce.
     nonce: u64,
@@ -534,20 +534,35 @@ struct SlimAccountBody {
 }
 
 impl SlimAccountBody {
-    /// Drops a field that holds its empty default, which is what makes the encoding slim.
-    fn shorten(value: B256, empty: B256) -> Bytes {
-        if value == empty {
-            Bytes::new()
-        } else {
-            value.into()
-        }
-    }
-
     /// Restores a dropped field to `empty`, rejecting any length the encoding never produces.
     fn restore(value: &[u8], empty: B256) -> alloy_rlp::Result<B256> {
         match value {
             [] => Ok(empty),
             _ => B256::try_from(value).map_err(|_| alloy_rlp::Error::UnexpectedLength),
+        }
+    }
+}
+
+/// Borrowed encode twin of [`SlimAccountBody`].
+#[derive(RlpEncodable)]
+struct SlimAccountBodyRef<'a> {
+    /// The account's nonce.
+    nonce: u64,
+    /// The account's balance.
+    balance: U256,
+    /// Empty when the account has no storage.
+    storage_root: &'a [u8],
+    /// Empty when the account has no code.
+    code_hash: &'a [u8],
+}
+
+impl<'a> SlimAccountBodyRef<'a> {
+    /// Drops a field that holds its empty default, which is what makes the encoding slim.
+    fn shorten(value: &'a B256, empty: B256) -> &'a [u8] {
+        if *value == empty {
+            &[]
+        } else {
+            value.as_slice()
         }
     }
 }

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -539,16 +539,15 @@ impl SlimAccountBody {
         if value == empty {
             Bytes::new()
         } else {
-            Bytes::copy_from_slice(value.as_slice())
+            value.into()
         }
     }
 
     /// Restores a dropped field to `empty`, rejecting any length the encoding never produces.
-    fn restore(value: &Bytes, empty: B256) -> alloy_rlp::Result<B256> {
-        match value.len() {
-            0 => Ok(empty),
-            32 => Ok(B256::from_slice(value)),
-            _ => Err(alloy_rlp::Error::UnexpectedLength),
+    fn restore(value: &[u8], empty: B256) -> alloy_rlp::Result<B256> {
+        match value {
+            [] => Ok(empty),
+            _ => B256::try_from(value).map_err(|_| alloy_rlp::Error::UnexpectedLength),
         }
     }
 }

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -4,13 +4,10 @@ use crate::{
     budget::DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS, metered_poll_nested_stream_with_budget,
     metrics::EthRequestHandlerMetrics,
 };
-use alloy_consensus::{
-    constants::{EMPTY_ROOT_HASH, KECCAK_EMPTY},
-    BlockHeader, ReceiptWithBloom,
-};
+use alloy_consensus::{constants::KECCAK_EMPTY, BlockHeader, ReceiptWithBloom};
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{Bytes, B256, U256};
-use alloy_rlp::{Encodable, RlpEncodable};
+use alloy_primitives::{Bytes, B256};
+use alloy_rlp::Encodable;
 use futures::StreamExt;
 use reth_eth_wire::{
     snap::{
@@ -28,7 +25,7 @@ use reth_network_p2p::{
     snap::client::SnapResponse,
 };
 use reth_network_peers::PeerId;
-use reth_primitives_traits::{Account, Block};
+use reth_primitives_traits::Block;
 use reth_storage_api::{
     errors::provider::ProviderResult, BalProvider, BlockReader, BytecodeReader,
     GetBlockAccessListLimit, HeaderProvider, RangeEnd, RangeResponse, StateProviderFactory,
@@ -553,8 +550,10 @@ where
         let mut account_data = Vec::with_capacity(accounts.len());
         for (hash, account) in accounts {
             let storage_root = state.storage_root_by_hash(hash)?;
-            account_data
-                .push(AccountData { hash, body: slim_account_body(&account, storage_root) });
+            account_data.push(AccountData::from_trie_account(
+                hash,
+                &account.into_trie_account(storage_root),
+            ));
         }
 
         Ok(AccountRangeMessage { request_id: req.request_id, accounts: account_data, proof })
@@ -610,11 +609,8 @@ where
             slots.push(
                 account_slots
                     .into_iter()
-                    .map(|(hash, value)| StorageData {
-                        hash,
-                        // snap clients verify proofs against RLP-encoded storage trie leaves.
-                        data: alloy_rlp::encode(value).into(),
-                    })
+                    // snap clients verify proofs against RLP-encoded storage trie leaves.
+                    .map(|(hash, value)| StorageData::from_value(hash, value))
                     .collect(),
             );
 
@@ -638,39 +634,6 @@ fn boundary_proof_keys<T>(origin: B256, last: Option<&(B256, T)>) -> Vec<B256> {
         Some((last, _)) => vec![origin, *last],
         None => vec![origin],
     }
-}
-
-/// Like the consensus trie account, but the code hash and storage root are empty byte strings
-/// rather than [`KECCAK_EMPTY`]/[`EMPTY_ROOT_HASH`] when the account has no code/storage, to
-/// avoid transferring the same 32 bytes for every EOA. Borrowed to encode without allocating.
-#[derive(RlpEncodable)]
-struct SlimAccountBody<'a> {
-    /// The account's nonce.
-    nonce: u64,
-    /// The account's balance.
-    balance: U256,
-    /// Empty when the account has no storage.
-    storage_root: &'a [u8],
-    /// Empty when the account has no code.
-    code_hash: &'a [u8],
-}
-
-/// RLP-encodes `account` in snap/2's slim format; see [`SlimAccountBody`].
-fn slim_account_body(account: &Account, storage_root: B256) -> Bytes {
-    let storage_root: &[u8] =
-        if storage_root == EMPTY_ROOT_HASH { &[] } else { storage_root.as_slice() };
-    let code_hash: &[u8] = match &account.bytecode_hash {
-        Some(hash) if *hash != KECCAK_EMPTY => hash.as_slice(),
-        _ => &[],
-    };
-
-    alloy_rlp::encode(SlimAccountBody {
-        nonce: account.nonce,
-        balance: account.balance,
-        storage_root,
-        code_hash,
-    })
-    .into()
 }
 
 /// An endless future.
@@ -850,12 +813,14 @@ pub enum IncomingEthRequest<N: NetworkPrimitives = EthNetworkPrimitives> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::constants::EMPTY_ROOT_HASH;
     use alloy_eips::{
         eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
         eip7594::{BlobTransactionSidecarVariant, Cell},
     };
-    use alloy_primitives::{keccak256, Address, TxHash, B128};
+    use alloy_primitives::{keccak256, Address, TxHash, B128, U256};
     use reth_network_api::test_utils::PeersHandle;
+    use reth_primitives_traits::Account;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_storage_api::noop::NoopProvider;
     use reth_transaction_pool::blobstore::{

--- a/crates/net/network/tests/it/snap/mod.rs
+++ b/crates/net/network/tests/it/snap/mod.rs
@@ -13,7 +13,6 @@ use alloy_eip7928::{
 };
 use alloy_eips::NumHash;
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
-use alloy_rlp::{Decodable, RlpDecodable};
 use alloy_trie::{nodes::RlpNode, proof::verify_proof, Nibbles};
 use reth_chainspec::Hardforks;
 use reth_eth_wire::{
@@ -205,19 +204,6 @@ fn assert_boundary_proof(root: B256, key: B256, expected_value: Option<Vec<u8>>,
     );
 }
 
-/// Owned decode counterpart of `eth_requests::SlimAccountBody`
-#[derive(Debug, RlpDecodable)]
-struct SlimAccountBody {
-    /// The account's nonce.
-    nonce: u64,
-    /// The account's balance.
-    balance: U256,
-    /// Empty when the account has no storage.
-    storage_root: Bytes,
-    /// Empty when the account has no code.
-    code_hash: Bytes,
-}
-
 /// A valid RLP-encoded EIP-7928 block access list for `address`, with its commitment hash.
 fn valid_bal(address: Address) -> (Bytes, B256) {
     let mut change = AccountChanges::new(address);
@@ -280,16 +266,16 @@ async fn account_range_roundtrip_carries_slim_encoding_and_proof() {
     };
     assert_eq!(request_id, 7);
     assert_eq!(returned.len(), expected.len());
-    for (AccountData { hash, body }, (expected_hash, expected_account)) in
-        returned.iter().zip(&expected)
-    {
-        assert_eq!(hash, expected_hash);
-        let decoded = SlimAccountBody::decode(&mut &body[..]).unwrap();
+    for (account, (expected_hash, expected_account)) in returned.iter().zip(&expected) {
+        assert_eq!(&account.hash, expected_hash);
+        let decoded = account.trie_account().unwrap();
         assert_eq!(decoded.nonce, expected_account.nonce);
         assert_eq!(decoded.balance, expected_account.balance);
-        // Freshly generated EOAs have no storage/code, so they get the slim (elided) encoding.
-        assert!(decoded.storage_root.is_empty());
-        assert!(decoded.code_hash.is_empty());
+        // Freshly generated EOAs have no storage/code, so the slim encoding elides both fields
+        // and they decode back to their defaults.
+        assert_eq!(decoded.storage_root, EMPTY_ROOT_HASH);
+        assert_eq!(decoded.code_hash, KECCAK_EMPTY);
+        assert_eq!(account, &AccountData::from_trie_account(*expected_hash, &decoded));
     }
 
     assert!(!proof.is_empty());
@@ -422,10 +408,8 @@ async fn storage_range_roundtrip_carries_rlp_values_and_proof() {
     assert_eq!(request_id, 9);
     assert_eq!(returned.len(), 1);
 
-    let decoded: Vec<_> = returned[0]
-        .iter()
-        .map(|slot| (slot.hash, U256::decode(&mut &slot.data[..]).unwrap()))
-        .collect();
+    let decoded: Vec<_> =
+        returned[0].iter().map(|slot| (slot.hash, slot.value().unwrap())).collect();
     let expected_bounded: Vec<_> =
         expected.iter().filter(|(hash, _)| *hash >= origin && *hash <= limit).copied().collect();
     assert_eq!(decoded, expected_bounded);
@@ -493,10 +477,8 @@ async fn storage_range_empty_window_returns_boundary_slot() {
         panic!("expected a storage ranges response");
     };
     assert_eq!(returned.len(), 1);
-    let decoded: Vec<_> = returned[0]
-        .iter()
-        .map(|slot| (slot.hash, U256::decode(&mut &slot.data[..]).unwrap()))
-        .collect();
+    let decoded: Vec<_> =
+        returned[0].iter().map(|slot| (slot.hash, slot.value().unwrap())).collect();
     assert_eq!(decoded, vec![expected[2]]);
 
     assert!(!proof.is_empty());
@@ -573,15 +555,11 @@ async fn storage_ranges_multi_account_bounds_only_first_account() {
         panic!("expected a storage ranges response");
     };
     assert_eq!(returned.len(), 2, "both accounts should appear");
-    let decoded_a: Vec<_> = returned[0]
-        .iter()
-        .map(|slot| (slot.hash, U256::decode(&mut &slot.data[..]).unwrap()))
-        .collect();
+    let decoded_a: Vec<_> =
+        returned[0].iter().map(|slot| (slot.hash, slot.value().unwrap())).collect();
     assert_eq!(decoded_a, expected_a, "the earlier account's range should be complete");
-    let decoded_b: Vec<_> = returned[1]
-        .iter()
-        .map(|slot| (slot.hash, U256::decode(&mut &slot.data[..]).unwrap()))
-        .collect();
+    let decoded_b: Vec<_> =
+        returned[1].iter().map(|slot| (slot.hash, slot.value().unwrap())).collect();
     assert!(decoded_b.len() < expected_b.len(), "the final account's range should be truncated");
     assert_eq!(decoded_b, expected_b[..decoded_b.len()]);
     assert!(!proof.is_empty());
@@ -610,10 +588,8 @@ async fn storage_ranges_multi_account_bounds_only_first_account() {
         panic!("expected a storage ranges response");
     };
     assert_eq!(returned.len(), 1, "only the bounded first account should appear");
-    let decoded_a: Vec<_> = returned[0]
-        .iter()
-        .map(|slot| (slot.hash, U256::decode(&mut &slot.data[..]).unwrap()))
-        .collect();
+    let decoded_a: Vec<_> =
+        returned[0].iter().map(|slot| (slot.hash, slot.value().unwrap())).collect();
     assert_eq!(decoded_a, expected_a[1..]);
     assert!(!proof.is_empty());
     assert_boundary_proof(storage_root_a, origin, Some(alloy_rlp::encode(expected_a[1].1)), &proof);

--- a/crates/net/p2p/src/snap/client.rs
+++ b/crates/net/p2p/src/snap/client.rs
@@ -1,9 +1,17 @@
-use crate::{download::DownloadClient, error::PeerRequestResult, priority::Priority};
+use crate::{
+    download::DownloadClient,
+    error::{PeerRequestResult, RequestError},
+    full_block::NoopFullBlockClient,
+    priority::Priority,
+};
 use futures::Future;
-use reth_eth_wire_types::snap::{
-    AccountRangeMessage, BlockAccessListsMessage, ByteCodesMessage, GetAccountRangeMessage,
-    GetBlockAccessListsMessage, GetByteCodesMessage, GetStorageRangesMessage, SnapProtocolMessage,
-    StorageRangesMessage,
+use reth_eth_wire_types::{
+    snap::{
+        AccountRangeMessage, BlockAccessListsMessage, ByteCodesMessage, GetAccountRangeMessage,
+        GetBlockAccessListsMessage, GetByteCodesMessage, GetStorageRangesMessage,
+        SnapProtocolMessage, StorageRangesMessage,
+    },
+    NetworkPrimitives,
 };
 
 /// Response types for snap sync requests
@@ -108,6 +116,60 @@ pub trait SnapClient: DownloadClient {
         request: GetBlockAccessListsMessage,
         priority: Priority,
     ) -> Self::Output;
+}
+
+/// Fails every snap request with [`RequestError::UnsupportedCapability`], so the noop client can
+/// stand in wherever a [`SnapClient`] bound is required but snap is not served.
+impl<Net> SnapClient for NoopFullBlockClient<Net>
+where
+    Net: NetworkPrimitives,
+{
+    type Output = futures::future::Ready<PeerRequestResult<SnapResponse>>;
+
+    fn get_account_range_with_priority(
+        &self,
+        _request: GetAccountRangeMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        unsupported()
+    }
+
+    fn get_storage_ranges(&self, _request: GetStorageRangesMessage) -> Self::Output {
+        unsupported()
+    }
+
+    fn get_storage_ranges_with_priority(
+        &self,
+        _request: GetStorageRangesMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        unsupported()
+    }
+
+    fn get_byte_codes(&self, _request: GetByteCodesMessage) -> Self::Output {
+        unsupported()
+    }
+
+    fn get_byte_codes_with_priority(
+        &self,
+        _request: GetByteCodesMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        unsupported()
+    }
+
+    fn get_block_access_lists_with_priority(
+        &self,
+        _request: GetBlockAccessListsMessage,
+        _priority: Priority,
+    ) -> Self::Output {
+        unsupported()
+    }
+}
+
+/// The noop answer to any snap request: immediately ready, no capability.
+fn unsupported() -> futures::future::Ready<PeerRequestResult<SnapResponse>> {
+    futures::future::ready(Err(RequestError::UnsupportedCapability))
 }
 
 #[cfg(test)]

--- a/crates/net/p2p/src/snap/client.rs
+++ b/crates/net/p2p/src/snap/client.rs
@@ -126,6 +126,7 @@ where
 {
     type Output = futures::future::Ready<PeerRequestResult<SnapResponse>>;
 
+    /// Fails the account range request as unsupported.
     fn get_account_range_with_priority(
         &self,
         _request: GetAccountRangeMessage,
@@ -134,10 +135,12 @@ where
         unsupported()
     }
 
+    /// Fails the storage ranges request as unsupported.
     fn get_storage_ranges(&self, _request: GetStorageRangesMessage) -> Self::Output {
         unsupported()
     }
 
+    /// Fails the prioritized storage ranges request as unsupported.
     fn get_storage_ranges_with_priority(
         &self,
         _request: GetStorageRangesMessage,
@@ -146,10 +149,12 @@ where
         unsupported()
     }
 
+    /// Fails the bytecode request as unsupported.
     fn get_byte_codes(&self, _request: GetByteCodesMessage) -> Self::Output {
         unsupported()
     }
 
+    /// Fails the prioritized bytecode request as unsupported.
     fn get_byte_codes_with_priority(
         &self,
         _request: GetByteCodesMessage,
@@ -158,6 +163,7 @@ where
         unsupported()
     }
 
+    /// Fails the block access lists request as unsupported.
     fn get_block_access_lists_with_priority(
         &self,
         _request: GetBlockAccessListsMessage,


### PR DESCRIPTION
Preparation for snap sync ([EIP-8189](https://eips.ethereum.org/EIPS/eip-8189)).

- Moves the snap/2 slim account codec into `reth-eth-wire-types`, so syncing clients decode ranges with the same code that serves them.
- Encodes through a borrowed representation, avoiding intermediate allocations in the serving path.
- Implements `SnapClient` for `NoopFullBlockClient` so generic node and test configurations can satisfy snap-capable client bounds while explicitly returning `UnsupportedCapability`.