### PR TITLE
fix(rpc): align transaction response types

### DIFF
--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -36,7 +36,7 @@ use reth_engine_primitives::{ConsensusEngineEvent, ConsensusEngineHandle};
 use reth_evm::ConfigureEvm;
 use reth_network_api::{noop::NoopNetwork, NetworkInfo, Peers};
 use reth_payload_primitives::PayloadTypes;
-use reth_primitives_traits::{NodePrimitives, TxTy};
+use reth_primitives_traits::NodePrimitives;
 use reth_rpc::{
     AdminApi, DebugApi, EngineEthApi, EthApi, EthApiBuilder, EthBundle, MinerApi, NetApi,
     OtterscanApi, RPCApi, RethApi, TraceApi, TxPoolApi, Web3Api,
@@ -50,7 +50,8 @@ use reth_rpc_eth_api::{
     },
     node::RpcNodeCoreAdapter,
     EthApiServer, EthApiTypes, FullEthApiServer, FullEthApiTypes, RpcBlock, RpcConvert,
-    RpcConverter, RpcHeader, RpcNodeCore, RpcReceipt, RpcTransaction, RpcTxReq,
+    RpcConverter, RpcFilledTransaction, RpcHeader, RpcNodeCore, RpcReceipt, RpcTransaction,
+    RpcTxReq,
 };
 use reth_rpc_eth_types::{receipt::EthReceiptConverter, EthConfig, EthSubscriptionIdProvider};
 use reth_rpc_layer::{AuthLayer, Claims, CompressionLayer, JwtAuthValidator, JwtSecret};
@@ -675,7 +676,7 @@ where
             RpcBlock<EthApi::NetworkTypes>,
             RpcReceipt<EthApi::NetworkTypes>,
             RpcHeader<EthApi::NetworkTypes>,
