### PR TITLE
fix(rpc): restore optional receipt conversion

### DIFF
--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -50,12 +50,21 @@ pub trait ReceiptConverter<N: NodePrimitives>: Debug + 'static {
         header: &SealedHeaderFor<N>,
     ) -> Result<Self::RpcLog, Self::Error>;
 
-    /// Converts primitive receipts from `block` to RPC representations.
+    /// Converts a set of primitive receipts to RPC representations. It is guaranteed that all
+    /// receipts are from the same block.
     fn convert_receipts(
         &self,
         receipts: Vec<ConvertReceiptInput<'_, N>>,
-        block: &SealedBlock<N::Block>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error>;
+
+    /// Converts primitive receipts from `block` to RPC representations.
+    fn convert_receipts_with_block(
+        &self,
+        receipts: Vec<ConvertReceiptInput<'_, N>>,
+        _block: &SealedBlock<N::Block>,
+    ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
+        self.convert_receipts(receipts)
+    }
 }
 
 /// A type that knows how to convert a consensus header into an RPC header.
@@ -170,8 +179,15 @@ pub trait RpcConvert: Send + Sync + Unpin + Debug + DynClone + 'static {
         header: &SealedHeaderFor<Self::Primitives>,
     ) -> Result<RpcLog<Self::Network>, Self::Error>;
 
-    /// Converts primitive receipts from `block` to RPC representations.
+    /// Converts a set of primitive receipts to RPC representations. It is guaranteed that all
+    /// receipts are from the same block.
     fn convert_receipts(
+        &self,
+        receipts: Vec<ConvertReceiptInput<'_, Self::Primitives>>,
+    ) -> Result<Vec<RpcReceipt<Self::Network>>, Self::Error>;
+
+    /// Converts primitive receipts from `block` to RPC representations.
+    fn convert_receipts_with_block(
         &self,
         receipts: Vec<ConvertReceiptInput<'_, Self::Primitives>>,
         block: &SealedBlock<BlockTy<Self::Primitives>>,
@@ -746,9 +762,16 @@ where
     fn convert_receipts(
         &self,
         receipts: Vec<ConvertReceiptInput<'_, Self::Primitives>>,
+    ) -> Result<Vec<RpcReceipt<Self::Network>>, Self::Error> {
+        self.receipt_converter.convert_receipts(receipts)
+    }
+
+    fn convert_receipts_with_block(
+        &self,
+        receipts: Vec<ConvertReceiptInput<'_, Self::Primitives>>,
         block: &SealedBlock<BlockTy<Self::Primitives>>,
     ) -> Result<Vec<RpcReceipt<Self::Network>>, Self::Error> {
-        self.receipt_converter.convert_receipts(receipts, block)
+        self.receipt_converter.convert_receipts_with_block(receipts, block)
     }
 
     fn convert_header(

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -136,7 +136,7 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
 
                 return Ok(self
                     .converter()
-                    .convert_receipts(inputs, block.sealed_block())
+                    .convert_receipts_with_block(inputs, block.sealed_block())
                     .map(Some)?)
             }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/receipt.rs
@@ -32,15 +32,6 @@ pub trait LoadReceipt:
     ) -> impl Future<Output = Result<RpcReceipt<Self::NetworkTypes>, Self::Error>> + Send {
         async move {
             let hash = meta.block_hash;
-            let block = match block {
-                Some(block) => block,
-                None => self
-                    .cache()
-                    .get_recovered_block(hash)
-                    .await
-                    .map_err(Self::Error::from_eth_err)?
-                    .ok_or(EthApiError::HeaderNotFound(hash.into()))?,
-            };
             // Use pre-fetched receipts if available, otherwise fetch from cache.
             let all_receipts = match all_receipts {
                 Some(receipts) => receipts,
@@ -55,20 +46,21 @@ pub trait LoadReceipt:
             let (gas_used, next_log_index) =
                 calculate_gas_used_and_next_log_index(meta.index, &all_receipts);
 
-            Ok(self
-                .converter()
-                .convert_receipts(
-                    vec![ConvertReceiptInput {
-                        tx: tx.as_recovered_ref(),
-                        gas_used: receipt.cumulative_gas_used() - gas_used,
-                        receipt,
-                        next_log_index,
-                        meta,
-                    }],
-                    block.sealed_block(),
-                )?
-                .pop()
-                .unwrap())
+            let inputs = vec![ConvertReceiptInput {
+                tx: tx.as_recovered_ref(),
+                gas_used: receipt.cumulative_gas_used() - gas_used,
+                receipt,
+                next_log_index,
+                meta,
+            }];
+            let mut receipts = match block {
+                Some(block) => {
+                    self.converter().convert_receipts_with_block(inputs, block.sealed_block())
+                }
+                None => self.converter().convert_receipts(inputs),
+            }?;
+
+            Ok(receipts.pop().unwrap())
         }
     }
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/subscriptions.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/subscriptions.rs
@@ -139,7 +139,7 @@ pub trait EthSubscriptions:
                         return None;
                     }
 
