### PR TITLE
refactor: reuse evm for block-level tracing

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -733,7 +733,7 @@ pub trait Call:
     /// This executes on a caller provided EVM, so the target transaction can then be run on the
     /// same EVM, keeping any block-scoped EVM state intact. The EVM's inspector configuration is
     /// left untouched; see
-    /// [`Self::inspect_transaction_in_block`] to replay without inspection and trace the target.
+    /// [`Trace::inspect_transaction_in_block`] to replay without inspection and trace the target.
     ///
     /// If the target index is greater than or equal to the iterator length, all transactions are
     /// replayed.

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -38,7 +38,7 @@ use reth_rpc_eth_types::{
     simulate::{self, EthSimulateError},
     EthApiError, StateCacheDb,
 };
-use reth_storage_api::{BlockIdReader, ProviderTx, StateProviderBox};
+use reth_storage_api::{BlockIdReader, ProviderTx};
 use revm::{
     context::Block,
     context_interface::{result::ResultAndState, Cfg, Transaction},
@@ -531,22 +531,6 @@ pub trait Call:
         tx_env: &TxEnvFor<Self::Evm>,
     ) -> Result<u64, Self::Error> {
         alloy_evm::call::caller_gas_allowance(&mut db, tx_env).map_err(Self::Error::from_eth_err)
-    }
-
-    /// Executes the closure with the state that corresponds to the given [`BlockId`].
-    fn with_state_at_block<F, R>(
-        &self,
-        at: BlockId,
-        f: F,
-    ) -> impl Future<Output = Result<R, Self::Error>> + Send
-    where
-        R: Send + 'static,
-        F: FnOnce(Self, StateProviderBox) -> Result<R, Self::Error> + Send + 'static,
-    {
-        self.spawn_blocking_io_fut(async move |this| {
-            let state = this.state_at_block_id(at).await?;
-            f(this, state)
-        })
     }
 
     /// Executes the `TxEnv` against the given [Database] without committing state

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -788,33 +788,6 @@ pub trait Call:
         Ok(index)
     }
 
-    /// Replays all transactions before the target transaction without inspection, then executes
-    /// the target transaction with the configured inspector, all on the given EVM.
-    ///
-    /// Note: This assumes the target transaction is in the given iterator.
-    /// Returns the index of the target transaction in the given iterator and its execution
-    /// result.
-    #[expect(clippy::type_complexity)]
-    fn inspect_transaction_in_block<'a, DB, I, Txs>(
-        &self,
-        evm: &mut EvmFor<Self::Evm, DB, I>,
-        transactions: Txs,
-        target_tx_hash: B256,
-        target_tx_env: TxEnvFor<Self::Evm>,
-    ) -> Result<(usize, ResultAndState<HaltReasonFor<Self::Evm>>), Self::Error>
-    where
-        DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
-        I: InspectorFor<Self::Evm, DB>,
-        Txs: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
-    {
-        evm.disable_inspector();
-        let index = self.replay_transactions_until_with_evm(evm, transactions, target_tx_hash)?;
-        evm.enable_inspector();
-
-        let res = evm.transact(target_tx_env).map_err(Self::Error::from_evm_err)?;
-        Ok((index, res))
-    }
-
     ///
     /// All `TxEnv` fields are derived from the given [`RpcTxReq`], if fields are
     /// `None`, they fall back to the [`reth_evm::EvmEnv`]'s settings.

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -24,8 +24,8 @@ use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
     EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
 };