-            TxTy<N>,
+            RpcFilledTransaction,
         > + EthApiTypes,
     EvmConfig: ConfigureEvm<Primitives = N> + 'static,
 {

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -2,7 +2,7 @@
 //! the `eth_` namespace.
 use crate::{
     helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
-    RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
+    RpcBlock, RpcFilledTransaction, RpcHeader, RpcReceipt, RpcTransaction,
 };
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{eip2930::AccessListResult, BlockId, BlockNumberOrTag};
@@ -16,9 +16,8 @@ use alloy_rpc_types_eth::{
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use reth_primitives_traits::TxTy;
 use reth_rpc_convert::RpcTxReq;
-use reth_rpc_eth_types::{EthApiError, EthCapabilities, FillTransaction};
+use reth_rpc_eth_types::{EthApiError, EthCapabilities, FillTransaction, SignTransaction};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -33,7 +32,7 @@ pub trait FullEthApiServer:
         RpcBlock<Self::NetworkTypes>,
         RpcReceipt<Self::NetworkTypes>,
         RpcHeader<Self::NetworkTypes>,
-        TxTy<Self::Primitives>,
+        RpcFilledTransaction,
     > + FullEthApi
     + Clone
 {
@@ -46,7 +45,7 @@ impl<T> FullEthApiServer for T where
             RpcBlock<T::NetworkTypes>,
             RpcReceipt<T::NetworkTypes>,
             RpcHeader<T::NetworkTypes>,
-            TxTy<T::Primitives>,
+            RpcFilledTransaction,
         > + FullEthApi
         + Clone
 {
@@ -61,7 +60,7 @@ pub trait EthApi<
     B: RpcObject,
     R: RpcObject,
     H: RpcObject,
-    RawTx: RpcObject,
+    FilledTx: RpcObject,
 >
 {
     /// Returns the protocol version encoded as a string.
@@ -263,7 +262,7 @@ pub trait EthApi<
 
     /// Fills the defaults on a given unsigned transaction.
     #[method(name = "fillTransaction")]
-    async fn fill_transaction(&self, request: TxReq) -> RpcResult<FillTransaction<RawTx>>;
+    async fn fill_transaction(&self, request: TxReq) -> RpcResult<FillTransaction<FilledTx>>;
 
     /// Simulate arbitrary number of transactions at an arbitrary blockchain index, with the
     /// optionality of state overrides
@@ -399,7 +398,7 @@ pub trait EthApi<
     /// Signs a transaction that can be submitted to the network at a later time using with
     /// `sendRawTransaction.`
     #[method(name = "signTransaction")]
-    async fn sign_transaction(&self, transaction: TxReq) -> RpcResult<Bytes>;
+    async fn sign_transaction(&self, transaction: TxReq) -> RpcResult<SignTransaction<T>>;
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
     #[method(name = "signTypedData")]
@@ -461,7 +460,7 @@ impl<T>
         RpcBlock<T::NetworkTypes>,
         RpcReceipt<T::NetworkTypes>,
         RpcHeader<T::NetworkTypes>,
-        TxTy<T::Primitives>,
+        RpcFilledTransaction,
     > for T
 where
     T: FullEthApi,
@@ -783,7 +782,7 @@ where
     async fn fill_transaction(
         &self,
         request: RpcTxReq<T::NetworkTypes>,
-    ) -> RpcResult<FillTransaction<TxTy<T::Primitives>>> {
+    ) -> RpcResult<FillTransaction<RpcFilledTransaction>> {
         trace!(target: "rpc::eth", ?request, "Serving eth_fillTransaction");
         Ok(EthTransactions::fill_transaction(self, request).await?)
     }
@@ -940,7 +939,10 @@ where
     }
 
     /// Handler for: `eth_signTransaction`
-    async fn sign_transaction(&self, request: RpcTxReq<T::NetworkTypes>) -> RpcResult<Bytes> {
+    async fn sign_transaction(
+        &self,
+        request: RpcTxReq<T::NetworkTypes>,
+    ) -> RpcResult<SignTransaction<RpcTransaction<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?request, "Serving eth_signTransaction");
         Ok(EthTransactions::sign_transaction(self, request).await?)
     }

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -4,8 +4,8 @@
 use super::{EthApiSpec, EthSigner, LoadBlock, LoadFee, LoadReceipt, LoadState, SpawnBlocking};
 use crate::{
     helpers::{estimate::EstimateCall, spec::SignersForRpc},
-    FromEthApiError, FullEthApiTypes, IntoEthApiError, RpcNodeCore, RpcNodeCoreExt, RpcReceipt,
-    RpcTransaction,
+    FromEthApiError, FullEthApiTypes, IntoEthApiError, RpcFilledTransaction, RpcNodeCore,
+    RpcNodeCoreExt, RpcReceipt, RpcTransaction,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -19,14 +19,14 @@ use alloy_rpc_types_eth::{state::EvmOverrides, TransactionInfo};
 use futures::{Future, StreamExt};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_primitives_traits::{
-    BlockBody, Recovered, RecoveredBlock, SignedTransaction, TxTy, WithEncoded,
+    BlockBody, Recovered, RecoveredBlock, SignedTransaction, WithEncoded,
 };
 use reth_rpc_convert::{transaction::RpcConvert, RpcTxReq, TransactionConversionError};
 use reth_rpc_eth_types::{
     block::convert_transaction_receipt,
     utils::binary_search,
     EthApiError::{self, TransactionConfirmationTimeout},
-    FillTransaction, SignError, TransactionSource,
+    FillTransaction, SignError, SignTransaction, TransactionSource,
 };
 use reth_storage_api::{
     BlockNumReader, BlockReaderIdExt, ProviderBlock, ProviderReceipt, ProviderTx, ReceiptProvider,
@@ -540,7 +540,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     fn fill_transaction(
         &self,
         mut request: RpcTxReq<Self::NetworkTypes>,
-    ) -> impl Future<Output = Result<FillTransaction<TxTy<Self::Primitives>>, Self::Error>> + Send
+    ) -> impl Future<Output = Result<FillTransaction<RpcFilledTransaction>, Self::Error>> + Send
     where
         Self: EthApiSpec + LoadBlock + EstimateCall + LoadFee,
     {
@@ -601,11 +601,11 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 }
             }
 
-            let tx = self.converter().build_simulate_v1_transaction(request)?;
+            let tx = request.as_ref().clone().build_consensus_tx().map_err(|err| {
+                Self::Error::from_eth_err(TransactionConversionError::FromTxReq(err.error))
+            })?;
 
-            let raw = tx.encoded_2718().into();
-
-            Ok(FillTransaction { raw, tx })
+            Ok(FillTransaction { tx })
         }
     }
 
@@ -640,19 +640,23 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         }
     }
 
