### PR TITLE
fix(static-file): respect prune checkpoints in consistency check

### DIFF
--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -53,6 +53,7 @@ mod tests {
     use reth_db::mdbx::{cursor::Cursor, RW};
     use reth_db_api::{
         cursor::{DbCursorRO, DbCursorRW},
+        models::StorageSettings,
         table::Table,
         tables,
         transaction::{DbTx, DbTxMut},
@@ -67,14 +68,15 @@ mod tests {
         providers::{StaticFileProvider, StaticFileWriter},
         test_utils::MockNodeTypesWithDB,
         AccountExtReader, BlockBodyIndicesProvider, BlockWriter, DatabaseProviderFactory,
-        ProviderFactory, ProviderResult, ReceiptProvider, StageCheckpointWriter,
-        StaticFileProviderFactory, StorageReader,
+        ProviderFactory, ProviderResult, PruneCheckpointWriter, ReceiptProvider,
+        StageCheckpointWriter, StaticFileProviderFactory, StorageReader,
     };
-    use reth_prune_types::{PruneMode, PruneModes};
+    use reth_prune_types::{PruneCheckpoint, PruneMode, PruneModes, PruneSegment};
     use reth_stages_api::{
         ExecInput, ExecutionStageThresholds, PipelineTarget, Stage, StageCheckpoint, StageId,
     };
     use reth_static_file_types::StaticFileSegment;
+    use reth_storage_api::StorageSettingsCache;
     use reth_testing_utils::generators::{
         self, random_block, random_block_range, random_receipt, BlockRangeParams,
     };
@@ -291,6 +293,42 @@ mod tests {
         provider_rw.commit()?;
 
         Ok(db)
+    }
+
+    fn seed_v2_data() -> TestStageDB {
+        let db = seed_data(90).unwrap();
+        db.factory.set_storage_settings_cache(StorageSettings::v2());
+        db
+    }
+
+    fn save_prune_checkpoints(
+        db: &TestStageDB,
+        checkpoints: impl IntoIterator<Item = (PruneSegment, BlockNumber, PruneMode)>,
+    ) {
+        let provider_rw = db.factory.provider_rw().unwrap();
+        for (segment, block_number, prune_mode) in checkpoints {
+            provider_rw
+                .save_prune_checkpoint(
+                    segment,
+                    PruneCheckpoint {
+                        block_number: Some(block_number),
+                        tx_number: None,
+                        prune_mode,
+                    },
+                )
+                .unwrap();
+        }
+        provider_rw.commit().unwrap();
+    }
+
+    fn assert_consistency(db: &TestStageDB, expected: Option<PipelineTarget>) {
+        assert_eq!(
+            db.factory
+                .static_file_provider()
+                .check_consistency(&db.factory.database_provider_ro().unwrap())
+                .unwrap(),
+            expected
+        );
     }
 
     /// Simulates losing data to corruption and compare the check consistency result
@@ -533,5 +571,63 @@ mod tests {
 
         // Fill the gap, and ensure no unwind is necessary.
         update_db_and_check::<tables::Receipts>(&db, current + 1, None);
+    }
+
+    #[test]
+    fn test_consistency_pruned_v2_segments() {
+        for prune_mode in [PruneMode::Distance(2_000_000), PruneMode::Before(90)] {
+            let db = seed_v2_data();
+
+            // Without prune checkpoints the missing v2 segments look like data loss.
+            assert_consistency(&db, Some(PipelineTarget::Unwind(0)));
+
+            save_prune_checkpoints(
+                &db,
+                [
+                    PruneSegment::SenderRecovery,
+                    PruneSegment::AccountHistory,
+                    PruneSegment::StorageHistory,
+                ]
+                .map(|segment| (segment, 89, prune_mode)),
+            );
+            assert_consistency(&db, None);
+        }
+    }
+
+    #[test]
+    fn test_consistency_unwind_bounded_by_prune_checkpoint() {
+        let db = seed_v2_data();
+
+        // Senders are only pruned up to block 50 while the stage checkpoint is at the tip:
+        // blocks 51..=89 did lose data, so an unwind is still required, but bounded by the
+        // prune checkpoint instead of going all the way to 0.
+        save_prune_checkpoints(
+            &db,
+            [
+                (PruneSegment::SenderRecovery, 50, PruneMode::Distance(39)),
+                (PruneSegment::AccountHistory, 89, PruneMode::Distance(2_000_000)),
+                (PruneSegment::StorageHistory, 89, PruneMode::Distance(2_000_000)),
+            ],
+        );
+        assert_consistency(&db, Some(PipelineTarget::Unwind(50)));
+    }
+
+    #[test]
+    fn test_consistency_receipts_distance_prune_checkpoint() {
+        let db = seed_data(90).unwrap();
+        let static_file_provider = db.factory.static_file_provider();
+
+        // Remove all receipts static files, like a node whose receipts have been
+        // distance-pruned away.
+        while let Some(block) =
+            static_file_provider.get_highest_static_file_block(StaticFileSegment::Receipts)
+        {
+            static_file_provider.delete_jar(StaticFileSegment::Receipts, block).unwrap();
+        }
+
+        assert_consistency(&db, Some(PipelineTarget::Unwind(0)));
+
+        save_prune_checkpoints(&db, [(PruneSegment::Receipts, 89, PruneMode::Distance(2_000_000))]);
+        assert_consistency(&db, None);
     }
 }

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1575,7 +1575,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         highest_block: Option<BlockNumber>,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
         N: NodePrimitives<Receipt: Value, BlockHeader: Value, SignedTx: Value>,
     {
         match segment {
@@ -1647,7 +1647,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         highest_static_file_block: Option<BlockNumber>,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
     {
         debug!(target: "reth::providers::static_file", "Ensuring invariants");
         let mut db_cursor = provider.tx_ref().cursor_read::<T>()?;
@@ -1693,15 +1693,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
         debug!(target: "reth::providers::static_file", ?stage_id, checkpoint_block_number, "Retrieved stage checkpoint");
 
+        let effective_coverage_block =
+            Self::effective_coverage_block(provider, segment, highest_static_file_block)?;
+
         // If the checkpoint is ahead, then we lost static file data. May be data corruption.
-        if checkpoint_block_number > highest_static_file_block {
+        if checkpoint_block_number > effective_coverage_block {
             info!(
                 target: "reth::providers::static_file",
                 checkpoint_block_number,
-                unwind_target = highest_static_file_block,
+                unwind_target = effective_coverage_block,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block));
+            return Ok(Some(effective_coverage_block));
         }
 
         // If the checkpoint is ahead, or matches, then nothing to do.
@@ -1781,7 +1784,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         block_from_key: F,
     ) -> ProviderResult<Option<BlockNumber>>
     where
-        Provider: DBProvider + BlockReader + StageCheckpointReader,
+        Provider: DBProvider + BlockReader + StageCheckpointReader + PruneCheckpointReader,
         T: Table,
         F: Fn(&T::Key) -> BlockNumber,
     {
@@ -1830,15 +1833,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         let checkpoint_block_number =
             provider.get_stage_checkpoint(stage_id)?.unwrap_or_default().block_number;
 
-        if checkpoint_block_number > highest_static_file_block {
+        let effective_coverage_block =
+            Self::effective_coverage_block(provider, segment, highest_static_file_block)?;
+
+        if checkpoint_block_number > effective_coverage_block {
             info!(
                 target: "reth::providers::static_file",
                 checkpoint_block_number,
-                unwind_target = highest_static_file_block,
+                unwind_target = effective_coverage_block,
                 ?segment,
                 "Setting unwind target."
             );
-            return Ok(Some(highest_static_file_block))
+            return Ok(Some(effective_coverage_block))
         }
 
         if checkpoint_block_number < highest_static_file_block {
@@ -1863,6 +1869,46 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         }
 
         Ok(None)
+    }
+
+    /// Returns the highest block accounted for in this segment, either through data
+    /// present in static files or through data intentionally removed by pruning.
+    ///
+    /// Data below a segment's prune checkpoint has been intentionally deleted, so its
+    /// absence from static files is not an inconsistency. Without this, a pruned segment
+    /// whose stage checkpoint is ahead of its (empty) static files is treated as data
+    /// corruption and triggers an unwind to block 0, which aborts the node on startup.
+    /// See <https://github.com/paradigmxyz/reth/issues/23463>.
+    fn effective_coverage_block<Provider>(
+        provider: &Provider,
+        segment: StaticFileSegment,
+        highest_static_file_block: BlockNumber,
+    ) -> ProviderResult<BlockNumber>
+    where
+        Provider: PruneCheckpointReader,
+    {
+        let Some(prune_segment) = Self::prune_segment_for_static_file(segment) else {
+            return Ok(highest_static_file_block)
+        };
+
+        let prune_checkpoint_block = provider
+            .get_prune_checkpoint(prune_segment)?
+            .and_then(|checkpoint| checkpoint.block_number)
+            .unwrap_or_default();
+
+        Ok(highest_static_file_block.max(prune_checkpoint_block))
+    }
+
+    /// Returns the prune segment that governs data availability for a static file segment,
+    /// or `None` if the segment is never pruned.
+    const fn prune_segment_for_static_file(segment: StaticFileSegment) -> Option<PruneSegment> {
+        match segment {
+            StaticFileSegment::Receipts => Some(PruneSegment::Receipts),
+            StaticFileSegment::TransactionSenders => Some(PruneSegment::SenderRecovery),
+            StaticFileSegment::AccountChangeSets => Some(PruneSegment::AccountHistory),
+            StaticFileSegment::StorageChangeSets => Some(PruneSegment::StorageHistory),
+            StaticFileSegment::Headers | StaticFileSegment::Transactions => None,
+        }
     }
 
     /// Returns the earliest available block number that has not been expired and is still

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -748,8 +748,12 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
         let current_block = if let Some(current_block_number) = self.current_block_number() {
             current_block_number
         } else {
-            self.increment_block(0)?;
-            0
+            // A fresh file does not necessarily start at block 0: a writer opened for a
+            // pruned segment may be positioned on a later fixed range, in which case its
+            // first block is the expected start of that range.
+            let first_block = self.writer.user_header().expected_block_start();
+            self.increment_block(first_block)?;
+            first_block
         };
 
         match current_block.cmp(&advance_to) {

--- a/crates/storage/provider/src/providers/static_file/writer_tests.rs
+++ b/crates/storage/provider/src/providers/static_file/writer_tests.rs
@@ -883,4 +883,28 @@ mod tests {
 
         drop(writer);
     }
+
+    /// `ensure_at_block` on a fresh file that does not start at block 0 (e.g. created for a
+    /// distance-pruned segment) must initialize the writer at the file's expected block
+    /// start instead of erroring out.
+    ///
+    /// See <https://github.com/paradigmxyz/reth/issues/23463>.
+    #[test]
+    fn test_ensure_at_block_on_empty_non_genesis_file() {
+        let static_dir = tempfile::tempdir().unwrap();
+        let provider = setup_test_provider(&static_dir, 100);
+
+        // A writer for block 250 opens a fresh empty file covering blocks 200..=299.
+        let mut writer = provider.get_writer(250, StaticFileSegment::TransactionSenders).unwrap();
+        assert_eq!(writer.current_block_number(), None);
+
+        writer.ensure_at_block(250).unwrap();
+        assert_eq!(writer.current_block_number(), Some(250));
+        writer.commit().unwrap();
+
+        assert_eq!(
+            provider.get_highest_static_file_block(StaticFileSegment::TransactionSenders),
+            Some(250)
+        );
+    }
 }


### PR DESCRIPTION
Backports #26565 onto the EVM2 integration branch.

Treats blocks covered by prune checkpoints as available during static-file consistency checks and initializes fresh static files at their expected range start. This prevents pruned Storage V2 snapshots from unwinding sender recovery to block 0.