### PR TITLE
fix(dns): rejoin TXT character-strings for EIP-1459 entries over 255 bytes

### DIFF
--- a/crates/net/dns/src/resolver.rs
+++ b/crates/net/dns/src/resolver.rs
@@ -2,7 +2,10 @@
 
 use dashmap::DashMap;
 pub use hickory_resolver::{net::NetError, TokioResolver};
-use hickory_resolver::{proto::rr::RData, ConnectionProvider};
+use hickory_resolver::{
+    proto::rr::{rdata::TXT, RData},
+    ConnectionProvider,
+};
 use std::future::Future;
 use tracing::trace;
 
@@ -27,11 +30,21 @@ impl<P: ConnectionProvider> Resolver for hickory_resolver::Resolver<P> {
                     RData::TXT(txt) => Some(txt),
                     _ => None,
                 })?;
-                let entry = txt.txt_data.first()?;
-                String::from_utf8(entry.to_vec()).ok()
+                txt_entry(txt)
             }
         }
     }
+}
+
+/// Joins all `<character-string>`s of a TXT record into a single entry.
+///
+/// [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035#section-3.3) limits a single
+/// `<character-string>` to 255 bytes, while an
+/// [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459) entry is only bounded by the 512 byte DNS
+/// UDP limit. Entries above 255 bytes are therefore published as several `<character-string>`s
+/// which have to be rejoined without a separator to recover the entry.
+fn txt_entry(txt: &TXT) -> Option<String> {
+    String::from_utf8(txt.txt_data.concat()).ok()
 }
 
 /// An asynchronous DNS resolver
