### PR TITLE
chore(rpc): bump default eth proof window to 100k blocks

### DIFF
--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -59,7 +59,7 @@ pub const DEFAULT_MAX_SIMULATE_BLOCKS: u64 = 256;
 pub const DEFAULT_MAX_STORAGE_VALUES_SLOTS: usize = 1024;
 
 /// The default eth historical proof window.
-pub const DEFAULT_ETH_PROOF_WINDOW: u64 = 0;
+pub const DEFAULT_ETH_PROOF_WINDOW: u64 = 100_000;
 
 /// The default eth tx fee cap is 1 ETH
 pub const DEFAULT_TX_FEE_CAP_WEI: u128 = 1_000_000_000_000_000_000u128;

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -490,7 +490,7 @@ RPC:
       --rpc.eth-proof-window <RPC_ETH_PROOF_WINDOW>
           The maximum proof window for historical proof generation. This value allows for generating historical proofs up to configured number of blocks from current tip (up to `tip - window`)
 
-          [default: 0]
+          [default: 100000]
 
       --rpc.proof-permits <COUNT>
           Maximum number of concurrent getproof requests


### PR DESCRIPTION
## Description

Bumps `DEFAULT_ETH_PROOF_WINDOW` from `0` to `100_000` blocks (~2 weeks on mainnet at 12s block times), so `eth_getProof` serves recent historical blocks out of the box.

With a default window of `0`, a node only serves proofs at the exact chain tip and rejects everything else with `ExceedsMaxProofWindow` unless the operator explicitly sets `--rpc.eth-proof-window`. Proof consumers (bridges, light clients, interop protocols) generally prove against finalized or slightly-lagging blocks, so default-configured nodes hard-fail those requests in practice.

`100_000` stays well within `MAX_ETH_PROOF_WINDOW` (`1_209_600`).

Also updates the generated CLI docs to match.