### PR TITLE
fix(trie): support partial persistence in changeset cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10456,6 +10456,7 @@ dependencies = [
  "rayon",
  "reth-chain-state",
  "reth-db",
+ "reth-db-api",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-metrics",

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -146,13 +146,13 @@ use reth_primitives_traits::{
     RecoveredBlock, SealedBlock, SealedHeader, SignerRecoverable,
 };
 use reth_provider::{
-    providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockReader, ChangeSetReader,
-    DatabaseProviderFactory, DatabaseProviderROFactory, ProviderError, PruneCheckpointReader,
-    StageCheckpointReader, StateProvider, StateProviderBox, StateProviderFactory, StateReader,
-    StorageChangeSetReader, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    BlockExecutionOutput, BlockReader, ChangeSetReader, DatabaseProviderFactory,
+    DatabaseProviderROFactory, ProviderError, PruneCheckpointReader, StageCheckpointReader,
+    StateProvider, StateProviderBox, StateProviderFactory, StateReader, StorageChangeSetReader,
+    StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
-use reth_storage_overlay::OverlayManager;
+use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
 use reth_trie::{
     hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
     HashedPostState, KeccakKeyHasher, LazyTrieData,

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -69,12 +69,11 @@ use reth_primitives_traits::{
     AlloyBlockHeader, FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedHeader,
 };
 use reth_provider::{
-    providers::OverlayStateProviderFactory, BlockExecutionOutput, BlockNumReader,
-    DatabaseProviderFactory, DatabaseProviderROFactory, HashedPostStateProvider, ProviderError,
-    PruneCheckpointReader, StageCheckpointReader, StateRootProvider, StorageSettingsCache,
-    TryIntoHistoricalStateProvider,
+    BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory, DatabaseProviderROFactory,
+    HashedPostStateProvider, ProviderError, PruneCheckpointReader, StageCheckpointReader,
+    StateRootProvider, StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
-use reth_storage_overlay::OverlayManager;
+use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
 use reth_tasks::utils::increase_thread_priority;
 use reth_trie::{
     hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
@@ -1352,11 +1351,10 @@ mod tests {
     use reth_evm_ethereum::EthEvmConfig;
     use reth_primitives_traits::{Account, StorageEntry};
     use reth_provider::{
-        providers::{BlockchainProvider, OverlayStateProviderFactory},
-        test_utils::create_test_provider_factory_with_chain_spec,
+        providers::BlockchainProvider, test_utils::create_test_provider_factory_with_chain_spec,
         HashingWriter,
     };
-    use reth_storage_overlay::OverlayManager;
+    use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
     use reth_testing_utils::generators;
     use reth_trie::test_utils::state_root;
     use revm::state::{AccountInfo, AccountStatus, EvmState, EvmStorageSlot, TransactionId};

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1121,10 +1121,8 @@ mod tests {
     use super::*;
     use alloy_primitives::{keccak256, Address, B256, U256};
     use reth_db_common::init::init_genesis;
-    use reth_provider::{
-        providers::OverlayStateProviderFactory, test_utils::create_test_provider_factory,
-    };
-    use reth_storage_overlay::OverlayManager;
+    use reth_provider::test_utils::create_test_provider_factory;
+    use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
     use reth_trie_parallel::proof_task::ProofTaskCtx;
     use reth_trie_sparse::ArenaParallelSparseTrie;
 

--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -33,32 +33,37 @@ use reth_errors::ProviderError;
 use reth_node_types::NodePrimitives;
 use reth_primitives_traits::{ReceiptTy, StorageEntry};
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::{ChangeSetReader, DBProvider, NodePrimitivesProvider, StorageSettingsCache};
+use reth_storage_api::{
+    ChangeSetReader, DBProvider, DbTxProvider, NodePrimitivesProvider, StorageSettingsCache,
+};
 use reth_storage_errors::provider::ProviderResult;
 use strum::{Display, EnumIs};
 
 /// Type alias for [`EitherReader`] constructors.
-type EitherReaderTy<'a, P, T> =
-    EitherReader<'a, CursorTy<<P as DBProvider>::Tx, T>, <P as NodePrimitivesProvider>::Primitives>;
+type EitherReaderTy<'a, P, T> = EitherReader<
+    'a,
+    CursorTy<<P as DbTxProvider>::Tx, T>,
+    <P as NodePrimitivesProvider>::Primitives,
+>;
 
 /// Type alias for [`EitherReader`] constructors.
 type DupEitherReaderTy<'a, P, T> = EitherReader<
     'a,
-    DupCursorTy<<P as DBProvider>::Tx, T>,
+    DupCursorTy<<P as DbTxProvider>::Tx, T>,
     <P as NodePrimitivesProvider>::Primitives,
 >;
 
 /// Type alias for dup [`EitherWriter`] constructors.
 type DupEitherWriterTy<'a, P, T> = EitherWriter<
     'a,
-    DupCursorMutTy<<P as DBProvider>::Tx, T>,
+    DupCursorMutTy<<P as DbTxProvider>::Tx, T>,
     <P as NodePrimitivesProvider>::Primitives,
 >;
 
 /// Type alias for [`EitherWriter`] constructors.
 type EitherWriterTy<'a, P, T> = EitherWriter<
     'a,
-    CursorMutTy<<P as DBProvider>::Tx, T>,
+    CursorMutTy<<P as DbTxProvider>::Tx, T>,
     <P as NodePrimitivesProvider>::Primitives,
 >;
 

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1,8 +1,8 @@
 use super::state::latest::LatestStateProvider;
 use crate::{
     providers::{
-        ConsistentProvider, OverlayStateProvider, OverlayStateProviderFactory, ProviderNodeTypes,
-        RocksDBProvider, StaticFileProvider, StaticFileProviderRWRefMut,
+        ConsistentProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider,
+        StaticFileProviderRWRefMut,
     },
     BalProvider, BalStoreHandle, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
     BlockReaderIdExt, BlockSource, CanonChainTracker, CanonStateNotifications,
@@ -36,7 +36,9 @@ use reth_storage_api::{
     StorageRangeResult, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{anchor_for_parent, AnchorForParent};
+use reth_storage_overlay::{
+    anchor_for_parent, AnchorForParent, OverlayStateProvider, OverlayStateProviderFactory,
+};
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -13,13 +13,14 @@ use crate::{
     },
     AccountReader, BlockBodyWriter, BlockExecutionWriter, BlockHashReader, BlockNumReader,
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
-    DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
-    HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
-    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, PersistenceFrontiers,
-    ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit,
-    RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
-    StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
-    TransactionsProvider, TransactionsProviderExt, TrieWriter,
+    DBProvider, DbTxProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter,
+    HeaderProvider, HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef,
+    HistoryWriter, LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown,
+    PersistenceFrontiers, ProviderError, ProviderHeader, PruneCheckpointReader,
+    PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory,
+    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
+    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
+    TransactionsProviderExt, TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
@@ -3980,13 +3981,15 @@ impl<TX: DbTxMut, N: NodeTypes> ChainStateBlockWriter for DatabaseProvider<TX, N
     }
 }
 
-impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider<TX, N> {
+impl<TX: DbTx + 'static, N: NodeTypes + 'static> DbTxProvider for DatabaseProvider<TX, N> {
     type Tx = TX;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         &self.tx
     }
+}
 
+impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider<TX, N> {
     fn tx_mut(&mut self) -> &mut Self::Tx {
         &mut self.tx
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -16,11 +16,11 @@ use crate::{
     DBProvider, DbTxProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter,
     HeaderProvider, HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef,
     HistoryWriter, LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown,
-    PersistenceFrontiers, ProviderError, ProviderHeader, PruneCheckpointReader,
-    PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory,
-    StageCheckpointReader, StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader,
-    StorageReader, StorageTrieWriter, TransactionVariant, TransactionsProvider,
-    TransactionsProviderExt, TrieWriter,
+    PersistenceFrontiers, ProviderError, PruneCheckpointReader, PruneCheckpointWriter,
+    RawRocksDBBatch, RevertsInit, RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader,
+    StateProviderBox, StateWriter, StaticFileProviderFactory, StatsReader, StorageReader,
+    StorageTrieWriter, TransactionVariant, TransactionsProvider, TransactionsProviderExt,
+    TrieWriter,
 };
 use alloy_consensus::{
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -20,7 +20,6 @@ pub use state::{
         HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,
     },
     latest::{LatestStateProvider, LatestStateProviderRef},
-    overlay::{OverlayStateProvider, OverlayStateProviderFactory},
 };
 
 mod blockchain_provider;

--- a/crates/storage/provider/src/providers/state/mod.rs
+++ b/crates/storage/provider/src/providers/state/mod.rs
@@ -1,4 +1,3 @@
 //! [`StateProvider`](crate::StateProvider) implementations
 pub(crate) mod historical;
 pub(crate) mod latest;
-pub(crate) mod overlay;

--- a/crates/storage/provider/src/providers/state/overlay.rs
+++ b/crates/storage/provider/src/providers/state/overlay.rs
@@ -164,8 +164,7 @@ impl<Provider> OverlayStateProvider<Provider>
 where
     Provider: DBProvider,
 {
-    /// Create new overlay state provider. The `Provider` must be cloneable, which generally means
-    /// it should be wrapped in an `Arc`.
+    /// Creates a new overlay state provider.
     pub const fn new(
         provider: Provider,
         trie_updates: Arc<TrieUpdatesSorted>,
@@ -174,9 +173,81 @@ where
     ) -> Self {
         Self { provider, trie_updates, hashed_post_state, is_v2 }
     }
+
+    /// Returns a borrowed overlay state provider.
+    pub fn as_ref(&self) -> OverlayStateProviderRef<'_, Provider> {
+        OverlayStateProviderRef {
+            provider: &self.provider,
+            trie_updates: &self.trie_updates,
+            hashed_post_state: &self.hashed_post_state,
+            is_v2: self.is_v2,
+        }
+    }
 }
 
 impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+    Provider::Tx: DbTx,
+{
+    type AccountTrieCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::AccountTrieCursor<'a>
+    where
+        Self: 'a;
+
+    type StorageTrieCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::StorageTrieCursor<'a>
+    where
+        Self: 'a;
+
+    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
+        account_trie_cursor(&self.provider, &self.trie_updates, self.is_v2)
+    }
+
+    fn storage_trie_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
+        storage_trie_cursor(&self.provider, &self.trie_updates, self.is_v2, hashed_address)
+    }
+}
+
+impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
+where
+    Provider: DBProvider,
+{
+    type AccountCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::AccountCursor<'a>
+    where
+        Self: 'a;
+
+    type StorageCursor<'a>
+        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::StorageCursor<'a>
+    where
+        Self: 'a;
+
+    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+        hashed_account_cursor(&self.provider, &self.hashed_post_state)
+    }
+
+    fn hashed_storage_cursor(
+        &self,
+        hashed_address: B256,
+    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+        hashed_storage_cursor(&self.provider, &self.hashed_post_state, hashed_address)
+    }
+}
+
+/// Borrowed state provider with in-memory trie and hashed-state overlays.
+#[derive(Debug, Clone, Copy)]
+pub struct OverlayStateProviderRef<'a, Provider: DBProvider> {
+    provider: &'a Provider,
+    trie_updates: &'a Arc<TrieUpdatesSorted>,
+    hashed_post_state: &'a Arc<HashedPostStateSorted>,
+    is_v2: bool,
+}
+
+impl<Provider> TrieCursorFactory for OverlayStateProviderRef<'_, Provider>
 where
     Provider: DBProvider,
     Provider::Tx: DbTx,
@@ -192,42 +263,18 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        let tx = self.provider.tx_ref();
-        let trie_updates = self.trie_updates.as_ref();
-        let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
-            Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
-                tx.cursor_read::<PackedAccountsTrie>()?,
-            ))
-        } else {
-            Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
-                tx.cursor_read::<tables::AccountsTrie>()?,
-            ))
-        };
-        Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
+        account_trie_cursor(self.provider, self.trie_updates, self.is_v2)
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        let tx = self.provider.tx_ref();
-        let trie_updates = self.trie_updates.as_ref();
-        let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
-            Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
-                tx.cursor_dup_read::<PackedStoragesTrie>()?,
-                hashed_address,
-            ))
-        } else {
-            Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
-                tx.cursor_dup_read::<tables::StoragesTrie>()?,
-                hashed_address,
-            ))
-        };
-        Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
+        storage_trie_cursor(self.provider, self.trie_updates, self.is_v2, hashed_address)
     }
 }
 
-impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
+impl<Provider> HashedCursorFactory for OverlayStateProviderRef<'_, Provider>
 where
     Provider: DBProvider,
 {
@@ -248,21 +295,101 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(self.provider.tx_ref());
-        let hashed_cursor_factory =
-            HashedPostStateCursorFactory::new(db_hashed_cursor_factory, &self.hashed_post_state);
-        hashed_cursor_factory.hashed_account_cursor()
+        hashed_account_cursor(self.provider, self.hashed_post_state)
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(self.provider.tx_ref());
-        let hashed_cursor_factory =
-            HashedPostStateCursorFactory::new(db_hashed_cursor_factory, &self.hashed_post_state);
-        hashed_cursor_factory.hashed_storage_cursor(hashed_address)
+        hashed_storage_cursor(self.provider, self.hashed_post_state, hashed_address)
     }
+}
+
+fn account_trie_cursor<'a, Provider>(
+    provider: &'a Provider,
+    trie_updates: &'a Arc<TrieUpdatesSorted>,
+    is_v2: bool,
+) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>, DatabaseError>
+where
+    Provider: DBProvider,
+    Provider::Tx: DbTx,
+{
+    let tx = provider.tx_ref();
+    let cursor: Box<dyn TrieCursor + Send> = if is_v2 {
+        Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
+            tx.cursor_read::<PackedAccountsTrie>()?,
+        ))
+    } else {
+        Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
+            tx.cursor_read::<tables::AccountsTrie>()?,
+        ))
+    };
+    Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
+}
+
+fn storage_trie_cursor<'a, Provider>(
+    provider: &'a Provider,
+    trie_updates: &'a Arc<TrieUpdatesSorted>,
+    is_v2: bool,
+    hashed_address: B256,
+) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieStorageCursor + Send + 'a>>, DatabaseError>
+where
+    Provider: DBProvider,
+    Provider::Tx: DbTx,
+{
+    let tx = provider.tx_ref();
+    let cursor: Box<dyn TrieStorageCursor + Send> = if is_v2 {
+        Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
+            tx.cursor_dup_read::<PackedStoragesTrie>()?,
+            hashed_address,
+        ))
+    } else {
+        Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
+            tx.cursor_dup_read::<tables::StoragesTrie>()?,
+            hashed_address,
+        ))
+    };
+    Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
+}
+
+fn hashed_account_cursor<'a, Provider>(
+    provider: &'a Provider,
+    hashed_post_state: &'a Arc<HashedPostStateSorted>,
+) -> Result<
+    <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        &'a Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::AccountCursor<'a>,
+    DatabaseError,
+>
+where
+    Provider: DBProvider,
+{
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let hashed_cursor_factory =
+        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
+    hashed_cursor_factory.hashed_account_cursor()
+}
+
+fn hashed_storage_cursor<'a, Provider>(
+    provider: &'a Provider,
+    hashed_post_state: &'a Arc<HashedPostStateSorted>,
+    hashed_address: B256,
+) -> Result<
+    <HashedPostStateCursorFactory<
+        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        &'a Arc<HashedPostStateSorted>,
+    > as HashedCursorFactory>::StorageCursor<'a>,
+    DatabaseError,
+>
+where
+    Provider: DBProvider,
+{
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let hashed_cursor_factory =
+        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
+    hashed_cursor_factory.hashed_storage_cursor(hashed_address)
 }
 
 #[cfg(all(test, feature = "partial-persistence"))]

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -35,7 +35,7 @@ use reth_primitives_traits::{
 use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
-    BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory,
+    BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory, DbTxProvider,
     HashedPostStateProvider, NodePrimitivesProvider, StageCheckpointReader, StateProofProvider,
     StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
     TryIntoHistoricalStateProvider,
@@ -512,15 +512,19 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Clone + 'static> DatabaseProvi
     }
 }
 
-impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DbTxProvider
     for MockEthProvider<T, ChainSpec>
 {
     type Tx = TxMock;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         &self.tx
     }