@@ -112,5 +125,106 @@ impl Resolver for TimeoutResolver {
     async fn lookup_txt(&self, _query: &str) -> Option<String> {
         tokio::time::sleep(self.0).await;
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::keccak256;
+    use data_encoding::BASE32_NOPAD;
+    use hickory_resolver::{
+        config::{ConnectionConfig, NameServerConfig, ResolverConfig},
+        net::runtime::TokioRuntimeProvider,
+        proto::{
+            op::{Message, OpCode},
+            rr::Record,
+            serialize::binary::{BinDecodable, BinEncodable},
+        },
+    };
+    use std::net::{Ipv4Addr, SocketAddr};
+    use tokio::net::UdpSocket;
+
+    /// Maximum size of a single RFC 1035 `<character-string>`.
+    const MAX_CHARACTER_STRING: usize = 255;
+
+    /// A branch entry of the size go-ethereum's writer emits, which exceeds what a single
+    /// `<character-string>` can hold.
+    fn long_branch_entry() -> String {
+        let children = (0u8..13)
+            .map(|i| BASE32_NOPAD.encode(&keccak256([i]).as_slice()[..16]))
+            .collect::<Vec<_>>()
+            .join(",");
+        format!("enrtree-branch:{children}")
+    }
+
+    fn character_strings(entry: &str) -> Vec<String> {
+        entry
+            .as_bytes()
+            .chunks(MAX_CHARACTER_STRING)
+            .map(|chunk| String::from_utf8(chunk.to_vec()).unwrap())
+            .collect()
+    }
+
+    /// Answers every query with a single TXT record made up of `strings`.
+    async fn spawn_txt_server(strings: Vec<String>) -> SocketAddr {
+        let socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = socket.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 512];
+            while let Ok((len, from)) = socket.recv_from(&mut buf).await {
+                let request = Message::from_bytes(&buf[..len]).unwrap();
+                let query = request.queries.first().unwrap().clone();
+
+                let mut response = Message::response(request.metadata.id, OpCode::Query);
+                response.metadata.authoritative = true;
+                response.metadata.recursion_desired = request.metadata.recursion_desired;
+                response.metadata.recursion_available = true;
+                response.answers.push(Record::from_rdata(
+                    query.name().clone(),
+                    60,
+                    RData::TXT(TXT::new(strings.clone())),
+                ));
+                response.queries.push(query);
+
+                socket.send_to(&response.to_bytes().unwrap(), from).await.unwrap();
+            }
+        });
+        addr
+    }
+
+    fn resolver_for(addr: SocketAddr) -> DnsResolver {
+        let mut connection = ConnectionConfig::udp();
+        connection.port = addr.port();
+        let config = ResolverConfig::from_parts(
+            None,
+            vec![],
+            vec![NameServerConfig::new(addr.ip(), true, vec![connection])],
+        );
+        DnsResolver::new(
+            TokioResolver::builder_with_config(config, TokioRuntimeProvider::default())
+                .build()
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn txt_entry_joins_character_strings() {
+        let entry = long_branch_entry();
+        let strings = character_strings(&entry);
+        assert!(entry.len() > MAX_CHARACTER_STRING);
+        assert!(strings.len() > 1);
+
+        assert_eq!(txt_entry(&TXT::new(strings)), Some(entry));
+    }
+
+    #[tokio::test]
+    async fn lookup_txt_reads_record_split_over_character_strings() {
+        let entry = long_branch_entry();
+        let addr = spawn_txt_server(character_strings(&entry)).await;
+
+        let resolved = resolver_for(addr).lookup_txt("YNEGZIWHOM7TOOSUATAPTM.example.org").await;
+
+        assert_eq!(resolved, Some(entry));
     }
 }


### PR DESCRIPTION
## Description

DNS discovery currently resolves **zero** nodes from every real enrtree, including
`all.mainnet.ethdisco.net`.

`lookup_txt` reads only the first `<character-string>` of a TXT record. RFC 1035 caps a single
`<character-string>` at 255 bytes, while an enrtree entry is bounded by the 512 byte DNS UDP limit
that EIP-1459 budgets against, and EIP-778 permits a 300 byte ENR, about 404 characters once
base64url encoded. Long entries are therefore normal rather than unusual: go-ethereum deliberately
sizes branch records up to 370 bytes, and 219 of 300 sampled records on the mainnet tree span several
character-strings. hickory returns one list element per character-string, so they have to be rejoined
with no separator, as Go's resolver does (`net/lookup.go`: "Multiple strings in one TXT record need
to be concatenated without separator").

The loss is total rather than partial because `verify_entry_hash` from #22582 works correctly: a
truncated record does not hash to its subdomain, so the entry is rejected and its whole subtree is
dropped. Mainnet's first branch record is short enough to survive, but the level-2 branches are 370
bytes, so both subtrees die before any ENR is reached. The failure is only visible as `HashMismatch`
debug logs, and discv4/discv5 keep supplying peers, which is presumably why it went unnoticed.

Measured against live trees, deduplicating ENRs until the service stayed idle:

| tree | before | after | go-ethereum |
| --- | --- | --- | --- |
| `all.mainnet.ethdisco.net` at seq 8393 | 0 | 3000 | 3000 |
| a 25 node tree with multi-string records, second publisher | 0 | 25 | 25 |
| its 25 node snap subtree | 0 | 25 | 25 |

## Change

`txt_entry` concatenates all of `txt_data` and performs a single UTF-8 decode over the joined bytes.
Decoding per chunk would be wrong in principle, since a multi-byte sequence can straddle a chunk
boundary. No new dependencies.

## Tests

- `txt_entry_joins_character_strings` covers the join directly.
- `lookup_txt_reads_record_split_over_character_strings` is end to end: a stub UDP nameserver bound
  on `127.0.0.1:0` encodes a real DNS response with `hickory_proto`, and a resolver built via
  `ResolverConfig::from_parts` resolves through it, so hickory's actual wire decoder is exercised
  rather than a hand-built `TXT` value.

Both fail without the change. Reverting `txt_entry` to `txt_data.first()` gives:

```
test resolver::tests::txt_entry_joins_character_strings ... FAILED
test resolver::tests::lookup_txt_reads_record_split_over_character_strings ... FAILED
  left: Some("enrtree-branch:XQ3H...,2M7CLAE7ZKRLNEAFM6ASQUST")
 right: Some("enrtree-branch:XQ3H...,2M7CLAE7ZKRLNEAFM6ASQUSTTU,WLT3...,JXQOS2YKRCDOIKRMGW2X36FJ2U")
```

The truncation cuts off mid-base32-label at byte 255, which is what makes the record fail its hash
check.

`cargo test -p reth-dns-discovery`: 22 passed, 1 ignored (the pre-existing live-network test), 2
doctests. `cargo +nightly fmt --check` and `cargo clippy -p reth-dns-discovery --all-targets` are
clean.

Before this change the crate could not represent a multi-string record at all. `MapResolver` stores
one already-joined `String` per name, so the split is unrepresentable, and the `impl` on
`hickory_resolver::Resolver<P>` carrying the bug had no test coverage of any kind. The stub
nameserver added here is the first test infrastructure in the crate that can express it.

## Scope

One adjacent issue is out of scope, pre-existing and not made worse by this change: `lookup_txt`
selects the first TXT record at a name via `answers().iter().find_map(...)`, whereas go-ethereum
iterates every TXT record and takes the first that parses as a known entry. A name serving an
unrelated TXT record ahead of the enrtree entry would still fail. Every public tree apex checked,
`all.mainnet.ethdisco.net`, `all.sepolia.ethdisco.net` and `all.hoodi.ethdisco.net`, serves exactly
one TXT record, so the present impact is nil, and fixing it means either teaching `lookup_txt` the
enrtree grammar or widening the `Resolver` trait to return every record, neither of which belongs in
a truncation fix.