-use reth_node_api::{BlockBody};
-use reth_primitives_traits::{Recovered};
+use reth_node_api::BlockBody;
+use reth_primitives_traits::Recovered;
 use reth_revm::{
     cancelled::CancelOnDrop,
     database::StateProviderDatabase,
@@ -299,7 +299,10 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
         bundles: Vec<Bundle<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>>,
         state_context: Option<StateContext>,
         mut state_override: Option<StateOverride>,
-    ) -> impl Future<Output = Result<Vec<Vec<EthCallResponse>>, Self::Error>> + Send {
+    ) -> impl Future<Output = Result<Vec<Vec<EthCallResponse>>, Self::Error>> + Send
+    where
+        Self: Trace,
+    {
         async move {
             // Check if the vector of bundles is empty
             if bundles.is_empty() {
@@ -354,14 +357,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 let mut all_results = Vec::with_capacity(bundles.len());
 
                 if replay_block_txs {
-                    let mut executor = RpcNodeCore::evm_config(&this)
-                        .executor_for_block(&mut db, block.sealed_block())
-                        .map_err(RethError::other)
-                        .map_err(Self::Error::from_eth_err)?;
-                    executor.apply_pre_execution_changes().map_err(Self::Error::from_eth_err)?;
-                    for tx in block.transactions_recovered().take(num_txs) {
-                        executor.execute_transaction(tx).map_err(Self::Error::from_eth_err)?;
-                    }
+                    this.replay_block_until(&mut db, &block, num_txs)?;
                 }
 
                 // transact all bundles
@@ -732,38 +728,36 @@ pub trait Call:
         }
     }
 
-    /// Replays all the transactions until the target transaction is found, on the given EVM.
+    /// Replays all transactions before the target transaction index on the given EVM.
     ///
-    /// Unlike [`Self::replay_transactions_until`], this executes on a caller provided EVM, so the
-    /// target transaction can then be run on the same EVM, keeping any block-scoped EVM state
-    /// intact. The EVM's inspector configuration is left untouched; see
+    /// This executes on a caller provided EVM, so the target transaction can then be run on the
+    /// same EVM, keeping any block-scoped EVM state intact. The EVM's inspector configuration is
+    /// left untouched; see
     /// [`Self::inspect_transaction_in_block`] to replay without inspection and trace the target.
     ///
-    /// Note: This assumes the target transaction is in the given iterator.
-    /// Returns the index of the target transaction in the given iterator.
+    /// If the target index is greater than or equal to the iterator length, all transactions are
+    /// replayed.
     fn replay_transactions_until_with_evm<'a, DB, I, Txs>(
         &self,
         evm: &mut EvmFor<Self::Evm, DB, I>,
         transactions: Txs,
-        target_tx_hash: B256,
-    ) -> Result<usize, Self::Error>
+        target_tx_index: usize,
+    ) -> Result<(), Self::Error>
     where
         DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
         I: InspectorFor<Self::Evm, DB>,
         Txs: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
-        let mut index = 0;
-        for tx in transactions {
-            if *tx.tx_hash() == target_tx_hash {
+        for (index, tx) in transactions.into_iter().enumerate() {
+            if index == target_tx_index {
                 // reached the target transaction
                 break
             }
 
             let tx_env = self.evm_config().tx_env(tx);
             evm.transact_commit(tx_env).map_err(Self::Error::from_evm_err)?;
-            index += 1;
         }
-        Ok(index)
+        Ok(())
     }
 
     ///

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -24,8 +24,8 @@ use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
     EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
 };
-use reth_node_api::BlockBody;
-use reth_primitives_traits::Recovered;
+use reth_node_api::{BlockBody};
+use reth_primitives_traits::{Recovered};
 use reth_revm::{
     cancelled::CancelOnDrop,
     database::StateProviderDatabase,
@@ -730,28 +730,6 @@ pub trait Call:
             .await
             .map(Some)
         }
-    }
-
-    /// Replays all the transactions until the target transaction is found.
-    ///
-    /// All transactions before the target transaction are executed and their changes are written to
-    /// the _runtime_ db ([`State`]).
-    ///
-    /// Note: This assumes the target transaction is in the given iterator.
-    /// Returns the index of the target transaction in the given iterator.
-    fn replay_transactions_until<'a, DB, I>(
-        &self,
-        db: &mut DB,
-        evm_env: EvmEnvFor<Self::Evm>,
-        transactions: I,
-        target_tx_hash: B256,
-    ) -> Result<usize, Self::Error>
-    where
-        DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
-        I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
-    {
-        let mut evm = self.evm_config().evm_with_env(db, evm_env);
-        self.replay_transactions_until_with_evm(&mut evm, transactions, target_tx_hash)
     }
 
     /// Replays all the transactions until the target transaction is found, on the given EVM.

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -22,7 +22,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::{ProviderError, RethError};
 use reth_evm::{
     block::BlockExecutor, env::BlockEnvironment, execute::BlockBuilder, ConfigureEvm, Evm,
-    EvmEnvFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
+    EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TransactionEnvMut, TxEnvFor,
 };
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
@@ -767,6 +767,29 @@ pub trait Call:
         I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
     {
         let mut evm = self.evm_config().evm_with_env(db, evm_env);
+        self.replay_transactions_until_with_evm(&mut evm, transactions, target_tx_hash)
+    }
+
+    /// Replays all the transactions until the target transaction is found, on the given EVM.
+    ///
+    /// Unlike [`Self::replay_transactions_until`], this executes on a caller provided EVM, so the
+    /// target transaction can then be run on the same EVM, keeping any block-scoped EVM state
+    /// intact. The EVM's inspector configuration is left untouched; see
+    /// [`Self::inspect_transaction_in_block`] to replay without inspection and trace the target.
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator.
+    fn replay_transactions_until_with_evm<'a, DB, I, Txs>(
+        &self,
+        evm: &mut EvmFor<Self::Evm, DB, I>,
+        transactions: Txs,
+        target_tx_hash: B256,
+    ) -> Result<usize, Self::Error>
+    where
+        DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
+        I: InspectorFor<Self::Evm, DB>,
+        Txs: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
+    {
         let mut index = 0;
         for tx in transactions {
             if *tx.tx_hash() == target_tx_hash {
@@ -779,6 +802,33 @@ pub trait Call:
             index += 1;
         }
         Ok(index)
+    }
+
+    /// Replays all transactions before the target transaction without inspection, then executes
+    /// the target transaction with the configured inspector, all on the given EVM.
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator and its execution
+    /// result.
+    #[expect(clippy::type_complexity)]
+    fn inspect_transaction_in_block<'a, DB, I, Txs>(
+        &self,
+        evm: &mut EvmFor<Self::Evm, DB, I>,
+        transactions: Txs,
+        target_tx_hash: B256,
+        target_tx_env: TxEnvFor<Self::Evm>,
+    ) -> Result<(usize, ResultAndState<HaltReasonFor<Self::Evm>>), Self::Error>
+    where
+        DB: Database<Error = EvmDatabaseError<ProviderError>> + DatabaseCommit + core::fmt::Debug,
+        I: InspectorFor<Self::Evm, DB>,
+        Txs: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
+    {
+        evm.disable_inspector();
+        let index = self.replay_transactions_until_with_evm(evm, transactions, target_tx_hash)?;
+        evm.enable_inspector();
+
+        let res = evm.transact(target_tx_env).map_err(Self::Error::from_evm_err)?;
+        Ok((index, res))
     }
 
     ///

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -6,16 +6,12 @@ use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
 use futures::Future;