+}
 
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + 'static> DBProvider
+    for MockEthProvider<T, ChainSpec>
+{
     fn tx_mut(&mut self) -> &mut Self::Tx {
         &mut self.tx
     }

--- a/crates/storage/rpc-provider/src/lib.rs
+++ b/crates/storage/rpc-provider/src/lib.rs
@@ -54,8 +54,8 @@ use reth_prune_types::{PruneCheckpoint, PruneSegment};
 pub mod rpc_response;
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
-    BlockBodyIndicesProvider, BlockReaderIdExt, BlockSource, DBProvider, NodePrimitivesProvider,
-    ReceiptProviderIdExt, StatsReader,
+    BlockBodyIndicesProvider, BlockReaderIdExt, BlockSource, DBProvider, DbTxProvider,
+    NodePrimitivesProvider, ReceiptProviderIdExt, StatsReader,
 };
 use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, KeccakKeyHasher, MultiProof, TrieInput,
@@ -1348,7 +1348,7 @@ where
     }
 }
 
-impl<P, Node, N> DBProvider for RpcBlockchainStateProvider<P, Node, N>
+impl<P, Node, N> DbTxProvider for RpcBlockchainStateProvider<P, Node, N>
 where
     P: Provider<N> + Clone + 'static,
     N: Network,
@@ -1356,12 +1356,19 @@ where
 {
     type Tx = TxMock;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         // We can't use a static here since TxMock doesn't allow direct construction
         // This is fine since we're just returning a mock transaction
-        unimplemented!("tx_ref not supported for RPC provider")
+        unimplemented!("tx not supported for RPC provider")
     }
+}
 
