### PR TITLE
refactor(rpc): lift blob params lookup out of receipt loop

### DIFF
--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -131,12 +131,12 @@ where
     fn convert_receipts(
         &self,
         inputs: Vec<ConvertReceiptInput<'_, N>>,
-        _block: &SealedBlock<N::Block>,
+        block: &SealedBlock<N::Block>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let mut receipts = Vec::with_capacity(inputs.len());
+        let blob_params = self.chain_spec.blob_params_at_timestamp(block.header().timestamp());
 
         for input in inputs {
-            let blob_params = self.chain_spec.blob_params_at_timestamp(input.meta.timestamp);
             receipts.push(build_receipt(input, blob_params, &self.build_rpc_receipt));
         }
 

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -1,7 +1,7 @@
 //! RPC receipt response builder, extends a layer one receipt with layer two data.
 
 use crate::EthApiError;
-use alloy_consensus::{ReceiptEnvelope, Transaction};
+use alloy_consensus::{BlockHeader, ReceiptEnvelope, Transaction};
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, TxKind};
 use alloy_rpc_types_eth::{Log, TransactionReceipt};


### PR DESCRIPTION
Moves the blob parameter lookup out of the per-receipt loop and derives it once from the block timestamp shared by all receipts.

Prompted by: @mattsse