-use reth_errors::{ProviderError, RethError};
+use reth_errors::RethError;
 use reth_evm::{
-    block::BlockExecutor, evm::EvmFactoryExt, tracing::TracingCtx, ConfigureEvm, Database, Evm,
-    EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TxEnvFor,
+    block::BlockExecutor, evm::EvmFactoryExt, tracing::TracingCtx, ConfigureEvm, Evm, EvmEnvFor,
+    EvmFor, HaltReasonFor, InspectorFor, IntoTxEnv, TxEnvFor,
 };
 use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock};
-use reth_revm::{
-    database::StateProviderDatabase,
-    db::{bal::EvmDatabaseError, State},
-};
 use reth_rpc_eth_types::cache::db::StateCacheDb;
 use reth_storage_api::{ProviderBlock, ProviderTx};
 use revm::{context::Block, context_interface::result::ResultAndState};
@@ -26,83 +22,17 @@ use std::sync::Arc;
 pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     /// Executes the [`TxEnvFor`] with [`reth_evm::EvmEnv`] against the given [Database] without
     /// committing state changes.
-    fn inspect<DB, I>(
+    fn inspect<'a>(
         &self,
-        db: DB,
+        db: &'a mut StateCacheDb,
         evm_env: EvmEnvFor<Self::Evm>,
-        tx_env: TxEnvFor<Self::Evm>,
-        inspector: I,
-    ) -> Result<ResultAndState<HaltReasonFor<Self::Evm>>, Self::Error>
-    where
-        DB: Database<Error = EvmDatabaseError<ProviderError>>,
-        I: InspectorFor<Self::Evm, DB>,
-    {
-        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
-        evm.transact(tx_env).map_err(Self::Error::from_evm_err)
-    }
-
-    /// Executes the transaction on top of the given [`BlockId`] with a tracer configured by the
-    /// config.
-    ///
-    /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`reth_evm::EvmEnv`] was inspected.
-    ///
-    /// Caution: this is blocking
-    fn trace_at<F, R>(
-        &self,
-        evm_env: EvmEnvFor<Self::Evm>,
-        tx_env: TxEnvFor<Self::Evm>,
-        config: TracingInspectorConfig,
-        at: BlockId,
-        f: F,
-    ) -> impl Future<Output = Result<R, Self::Error>> + Send
-    where
-        R: Send + 'static,
-        F: FnOnce(
-                TracingInspector,
-                ResultAndState<HaltReasonFor<Self::Evm>>,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-    {
-        self.with_state_at_block(at, move |this, state| {
-            let mut db = State::builder().with_database(StateProviderDatabase::new(state)).build();
-            let mut inspector = TracingInspector::new(config);
-            let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
-            f(inspector, res)
-        })
-    }
-
-    /// Same as [`trace_at`](Self::trace_at) but also provides the used database to the callback.
-    ///
-    /// Executes the transaction on top of the given [`BlockId`] with a tracer configured by the
-    /// config.
-    ///
-    /// The callback is then called with the [`TracingInspector`] and the [`ResultAndState`] after
-    /// the configured [`reth_evm::EvmEnv`] was inspected.
-    fn spawn_trace_at_with_state<F, R>(
-        &self,
-        evm_env: EvmEnvFor<Self::Evm>,
-        tx_env: TxEnvFor<Self::Evm>,
-        config: TracingInspectorConfig,
-        at: BlockId,
-        f: F,
-    ) -> impl Future<Output = Result<R, Self::Error>> + Send
-    where
-        F: FnOnce(
-                TracingInspector,
-                ResultAndState<HaltReasonFor<Self::Evm>>,
-                StateCacheDb,
-            ) -> Result<R, Self::Error>
-            + Send
-            + 'static,
-        R: Send + 'static,
-    {
-        self.spawn_with_state_at_block(at, move |this, mut db| {
-            let mut inspector = TracingInspector::new(config);
-            let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
-            f(inspector, res, db)
-        })
+        tx_env: impl IntoTxEnv<TxEnvFor<Self::Evm>>,
+        inspector: impl InspectorFor<Self::Evm, &'a mut StateCacheDb>,
+    ) -> Result<ResultAndState<HaltReasonFor<Self::Evm>>, Self::Error> {
+        self.evm_config()
+            .evm_with_env_and_inspector(db, evm_env, inspector)
+            .transact(tx_env)
+            .map_err(Self::Error::from_evm_err)
     }
 
     /// Retrieves the transaction if it exists and returns its trace.

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -105,11 +105,14 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             let parent_block = block.parent_hash();
 
             self.spawn_with_state_at_block(parent_block, move |this, mut db| {
-                let (_, res, _) = this.inspect_transaction_in_block(
+                let (res, _) = this.inspect_transaction_in_block(
                     &block,
                     &mut db,
                     &mut inspector,
-                    *tx.tx_hash(),
+                    // index should always be available because `transaction_and_block` only
+                    // returns transactions included in a block
+                    tx_info.index.expect("transaction_and_block only returns block transactions")
+                        as usize,
                     tx,
                 )?;
                 f(tx_info, inspector, res, db)
@@ -119,19 +122,19 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         }
     }
 
-    /// Replays all the transactions until the target transaction is found.
+    /// Replays all transactions before the target transaction index.
     ///
     /// All transactions before the target transaction are executed and their changes are written to
     /// the _runtime_ db ([`State`]).
     ///
-    /// Note: This assumes the target transaction is in the given iterator.
-    /// Returns the index of the target transaction in the given iterator.
+    /// If the target index is greater than or equal to the block's transaction count, all
+    /// transactions are replayed.
     fn replay_block_until(
         &self,
         db: &mut StateCacheDb,
         block: &RecoveredBlock<BlockTy<Self::Primitives>>,
-        target_tx_hash: B256,
-    ) -> Result<usize, Self::Error> {
+        target_tx_index: usize,
+    ) -> Result<(), Self::Error> {
         self.apply_pre_execution_changes(block, db)?;
 
         let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
@@ -139,26 +142,21 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         self.replay_transactions_until_with_evm(
             &mut evm,
             block.transactions_recovered(),
-            target_tx_hash,
+            target_tx_index,
         )
     }
 
     /// Replays all transactions before the target transaction without inspection, then executes
     /// the target transaction with the configured inspector, all on the given EVM.
-    ///
-    /// Note: This assumes the target transaction is in the given iterator.
-    /// Returns the index of the target transaction in the given iterator and its execution
-    /// result.
     #[expect(clippy::type_complexity)]
     fn inspect_transaction_in_block<'a>(
         &self,
         block: &RecoveredBlock<BlockTy<Self::Primitives>>,
         db: &'a mut StateCacheDb,
         inspector: impl InspectorFor<Self::Evm, &'a mut StateCacheDb>,
-        target_tx_hash: B256,
+        target_tx_index: usize,
         target_tx_env: impl IntoTxEnv<TxEnvFor<Self::Evm>>,
-    ) -> Result<(usize, ResultAndState<HaltReasonFor<Self::Evm>>, EvmEnvFor<Self::Evm>), Self::Error>
-    {
+    ) -> Result<(ResultAndState<HaltReasonFor<Self::Evm>>, EvmEnvFor<Self::Evm>), Self::Error> {
         let block_txs = block.transactions_recovered();
 
         self.apply_pre_execution_changes(block, db)?;
@@ -167,14 +165,14 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
 
         evm.disable_inspector();
-        let index = self.replay_transactions_until_with_evm(&mut evm, block_txs, target_tx_hash)?;
+        self.replay_transactions_until_with_evm(&mut evm, block_txs, target_tx_index)?;
         evm.enable_inspector();
 
         let res = evm.transact(target_tx_env).map_err(Self::Error::from_evm_err)?;
 
         let (_, evm_env) = evm.finish();
 
-        Ok((index, res, evm_env))
+        Ok((res, evm_env))
     }
 
     /// Executes all transactions of a block up to a given index.

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 
 /// Executes CPU heavy tasks.
 pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
-    /// Executes the [`TxEnvFor`] with [`reth_evm::EvmEnv`] against the given [Database] without
-    /// committing state changes.
+    /// Executes the [`TxEnvFor`] with [`reth_evm::EvmEnv`] against the given [`StateCacheDb`]
+    /// without committing state changes.
     fn inspect<'a>(
         &self,
         db: &'a mut StateCacheDb,
@@ -125,7 +125,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     /// Replays all transactions before the target transaction index.
     ///
     /// All transactions before the target transaction are executed and their changes are written to
-    /// the _runtime_ db ([`State`]).
+    /// the _runtime_ db ([`StateCacheDb`]).
     ///
     /// If the target index is greater than or equal to the block's transaction count, all
     /// transactions are replayed.
@@ -315,8 +315,8 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
     /// 2. configures the EVM env
     /// 3. loops over all transactions and executes them
     /// 4. calls the callback with the transaction info, the execution result, the changed state
-    ///    _after_ the transaction [`StateProviderDatabase`] and the database that points to the
-    ///    state right _before_ the transaction.
+    ///    _after_ the transaction [`StateCacheDb`] and the database that points to the state right
+    ///    _before_ the transaction.
     fn trace_block_with<F, R>(
         &self,
         block_id: BlockId,

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -119,6 +119,30 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         }
     }
 