+impl<P, Node, N> DBProvider for RpcBlockchainStateProvider<P, Node, N>
+where
+    P: Provider<N> + Clone + 'static,
+    N: Network,
+    Node: NodeTypes,
+{
     fn tx_mut(&mut self) -> &mut Self::Tx {
         unimplemented!("tx_mut not supported for RPC provider")
     }

--- a/crates/storage/storage-api/src/database_provider.rs
+++ b/crates/storage/storage-api/src/database_provider.rs
@@ -11,13 +11,22 @@ use reth_db_api::{
 use reth_prune_types::PruneModes;
 use reth_storage_errors::provider::ProviderResult;
 
-/// Database provider.
-pub trait DBProvider: Sized {
+/// Provides shared access to a database transaction.
+#[auto_impl::auto_impl(&)]
+pub trait DbTxProvider {
     /// Underlying database transaction held by the provider.
     type Tx: DbTx;
 
+    /// Returns the underlying database transaction.
+    fn tx(&self) -> &Self::Tx;
+}
+
+/// Database provider.
+pub trait DBProvider: DbTxProvider + Sized {
     /// Returns a reference to the underlying transaction.
-    fn tx_ref(&self) -> &Self::Tx;
+    fn tx_ref(&self) -> &Self::Tx {
+        self.tx()
+    }
 
     /// Returns a mutable reference to the underlying transaction.
     fn tx_mut(&mut self) -> &mut Self::Tx;

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 
 #[cfg(feature = "db-api")]
-use crate::{DBProvider, DatabaseProviderFactory, StorageChangeSetReader, StorageSettingsCache};
+use crate::{
+    DBProvider, DatabaseProviderFactory, DbTxProvider, StorageChangeSetReader, StorageSettingsCache,
+};
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
@@ -683,13 +685,16 @@ impl<C: Send + Sync, N: Send + Sync> BlockBodyIndicesProvider for NoopProvider<C
 }
 
 #[cfg(feature = "db-api")]
-impl<ChainSpec: Send + Sync, N: NodePrimitives> DBProvider for NoopProvider<ChainSpec, N> {
+impl<ChainSpec: Send + Sync, N: NodePrimitives> DbTxProvider for NoopProvider<ChainSpec, N> {
     type Tx = TxMock;
 
-    fn tx_ref(&self) -> &Self::Tx {
+    fn tx(&self) -> &Self::Tx {
         &self.tx
     }
+}
 
+#[cfg(feature = "db-api")]
+impl<ChainSpec: Send + Sync, N: NodePrimitives> DBProvider for NoopProvider<ChainSpec, N> {
     fn tx_mut(&mut self) -> &mut Self::Tx {
         &mut self.tx
     }

--- a/crates/storage/storage-overlay/Cargo.toml
+++ b/crates/storage/storage-overlay/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # reth
 reth-chain-state.workspace = true
+reth-db-api.workspace = true
 reth-errors.workspace = true
 reth-ethereum-primitives.workspace = true
 reth-metrics.workspace = true

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -14,6 +14,7 @@ use reth_storage_api::{
     StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted};
+use reth_trie_db::DatabaseHashedPostState;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -69,6 +70,8 @@ pub struct OverlayBuilder<N: NodePrimitives = EthPrimitives> {
     overlay_manager: OverlayManager<N>,
     /// Anchor hash of the reused sparse trie, if this task reused one.
     reused_sparse_trie_anchor_hash: Option<B256>,
+    /// Whether building the overlay may query revert changesets.
+    no_reverts: bool,
     /// Metrics for overlay construction.
     metrics: OverlayBuilderMetrics,
 }
@@ -81,6 +84,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             overlay_source: Some(OverlaySource::Managed),
             overlay_manager,
             reused_sparse_trie_anchor_hash: None,
+            no_reverts: false,
             metrics: OverlayBuilderMetrics::default(),
         }
     }
@@ -97,6 +101,12 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     /// already covered by its anchor-to-parent range.
     pub const fn with_skip_overlay_for_reused_sparse_trie(mut self, anchor_hash: B256) -> Self {
         self.reused_sparse_trie_anchor_hash = Some(anchor_hash);
+        self
+    }
+
+    /// Returns an error instead of querying revert changesets when reverts are required.
+    pub const fn with_no_reverts(mut self) -> Self {
+        self.no_reverts = true;
         self
     }
 
@@ -200,6 +210,13 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         // Collect any reverts which are required to bring the DB view back to the anchor hash.
         let (trie_updates, hashed_post_state) = match anchor_for_parent {
             AnchorForParent::RevertsRequired { anchor, finish, .. } => {
+                if self.no_reverts {
+                    return Err(ProviderError::other(std::io::Error::other(format!(
+                        "reverts are disabled, but overlay for parent {} requires reverting Finish #{} ({}) to anchor #{} ({})",
+                        self.parent_hash, finish.number, finish.hash, anchor.number, anchor.hash,
+                    ))))
+                }
+
                 let revert_blocks = anchor.number + 1..=finish.number;
 
                 debug!(
@@ -213,9 +230,13 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     let _guard = debug_span!(target: "storage::overlay", "retrieving_trie_reverts")
                         .entered();
                     let start = Instant::now();
-                    let accumulated_reverts = self
-                        .overlay_manager
-                        .get_or_compute_cached_changesets_range(provider, revert_blocks.clone())?;
+                    let accumulated_reverts =
+                        self.overlay_manager.get_or_compute_cached_changesets_range_at_frontiers(
+                            provider,
+                            revert_blocks.clone(),
+                            state_trie_tip_block,
+                            finish_tip_block,
+                        )?;
                     retrieve_trie_reverts_duration = start.elapsed();
                     accumulated_reverts
                 };
@@ -225,7 +246,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         debug_span!(target: "storage::overlay", "retrieving_hashed_state_reverts")
                             .entered();
                     let start = Instant::now();
-                    let res = reth_trie_db::from_reverts_auto(provider, revert_blocks)?;
+                    let res = HashedPostStateSorted::from_reverts(provider, revert_blocks)?;
                     retrieve_hashed_state_reverts_duration = start.elapsed();
                     res
                 };
@@ -719,6 +740,21 @@ mod tests {
 
         assert!(overlay.hashed_post_state.is_empty());
         assert!(overlay.trie_updates.is_empty());
+    }
+
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn no_reverts_errors_when_reverts_are_required() {
+        let (factory, blocks) = setup_frontiers(2, 3);
+        let provider = factory.provider().unwrap();
+
+        let error = OverlayManager::<EthPrimitives>::default()
+            .overlay_builder(blocks[1].recovered_block().hash())
+            .with_no_reverts()
+            .build_overlay(&provider)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("reverts are disabled"));
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -7,15 +7,18 @@
 //! - **Reorg support**: Quickly access changesets to revert blocks during chain reorganizations
 //! - **Memory efficiency**: Explicit eviction releases persisted changesets
 
+use crate::{database_state_frontiers, OverlayManager, OverlayStateProvider};
+use alloy_eips::BlockNumHash;
 use alloy_primitives::{map::B256Map, BlockNumber, B256};
 use parking_lot::RwLock;
 use reth_metrics::{
     metrics::{Counter, Gauge},
     Metrics,
 };
-use reth_primitives_traits::FastInstant as Instant;
+use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_storage_api::{
-    BlockNumReader, ChangeSetReader, DBProvider, StorageChangeSetReader, StorageSettingsCache,
+    BlockNumReader, ChangeSetReader, DBProvider, PruneCheckpointReader, StageCheckpointReader,
+    StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use reth_trie::trie_cursor::{InMemoryTrieCursorFactory, TrieCursor, TrieCursorFactory};
@@ -29,9 +32,9 @@ use std::{
 use tracing::{debug, warn};
 
 #[cfg(test)]
-use reth_trie::{changesets::compute_trie_changesets, TrieInputSorted};
+use reth_trie::{changesets::compute_trie_changesets, HashedPostStateSorted, TrieInputSorted};
 #[cfg(test)]
-use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseStateRoot};
+use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseHashedPostState, DatabaseStateRoot};
 
 /// Computes block trie updates using the changeset cache.
 ///
@@ -48,7 +51,6 @@ use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseStateRoot};
 ///
 /// # Arguments
 ///
-/// * `cache` - Handle to the changeset cache for retrieving trie reverts
 /// * `provider` - Database provider for accessing changesets and block data
 /// * `block_number` - Block number to compute trie updates for
 ///
@@ -62,45 +64,63 @@ use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseStateRoot};
 /// - Block number exceeds database tip
 /// - Database access fails
 /// - Cache retrieval fails
-pub(crate) fn compute_block_trie_updates<Provider>(
-    cache: &ChangesetCache,
+pub(crate) fn compute_block_trie_updates<N, Provider>(
+    overlay_manager: &OverlayManager<N>,
     provider: &Provider,
     block_number: BlockNumber,
 ) -> ProviderResult<TrieUpdatesSorted>
 where
+    N: NodePrimitives,
     Provider: DBProvider
         + ChangeSetReader
         + StorageChangeSetReader
+        + PruneCheckpointReader
+        + StageCheckpointReader
         + BlockNumReader
         + StorageSettingsCache,
 {
     reth_trie_db::with_adapter!(provider, |A| {
-        compute_block_trie_updates_inner::<_, A>(cache, provider, block_number)
+        compute_block_trie_updates_inner::<_, _, A>(overlay_manager, provider, block_number)
     })
 }
 
-fn compute_block_trie_updates_inner<Provider, A>(
-    cache: &ChangesetCache,
+fn compute_block_trie_updates_inner<N, Provider, A>(
+    overlay_manager: &OverlayManager<N>,
     provider: &Provider,
     block_number: BlockNumber,
 ) -> ProviderResult<TrieUpdatesSorted>
 where
+    N: NodePrimitives,
     Provider: DBProvider
         + ChangeSetReader
         + StorageChangeSetReader
+        + PruneCheckpointReader
+        + StageCheckpointReader
         + BlockNumReader
         + StorageSettingsCache,
     A: TrieTableAdapter,
 {
     let tx = provider.tx_ref();
-
-    let db_tip_block = provider.best_block_number()?;
+    let cache = overlay_manager.changeset_cache();
+    let (partial_state_trie, finish) = database_state_frontiers(provider)?;
 
     // Step 1: Get the trie changesets for the target block from cache
-    let changesets = cache.get_or_compute(provider, block_number)?;
+    let changesets = cache.get_or_compute(
+        overlay_manager,
+        provider,
+        block_number,
+        partial_state_trie,
+        finish,
+    )?;
 
     // Step 2: Get the trie reverts for the state after the target block using the cache
-    let reverts = cache.get_or_compute_range(provider, (block_number + 1)..=db_tip_block)?;
+    let reverts = cache.get_or_compute_range(
+        overlay_manager,
+        provider,
+        (block_number + 1)..=finish.number,
+        partial_state_trie,
+        finish,
+    )?;
 
     // Step 3: Create an InMemoryTrieCursorFactory with the reverts
     // This gives us the trie state as it was after the target block was processed
@@ -194,19 +214,30 @@ impl ChangesetCache {
     /// # Returns
     ///
     /// Changesets for the block, either from cache or computed on-the-fly.
-    pub(crate) fn get_or_compute<P>(
+    pub(crate) fn get_or_compute<N, P>(
         &self,
+        overlay_manager: &OverlayManager<N>,
         provider: &P,
         block_number: BlockNumber,
+        partial_state_trie: BlockNumHash,
+        finish: BlockNumHash,
     ) -> ProviderResult<Arc<TrieUpdatesSorted>>
     where
+        N: NodePrimitives,
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
+            + PruneCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,
     {
-        self.get_or_compute_range(provider, block_number..=block_number)
+        self.get_or_compute_range(
+            overlay_manager,
+            provider,
+            block_number..=block_number,
+            partial_state_trie,
+            finish,
+        )
     }
 
     /// Gets or computes trie reverts for a range of blocks.
@@ -235,38 +266,40 @@ impl ChangesetCache {
     /// - Database access fails
     /// - Block hash lookup fails
     /// - Changeset computation fails
-    pub(crate) fn get_or_compute_range<P>(
+    pub(crate) fn get_or_compute_range<N, P>(
         &self,
+        overlay_manager: &OverlayManager<N>,
         provider: &P,
         range: RangeInclusive<BlockNumber>,
+        partial_state_trie: BlockNumHash,
+        finish: BlockNumHash,
     ) -> ProviderResult<Arc<TrieUpdatesSorted>>
     where
+        N: NodePrimitives,
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
+            + PruneCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,
     {
-        let db_tip_block = provider.best_block_number()?;
-
         let start_block = *range.start();
         let end_block = *range.end();
+        let timer = Instant::now();
 
-        // If range end is beyond the tip, return an error
-        if end_block > db_tip_block {
+        if end_block > finish.number {
             return Err(ProviderError::InsufficientChangesets {
                 requested: end_block,
-                available: 0..=db_tip_block,
+                available: 0..=finish.number,
             });
         }
-
-        let timer = Instant::now();
 
         debug!(
             target: "trie::changeset_cache",
             start_block,
             end_block,
-            db_tip_block,
+            ?partial_state_trie,
+            ?finish,
             "Starting get_or_compute_range"
         );
 
@@ -368,10 +401,21 @@ impl ChangesetCache {
             "Changeset cache MISS in range, falling back to aggregate DB-based computation"
         );
 
+        let overlay = overlay_manager
+            .overlay_builder(finish.hash)
+            .with_no_reverts()
+            .build_overlay_at_frontiers(provider, partial_state_trie, finish)?;
+        let state_trie_provider = OverlayStateProvider::new(
+            provider,
+            overlay,
+            provider.cached_storage_settings().is_v2(),
+        );
+
         let accumulated_reverts = Arc::new(reth_trie_db::compute_range_trie_changesets(
             provider,
+            &state_trie_provider,
             start_block..=end_block,
-            db_tip_block,
+            finish.number,
         )?);
 
         let elapsed = timer.elapsed();
@@ -574,6 +618,7 @@ impl ChangesetCacheInner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Overlay;
     use alloy_consensus::Header;
     use alloy_primitives::{
         keccak256,
@@ -597,6 +642,10 @@ mod tests {
     // Helper function to create empty TrieUpdatesSorted for testing
     fn create_test_changesets() -> Arc<TrieUpdatesSorted> {
         Arc::new(TrieUpdatesSorted::new(vec![], B256Map::default()))
+    }
+
+    fn empty_overlay() -> Overlay {
+        Overlay { trie_updates: Arc::default(), hashed_post_state: Arc::default() }
     }
 
     fn insert_test_changesets(
@@ -690,9 +739,9 @@ mod tests {
         A: TrieTableAdapter,
     {
         let individual_state_revert =
-            reth_trie_db::from_reverts_auto(provider, block_number..=block_number).unwrap();
+            HashedPostStateSorted::from_reverts(provider, block_number..=block_number).unwrap();
         let cumulative_state_revert =
-            reth_trie_db::from_reverts_auto(provider, (block_number + 1)..).unwrap();
+            HashedPostStateSorted::from_reverts(provider, (block_number + 1)..).unwrap();
 
         let mut cumulative_state_revert_prev = cumulative_state_revert.clone();
         cumulative_state_revert_prev.extend_ref_and_sort(&individual_state_revert);
@@ -780,7 +829,11 @@ mod tests {
             );
         }
 
-        let accumulated = cache.get_or_compute_range(&*provider, 1..=2).unwrap();
+        let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();
+        let (partial_state_trie, finish) = database_state_frontiers(&*provider).unwrap();
+        let accumulated = cache
+            .get_or_compute_range(&overlay_manager, &*provider, 1..=2, partial_state_trie, finish)
+            .unwrap();
         assert_eq!(accumulated.account_nodes_ref(), &[(path, Some(older_node))]);
     }
 
@@ -853,7 +906,15 @@ mod tests {
         provider.save_stage_checkpoint(StageId::Finish, StageCheckpoint::new(3)).unwrap();
         reth_trie_db::with_adapter!(provider, |A| seed_tip_trie_tables::<_, A>(&*provider));
 
-        let actual = reth_trie_db::compute_range_trie_changesets(&*provider, 1..=3, 3).unwrap();
+        let overlay = empty_overlay();
+        let state_trie_provider = OverlayStateProvider::new(
+            &*provider,
+            overlay,
+            provider.cached_storage_settings().is_v2(),
+        );
+        let actual =
+            reth_trie_db::compute_range_trie_changesets(&*provider, &state_trie_provider, 1..=3, 3)
+                .unwrap();
         let storage_revert = actual
             .storage_tries_ref()
             .get(&hashed_address)
@@ -862,11 +923,17 @@ mod tests {
         assert!(storage_revert.storage_nodes_ref().is_empty());
 
         let cache = ChangesetCache::new();
-        let from_cache_api = cache.get_or_compute_range(&*provider, 1..=3).unwrap();
+        let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();
+        let (partial_state_trie, finish) = database_state_frontiers(&*provider).unwrap();
+        let from_cache_api = cache
+            .get_or_compute_range(&overlay_manager, &*provider, 1..=3, partial_state_trie, finish)
+            .unwrap();
         assert_eq!(*from_cache_api, actual);
         assert_eq!(cache.inner.read().entries.len(), 1);
 
-        let block_changesets = cache.get_or_compute(&*provider, 2).unwrap();
+        let block_changesets = cache
+            .get_or_compute(&overlay_manager, &*provider, 2, partial_state_trie, finish)
+            .unwrap();
         assert_eq!(*block_changesets, legacy_compute_block_trie_changesets(&*provider, 2));
         assert_eq!(cache.inner.read().entries.len(), 2);
     }
@@ -930,7 +997,15 @@ mod tests {
         reth_trie_db::with_adapter!(provider, |A| seed_tip_trie_tables::<_, A>(&*provider));
 
         let expected = legacy_compute_range_trie_changesets(&*provider, 2..=3);
-        let actual = reth_trie_db::compute_range_trie_changesets(&*provider, 2..=3, 3).unwrap();
+        let overlay = empty_overlay();
+        let state_trie_provider = OverlayStateProvider::new(
+            &*provider,
+            overlay,
+            provider.cached_storage_settings().is_v2(),
+        );
+        let actual =
+            reth_trie_db::compute_range_trie_changesets(&*provider, &state_trie_provider, 2..=3, 3)
+                .unwrap();
         assert_eq!(actual, expected);
     }
 

--- a/crates/storage/storage-overlay/src/lib.rs
+++ b/crates/storage/storage-overlay/src/lib.rs
@@ -10,3 +10,6 @@ pub(crate) use changeset_cache::ChangesetCache;
 
 mod manager;
 pub use manager::*;
+
+mod provider;
+pub use provider::*;

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -4,7 +4,11 @@
 //! parent has not been persisted yet. [`OverlayManager`] tracks those in-memory blocks and
 //! builds reusable flattened state trie overlays on demand.
 
-use crate::{changeset_cache::compute_block_trie_updates, ChangesetCache, OverlayBuilder};
+use crate::{
+    changeset_cache::compute_block_trie_updates, database_state_frontiers, ChangesetCache,
+    OverlayBuilder,
+};
+use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
@@ -19,7 +23,8 @@ use reth_primitives_traits::{
     AlloyBlockHeader, FastInstant, NodePrimitives,
 };
 use reth_storage_api::{
-    BlockNumReader, ChangeSetReader, DBProvider, StorageChangeSetReader, StorageSettingsCache,
+    BlockNumReader, ChangeSetReader, DBProvider, PruneCheckpointReader, StageCheckpointReader,
+    StorageChangeSetReader, StorageSettingsCache,
 };
 #[cfg(feature = "rayon")]
 use reth_tasks::WorkerPool;
@@ -101,6 +106,10 @@ impl<N: NodePrimitives> OverlayManager<N> {
         OverlayBuilder::new(parent_hash, self.clone())
     }
 
+    pub(crate) const fn changeset_cache(&self) -> &ChangesetCache {
+        &self.changeset_cache
+    }
+
     /// Gets or computes cached changesets for an inclusive block range.
     pub fn get_or_compute_cached_changesets_range<P>(
         &self,
@@ -111,10 +120,36 @@ impl<N: NodePrimitives> OverlayManager<N> {
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
+            + PruneCheckpointReader
+            + StageCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,
     {
-        self.changeset_cache.get_or_compute_range(provider, range)
+        let (partial_state_trie, finish) = database_state_frontiers(provider)?;
+        self.get_or_compute_cached_changesets_range_at_frontiers(
+            provider,
+            range,
+            partial_state_trie,
+            finish,
+        )
+    }
+
+    pub(crate) fn get_or_compute_cached_changesets_range_at_frontiers<P>(
+        &self,
+        provider: &P,
+        range: RangeInclusive<BlockNumber>,
+        partial_state_trie: BlockNumHash,
+        finish: BlockNumHash,
+    ) -> ProviderResult<Arc<TrieUpdatesSorted>>
+    where
+        P: DBProvider
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + PruneCheckpointReader
+            + BlockNumReader
+            + StorageSettingsCache,
+    {
+        self.changeset_cache.get_or_compute_range(self, provider, range, partial_state_trie, finish)
     }
 
     /// Evicts cached changesets for blocks below `up_to_block`.
@@ -132,10 +167,12 @@ impl<N: NodePrimitives> OverlayManager<N> {
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
+            + PruneCheckpointReader
+            + StageCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,
     {
-        compute_block_trie_updates(&self.changeset_cache, provider, block_number)
+        compute_block_trie_updates(self, provider, block_number)
     }
 
     /// Takes the preserved sparse trie if present.

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -11,7 +11,7 @@ use reth_primitives_traits::{
 };
 use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-    DatabaseProviderROFactory, PruneCheckpointReader, StageCheckpointReader,
+    DatabaseProviderROFactory, DbTxProvider, PruneCheckpointReader, StageCheckpointReader,
     StorageChangeSetReader, StorageSettingsCache,
 };
 use reth_trie::{
@@ -138,11 +138,11 @@ where
             res
         };
 
-        let Overlay { trie_updates, hashed_post_state } = self.get_overlay(&provider)?;
+        let overlay = self.get_overlay(&provider)?;
 
         let is_v2 = provider.cached_storage_settings().is_v2();
         self.metrics.database_provider_ro_duration.record(overall_start.elapsed());
-        Ok(OverlayStateProvider::new(provider, trie_updates, hashed_post_state, is_v2))
+        Ok(OverlayStateProvider::new(provider, overlay, is_v2))
     }
 }
 
@@ -154,114 +154,20 @@ where
 #[derive(Debug)]
 pub struct OverlayStateProvider<Provider> {
     provider: Provider,
-    trie_updates: Arc<TrieUpdatesSorted>,
-    hashed_post_state: Arc<HashedPostStateSorted>,
+    overlay: Overlay,
     is_v2: bool,
 }
 
 impl<Provider> OverlayStateProvider<Provider> {
     /// Creates a new overlay state provider.
-    pub const fn new(
-        provider: Provider,
-        trie_updates: Arc<TrieUpdatesSorted>,
-        hashed_post_state: Arc<HashedPostStateSorted>,
-        is_v2: bool,
-    ) -> Self {
-        Self { provider, trie_updates, hashed_post_state, is_v2 }
-    }
-
-    /// Returns a borrowed overlay state provider.
-    pub fn as_ref(&self) -> OverlayStateProviderRef<'_, Provider> {
-        OverlayStateProviderRef {
-            provider: &self.provider,
-            trie_updates: &self.trie_updates,
-            hashed_post_state: &self.hashed_post_state,
-            is_v2: self.is_v2,
-        }
+    pub const fn new(provider: Provider, overlay: Overlay, is_v2: bool) -> Self {
+        Self { provider, overlay, is_v2 }
     }
 }
 
 impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
 where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
-{
-    type AccountTrieCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::AccountTrieCursor<'a>
-    where
-        Self: 'a;
-
-    type StorageTrieCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as TrieCursorFactory>::StorageTrieCursor<'a>
-    where
-        Self: 'a;
-
-    fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        account_trie_cursor(&self.provider, &self.trie_updates, self.is_v2)
-    }
-
-    fn storage_trie_cursor(
-        &self,
-        hashed_address: B256,
-    ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        storage_trie_cursor(&self.provider, &self.trie_updates, self.is_v2, hashed_address)
-    }
-}
-
-impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
-where
-    Provider: DBProvider,
-{
-    type AccountCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::AccountCursor<'a>
-    where
-        Self: 'a;
-
-    type StorageCursor<'a>
-        = <OverlayStateProviderRef<'a, Provider> as HashedCursorFactory>::StorageCursor<'a>
-    where
-        Self: 'a;
-
-    fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        hashed_account_cursor(&self.provider, &self.hashed_post_state)
-    }
-
-    fn hashed_storage_cursor(
-        &self,
-        hashed_address: B256,
-    ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        hashed_storage_cursor(&self.provider, &self.hashed_post_state, hashed_address)
-    }
-}
-
-/// Borrowed state provider with in-memory trie and hashed-state overlays.
-#[derive(Debug)]
-pub struct OverlayStateProviderRef<'a, Provider> {
-    provider: &'a Provider,
-    trie_updates: &'a Arc<TrieUpdatesSorted>,
-    hashed_post_state: &'a Arc<HashedPostStateSorted>,
-    is_v2: bool,
-}
-
-impl<'a, Provider> OverlayStateProviderRef<'a, Provider>
-where
-    Provider: StorageSettingsCache,
-{
-    /// Creates an overlay state provider that borrows the database provider and overlay data.
-    pub fn new(provider: &'a Provider, overlay: &'a Overlay) -> Self {
-        Self {
-            provider,
-            trie_updates: &overlay.trie_updates,
-            hashed_post_state: &overlay.hashed_post_state,
-            is_v2: provider.cached_storage_settings().is_v2(),
-        }
-    }
-}
-
-impl<Provider> TrieCursorFactory for OverlayStateProviderRef<'_, Provider>
-where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
+    Provider: DbTxProvider,
 {
     type AccountTrieCursor<'a>
         = InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>
@@ -274,20 +180,20 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        account_trie_cursor(self.provider, self.trie_updates, self.is_v2)
+        account_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2)
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        storage_trie_cursor(self.provider, self.trie_updates, self.is_v2, hashed_address)
+        storage_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2, hashed_address)
     }
 }
 
-impl<Provider> HashedCursorFactory for OverlayStateProviderRef<'_, Provider>
+impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
 where
-    Provider: DBProvider,
+    Provider: DbTxProvider,
 {
     type AccountCursor<'a>
         = <HashedPostStateCursorFactory<
@@ -306,14 +212,14 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        hashed_account_cursor(self.provider, self.hashed_post_state)
+        hashed_account_cursor(&self.provider, &self.overlay.hashed_post_state)
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        hashed_storage_cursor(self.provider, self.hashed_post_state, hashed_address)
+        hashed_storage_cursor(&self.provider, &self.overlay.hashed_post_state, hashed_address)
     }
 }
 
@@ -323,10 +229,9 @@ fn account_trie_cursor<'a, Provider>(
     is_v2: bool,
 ) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>, DatabaseError>
 where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
+    Provider: DbTxProvider,
 {
-    let tx = provider.tx_ref();
+    let tx = provider.tx();
     let cursor: Box<dyn TrieCursor + Send> = if is_v2 {
         Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
             tx.cursor_read::<PackedAccountsTrie>()?,
@@ -346,10 +251,9 @@ fn storage_trie_cursor<'a, Provider>(
     hashed_address: B256,
 ) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieStorageCursor + Send + 'a>>, DatabaseError>
 where
-    Provider: DBProvider,
-    Provider::Tx: DbTx,
+    Provider: DbTxProvider,
 {
-    let tx = provider.tx_ref();
+    let tx = provider.tx();
     let cursor: Box<dyn TrieStorageCursor + Send> = if is_v2 {
         Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
             tx.cursor_dup_read::<PackedStoragesTrie>()?,
@@ -375,9 +279,9 @@ fn hashed_account_cursor<'a, Provider>(
     DatabaseError,
 >
 where
-    Provider: DBProvider,
+    Provider: DbTxProvider,
 {
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
     let hashed_cursor_factory =
         HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
     hashed_cursor_factory.hashed_account_cursor()
@@ -395,9 +299,9 @@ fn hashed_storage_cursor<'a, Provider>(
     DatabaseError,
 >
 where
-    Provider: DBProvider,
+    Provider: DbTxProvider,
 {
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx_ref());
+    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
     let hashed_cursor_factory =
         HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
     hashed_cursor_factory.hashed_storage_cursor(hashed_address)

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -17,7 +17,6 @@ use reth_storage_api::{
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
-    updates::TrieUpdatesSorted,
     HashedPostStateSorted,
 };
 use reth_trie_db::{
@@ -180,14 +179,34 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        account_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2)
+        let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
+            Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
+                self.provider.tx().cursor_read::<PackedAccountsTrie>()?,
+            ))
+        } else {
+            Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
+                self.provider.tx().cursor_read::<tables::AccountsTrie>()?,
+            ))
+        };
+        Ok(InMemoryTrieCursor::new_account(cursor, &self.overlay.trie_updates))
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        storage_trie_cursor(&self.provider, &self.overlay.trie_updates, self.is_v2, hashed_address)
+        let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
+            Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
+                self.provider.tx().cursor_dup_read::<PackedStoragesTrie>()?,
+                hashed_address,
+            ))
+        } else {
+            Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
+                self.provider.tx().cursor_dup_read::<tables::StoragesTrie>()?,
+                hashed_address,
+            ))
+        };
+        Ok(InMemoryTrieCursor::new_storage(cursor, &self.overlay.trie_updates, hashed_address))
     }
 }
 
