### PR TITLE
fix(fs-util): append .tmp instead of replacing the extension in atomic_write_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9043,6 +9043,7 @@ version = "2.4.1"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/fs-util/Cargo.toml
+++ b/crates/fs-util/Cargo.toml
@@ -16,3 +16,6 @@ workspace = true
 serde_json = { workspace = true, features = ["std"] }
 serde.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/fs-util/src/lib.rs
+++ b/crates/fs-util/src/lib.rs
@@ -330,8 +330,20 @@ where
     F: FnOnce(&mut File) -> std::result::Result<(), E>,
     E: Into<Box<dyn core::error::Error + Send + Sync>>,
 {
-    let mut tmp_path = file_path.to_path_buf();
-    tmp_path.set_extension("tmp");
+    // `set_extension` replaces the extension instead of appending to it, so
+    // `a.json` and `a.toml` in one directory both map to `a.tmp`, and a target
+    // that already ends in `.tmp` maps to itself. In that last case the
+    // "temporary" file is the destination, which `File::create` truncates
+    // before `write_fn` runs and `remove_file` deletes if it fails.
+    let file_name = file_path.file_name().ok_or_else(|| {
+        FsPathError::create_file(
+            io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"),
+            file_path,
+        )
+    })?;
+    let mut tmp_name = file_name.to_os_string();
+    tmp_name.push(".tmp");
+    let tmp_path = file_path.with_file_name(tmp_name);
 
     // Write to the temporary file
     let mut file =
@@ -367,4 +379,49 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn atomic_write_file_does_not_clobber_a_sibling_tmp_file() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("data.json");
+        let decoy = dir.path().join("data.tmp");
+        write(&decoy, b"unrelated").unwrap();
+
+        atomic_write_file(&target, |file| file.write_all(b"payload")).unwrap();
+
+        assert_eq!(read(&target).unwrap(), b"payload");
+        assert_eq!(read(&decoy).unwrap(), b"unrelated");
+    }
+
+    #[test]
+    fn atomic_write_file_keeps_a_tmp_target_intact_when_the_write_fails() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("state.tmp");
+        write(&target, b"original").unwrap();
+
+        let err = atomic_write_file(&target, |_file| -> std::result::Result<(), Error> {
+            Err(Error::other("write failed"))
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, FsPathError::Write { .. }));
+        assert_eq!(read(&target).unwrap(), b"original");
+    }
+
+    #[test]
+    fn atomic_write_file_replaces_a_tmp_target_on_success() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("state.tmp");
+        write(&target, b"original").unwrap();
+
+        atomic_write_file(&target, |file| file.write_all(b"replacement")).unwrap();
+
+        assert_eq!(read(&target).unwrap(), b"replacement");
+    }
 }


### PR DESCRIPTION
`atomic_write_file` derives its temporary path with `set_extension`, which replaces the extension rather than appending to it:

```rust
let mut tmp_path = file_path.to_path_buf();
tmp_path.set_extension("tmp");
```

Two consequences follow.

**Sibling collision.** `a.json` and `a.toml` in one directory both map to `a.tmp`. Two concurrent atomic writes to different destinations share a single temporary path, and an unrelated file that happens to be named `a.tmp` is destroyed.

**Self collision.** A destination already ending in `.tmp` maps to itself, so `tmp_path == file_path`. The write is then not atomic at all: `File::create` truncates the destination before `write_fn` runs, and if `write_fn` fails the cleanup `remove_file` deletes the destination outright.

Neither in-tree caller reaches this today, since `nippy-jar` writes `*.conf` and the ExEx WAL writes `{id}.wal`. `reth-fs-util` is published, so external callers can.

## Reproduction

```rust
let dir = tempdir().unwrap();
let target = dir.path().join("state.tmp");
write(&target, b"original").unwrap();

let _ = atomic_write_file(&target, |_f| Err::<(), io::Error>(io::Error::other("boom")));

assert!(target.exists()); // fails on main: the file is gone
```

## Fix

Append `.tmp` to the file name rather than replacing the extension, so `a.json` becomes `a.json.tmp` and `state.tmp` becomes `state.tmp.tmp`. A path with no file name is rejected instead of silently resolving to a sibling of the parent directory.

## Tests

Three, scoped to this behaviour. Two fail on `main` and pass with the fix:

- an unrelated `data.tmp` survives an atomic write to `data.json`
- a `.tmp` destination keeps its contents when `write_fn` fails
- a `.tmp` destination is still replaced correctly on success (passes either way, pins the happy path)

## Verification

- `cargo test -p reth-fs-util` — 3 passed
- `cargo +nightly fmt -p reth-fs-util -- --check` — clean
- `cargo clippy -p reth-fs-util --all-targets -- -D warnings` — clean

`Cargo.lock` is included because this adds `tempfile` as a dev-dependency.

I opened #26589 earlier with test coverage only; this one is a behaviour fix and stands alone.