-    /// Signs a transaction request using the given account in request
-    /// Returns the EIP-2718 encoded signed transaction.
+    /// Signs a transaction request using the given account in the request.
     fn sign_transaction(
         &self,
         request: RpcTxReq<Self::NetworkTypes>,
-    ) -> impl Future<Output = Result<Bytes, Self::Error>> + Send {
+    ) -> impl Future<Output = Result<SignTransaction<RpcTransaction<Self::NetworkTypes>>, Self::Error>>
+           + Send {
         async move {
             let from = match request.as_ref().from() {
                 Some(from) => from,
                 None => return Err(SignError::NoAccount.into_eth_err()),
             };
 
-            Ok(self.sign_request(&from, request).await?.encoded_2718().into())
+            let transaction = self.sign_request(&from, request).await?;
+            let raw = transaction.encoded_2718().into();
+            let tx = self.converter().fill_pending(transaction.with_signer(from))?;
+
+            Ok(SignTransaction { raw, tx })
         }
     }
 

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -32,7 +32,10 @@ pub use reth_rpc_convert::*;
 pub use reth_rpc_eth_types::error::{
     AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
 };
-pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
+pub use types::{
+    EthApiTypes, FullEthApiTypes, RpcBlock, RpcFilledTransaction, RpcHeader, RpcReceipt,
+    RpcTransaction,
+};
 
 #[cfg(feature = "client")]
 pub use bundle::{EthBundleApiClient, EthCallBundleApiClient};

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -36,6 +36,9 @@ pub trait EthApiTypes: Send + Sync + Clone {
 /// Adapter for network specific block type.
 pub type RpcBlock<T> = Block<RpcTransaction<T>, RpcHeader<T>>;
 
+/// Adapter for the unsigned transaction returned by `eth_fillTransaction`.
+pub type RpcFilledTransaction = alloy_consensus::TypedTransaction;
+
 /// Adapter for network specific receipt type.
 pub type RpcReceipt<T> = <T as RpcTypes>::Receipt;
 

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -27,7 +27,7 @@ pub mod transaction;
 pub mod tx_forward;
 pub mod utils;
 
-pub use alloy_rpc_types_eth::FillTransaction;
+pub use alloy_rpc_types_eth::{FillTransaction, SignTransaction};
 pub use block::CachedTransaction;
 pub use builder::config::{EthConfig, EthFilterConfig};
 pub use cache::{

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -5,14 +5,13 @@ use alloy_rpc_types_eth::{
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::core::RpcResult as Result;
-use reth_primitives_traits::TxTy;
 use reth_rpc_api::{EngineEthApiServer, EthApiServer};
 use reth_rpc_convert::RpcTxReq;
 /// Re-export for convenience
 pub use reth_rpc_engine_api::EngineApi;
 use reth_rpc_eth_api::{
-    EngineEthFilter, FullEthApiTypes, QueryLimits, RpcBlock, RpcHeader, RpcLog, RpcReceipt,
-    RpcTransaction,
+    EngineEthFilter, FullEthApiTypes, QueryLimits, RpcBlock, RpcFilledTransaction, RpcHeader,
+    RpcLog, RpcReceipt, RpcTransaction,
 };
 use serde_json::Value;
 use tracing_futures::Instrument;
@@ -53,7 +52,7 @@ where
             RpcBlock<Eth::NetworkTypes>,
             RpcReceipt<Eth::NetworkTypes>,
             RpcHeader<Eth::NetworkTypes>,
-            TxTy<Eth::Primitives>,
+            RpcFilledTransaction,
         > + FullEthApiTypes,
     EthFilter: EngineEthFilter<RpcLog<Eth::NetworkTypes>>,
 {

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -132,12 +132,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eth::helpers::types::EthRpcConverter;
+    use crate::eth::{helpers::types::EthRpcConverter, DevSigner};
     use alloy_consensus::{
-        BlobTransactionSidecar, Block, Header, SidecarBuilder, SimpleCoder, Transaction,
+        BlobTransactionSidecar, Block, Header, SidecarBuilder, SimpleCoder, Transaction, TxEnvelope,
     };
+    use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{map::AddressMap, Address, Bytes, U256};
-    use alloy_rpc_types_eth::request::TransactionRequest;
+    use alloy_rpc_types_eth::{request::TransactionRequest, TransactionInput};
     use reth_chainspec::{ChainSpec, ChainSpecBuilder};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_network_api::noop::NoopNetwork;
@@ -197,6 +198,32 @@ mod tests {
         Bytes::from(hex!(
             "02f871018303579880850555633d1b82520894eee27662c2b8eba3cd936a23f039f3189633e4c887ad591c62bdaeb180c080a07ea72c68abfb8fca1bd964f0f99132ed9280261bdca3e549546c0205e800f7d0a05b4ef3039e9c9b9babc179a1878fb825b5aaf5aed2fa8744854150157b08d6f3"
         ))
+    }
+
+    #[tokio::test]
+    async fn sign_transaction_returns_raw_and_transaction() {
+        let eth_api = mock_eth_api(Default::default());
+        let signer = DevSigner::random_signers(1).pop().unwrap();
+        let from = signer.accounts()[0];
+        eth_api.signers().write().push(signer);
+
+        let request = TransactionRequest {
+            chain_id: Some(1),
+            from: Some(from),
+            to: Some(Address::random().into()),
+            gas: Some(21_000),
+            gas_price: Some(1_000),
+            value: Some(U256::from(1_000)),
+            input: TransactionInput::default(),
+            nonce: Some(0),
+            ..Default::default()
+        };
+
+        let signed = eth_api.sign_transaction(request).await.unwrap();
+        let decoded = TxEnvelope::decode_2718(&mut signed.raw.as_ref()).unwrap();
+
+        assert_eq!(signed.tx.as_ref(), &decoded);
+        assert_eq!(signed.tx.inner.signer(), from);
     }
 
     #[tokio::test]

--- a/crates/rpc/rpc/src/otterscan.rs
+++ b/crates/rpc/rpc/src/otterscan.rs
@@ -12,12 +12,11 @@ use alloy_rpc_types_trace::{
 };
 use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
-use reth_primitives_traits::TxTy;
 use reth_rpc_api::{EthApiServer, OtterscanServer};
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
-    FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
+    FullEthApiTypes, RpcBlock, RpcFilledTransaction, RpcHeader, RpcReceipt, RpcTransaction,
 };
 use reth_rpc_eth_types::{utils::binary_search, EthApiError};
 use reth_rpc_server_types::result::internal_rpc_err;
@@ -74,7 +73,7 @@ where
             RpcBlock<Eth::NetworkTypes>,
             RpcReceipt<Eth::NetworkTypes>,
             RpcHeader<Eth::NetworkTypes>,
-            TxTy<Eth::Primitives>,
+            RpcFilledTransaction,
         > + EthTransactions
         + TraceExt
         + 'static,


### PR DESCRIPTION
Depends on [alloy-rs/alloy#4114](https://github.com/alloy-rs/alloy/pull/4114).

Aligns `eth_fillTransaction` and `eth_signTransaction` with [ethereum/execution-apis#803](https://github.com/ethereum/execution-apis/pull/803): fill returns `{ tx }` with an unsigned transaction, while sign returns `{ raw, tx }` with the signed RPC transaction object. Adds a regression test verifying the signed object matches the encoded transaction.

Validated against the Alloy PR with `cargo +nightly fmt --all`, an all-target/all-feature RPC check, and all 57 `reth-rpc` tests.