-                    match converter.convert_receipts(inputs, block.sealed_block()) {
+                    match converter.convert_receipts_with_block(inputs, block.sealed_block()) {
                         Ok(rpc_receipts) => Some(rpc_receipts),
                         Err(err) => {
                             error!(target = "rpc", %err, "Failed to convert receipts");

--- a/crates/rpc/rpc-eth-types/src/block.rs
+++ b/crates/rpc/rpc-eth-types/src/block.rs
@@ -183,7 +183,7 @@ where
         calculate_gas_used_and_next_log_index(meta.index, all_receipts);
 
     converter
-        .convert_receipts(
+        .convert_receipts_with_block(
             vec![ConvertReceiptInput {
                 tx: tx.recovered_tx(),
                 gas_used: receipt.cumulative_gas_used() - gas_used,

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -131,12 +131,12 @@ where
     fn convert_receipts(
         &self,
         inputs: Vec<ConvertReceiptInput<'_, N>>,
-        _block: &SealedBlock<N::Block>,
+        block: &SealedBlock<N::Block>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let mut receipts = Vec::with_capacity(inputs.len());
+        let blob_params = self.chain_spec.blob_params_at_timestamp(block.header().timestamp());
 
         for input in inputs {
-            let blob_params = self.chain_spec.blob_params_at_timestamp(input.meta.timestamp);
             receipts.push(build_receipt(input, blob_params, &self.build_rpc_receipt));
         }
 

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -1,7 +1,7 @@
 //! RPC receipt response builder, extends a layer one receipt with layer two data.
 
 use crate::EthApiError;
-use alloy_consensus::{ReceiptEnvelope, Transaction};
+use alloy_consensus::{BlockHeader, ReceiptEnvelope, Transaction};
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, TxKind};
 use alloy_rpc_types_eth::{Log, TransactionReceipt};

--- a/crates/rpc/rpc-eth-types/src/receipt.rs
+++ b/crates/rpc/rpc-eth-types/src/receipt.rs
@@ -1,13 +1,13 @@
 //! RPC receipt response builder, extends a layer one receipt with layer two data.
 
 use crate::EthApiError;
-use alloy_consensus::{BlockHeader, ReceiptEnvelope, Transaction};
+use alloy_consensus::{ReceiptEnvelope, Transaction};
 use alloy_eips::eip7840::BlobParams;
 use alloy_primitives::{Address, TxKind};
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
 use reth_chainspec::EthChainSpec;
 use reth_ethereum_primitives::Receipt;
-use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeaderFor, TransactionMeta};
+use reth_primitives_traits::{NodePrimitives, SealedHeaderFor, TransactionMeta};
 use reth_rpc_convert::transaction::{ConvertReceiptInput, ReceiptConverter};
 use std::sync::Arc;
 
@@ -131,10 +131,11 @@ where
     fn convert_receipts(
         &self,
         inputs: Vec<ConvertReceiptInput<'_, N>>,
-        block: &SealedBlock<N::Block>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let mut receipts = Vec::with_capacity(inputs.len());
-        let blob_params = self.chain_spec.blob_params_at_timestamp(block.header().timestamp());
+        let blob_params = inputs
+            .first()
+            .and_then(|input| self.chain_spec.blob_params_at_timestamp(input.meta.timestamp));
 
         for input in inputs {
             receipts.push(build_receipt(input, blob_params, &self.build_rpc_receipt));


### PR DESCRIPTION
Restores block-optional receipt conversion and dispatches based on whether the block is available. Shared blob parameters are derived from the first conversion input timestamp, avoiding a required block fetch while preserving block-aware converters.