### PR TITLE
fix(download): correct archive completion accounting

### DIFF
--- a/crates/cli/commands/src/download/archive.rs
+++ b/crates/cli/commands/src/download/archive.rs
@@ -178,6 +178,9 @@ impl ArchiveProcessor {
                         state = ArchiveAttemptState::Complete;
                     } else {
                         warn!(target: "reth::cli", file = %archive.file_name, component = %self.archive.component, attempt, "Archive extracted, but output verification failed, retrying");
+                        if mode == ArchiveMode::Cached {
+                            self.ctx.session().rollback_archive_download(archive.size);
+                        }
                         state = ArchiveAttemptState::RetryAttempt;
                     }
                 }
@@ -265,10 +268,8 @@ impl ArchiveProcessor {
         let download_result = {
             let mut download_progress = ArchiveDownloadProgress::new(self.ctx.session().progress());
             let result = fetcher.download(Some(&mut download_progress));
-            if let Ok(ref downloaded) = result &&
-                download_progress.has_tracked_bytes()
-            {
-                download_progress.complete(downloaded.size);
+            if result.is_ok() {
+                download_progress.complete(self.archive().size);
             }
             result
         };
@@ -290,6 +291,9 @@ impl ArchiveProcessor {
 
         let extract_result = self.extract_cached_archive(&downloaded.path, format);
         fetcher.cleanup_downloaded_files();
+        if extract_result.is_err() {
+            self.ctx.session().rollback_archive_download(self.archive().size);
+        }
         extract_result
     }
 

--- a/crates/cli/commands/src/download/archive.rs
+++ b/crates/cli/commands/src/download/archive.rs
@@ -370,3 +370,71 @@ impl ArchiveMode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::download::manifest::{OutputFileChecksum, SnapshotComponentType};
+
+    #[test]
+    fn cached_extraction_failure_does_not_keep_completed_bytes() {
+        failed_archive_can_be_retried(false);
+    }
+
+    #[test]
+    fn cached_verification_failure_does_not_keep_completed_bytes() {
+        failed_archive_can_be_retried(true);
+    }
+
+    fn failed_archive_can_be_retried(valid_archive: bool) {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let cache = dir.path().join("cache");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&cache).unwrap();
+        let source = dir.path().join("state.tar.zst");
+        let data = b"snapshot";
+        let mut tar = tar::Builder::new(zstd::Encoder::new(Vec::new(), 0).unwrap());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, "db/state", data.as_slice()).unwrap();
+        let bytes = tar.into_inner().unwrap().finish().unwrap();
+        fs::write(&source, if valid_archive { bytes.as_slice() } else { b"invalid zstd" }).unwrap();
+        let mut archive = PlannedArchive {
+            ty: SnapshotComponentType::State,
+            component: "state".into(),
+            archive: SnapshotArchive {
+                url: url::Url::from_file_path(&source).unwrap().to_string(),
+                file_name: "state.tar.zst".into(),
+                size: bytes.len() as u64,
+                blake3: None,
+                output_files: vec![OutputFileChecksum {
+                    path: "db/state".into(),
+                    size: data.len() as u64,
+                    blake3: blake3::hash(b"wrong").to_hex().to_string(),
+                }],
+            },
+        };
+        let token = CancellationToken::new();
+        let progress = SharedProgress::new(bytes.len() as u64 + 5, 8, 2, token.clone());
+        progress.record_archive_download_complete(5);
+        let session = DownloadSession::new(
+            Some(Arc::clone(&progress)),
+            Some(DownloadRequestLimiter::new(1)),
+            token,
+        );
+        let ctx = ArchiveProcessContext::new(target.clone(), Some(cache), session);
+        assert!(ArchiveProcessor::new(archive.clone(), ctx.clone()).run().is_err());
+        assert_eq!(progress.logical_downloaded_bytes(), 5);
+
+        fs::write(&source, &bytes).unwrap();
+        archive.archive.output_files[0].blake3 = blake3::hash(data).to_hex().to_string();
+        // Force the second run through extraction even if the first run left its output behind.
+        let _ = fs::remove_file(target.join("db/state"));
+        ArchiveProcessor::new(archive, ctx).run().unwrap();
+        assert_eq!(progress.logical_downloaded_bytes(), bytes.len() as u64 + 5);
+        assert_eq!(fs::read(target.join("db/state")).unwrap(), data);
+    }
+}