+    /// Replays all the transactions until the target transaction is found.
+    ///
+    /// All transactions before the target transaction are executed and their changes are written to
+    /// the _runtime_ db ([`State`]).
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator.
+    fn replay_block_until(
+        &self,
+        db: &mut StateCacheDb,
+        block: &RecoveredBlock<BlockTy<Self::Primitives>>,
+        target_tx_hash: B256,
+    ) -> Result<usize, Self::Error> {
+        self.apply_pre_execution_changes(block, db)?;
+
+        let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
+        let mut evm = self.evm_config().evm_with_env(db, evm_env);
+        self.replay_transactions_until_with_evm(
+            &mut evm,
+            block.transactions_recovered(),
+            target_tx_hash,
+        )
+    }
+
     /// Replays all transactions before the target transaction without inspection, then executes
     /// the target transaction with the configured inspector, all on the given EVM.
     ///

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -181,11 +181,15 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
 
                 this.apply_pre_execution_changes(&block, &mut db)?;
 
-                // replay all transactions prior to the targeted transaction
-                this.replay_transactions_until(&mut db, evm_env.clone(), block_txs, *tx.tx_hash())?;
-
+                let target_hash = *tx.tx_hash();
                 let tx_env = this.evm_config().tx_env(tx);
-                let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
+
+                let mut evm =
+                    this.evm_config().evm_with_env_and_inspector(&mut db, evm_env, &mut inspector);
+                let (_, res) =
+                    this.inspect_transaction_in_block(&mut evm, block_txs, target_hash, tx_env)?;
+                drop(evm);
+
                 f(tx_info, inspector, res, db)
             })
             .await

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -11,7 +11,7 @@ use reth_evm::{
     block::BlockExecutor, evm::EvmFactoryExt, tracing::TracingCtx, ConfigureEvm, Evm, EvmEnvFor,
     EvmFor, HaltReasonFor, InspectorFor, IntoTxEnv, TxEnvFor,
 };
