### PR TITLE
refactor(storage): move OverlayStateProvider and let it use a Provider ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10456,6 +10456,7 @@ dependencies = [
  "rayon",
  "reth-chain-state",
  "reth-db",
+ "reth-db-api",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-metrics",

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -146,13 +146,13 @@ use reth_primitives_traits::{
     RecoveredBlock, SealedBlock, SealedHeader, SignerRecoverable,
 };
 use reth_provider::{
-    providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockReader, ChangeSetReader,
-    DatabaseProviderFactory, DatabaseProviderROFactory, ProviderError, PruneCheckpointReader,
-    StageCheckpointReader, StateProvider, StateProviderBox, StateProviderFactory, StateReader,
-    StorageChangeSetReader, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    BlockExecutionOutput, BlockReader, ChangeSetReader, DatabaseProviderFactory,
+    DatabaseProviderROFactory, ProviderError, PruneCheckpointReader, StageCheckpointReader,
+    StateProvider, StateProviderBox, StateProviderFactory, StateReader, StorageChangeSetReader,
+    StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
-use reth_storage_overlay::OverlayManager;
+use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
 use reth_trie::{
     hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
     HashedPostState, KeccakKeyHasher, LazyTrieData,

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -69,12 +69,11 @@ use reth_primitives_traits::{
     AlloyBlockHeader, FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedHeader,
 };
 use reth_provider::{
-    providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockNumReader,
-    DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider, ProviderError,
-    PruneCheckpointReader, StageCheckpointReader, StateRootProvider, StorageSettingsCache,
-    TryIntoHistoricalStateProvider,
+    BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory, DatabaseProviderROFactory,
+    HashedPostStateProvider, ProviderError, PruneCheckpointReader, StageCheckpointReader,
+    StateRootProvider, StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
-use reth_storage_overlay::OverlayManager;
+use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
 use reth_tasks::utils::increase_thread_priority;
 use reth_trie::{
     hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
@@ -1352,11 +1351,10 @@ mod tests {
     use reth_evm_ethereum::EthEvmConfig;
     use reth_primitives_traits::{Account, StorageEntry};
     use reth_provider::{
-        providers::{BlockchainProvider, OverlayStateProviderFactory},
-        test_utils::create_test_provider_factory_with_chain_spec,
+        providers::BlockchainProvider, test_utils::create_test_provider_factory_with_chain_spec,
         HashingWriter,
     };
-    use reth_storage_overlay::OverlayManager;
+    use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
     use reth_testing_utils::generators;
     use reth_trie::test_utils::state_root;
     use revm::state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot, TransactionId};

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1121,10 +1121,8 @@ mod tests {
     use super::*;
     use alloy_primitives::{keccak256, Address, B256, U256};
     use reth_db_common::init::init_genesis;
-    use reth_provider::{
-        providers::OverlayStateProviderFactory, test_utils::create_test_provider_factory,
-    };
-    use reth_storage_overlay::OverlayManager;
+    use reth_provider::test_utils::create_test_provider_factory;
+    use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
     use reth_trie_parallel::proof_task::ProofTaskCtx;
     use reth_trie_sparse::ArenaParallelSparseTrie;
 

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -33,32 +33,37 @@ use reth_errors::ProviderError;
 use reth_node_types::NodePrimitives;
 use reth_primitives_traits::{ReceiptTy, StorageEntry};
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::{ChangeSetReader, DBProvider, NodePrimitivesProvider, StorageSettingsCache};
+use reth_storage_api::{
+    ChangeSetReader, DBProvider, DbTxProvider, NodePrimitivesProvider, StorageSettingsCache,
+};
 use reth_storage_errors::provider::ProviderResult;
 use strum::{Display, EnumIs};
 
 /// Type alias for [`EitherReader`] constructors.
-type EitherReaderTy<'a, P, T> =
-    EitherReader<'a, CursorTy<<P as DBProvider>::Tx, T>, <P as NodePrimitivesProvider>::Primitives>;
+type EitherReaderTy<'a, P, T> = EitherReader<
+    'a,
+    CursorTy<<P as DbTxProvider>::Tx, T>,
+    <P as NodePrimitivesProvider>::Primitives,
+>;
 
 /// Type alias for [`EitherReader`] constructors.
 type DupEitherReaderTy<'a, P, T> = EitherReader<
     'a,
-    DupCursorTy<<P as DBProvider>::Tx, T>,
+    DupCursorTy<<P as DbTxProvider>::Tx, T>,
     <P as NodePrimitivesProvider>::Primitives,
 >;
 
 /// Type alias for dup [`EitherWriter`] constructors.
 type DupEitherWriterTy<'a, P, T> = EitherWriter<
     'a,
-    DupCursorMutTy<<P as DBProvider>::Tx, T>,
+    DupCursorMutTy<<P as DbTxProvider>::Tx, T>,
     <P as NodePrimitivesProvider>::Primitives,
 >;
 
 /// Type alias for [`EitherWriter`] constructors.
 type EitherWriterTy<'a, P, T> = EitherWriter<
     'a,
-    CursorMutTy<<P as DBProvider>::Tx, T>,
+    CursorMutTy<<P as DbTxProvider>::Tx, T>,
     <P as NodePrimitivesProvider>::Primitives,
 >;
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1,8 +1,8 @@
 use super::state::latest::LatestStateProvider;
 use crate::{
     providers::{
-        ConsistentProvider, OverlayStateProvider, OverlayStateProviderFactory, ProviderNodeTypes,
-        RocksDBProvider, StaticFileProvider, StaticFileProviderRWRefMut,
+        ConsistentProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider,
+        StaticFileProviderRWRefMut,
     },
     BalProvider, BalStoreHandle, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
     BlockReaderIdExt, BlockSource, CanonChainTracker, CanonStateNotifications,
@@ -36,7 +36,9 @@ use reth_storage_api::{
     StorageRangeResult, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{anchor_for_parent, AnchorForParent};
+use reth_storage_overlay::{
+    anchor_for_parent, AnchorForParent, OverlayStateProvider, OverlayStateProviderFactory,
+};
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -13,13 +13,14 @@ use crate::{
     },
     AccountReader, BlockBodyWriter, BlockExecutionWriter, BlockHashReader, BlockNumReader,
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
-    DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
-    HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
-    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, PersistenceFrontiers,
-    ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit,
-    RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
-    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
-    TransactionsProvider, TransactionsProviderExt, TrieWriter,
+    DBProvider, DbTxProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter,
+    HeaderProvider, HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef,
+    HistoryWriter, LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown,
+    PersistenceFrontiers, ProviderError, ProviderHeader, PruneCheckpointReader,
+    PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory,
+    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
+    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
+    TransactionsProviderExt, TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -3980,13 +3981,15 @@ impl<TX: DbTxMut, N: NodeTypes> ChainStateBlockWriter for DatabaseProvider<TX, N
     }
 }
 
-impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider<TX, N> {
+impl<TX: DbTx + 'static, N: NodeTypes + 'static> DbTxProvider for DatabaseProvider<TX, N> {
     type Tx = TX;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         &self.tx
     }
+}
 
+impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider<TX, N> {
     fn tx_mut(&mut self) -> &mut Self::Tx {
         &mut self.tx
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -16,11 +16,11 @@ use crate::{
     DBProvider, DbTxProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter,
     HeaderProvider, HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef,
     HistoryWriter, LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown,
-    PersistenceFrontiers, ProviderError, ProviderHeader, PruneCheckpointReader,
-    PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory,
-    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
-    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
-    TransactionsProviderExt, TrieWriter,
+    PersistenceFrontiers, ProviderError, PruneCheckpointReader, PruneCheckpointWriter,
+    RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader,
+    StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader, StorageReader,
+    StorageTrieWriter, TransactionVariant, TransactionsProvider, TransactionsProviderExt,
+    TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -20,7 +20,6 @@ pub use state::{
         HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,
     },
     latest::{LatestStateProvider, LatestStateProviderRef},
-    overlay::{OverlayStateProvider, OverlayStateProviderFactory},
 };
 
 mod blockchain_provider;

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -1,4 +1,3 @@
 //! [`StateProvider`](crate::StateProvider) implementations
 pub(crate) mod historical;
 pub(crate) mod latest;
-pub(crate) mod overlay;

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -164,8 +164,7 @@ impl<Provider> OverlayStateProvider<Provider>
 where
     Provider: DBProvider,
 {
-    /// Create new overlay state provider. The `Provider` must be cloneable, which generally means
-    /// it should be wrapped in an `Arc`.
+    /// Creates a new overlay state provider.
     pub const fn new(
         provider: Provider,
         trie_updates: Arc<TrieUpdatesSorted>,
@@ -174,9 +173,81 @@ where
     ) -> Self {
         Self { provider, trie_updates, hashed_post_state, is_v2 }
     }
+
+    /// Returns a borrowed overlay state provider.
+    pub fn as_ref(&self) -> OverlayStateProviderRef<'_, Provider> {
+        OverlayStateProviderRef {
+            provider: &self.provider,
+            trie_updates: &self.trie_updates,
+            hashed_post_state: &self.hashed_post_state,
+            is_v2: self.is_v2,
+        }
+    }
 }
 
 impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+    Provider::Tx: DbTx,
+{
+    type AccountTrieCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::AccountTrieCursor<'a>
+    where
+        Self: 'a;
+
+    type StorageTrieCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::StorageTrieCursor<'a>
+    where
+        Self: 'a;
+
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
+        account_trie_cursor(&self.provider, &self.trie_updates, self.is_v2)
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
+        storage_trie_cursor(&self.provider, &self.trie_updates, self.is_v2, hashed_address)
+    }
+}
+
+impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+{
+    type AccountCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::AccountCursor<'a>
+    where
+        Self: 'a;
+
+    type StorageCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::StorageCursor<'a>
+    where
+        Self: 'a;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+        hashed_account_cursor(&self.provider, &self.hashed_post_state)
+    }
+
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+        hashed_storage_cursor(&self.provider, &self.hashed_post_state, hashed_address)
+    }
+}
+
+/// Borrowed state provider with in-memory trie and hashed-state overlays.
+#[derive(Debug, Clone, Copy)]
+pub struct OverlayStateProviderRef<'a, Provider: DBProvider> {
+    provider: &'a Provider,
+    trie_updates: &'a Arc<TrieUpdatesSorted>,
+    hashed_post_state: &'a Arc<HashedPostStateSorted>,
+    is_v2: bool,
+}
+
+impl<Provider> TrieCursorFactory for OverlayStateProviderRef<'_, Provider>
 where
     Provider: DBProvider,
     Provider::Tx: DbTx,
@@ -192,42 +263,18 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        let tx = self.provider.tx_ref();
-        let trie_updates = self.trie_updates.as_ref();
-        let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
-            Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
-                tx.cursor_read::<PackedAccountsTrie>()?,
-            ))
-        } else {
-            Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
-                tx.cursor_read::<tables::AccountsTrie>()?,
-            ))
-        };
-        Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
+        account_trie_cursor(self.provider, self.trie_updates, self.is_v2)
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        let tx = self.provider.tx_ref();
-        let trie_updates = self.trie_updates.as_ref();
-        let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
-            Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
-                tx.cursor_dup_read::<PackedStoragesTrie>()?,
-                hashed_address,
-            ))
-        } else {
-            Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
-                tx.cursor_dup_read::<tables::StoragesTrie>()?,
-                hashed_address,
-            ))
-        };
-        Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
+        storage_trie_cursor(self.provider, self.trie_updates, self.is_v2, hashed_address)
     }
 }
 
-impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
+impl<Provider> HashedCursorFactory for OverlayStateProviderRef<'_, Provider>
 where
     Provider: DBProvider,
 {
@@ -248,21 +295,101 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(self.provider.tx_ref());
-        let hashed_cursor_factory =
-            HashedPostStateCursorFactory::new(db_hashed_cursor_factory, &self.hashed_post_state);
-        hashed_cursor_factory.hashed_account_cursor()
+        hashed_account_cursor(self.provider, self.hashed_post_state)
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(self.provider.tx_ref());
-        let hashed_cursor_factory =
-            HashedPostStateCursorFactory::new(db_hashed_cursor_factory, &self.hashed_post_state);
-        hashed_cursor_factory.hashed_storage_cursor(hashed_address)
+        hashed_storage_cursor(self.provider, self.hashed_post_state, hashed_address)
     }
+}
+
+fn account_trie_cursor<'a, Provider>(
+    provider: &'a Provider,
+    trie_updates: &'a Arc<TrieUpdatesSorted>,
+    is_v2: bool,
+) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>, DatabaseError>
+where
+    Provider: DBProvider,
+    Provider::Tx: DbTx,
+{
+    let tx = provider.tx_ref();
+    let cursor: Box<dyn TrieCursor + Send> = if is_v2 {
+        Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
+            tx.cursor_read::<PackedAccountsTrie>()?,
+        ))
+    } else {
+        Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
+            tx.cursor_read::<tables::AccountsTrie>()?,
+        ))
+    };
+    Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
+}
+
+fn storage_trie_cursor<'a, Provider>(
+    provider: &'a Provider,
+    trie_updates: &'a Arc<TrieUpdatesSorted>,
+    is_v2: bool,
+    hashed_address: B256,
+) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieStorageCursor + Send + 'a>>, DatabaseError>
+where
+    Provider: DBProvider,
+    Provider::Tx: DbTx,
+{
+    let tx = provider.tx_ref();
+    let cursor: Box<dyn TrieStorageCursor + Send> = if is_v2 {
+        Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
+            tx.cursor_dup_read::<PackedStoragesTrie>()?,
+            hashed_address,
+        ))
+    } else {
+        Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
+            tx.cursor_dup_read::<tables::StoragesTrie>()?,
+            hashed_address,
+        ))
+    };
+    Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
+}
+
+fn hashed_account_cursor<'a, Provider>(
+    provider: &'a Provider,
+    hashed_post_state: &'a Arc<HashedPostStateSorted>,
+) -> Result<
+    <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        &'a Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::AccountCursor<'a>,
+    DatabaseError,
+>
+where
+    Provider: DBProvider,
+{
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let hashed_cursor_factory =
+        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
+    hashed_cursor_factory.hashed_account_cursor()
+}
+
+fn hashed_storage_cursor<'a, Provider>(
+    provider: &'a Provider,
+    hashed_post_state: &'a Arc<HashedPostStateSorted>,
+    hashed_address: B256,
+) -> Result<
+    <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        &'a Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::StorageCursor<'a>,
+    DatabaseError,
+>
+where
+    Provider: DBProvider,
+{
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let hashed_cursor_factory =
+        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
+    hashed_cursor_factory.hashed_storage_cursor(hashed_address)
 }
 
 #[cfg(all(test, feature = "partial-persistence"))]

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -35,7 +35,7 @@ use reth_primitives_traits::{
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
-    BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory,
+    BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory, DbTxProvider,
     HashedPostStateProvider, NodePrimitivesProvider, StageCheckpointReader, StateProofProvider,
     StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
     TryIntoHistoricalStateProvider,
@@ -512,15 +512,19 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProvi
     }
 }
 
-impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DbTxProvider
     for MockEthProvider<T, ChainSpec>
 {
     type Tx = TxMock;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         &self.tx
     }
+}
 
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
+    for MockEthProvider<T, ChainSpec>
+{
     fn tx_mut(&mut self) -> &mut Self::Tx {
         &mut self.tx
     }

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -54,8 +54,8 @@ use reth_prune_types::{PruneCheckpoint, PruneSegment};
 pub mod rpc_response;
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
-    BlockBodyIndicesProvider, BlockReaderIdExt, BlockSource, DBProvider, NodePrimitivesProvider,
-    ReceiptProviderIdExt, StatsReader,
+    BlockBodyIndicesProvider, BlockReaderIdExt, BlockSource, DBProvider, DbTxProvider,
+    NodePrimitivesProvider, ReceiptProviderIdExt, StatsReader,
 };
 use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, KeccakKeyHasher, MultiProof, TrieInput,
@@ -1348,7 +1348,7 @@ where
     }
 }
 
-impl<P, Node, N> DBProvider for RpcBlockchainStateProvider<P, Node, N>
+impl<P, Node, N> DbTxProvider for RpcBlockchainStateProvider<P, Node, N>
 where
     P: Provider<N> + Clone + 'static,
     N: Network,
@@ -1356,12 +1356,19 @@ where
 {
     type Tx = TxMock;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         // We can't use a static here since TxMock doesn't allow direct construction
         // This is fine since we're just returning a mock transaction
-        unimplemented!("tx_ref not supported for RPC provider")
+        unimplemented!("tx not supported for RPC provider")
     }