@@ -212,99 +231,23 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        hashed_account_cursor(&self.provider, &self.overlay.hashed_post_state)
+        HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(self.provider.tx()),
+            &self.overlay.hashed_post_state,
+        )
+        .hashed_account_cursor()
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        hashed_storage_cursor(&self.provider, &self.overlay.hashed_post_state, hashed_address)
+        HashedPostStateCursorFactory::new(
+            DatabaseHashedCursorFactory::new(self.provider.tx()),
+            &self.overlay.hashed_post_state,
+        )
+        .hashed_storage_cursor(hashed_address)
     }
-}
-
-fn account_trie_cursor<'a, Provider>(
-    provider: &'a Provider,
-    trie_updates: &'a Arc<TrieUpdatesSorted>,
-    is_v2: bool,
-) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>, DatabaseError>
-where
-    Provider: DbTxProvider,
-{
-    let tx = provider.tx();
-    let cursor: Box<dyn TrieCursor + Send> = if is_v2 {
-        Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
-            tx.cursor_read::<PackedAccountsTrie>()?,
-        ))
-    } else {
-        Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
-            tx.cursor_read::<tables::AccountsTrie>()?,
-        ))
-    };
-    Ok(InMemoryTrieCursor::new_account(cursor, trie_updates))
-}
-
-fn storage_trie_cursor<'a, Provider>(
-    provider: &'a Provider,
-    trie_updates: &'a Arc<TrieUpdatesSorted>,
-    is_v2: bool,
-    hashed_address: B256,
-) -> Result<InMemoryTrieCursor<'a, Box<dyn TrieStorageCursor + Send + 'a>>, DatabaseError>
-where
-    Provider: DbTxProvider,
-{
-    let tx = provider.tx();
-    let cursor: Box<dyn TrieStorageCursor + Send> = if is_v2 {
-        Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
-            tx.cursor_dup_read::<PackedStoragesTrie>()?,
-            hashed_address,
-        ))
-    } else {
-        Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
-            tx.cursor_dup_read::<tables::StoragesTrie>()?,
-            hashed_address,
-        ))
-    };
-    Ok(InMemoryTrieCursor::new_storage(cursor, trie_updates, hashed_address))
-}
-
-fn hashed_account_cursor<'a, Provider>(
-    provider: &'a Provider,
-    hashed_post_state: &'a Arc<HashedPostStateSorted>,
-) -> Result<
-    <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<&'a Provider::Tx>,
-        &'a Arc<HashedPostStateSorted>,
-    > as HashedCursorFactory>::AccountCursor<'a>,
-    DatabaseError,
->
-where
-    Provider: DbTxProvider,
-{
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
-    let hashed_cursor_factory =
-        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
-    hashed_cursor_factory.hashed_account_cursor()
-}
-
-fn hashed_storage_cursor<'a, Provider>(
-    provider: &'a Provider,
-    hashed_post_state: &'a Arc<HashedPostStateSorted>,
-    hashed_address: B256,
-) -> Result<
-    <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<&'a Provider::Tx>,
-        &'a Arc<HashedPostStateSorted>,
-    > as HashedCursorFactory>::StorageCursor<'a>,
-    DatabaseError,
->
-where
-    Provider: DbTxProvider,
-{
-    let db_hashed_cursor_factory = DatabaseHashedCursorFactory::new(provider.tx());
-    let hashed_cursor_factory =
-        HashedPostStateCursorFactory::new(db_hashed_cursor_factory, hashed_post_state);
-    hashed_cursor_factory.hashed_storage_cursor(hashed_address)
 }
 
 #[cfg(all(test, feature = "partial-persistence"))]