-use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock};
+use reth_primitives_traits::{BlockBody, BlockTy, Recovered, RecoveredBlock};
 use reth_rpc_eth_types::cache::db::StateCacheDb;
 use reth_storage_api::{ProviderBlock, ProviderTx};
 use revm::{context::Block, context_interface::result::ResultAndState};
@@ -100,31 +100,57 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             };
             let (tx, tx_info) = transaction.split();
 
-            let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
-
             // we need to get the state of the parent block because we're essentially replaying the
             // block the transaction is included in
             let parent_block = block.parent_hash();
 
             self.spawn_with_state_at_block(parent_block, move |this, mut db| {
-                let block_txs = block.transactions_recovered();
-
-                this.apply_pre_execution_changes(&block, &mut db)?;
-
-                let target_hash = *tx.tx_hash();
-                let tx_env = this.evm_config().tx_env(tx);
-
-                let mut evm =
-                    this.evm_config().evm_with_env_and_inspector(&mut db, evm_env, &mut inspector);
-                let (_, res) =
-                    this.inspect_transaction_in_block(&mut evm, block_txs, target_hash, tx_env)?;
-                drop(evm);
-
+                let (_, res, _) = this.inspect_transaction_in_block(
+                    &block,
+                    &mut db,
+                    &mut inspector,
+                    *tx.tx_hash(),
+                    tx,
+                )?;
                 f(tx_info, inspector, res, db)
             })
             .await
             .map(Some)
         }