+}
 
+impl<P, Node, N> DBProvider for RpcBlockchainStateProvider<P, Node, N>
+where
+    P: Provider<N> + Clone + 'static,
+    N: Network,
+    Node: NodeTypes,
+{
     fn tx_mut(&mut self) -> &mut Self::Tx {
         unimplemented!("tx_mut not supported for RPC provider")
     }

--- a/crates/storage/storage-api/src/database_provider.rs
+++ b/crates/storage/storage-api/src/database_provider.rs
@@ -11,13 +11,22 @@ use reth_db_api::{
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderResult;
 
-/// Database provider.
-pub trait DBProvider: Sized {
+/// Provides shared access to a database transaction.
+#[auto_impl::auto_impl(&)]
+pub trait DbTxProvider {
     /// Underlying database transaction held by the provider.
     type Tx: DbTx;
 
+    /// Returns the underlying database transaction.
+    fn tx(&self) -> &Self::Tx;
+}
+
+/// Database provider.
+pub trait DBProvider: DbTxProvider + Sized {
     /// Returns a reference to the underlying transaction.
-    fn tx_ref(&self) -> &Self::Tx;
+    fn tx_ref(&self) -> &Self::Tx {
+        self.tx()
+    }
 
     /// Returns a mutable reference to the underlying transaction.
     fn tx_mut(&mut self) -> &mut Self::Tx;

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 
 #[cfg(feature = "db-api")]
-use crate::{DBProvider, DatabaseProviderFactory, StorageChangeSetReader, StorageSettingsCache};
+use crate::{
+    DBProvider, DatabaseProviderFactory, DbTxProvider, StorageChangeSetReader, StorageSettingsCache,
+};
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
@@ -683,13 +685,16 @@ impl<C: Send + Sync, N: Send + Sync> BlockBodyIndicesProvider for NoopProvider<C
 }
 
 #[cfg(feature = "db-api")]
-impl<ChainSpec: Send + Sync, N: NodePrimitives> DBProvider for NoopProvider<ChainSpec, N> {
+impl<ChainSpec: Send + Sync, N: NodePrimitives> DbTxProvider for NoopProvider<ChainSpec, N> {
     type Tx = TxMock;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         &self.tx
     }
+}
 
+#[cfg(feature = "db-api")]
+impl<ChainSpec: Send + Sync, N: NodePrimitives> DBProvider for NoopProvider<ChainSpec, N> {
     fn tx_mut(&mut self) -> &mut Self::Tx {
         &mut self.tx
     }

--- a/crates/storage/storage-overlay/Cargo.toml
+++ b/crates/storage/storage-overlay/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-chain-state.workspace = true
+reth-db-api.workspace = true
 reth-errors.workspace = true
 reth-ethereum-primitives.workspace = true
 reth-metrics.workspace = true

--- a/crates/storage/storage-overlay/src/lib.rs
+++ b/crates/storage/storage-overlay/src/lib.rs
@@ -10,3 +10,6 @@ pub(crate) use changeset_cache::ChangesetCache;
 
 mod manager;
 pub use manager::*;
+
+mod provider;
+pub use provider::*;

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -11,7 +11,7 @@ use reth_primitives_traits::{
 };
 use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-    DatabaseProviderROFactory, PruneCheckpointReader, StageCheckpointReader,
+    DatabaseProviderROFactory, DbTxProvider, PruneCheckpointReader, StageCheckpointReader,
     StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_trie::{
@@ -138,11 +138,11 @@ where
             res
         };
 
-        let Overlay { trie_updates, hashed_post_state } = self.get_overlay(&provider)?;
+        let overlay = self.get_overlay(&provider)?;
 
         let is_v2 = provider.cached_storage_settings().is_v2();
         self.metrics.database_provider_ro_duration.record(overall_start.elapsed());
-        Ok(OverlayStateProvider::new(provider, trie_updates, hashed_post_state, is_v2))
+        Ok(OverlayStateProvider::new(provider, overlay, is_v2))
     }
 }
 
@@ -154,114 +154,20 @@ where
 #[derive(Debug)]
 pub struct OverlayStateProvider<Provider> {
     provider: Provider,
-    trie_updates: Arc<TrieUpdatesSorted>,
-    hashed_post_state: Arc<HashedPostStateSorted>,
+    overlay: Overlay,
     is_v2: bool,
 }
 
 impl<Provider> OverlayStateProvider<Provider> {
     /// Creates a new overlay state provider.
-    pub const fn new(
-        provider: Provider,
-        trie_updates: Arc<TrieUpdatesSorted>,
-        hashed_post_state: Arc<HashedPostStateSorted>,
-        is_v2: bool,
-    ) -> Self {
-        Self { provider, trie_updates, hashed_post_state, is_v2 }
-    }
-
-    /// Returns a borrowed overlay state provider.
-    pub fn as_ref(&self) -> OverlayStateProviderRef<'_, Provider> {
-        OverlayStateProviderRef {
-            provider: &self.provider,
-            trie_updates: &self.trie_updates,
-            hashed_post_state: &self.hashed_post_state,
-            is_v2: self.is_v2,
-        }
+    pub const fn new(provider: Provider, overlay: Overlay, is_v2: bool) -> Self {
+        Self { provider, overlay, is_v2 }
     }
 }
 
 impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
 where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
-{
-    type AccountTrieCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::AccountTrieCursor<'a>
-    where
-        Self: 'a;
-
-    type StorageTrieCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::StorageTrieCursor<'a>
-    where
-        Self: 'a;
-
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        account_trie_cursor(&self.provider, &self.trie_updates, self.is_v2)
-    }
-
-    fn storage_trie_cursor(
-        &self,
-        hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        storage_trie_cursor(&self.provider, &self.trie_updates, self.is_v2, hashed_address)
-    }
-}
-
-impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
-where
-    Provider: DBProvider,
-{
-    type AccountCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::AccountCursor<'a>
-    where
-        Self: 'a;
-
-    type StorageCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::StorageCursor<'a>
-    where
-        Self: 'a;
-
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        hashed_account_cursor(&self.provider, &self.hashed_post_state)
-    }
-
-    fn hashed_storage_cursor(
-        &self,
-        hashed_address: B256,
-    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        hashed_storage_cursor(&self.provider, &self.hashed_post_state, hashed_address)
-    }
-}
-
-/// Borrowed state provider with in-memory trie and hashed-state overlays.
-#[derive(Debug)]
-pub struct OverlayStateProviderRef<'a, Provider> {
-    provider: &'a Provider,
-    trie_updates: &'a Arc<TrieUpdatesSorted>,
-    hashed_post_state: &'a Arc<HashedPostStateSorted>,
-    is_v2: bool,
-}
-
-impl<'a, Provider> OverlayStateProviderRef<'a, Provider>
-where
-    Provider: StorageSettingsCache,
-{
-    /// Creates an overlay state provider that borrows the database provider and overlay data.
-    pub fn new(provider: &'a Provider, overlay: &'a Overlay) -> Self {
-        Self {
-            provider,
-            trie_updates: &overlay.trie_updates,
-            hashed_post_state: &overlay.hashed_post_state,
-            is_v2: provider.cached_storage_settings().is_v2(),
-        }
-    }
-}
-
-impl<Provider> TrieCursorFactory for OverlayStateProviderRef<'_, Provider>
-where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
+    Provider: DbTxProvider,
 {
     type AccountTrieCursor<'a>
         = InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>
@@ -274,20 +180,20 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        account_trie_cursor(self.provider, self.trie_updates, self.is_v2)
+        account_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2)
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        storage_trie_cursor(self.provider, self.trie_updates, self.is_v2, hashed_address)
+        storage_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2, hashed_address)
     }
 }
 
