### PR TITLE
fix(engine): validate forkchoice markers before updating

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3452,6 +3452,15 @@ where
         &self,
         state: ForkchoiceState,
     ) -> Result<(), OnForkChoiceUpdated> {
+        // Validate safe before updating finalized so an invalid forkchoice state cannot leave the
+        // finalized marker updated.
+        if !state.safe_block_hash.is_zero() &&
+            matches!(self.find_canonical_header(state.safe_block_hash), Ok(None))
+        {
+            debug!(target: "engine::tree", "Safe block not found in canonical chain");
+            return Err(OnForkChoiceUpdated::invalid_state())
+        }
+
         // Ensure that the finalized block, if not zero, is known and in the canonical chain
         // after the head block is canonicalized.
         //

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -2480,6 +2480,34 @@ mod forkchoice_updated_tests {
         assert!(result.is_none(), "Non-canonical head should return None");
     }
 
+    #[tokio::test]
+    async fn test_invalid_safe_does_not_update_finalized() {
+        let mut test_harness = TestHarness::new(MAINNET.clone());
+        let blocks: Vec<_> = test_harness.block_builder.get_executed_blocks(0..3).collect();
+        test_harness = test_harness.with_blocks(blocks.clone());
+
+        let previous_finalized = blocks[0].recovered_block().clone_sealed_header();
+        test_harness.tree.canonical_in_memory_state.set_finalized(previous_finalized.clone());
+
+        let state = ForkchoiceState {
+            head_block_hash: blocks[2].recovered_block().hash(),
+            safe_block_hash: B256::random(),
+            finalized_block_hash: blocks[1].recovered_block().hash(),
+        };
+        let outcome = test_harness
+            .tree
+            .handle_canonical_head(state, &None)
+            .unwrap()
+            .expect("canonical head should produce an outcome")
+            .outcome;
+        assert_matches!(outcome.await, Err(ForkchoiceUpdateError::InvalidState));
+        assert_eq!(
+            test_harness.tree.canonical_in_memory_state.get_finalized_num_hash(),
+            Some(previous_finalized.num_hash())
+        );
+        assert!(test_harness.action_rx.try_recv().is_err());
+    }
+
     /// Test that verifies chain update application
     #[tokio::test]
     async fn test_apply_chain_update() {


### PR DESCRIPTION
Checks the safe block hash before updating finalized, preserving the existing marker update paths. Previously, a valid finalized hash followed by an invalid safe hash returned `InvalidState` after finalized had already advanced. The regression test verifies that the rejected update leaves finalized state and the persistence queue unchanged.