+    }
+
+    /// Replays all transactions before the target transaction without inspection, then executes
+    /// the target transaction with the configured inspector, all on the given EVM.
+    ///
+    /// Note: This assumes the target transaction is in the given iterator.
+    /// Returns the index of the target transaction in the given iterator and its execution
+    /// result.
+    #[expect(clippy::type_complexity)]
+    fn inspect_transaction_in_block<'a>(
+        &self,
+        block: &RecoveredBlock<BlockTy<Self::Primitives>>,
+        db: &'a mut StateCacheDb,
+        inspector: impl InspectorFor<Self::Evm, &'a mut StateCacheDb>,
+        target_tx_hash: B256,
+        target_tx_env: impl IntoTxEnv<TxEnvFor<Self::Evm>>,
+    ) -> Result<(usize, ResultAndState<HaltReasonFor<Self::Evm>>, EvmEnvFor<Self::Evm>), Self::Error>
+    {
+        let block_txs = block.transactions_recovered();
+
+        self.apply_pre_execution_changes(block, db)?;
+
+        let evm_env = self.evm_env_for_header(block.sealed_block().sealed_header())?;
+        let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
+
+        evm.disable_inspector();
+        let index = self.replay_transactions_until_with_evm(&mut evm, block_txs, target_tx_hash)?;
+        evm.enable_inspector();
+
+        let res = evm.transact(target_tx_env).map_err(Self::Error::from_evm_err)?;
+
+        let (_, evm_env) = evm.finish();
+
+        Ok((index, res, evm_env))
     }
 
     /// Executes all transactions of a block up to a given index.

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -124,29 +124,33 @@ where
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
+                let block_hash = block.hash();
+                let block_env = evm_env.block_env.clone();
+
+                let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
+                // single EVM for the whole block so that block-scoped EVM state stays intact
+                let mut evm =
+                    eth_api.evm_config().evm_with_env_and_inspector(&mut db, evm_env, inspector);
+
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
-                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
                 while let Some((index, tx)) = transactions.next() {
                     let tx_hash = *tx.tx_hash();
                     let tx_env = eth_api.evm_config().tx_env(tx);
 
-                    let res = eth_api.inspect(
-                        &mut db,
-                        evm_env.clone(),
-                        tx_env.clone(),
-                        &mut inspector,
-                    )?;
+                    let res = evm.transact(tx_env.clone()).map_err(Eth::Error::from_evm_err)?;
+
+                    let (evm_db, inspector, _) = evm.components_mut();
                     let result = inspector
                         .get_result(
                             Some(TransactionContext {
-                                block_hash: Some(block.hash()),
+                                block_hash: Some(block_hash),
                                 tx_hash: Some(tx_hash),
                                 tx_index: Some(index),
                             }),
                             &tx_env,
-                            &evm_env.block_env,
+                            &block_env,
                             &res,
-                            &mut db,
+                            evm_db,
                         )
                         .map_err(Eth::Error::from_eth_err)?;
 
@@ -155,7 +159,7 @@ where
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit(res.state)
+                        evm_db.commit(res.state)
                     }
                 }
 
@@ -245,25 +249,30 @@ where
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
-                // replay all transactions prior to the targeted transaction
-                let index = eth_api.replay_transactions_until(
-                    &mut db,
-                    evm_env.clone(),
-                    block_txs,
-                    *tx.tx_hash(),
-                )?;
-
-                let tx_env = eth_api.evm_config().tx_env(&tx);
+                let target_hash = *tx.tx_hash();
 
                 let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                let res =
-                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
+                let mut evm = eth_api.evm_config().evm_with_env_and_inspector(
+                    &mut db,
+                    evm_env,
+                    &mut inspector,
+                );
+
+                let tx_env = eth_api.evm_config().tx_env(&tx);
+                let (index, res) = eth_api.inspect_transaction_in_block(
+                    &mut evm,
+                    block_txs,
+                    target_hash,
+                    tx_env.clone(),
+                )?;
+                let (_, evm_env) = evm.finish();
+
                 let trace = inspector
                     .get_result(
                         Some(TransactionContext {
                             block_hash: Some(block_hash),
                             tx_index: Some(index),
-                            tx_hash: Some(*tx.tx_hash()),
+                            tx_hash: Some(target_hash),
                         }),
                         &tx_env,
                         &evm_env.block_env,
@@ -447,10 +456,10 @@ where
                     let transactions = block.transactions_recovered().take(num_txs);
 
                     // Execute all transactions until index
+                    let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
                     for tx in transactions {
                         let tx_env = eth_api.evm_config().tx_env(tx);
-                        let res = eth_api.transact(&mut db, evm_env.clone(), tx_env)?;
-                        db.commit(res.state);
+                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
                     }
                 }
 
@@ -740,21 +749,24 @@ where
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
                 let mut roots = Vec::with_capacity(block.body().transactions().len());