--- a/crates/cli/commands/src/download/extract.rs
+++ b/crates/cli/commands/src/download/extract.rs
@@ -1,8 +1,9 @@
 use super::{
     fetch::{ArchiveFetcher, DownloadedArchive},
     progress::{
-        ArchiveExtractionProgress, ArchiveExtractionProgressHandle, DownloadProgress,
-        DownloadRequestLimiter, ProgressReader, SharedProgress, SharedProgressReader,
+        ArchiveDownloadProgress, ArchiveExtractionProgress, ArchiveExtractionProgressHandle,
+        DownloadProgress, DownloadRequestLimiter, ProgressReader, SharedProgress,
+        SharedProgressReader,
     },
     session::DownloadSession,
     MAX_DOWNLOAD_RETRIES, RETRY_BACKOFF_SECS,
@@ -375,7 +376,12 @@ fn download_and_extract(
 ) -> Result<()> {
     let quiet = session.progress().is_some();
     let fetcher = ArchiveFetcher::new(url.to_string(), target_dir, session.clone());
-    let DownloadedArchive { path: downloaded_path, size: total_size } = fetcher.download(None)?;
+    let DownloadedArchive { path: downloaded_path, size: total_size } = {
+        let mut download_progress = ArchiveDownloadProgress::new(session.progress());
+        let downloaded = fetcher.download(Some(&mut download_progress))?;
+        download_progress.complete(downloaded.size);
+        downloaded
+    };
 
     let file_name =
         downloaded_path.file_name().map(|f| f.to_string_lossy().to_string()).unwrap_or_default();

--- a/crates/cli/commands/src/download/fetch.rs
+++ b/crates/cli/commands/src/download/fetch.rs
@@ -624,17 +624,25 @@ impl SegmentedDownload {
             }
         });
 
+        let downloaded_bytes = piece_progress_bytes.load(Ordering::Relaxed);
         if let Some(error) = terminal_failure.take() {
             if let Some(shared) = shared {
-                shared.sub_active_download_bytes(piece_progress_bytes.load(Ordering::Relaxed));
+                shared.sub_active_download_bytes(downloaded_bytes);
             }
             paths.cleanup_partial();
             return Err(error.wrap_err("Parallel download failed"))
         }
 
+        if !segmented_download_completed(cancel_token, downloaded_bytes, total_size) {
+            if let Some(shared) = shared {
+                shared.sub_active_download_bytes(downloaded_bytes);
+            }
+            paths.cleanup_partial();
+            eyre::bail!("Parallel download did not complete");
+        }
+
         if let Some(shared) = shared {
-            shared.sub_active_download_bytes(piece_progress_bytes.load(Ordering::Relaxed));
-            shared.record_archive_download_complete(total_size);
+            shared.sub_active_download_bytes(downloaded_bytes);
         }
 
         paths.finalize()?;
@@ -977,6 +985,15 @@ fn panic_payload_message(payload: Box<dyn Any + Send + 'static>) -> String {
     }
 }
 