@@ -320,7 +263,10 @@ mod tests {
     };
     use reth_stages_types::{FinishCheckpoint, StageCheckpoint, StageId};
     use reth_storage_api::StageCheckpointWriter;
-    use reth_trie::{BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, Nibbles};
+    use reth_trie::{
+        updates::TrieUpdatesSorted, BranchNodeCompact, ComputedTrieData, HashedPostState,
+        HashedStorage, Nibbles,
+    };
 
     fn with_unique_trie_data(
         block: &ExecutedBlock<EthPrimitives>,

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -1,3 +1,4 @@
+use crate::{database_state_frontiers, Overlay, OverlayBuilder};
 use alloy_primitives::{BlockHash, B256};
 use metrics::{Counter, Histogram};
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
@@ -13,7 +14,6 @@ use reth_storage_api::{
     DatabaseProviderROFactory, PruneCheckpointReader, StageCheckpointReader,
     StorageChangeSetReader, StorageSettingsCache,
 };
-use reth_storage_overlay::{database_state_frontiers, Overlay, OverlayBuilder};
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
     trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
@@ -118,7 +118,6 @@ where
     F: DatabaseProviderFactory,
     F::Provider: StageCheckpointReader
         + PruneCheckpointReader
-        + DBProvider
         + BlockNumReader
         + ChangeSetReader
         + StorageChangeSetReader
@@ -153,17 +152,14 @@ where
 /// on top of a database provider, implementing [`TrieCursorFactory`] and [`HashedCursorFactory`]
 /// using the in-memory overlay factories.
 #[derive(Debug)]
-pub struct OverlayStateProvider<Provider: DBProvider> {
+pub struct OverlayStateProvider<Provider> {
     provider: Provider,
     trie_updates: Arc<TrieUpdatesSorted>,
     hashed_post_state: Arc<HashedPostStateSorted>,
     is_v2: bool,
 }
 
-impl<Provider> OverlayStateProvider<Provider>
-where
-    Provider: DBProvider,
-{
+impl<Provider> OverlayStateProvider<Provider> {
     /// Creates a new overlay state provider.
     pub const fn new(
         provider: Provider,
@@ -239,12 +235,27 @@ where
 }
 
 /// Borrowed state provider with in-memory trie and hashed-state overlays.
-#[derive(Debug, Clone, Copy)]
-pub struct OverlayStateProviderRef<'a, Provider: DBProvider> {
+#[derive(Debug)]
+pub struct OverlayStateProviderRef<'a, Provider> {
     provider: &'a Provider,
     trie_updates: &'a Arc<TrieUpdatesSorted>,
     hashed_post_state: &'a Arc<HashedPostStateSorted>,
     is_v2: bool,
+}
+
+impl<'a, Provider> OverlayStateProviderRef<'a, Provider>
+where
+    Provider: StorageSettingsCache,
+{
+    /// Creates an overlay state provider that borrows the database provider and overlay data.
+    pub fn new(provider: &'a Provider, overlay: &'a Overlay) -> Self {
+        Self {
+            provider,
+            trie_updates: &overlay.trie_updates,
+            hashed_post_state: &overlay.hashed_post_state,
+            is_v2: provider.cached_storage_settings().is_v2(),
+        }
+    }
 }
 
 impl<Provider> TrieCursorFactory for OverlayStateProviderRef<'_, Provider>
@@ -395,16 +406,16 @@ where
 #[cfg(all(test, feature = "partial-persistence"))]
 mod tests {
     use super::*;
-    use crate::{
-        test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
-        BlockWriter, ProviderFactory,
-    };
+    use crate::OverlayManager;
     use alloy_primitives::U256;
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
+    use reth_provider::{
+        test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
+        BlockWriter, ProviderFactory,
+    };
     use reth_stages_types::{FinishCheckpoint, StageCheckpoint, StageId};
     use reth_storage_api::StageCheckpointWriter;
-    use reth_storage_overlay::OverlayManager;
     use reth_trie::{BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, Nibbles};
 
     fn with_unique_trie_data(

--- a/crates/trie/db/src/changesets.rs
+++ b/crates/trie/db/src/changesets.rs
@@ -3,17 +3,17 @@
 //! This module reconstructs trie changesets from database state. The resulting changesets contain
 //! the old trie node values needed to revert a block or contiguous range of blocks.
 
-use crate::{
-    DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory, TrieTableAdapter,
-};
+use crate::DatabaseHashedPostState;
 use alloy_primitives::BlockNumber;
-use reth_storage_api::{
-    BlockNumReader, ChangeSetReader, DBProvider, StorageChangeSetReader, StorageSettingsCache,
-};
+use reth_storage_api::{BlockNumReader, ChangeSetReader, StorageChangeSetReader};
 use reth_storage_errors::provider::ProviderError;
-use reth_trie::TrieInputSorted;
+use reth_trie::{
+    hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
+    trie_cursor::{InMemoryTrieCursorFactory, TrieCursorFactory},
+    StateRoot,
+};
 use reth_trie_common::updates::TrieUpdatesSorted;
-use std::{ops::RangeInclusive, sync::Arc};
+use std::ops::RangeInclusive;
 use tracing::debug;
 
 /// Computes trie changesets for a block.
@@ -25,25 +25,22 @@ use tracing::debug;
 ///
 /// Returns an error if the block exceeds the database tip, database access fails, or state root
 /// computation fails.
-pub fn compute_block_trie_changesets<Provider>(
+pub fn compute_block_trie_changesets<Provider, StateTrieProvider>(
     provider: &Provider,
+    state_trie_provider: &StateTrieProvider,
     block_number: BlockNumber,
 ) -> Result<TrieUpdatesSorted, ProviderError>
 where
-    Provider: DBProvider
-        + ChangeSetReader
-        + StorageChangeSetReader
-        + BlockNumReader
-        + StorageSettingsCache,
+    Provider: ChangeSetReader + StorageChangeSetReader + BlockNumReader,
+    StateTrieProvider: TrieCursorFactory + HashedCursorFactory,
 {
     let db_tip_block = provider.best_block_number()?;
-    crate::with_adapter!(provider, |A| {
-        compute_range_trie_changesets_inner::<_, A>(
-            provider,
-            block_number..=block_number,
-            db_tip_block,
-        )
-    })
+    compute_range_trie_changesets(
+        provider,
+        state_trie_provider,
+        block_number..=block_number,
+        db_tip_block,
+    )
 }
 
 /// Computes aggregate trie changesets for an inclusive block range.
@@ -55,35 +52,15 @@ where
 ///
 /// Returns an error if the range exceeds `db_tip_block`, database access fails, or state root
 /// computation fails.
-pub fn compute_range_trie_changesets<Provider>(
+pub fn compute_range_trie_changesets<Provider, StateTrieProvider>(
     provider: &Provider,
+    state_trie_provider: &StateTrieProvider,
     range: RangeInclusive<BlockNumber>,
     db_tip_block: BlockNumber,
 ) -> Result<TrieUpdatesSorted, ProviderError>
 where
-    Provider: DBProvider
-        + ChangeSetReader
-        + StorageChangeSetReader
-        + BlockNumReader
-        + StorageSettingsCache,
-{
-    crate::with_adapter!(provider, |A| {
-        compute_range_trie_changesets_inner::<_, A>(provider, range, db_tip_block)
-    })
-}
-
-fn compute_range_trie_changesets_inner<Provider, A>(
-    provider: &Provider,
-    range: RangeInclusive<BlockNumber>,
-    db_tip_block: BlockNumber,
-) -> Result<TrieUpdatesSorted, ProviderError>
-where
-    Provider: DBProvider
-        + ChangeSetReader
-        + StorageChangeSetReader
-        + BlockNumReader
-        + StorageSettingsCache,
-    A: TrieTableAdapter,
+    Provider: ChangeSetReader + StorageChangeSetReader + BlockNumReader,
+    StateTrieProvider: TrieCursorFactory + HashedCursorFactory,
 {
     let start_block = *range.start();
     let end_block = *range.end();
@@ -108,13 +85,8 @@ where
     );
 
     // Collect the state revert for the requested range.
-    let range_state_revert = crate::state::from_reverts_auto(provider, range)?;
+    let range_state_revert = reth_trie::HashedPostStateSorted::from_reverts(provider, range)?;
     let range_prefix_sets = range_state_revert.construct_prefix_sets();
-
-    type DbStateRoot<'a, TX, A> = reth_trie::StateRoot<
-        DatabaseTrieCursorFactory<&'a TX, A>,
-        DatabaseHashedCursorFactory<&'a TX>,
-    >;
 
     let (range_nodes, range_state) = if end_block == db_tip_block {
         debug!(
@@ -125,25 +97,25 @@ where
             "Skipping tail trie revert computation for tip-ended range"
         );
 
-        (Arc::default(), Arc::new(range_state_revert))
+        (TrieUpdatesSorted::default(), range_state_revert)
     } else {
         // Collect the state revert from the database tip to just after the range.
         let tail_state_revert = end_block
             .checked_add(1)
-            .map(|next_block| crate::state::from_reverts_auto(provider, next_block..))
+            .map(|next_block| {
+                reth_trie::HashedPostStateSorted::from_reverts(provider, next_block..)
+            })
             .transpose()?
             .unwrap_or_default();
 
         // Compute trie reverts from the database tip to just after the range.
-        let tail_input = TrieInputSorted::new(
-            Arc::default(),
-            Arc::new(tail_state_revert.clone()),
-            tail_state_revert.construct_prefix_sets(),
-        );
-        let tail_trie_revert = DbStateRoot::<_, A>::overlay_root_from_nodes_with_updates(
-            provider.tx_ref(),
-            tail_input,
+        let tail_prefix_sets = tail_state_revert.construct_prefix_sets().freeze();
+        let tail_trie_revert = StateRoot::new(
+            state_trie_provider,
+            HashedPostStateCursorFactory::new(state_trie_provider, &tail_state_revert),
         )
+        .with_prefix_sets(tail_prefix_sets)
+        .root_with_updates()
         .map_err(ProviderError::other)?
         .1
         .into_sorted();
@@ -152,15 +124,18 @@ where
         let mut pre_range_state_revert = tail_state_revert;
         pre_range_state_revert.extend_ref_and_sort(&range_state_revert);
 
-        (Arc::new(tail_trie_revert), Arc::new(pre_range_state_revert))
+        (tail_trie_revert, pre_range_state_revert)
     };
 
-    let range_input = TrieInputSorted::new(range_nodes, range_state, range_prefix_sets);
-    let range_trie_revert =
-        DbStateRoot::<_, A>::overlay_root_from_nodes_with_updates(provider.tx_ref(), range_input)
-            .map_err(ProviderError::other)?
-            .1
-            .into_sorted();
+    let range_trie_revert = StateRoot::new(
+        InMemoryTrieCursorFactory::new(state_trie_provider, &range_nodes),
+        HashedPostStateCursorFactory::new(state_trie_provider, &range_state),
+    )
+    .with_prefix_sets(range_prefix_sets.freeze())
+    .root_with_updates()
+    .map_err(ProviderError::other)?
+    .1
+    .into_sorted();
 
     debug!(
         target: "trie::changesets",

--- a/crates/trie/db/src/lib.rs
+++ b/crates/trie/db/src/lib.rs
@@ -17,7 +17,7 @@ pub use hashed_cursor::{
 pub use prefix_set::load_prefix_sets_with_provider;
 pub use proof::{DatabaseProof, DatabaseStorageProof};
 pub use reth_db_api::tables::{PackedAccountsTrie, PackedStoragesTrie};
-pub use state::{from_reverts_auto, DatabaseHashedPostState, DatabaseStateRoot};
+pub use state::{DatabaseHashedPostState, DatabaseStateRoot};
 pub use storage::{hashed_storage_from_reverts_with_provider, DatabaseStorageRoot};
 pub use trie_cursor::{
     DatabaseAccountTrieCursor, DatabaseStorageTrieCursor, DatabaseTrieCursorFactory,

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -5,9 +5,7 @@ use reth_db_api::{
     transaction::DbTx,
 };
 use reth_execution_errors::StateRootError;
-use reth_storage_api::{
-    BlockNumReader, ChangeSetReader, DBProvider, StorageChangeSetReader, StorageSettingsCache,
-};
+use reth_storage_api::{ChangeSetReader, DBProvider, StorageChangeSetReader, StorageSettingsCache};
 use reth_storage_errors::provider::ProviderError;
 use reth_trie::{
     hashed_cursor::HashedPostStateCursorFactory, trie_cursor::InMemoryTrieCursorFactory,
@@ -146,7 +144,7 @@ pub trait DatabaseHashedPostState: Sized {
     /// Initializes [`HashedPostStateSorted`] from reverts. Iterates over state reverts in the
     /// specified range and aggregates them into sorted hashed state.
     fn from_reverts(
-        provider: &(impl ChangeSetReader + StorageChangeSetReader + BlockNumReader + DBProvider),
+        provider: &(impl ChangeSetReader + StorageChangeSetReader),
         range: impl RangeBounds<BlockNumber>,
     ) -> Result<HashedPostStateSorted, ProviderError>;
 }
@@ -263,18 +261,6 @@ impl<'a, TX: DbTx, A: crate::TrieTableAdapter> DatabaseStateRoot<'a, TX>
     }
 }
 
-/// Calls [`HashedPostStateSorted::from_reverts`].
-pub fn from_reverts_auto(
-    provider: &(impl ChangeSetReader
-          + StorageChangeSetReader
-          + BlockNumReader
-          + DBProvider
-          + StorageSettingsCache),
-    range: impl RangeBounds<BlockNumber>,
-) -> Result<HashedPostStateSorted, ProviderError> {
-    HashedPostStateSorted::from_reverts(provider, range)
-}
-
 impl DatabaseHashedPostState for HashedPostStateSorted {
     /// Builds a sorted hashed post-state from reverts.
     ///
@@ -287,7 +273,7 @@ impl DatabaseHashedPostState for HashedPostStateSorted {
     /// - Returns keys already ordered for trie iteration.
     #[instrument(target = "trie::db", skip(provider), fields(range))]
     fn from_reverts(
-        provider: &(impl ChangeSetReader + StorageChangeSetReader + BlockNumReader + DBProvider),
+        provider: &(impl ChangeSetReader + StorageChangeSetReader),
         range: impl RangeBounds<BlockNumber>,
     ) -> Result<Self, ProviderError> {
         // Extract concrete start/end values to use for both account and storage changesets.

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1190,7 +1190,7 @@ mod tests {
         let chain_spec = Arc::new(ChainSpec::default());
         let anchor_hash = chain_spec.genesis_hash();
         let provider_factory = create_test_provider_factory_with_chain_spec(chain_spec);
-        let factory = reth_provider::providers::OverlayStateProviderFactory::new(
+        let factory = reth_storage_overlay::OverlayStateProviderFactory::new(
             provider_factory,
             reth_storage_overlay::OverlayManager::<
                 reth_ethereum_primitives::EthPrimitives,


### PR DESCRIPTION
Make sure to include the partial_state_trie->Finish overlay blocks when constructing the db tip view during trie changeset calculations. Without this overlay the db tip is not in a consistent state.