-impl<Provider> HashedCursorFactory for OverlayStateProviderRef<'_, Provider>
+impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
 where
-    Provider: DBProvider,
+    Provider: DbTxProvider,
 {
     type AccountCursor<'a>
         = <HashedPostStateCursorFactory<
@@ -306,14 +212,14 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        hashed_account_cursor(self.provider, self.hashed_post_state)
+        hashed_account_cursor(&self.provider, &self.overlay.hashed_post_state)
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        hashed_storage_cursor(self.provider, self.hashed_post_state, hashed_address)
+        hashed_storage_cursor(&self.provider, &self.overlay.hashed_post_state, hashed_address)
     }
 }
 
@@ -323,10 +229,9 @@ fn account_trie_cursor<'a, Provider>(
     is_v2: bool,
 ) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>, DatabaseError>
 where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
+    Provider: DbTxProvider,
 {
-    let tx = provider.tx_ref();
+    let tx = provider.tx();
     let cursor: Box<dyn TrieCursor + Send> = if is_v2 {
         Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
             tx.cursor_read::<PackedAccountsTrie>()?,
@@ -346,10 +251,9 @@ fn storage_trie_cursor<'a, Provider>(
     hashed_address: B256,
 ) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieStorageCursor + Send + 'a>>, DatabaseError>
 where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
+    Provider: DbTxProvider,
 {
-    let tx = provider.tx_ref();
+    let tx = provider.tx();
     let cursor: Box<dyn TrieStorageCursor + Send> = if is_v2 {
         Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
             tx.cursor_dup_read::<PackedStoragesTrie>()?,
@@ -375,9 +279,9 @@ fn hashed_account_cursor<'a, Provider>(
     DatabaseError,
 >
 where
-    Provider: DBProvider,
+    Provider: DbTxProvider,
 {
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
     let hashed_cursor_factory =
         HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
     hashed_cursor_factory.hashed_account_cursor()
@@ -395,9 +299,9 @@ fn hashed_storage_cursor<'a, Provider>(
     DatabaseError,
 >
 where
-    Provider: DBProvider,
+    Provider: DbTxProvider,
 {
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
     let hashed_cursor_factory =
         HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
     hashed_cursor_factory.hashed_storage_cursor(hashed_address)

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -17,7 +17,6 @@ use reth_storage_api::{
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
-    updates::TrieUpdatesSorted,
     HashedPostStateSorted,
 };
 use reth_trie_db::{
@@ -180,14 +179,34 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        account_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2)
+        let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
+            Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
+                self.provider.tx().cursor_read::<PackedAccountsTrie>()?,
+            ))
+        } else {
+            Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
+                self.provider.tx().cursor_read::<tables::AccountsTrie>()?,
+            ))
+        };
+        Ok(InMemoryTrieCursor::new_account(cursor, &self.overlay.trie_updates))
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        storage_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2, hashed_address)
+        let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
+            Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
+                self.provider.tx().cursor_dup_read::<PackedStoragesTrie>()?,
+                hashed_address,
+            ))
+        } else {
+            Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
+                self.provider.tx().cursor_dup_read::<tables::StoragesTrie>()?,
+                hashed_address,
+            ))
+        };
+        Ok(InMemoryTrieCursor::new_storage(cursor, &self.overlay.trie_updates, hashed_address))
     }
 }
 