+/// Returns whether every byte completed before cancellation.
+fn segmented_download_completed(
+    cancel_token: &CancellationToken,
+    downloaded_bytes: u64,
+    total_size: u64,
+) -> bool {
+    !cancel_token.is_cancelled() && downloaded_bytes == total_size
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1064,5 +1081,45 @@ mod tests {
         assert_eq!(downloaded.size, b"local archive bytes".len() as u64);
         assert!(!cache_dir.join("state.tar.zst").exists());
         assert!(!cache_dir.join("state.tar.zst.part").exists());
+    }
+
+    #[test]
+    fn cancelled_segmented_download_does_not_finalize_incomplete_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let total_size = 8;
+        let pieces = build_download_pieces(total_size, 4);
+        let plan = SegmentedDownloadPlan {
+            piece_size: 4,
+            piece_count: pieces.len(),
+            worker_count: 1,
+            pieces,
+        };
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+        let progress = SharedProgress::new(total_size, 0, 1, cancel_token.clone());
+        let session = DownloadSession::new(
+            Some(progress),
+            Some(DownloadRequestLimiter::new(1)),
+            cancel_token,
+        );
+        let url = "http://127.0.0.1:1/state.tar.zst";
+        let paths = DownloadPaths::from_url(url, dir.path());
+        let download =
+            SegmentedDownload::new(url.to_string(), paths, total_size, plan, session, None);
+
+        assert!(download.run().is_err());
+        assert!(!dir.path().join("state.tar.zst").exists());
+        assert!(!dir.path().join("state.tar.zst.part").exists());
+    }
+
+    #[test]
+    fn segmented_completion_requires_all_bytes_and_no_cancellation() {
+        let cancel_token = CancellationToken::new();
+
+        assert!(!segmented_download_completed(&cancel_token, 7, 8));
+        assert!(segmented_download_completed(&cancel_token, 8, 8));
+
+        cancel_token.cancel();
+        assert!(!segmented_download_completed(&cancel_token, 8, 8));
     }
 }

--- a/crates/cli/commands/src/download/progress.rs
+++ b/crates/cli/commands/src/download/progress.rs
@@ -215,6 +215,11 @@ impl SharedProgress {
         self.completed_download_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
+    /// Removes a completed download contribution when the archive must be retried.
+    pub(crate) fn rollback_archive_download(&self, bytes: u64) {
+        sub_bytes(&self.completed_download_bytes, bytes);
+    }
+
     /// Records an archive whose extracted outputs have fully verified.
     pub(crate) fn record_archive_output_complete(&self, bytes: u64) {
         self.completed_output_bytes.fetch_add(bytes, Ordering::Relaxed);
@@ -457,11 +462,6 @@ impl<'a> ArchiveDownloadProgress<'a> {
         if let Some(progress) = self.progress {
             progress.add_active_download_bytes(bytes);
         }
-    }
-
-    /// Returns whether this tracker has recorded any logical bytes itself.
-    pub(crate) fn has_tracked_bytes(&self) -> bool {
-        self.downloaded > 0
     }
 
     /// Moves this archive from active download bytes into completed download bytes.
@@ -803,6 +803,23 @@ mod tests {
 
         assert_eq!(progress.logical_downloaded_bytes(), 0);
         assert_eq!(progress.active_downloads.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn completed_archive_retry_counts_download_once() {
+        let progress = SharedProgress::new(40, 80, 2, CancellationToken::new());
+        progress.record_archive_download_complete(5);
+
+        let mut first_attempt = ArchiveDownloadProgress::new(Some(&progress));
+        first_attempt.record_downloaded(10);
+        first_attempt.complete(20);
+        progress.rollback_archive_download(20);
+
+        let mut second_attempt = ArchiveDownloadProgress::new(Some(&progress));
+        second_attempt.record_downloaded(10);
+        second_attempt.complete(20);
+
+        assert_eq!(progress.logical_downloaded_bytes(), 25);
     }
 
     #[test]

--- a/crates/cli/commands/src/download/session.rs
+++ b/crates/cli/commands/src/download/session.rs
@@ -60,6 +60,13 @@ impl DownloadSession {
             progress.record_archive_output_complete(bytes);
         }
     }
+
+    /// Removes a completed download contribution when the archive must be retried.
+    pub(crate) fn rollback_archive_download(&self, bytes: u64) {
+        if let Some(progress) = self.progress() {
+            progress.rollback_archive_download(bytes);
+        }
+    }
 }
 
 /// Paths used while processing one archive, plus the shared download session.


### PR DESCRIPTION
Rolls back compressed download progress when cached extraction or output verification fails, and prevents cancelled or incomplete segmented downloads from being finalized. Adds archive-pipeline regressions for failed attempts followed by successful retries.

Related to #23146.

# PR stack
Review in order:

1. test(cli): cover snapshot downloads with a mock HTTP server #27009
2. fix(download): correct archive completion accounting #26601 — this PR
3. fix(download): resume segmented downloads across restarts #26604