+                // single EVM for the whole block so that block-scoped EVM state stays intact
+                let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
                 for tx in block.transactions_recovered() {
                     let tx_env = eth_api.evm_config().tx_env(tx);
-                    {
-                        let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
-                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
-                    }
+                    evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
+
+                    let state = evm.db_mut();
                     // Merge transitions into cumulative bundle_state
-                    db.merge_transitions(BundleRetention::PlainState);
+                    state.merge_transitions(BundleRetention::PlainState);
                     // Compute state root from the accumulated state changes
-                    let hashed_state = db
+                    let hashed_state = state
                         .database
-                        .hashed_post_state(&db.bundle_state)
+                        .hashed_post_state(&state.bundle_state)
                         .map_err(Eth::Error::from_eth_err)?;
-                    let root =
-                        db.database.state_root(hashed_state).map_err(Eth::Error::from_eth_err)?;
+                    let root = state
+                        .database
+                        .state_root(hashed_state)
+                        .map_err(Eth::Error::from_eth_err)?;
                     roots.push(root);
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -229,46 +229,28 @@ where
             None => return Err(EthApiError::TracingTransactionNotFound.into()),
             Some(res) => res,
         };
-        let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
-
-        // we need to get the state of the parent block because we're essentially replaying the
-        // block the transaction is included in
-        let state_at: BlockId = block.parent_hash().into();
-        let block_hash = block.hash();
 
         self.eth_api()