@@ -212,99 +231,23 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        hashed_account_cursor(&self.provider, &self.overlay.hashed_post_state)
+        HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(self.provider.tx()),
+            &self.overlay.hashed_post_state,
+        )
+        .hashed_account_cursor()
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        hashed_storage_cursor(&self.provider, &self.overlay.hashed_post_state, hashed_address)
+        HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(self.provider.tx()),
+            &self.overlay.hashed_post_state,
+        )
+        .hashed_storage_cursor(hashed_address)
     }
-}
-
-fn account_trie_cursor<'a, Provider>(
-    provider: &'a Provider,
-    trie_updates: &'a Arc<TrieUpdatesSorted>,
-    is_v2: bool,
-) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>, DatabaseError>
-where
-    Provider: DbTxProvider,
-{
-    let tx = provider.tx();
-    let cursor: Box<dyn TrieCursor + Send> = if is_v2 {
-        Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
-            tx.cursor_read::<PackedAccountsTrie>()?,
-        ))
-    } else {
-        Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
-            tx.cursor_read::<tables::AccountsTrie>()?,
-        ))
-    };
-    Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
-}
-
-fn storage_trie_cursor<'a, Provider>(
-    provider: &'a Provider,
-    trie_updates: &'a Arc<TrieUpdatesSorted>,
-    is_v2: bool,
-    hashed_address: B256,
-) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieStorageCursor + Send + 'a>>, DatabaseError>
-where
-    Provider: DbTxProvider,
-{
-    let tx = provider.tx();
-    let cursor: Box<dyn TrieStorageCursor + Send> = if is_v2 {
-        Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
-            tx.cursor_dup_read::<PackedStoragesTrie>()?,
-            hashed_address,
-        ))
-    } else {
-        Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
-            tx.cursor_dup_read::<tables::StoragesTrie>()?,
-            hashed_address,
-        ))
-    };
-    Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
-}
-
-fn hashed_account_cursor<'a, Provider>(
-    provider: &'a Provider,
-    hashed_post_state: &'a Arc<HashedPostStateSorted>,
-) -> Result<
-    <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<&'a Provider::Tx>,
-        &'a Arc<HashedPostStateSorted>,
-    > as HashedCursorFactory>::AccountCursor<'a>,
-    DatabaseError,
->
-where
-    Provider: DbTxProvider,
-{
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
-    let hashed_cursor_factory =
-        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
-    hashed_cursor_factory.hashed_account_cursor()
-}
-
-fn hashed_storage_cursor<'a, Provider>(
-    provider: &'a Provider,
-    hashed_post_state: &'a Arc<HashedPostStateSorted>,
-    hashed_address: B256,
-) -> Result<
-    <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<&'a Provider::Tx>,
-        &'a Arc<HashedPostStateSorted>,
-    > as HashedCursorFactory>::StorageCursor<'a>,
-    DatabaseError,
->
-where
-    Provider: DbTxProvider,
-{
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
-    let hashed_cursor_factory =
-        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
-    hashed_cursor_factory.hashed_storage_cursor(hashed_address)
 }
 
 #[cfg(all(test, feature = "partial-persistence"))]
@@ -320,7 +263,10 @@ mod tests {
     };
     use reth_stages_types::{FinishCheckpoint, StageCheckpoint, StageId};
     use reth_storage_api::StageCheckpointWriter;
-    use reth_trie::{BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, Nibbles};
+    use reth_trie::{
+        updates::TrieUpdatesSorted, BranchNodeCompact, ComputedTrieData, HashedPostState,
+        HashedStorage, Nibbles,
+    };
 
     fn with_unique_trie_data(
         block: &ExecutedBlock<EthPrimitives>,

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -1,3 +1,4 @@
+use crate::{database_state_frontiers, Overlay, OverlayBuilder};
 use alloy_primitives::{BlockHash, B256};
 use metrics::{Counter, Histogram};
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
@@ -13,7 +14,6 @@ use reth_storage_api::{
     DatabaseProviderROFactory, PruneCheckpointReader, StageCheckpointReader,
     StorageChangeSetReader, StorageSettingsCache,
 };
-use reth_storage_overlay::{database_state_frontiers, Overlay, OverlayBuilder};
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
@@ -118,7 +118,6 @@ where
     F: DatabaseProviderFactory,
     F::Provider: StageCheckpointReader
         + PruneCheckpointReader
-        + DBProvider
         + BlockNumReader
         + ChangeSetReader
         + StorageChangeSetReader
@@ -153,17 +152,14 @@ where
 /// on top of a database provider, implementing [`TrieCursorFactory`] and [`HashedCursorFactory`]
 /// using the in-memory overlay factories.
 #[derive(Debug)]
-pub struct OverlayStateProvider<Provider: DBProvider> {
+pub struct OverlayStateProvider<Provider> {
     provider: Provider,
     trie_updates: Arc<TrieUpdatesSorted>,
     hashed_post_state: Arc<HashedPostStateSorted>,
     is_v2: bool,
 }
 
-impl<Provider> OverlayStateProvider<Provider>
-where
-    Provider: DBProvider,
-{
+impl<Provider> OverlayStateProvider<Provider> {
     /// Creates a new overlay state provider.
     pub const fn new(
         provider: Provider,
@@ -239,12 +235,27 @@ where
 }
 
 /// Borrowed state provider with in-memory trie and hashed-state overlays.
-#[derive(Debug, Clone, Copy)]
-pub struct OverlayStateProviderRef<'a, Provider: DBProvider> {
+#[derive(Debug)]
+pub struct OverlayStateProviderRef<'a, Provider> {
     provider: &'a Provider,
     trie_updates: &'a Arc<TrieUpdatesSorted>,
     hashed_post_state: &'a Arc<HashedPostStateSorted>,
     is_v2: bool,
+}
+
+impl<'a, Provider> OverlayStateProviderRef<'a, Provider>
+where
+    Provider: StorageSettingsCache,
+{
+    /// Creates an overlay state provider that borrows the database provider and overlay data.
+    pub fn new(provider: &'a Provider, overlay: &'a Overlay) -> Self {
+        Self {
+            provider,
+            trie_updates: &overlay.trie_updates,
+            hashed_post_state: &overlay.hashed_post_state,
+            is_v2: provider.cached_storage_settings().is_v2(),
+        }
+    }
 }
 
 impl<Provider> TrieCursorFactory for OverlayStateProviderRef<'_, Provider>
@@ -395,16 +406,16 @@ where
 #[cfg(all(test, feature = "partial-persistence"))]
 mod tests {
     use super::*;
-    use crate::{
-        test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
-        BlockWriter, ProviderFactory,
-    };
+    use crate::OverlayManager;
     use alloy_primitives::U256;
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
+    use reth_provider::{
+        test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
+        BlockWriter, ProviderFactory,
+    };
     use reth_stages_types::{FinishCheckpoint, StageCheckpoint, StageId};
     use reth_storage_api::StageCheckpointWriter;
-    use reth_storage_overlay::OverlayManager;
     use reth_trie::{BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, Nibbles};
 
     fn with_unique_trie_data(

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1190,7 +1190,7 @@ mod tests {
         let chain_spec = Arc::new(ChainSpec::default());
         let anchor_hash = chain_spec.genesis_hash();
         let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec);
-        let factory = reth_provider::providers::OverlayStateProviderFactory::new(
+        let factory = reth_storage_overlay::OverlayStateProviderFactory::new(
             provider_factory,
             reth_storage_overlay::OverlayManager::<
                 reth_ethereum_primitives::EthPrimitives,


### PR DESCRIPTION
Moves OverlayStateProvider and its factory into reth-storage-overlay. This will prevent a dependency cycle in a follow-up PR.

Splits DbProvider into DbTxProvider+DbProvider. DbProvider on its own must be owned, by splitting out just the tx_ref method into its own trait we can let OverlayStateProvider use either an owned or borrowed provider with no changes.