-            .spawn_with_state_at_block(state_at, move |eth_api, mut db| {
-                let block_txs = block.transactions_recovered();
-
+            .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 // configure env for the target transaction
                 let tx = transaction.into_recovered();
 
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
-
-                let target_hash = *tx.tx_hash();
-
                 let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                let mut evm = eth_api.evm_config().evm_with_env_and_inspector(
-                    &mut db,
-                    evm_env,
-                    &mut inspector,
-                );
-
                 let tx_env = eth_api.evm_config().tx_env(&tx);
-                let (index, res) = eth_api.inspect_transaction_in_block(
-                    &mut evm,
-                    block_txs,
-                    target_hash,
+                let (index, res, evm_env) = eth_api.inspect_transaction_in_block(
+                    &block,
+                    &mut db,
+                    &mut inspector,
+                    *tx.tx_hash(),
                     tx_env.clone(),
                 )?;
-                let (_, evm_env) = evm.finish();
 
                 let trace = inspector
                     .get_result(
                         Some(TransactionContext {
-                            block_hash: Some(block_hash),
+                            block_hash: Some(block.hash()),
                             tx_index: Some(index),
-                            tx_hash: Some(target_hash),
+                            tx_hash: Some(*tx.tx_hash()),
                         }),
                         &tx_env,
                         &evm_env.block_env,
@@ -745,7 +727,6 @@ where
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
                 let mut roots = Vec::with_capacity(block.body().transactions().len());
-                // single EVM for the whole block so that block-scoped EVM state stays intact
                 let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env);
                 for tx in block.transactions_recovered() {
                     let tx_env = eth_api.evm_config().tx_env(tx);

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -124,42 +124,38 @@ where
 
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
-                let block_hash = block.hash();
                 let block_env = evm_env.block_env.clone();
 
+                let mut transactions = block.transactions_recovered().enumerate().peekable();
                 let inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                // single EVM for the whole block so that block-scoped EVM state stays intact
                 let mut evm =
                     eth_api.evm_config().evm_with_env_and_inspector(&mut db, evm_env, inspector);
-
-                let mut transactions = block.transactions_recovered().enumerate().peekable();
                 while let Some((index, tx)) = transactions.next() {
-                    let tx_hash = *tx.tx_hash();
                     let tx_env = eth_api.evm_config().tx_env(tx);
 
                     let res = evm.transact(tx_env.clone()).map_err(Eth::Error::from_evm_err)?;
 
-                    let (evm_db, inspector, _) = evm.components_mut();
+                    let (db, inspector, _) = evm.components_mut();
                     let result = inspector
                         .get_result(
                             Some(TransactionContext {
-                                block_hash: Some(block_hash),
-                                tx_hash: Some(tx_hash),
+                                block_hash: Some(block.hash()),
+                                tx_hash: Some(*tx.tx_hash()),
                                 tx_index: Some(index),
                             }),
                             &tx_env,
                             &block_env,
                             &res,
-                            evm_db,
+                            db,
                         )
                         .map_err(Eth::Error::from_eth_err)?;
 
-                    results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
+                    results.push(TraceResult::Success { result, tx_hash: Some(*tx.tx_hash()) });
                     if transactions.peek().is_some() {
                         inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        evm_db.commit(res.state)
+                        db.commit(res.state)
                     }
                 }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -233,15 +233,21 @@ where
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 // configure env for the target transaction
-                let tx = transaction.into_recovered();
+                let (tx, tx_info) = transaction.split();
+
+                // index should always be available because `transaction_and_block` only
+                // returns transactions included in a block
+                let index =
+                    tx_info.index.expect("transaction_and_block only returns block transactions")
+                        as usize;
 
                 let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
                 let tx_env = eth_api.evm_config().tx_env(&tx);
-                let (index, res, evm_env) = eth_api.inspect_transaction_in_block(
+                let (res, evm_env) = eth_api.inspect_transaction_in_block(
                     &block,
                     &mut db,
                     &mut inspector,
-                    *tx.tx_hash(),
+                    index,
                     tx_env.clone(),
                 )?;
 
@@ -347,11 +353,7 @@ where
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 // 1. replay the required number of transactions
-                eth_api.replay_block_until(
-                    &mut db,
-                    &block,
-                    *block.body().transactions()[tx_index].tx_hash(),
-                )?;
+                eth_api.replay_block_until(&mut db, &block, tx_index)?;
 
                 // 2. now execute the trace call on this state
                 let (evm_env, tx_env) =
@@ -422,16 +424,8 @@ where
                 if replay_block_txs {
                     // only need to replay the transactions in the block if not all transactions are
                     // to be replayed
-                    eth_api.apply_pre_execution_changes(&block, &mut db)?;
-
-                    let transactions = block.transactions_recovered().take(num_txs);
-
                     // Execute all transactions until index
-                    let mut evm = eth_api.evm_config().evm_with_env(&mut db, evm_env.clone());
-                    for tx in transactions {
-                        let tx_env = eth_api.evm_config().tx_env(tx);
-                        evm.transact_commit(tx_env).map_err(Eth::Error::from_evm_err)?;
-                    }
+                    eth_api.replay_block_until(&mut db, &block, num_txs)?;
                 }
 
                 // Trace all bundles

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -344,23 +344,16 @@ where
 
         let evm_env = self.eth_api().evm_env_for_header(block.sealed_block().sealed_header())?;
 
-        // execute after the parent block, replaying `tx_index` transactions
-        let state_at = block.parent_hash();
-
         self.eth_api()
-            .spawn_with_state_at_block(state_at, move |eth_api, mut db| {
-                // 1. apply pre-execution changes
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
-
-                // 2. replay the required number of transactions
-                eth_api.replay_transactions_until(
+            .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
+                // 1. replay the required number of transactions
+                eth_api.replay_block_until(
                     &mut db,
-                    evm_env.clone(),
-                    block.transactions_recovered(),
+                    &block,
                     *block.body().transactions()[tx_index].tx_hash(),
                 )?;
 
-                // 3. now execute the trace call on this state
+                // 2. now execute the trace call on this state
                 let (evm_env, tx_env) =
                     eth_api.prepare_call_env(evm_env, call, &mut db, overrides)?;
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -19,7 +19,6 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
-use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{BlockBody, BlockHeader};
 use reth_rpc_api::TraceApiServer;
 use reth_rpc_convert::RpcTxReq;
@@ -128,12 +127,13 @@ where
             .map(<Eth::Pool as TransactionPool>::Transaction::pooled_into_consensus);
 
         let (evm_env, at) = self.eth_api().evm_env_at(block_id.unwrap_or_default()).await?;
-        let tx_env = self.eth_api().evm_config().tx_env(tx);
-
-        let config = TracingInspectorConfig::from_parity_config(&trace_types);
 
         self.eth_api()
-            .spawn_trace_at_with_state(evm_env, tx_env, config, at, move |inspector, res, db| {
+            .spawn_with_state_at_block(at, move |this, mut db| {
+                let mut inspector =
+                    TracingInspector::new(TracingInspectorConfig::from_parity_config(&trace_types));
+                let res = this.inspect(&mut db, evm_env, tx, &mut inspector)?;
+
                 inspector
                     .into_parity_builder()
                     .into_trace_results_with_state(&res, &trace_types, &db)


### PR DESCRIPTION
Closes #17045.

The debug replay endpoints (`debug_traceBlock`, `debug_traceTransaction`, the `debug_traceCallMany` prefix, `debug_intermediateRoots`) and `Trace::spawn_trace_transaction_in_block_with_inspector`, which backs `trace_transaction`, `trace_get`, `trace_replayTransaction` and the `ots_*` trace endpoints, built a fresh EVM for every replayed transaction. Besides the redundant constructions, this is incorrect for downstream EVMs that carry lazily initialized block-scoped state, such as Celo's fee-currency context or OP's `L1BlockInfo`: every new EVM re-initializes that state from mid-block state. The prefix and the target now run on a single EVM with the inspector disabled during the prefix, matching how the block executor and the `trace_block*` path already behave.

Call simulations (`debug_traceCall`, `trace_call`, `trace_callMany` and the bundle calls of `debug_traceCallMany`) intentionally keep one EVM per call: `prepare_call_env` produces a per-call env and an EVM's env cannot be replaced. Those sites are documented accordingly.

Stock Ethereum has no block-scoped EVM state, so the regression tests use a test EVM factory whose EVMs cache a storage value per block on first use. With the fix reverted, `debug_traceBlock` observes `[1, 2, 2]` where `[1, 1, 1]` is expected. `MockEthProvider` gains opt-in recovered block lookups to back these tests.

This is an alternative to #26523 by @palango with the same approach and functionality; the commits carry co-authorship credit.


supersedes #26561