### PR TITLE
fix(rpc): cap eth_getMultiProof total slots like the storage_values sibling

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -206,6 +206,19 @@ pub trait EthState: LoadState + SpawnBlocking {
                 .map_err(RethError::other)
                 .map_err(EthApiError::Internal)?;
 
+            // Proof generation is far costlier per slot than a plain storage
+            // read, so the sibling cap in `storage_values` applies here with
+            // more force: an unbounded target list lets one request drive
+            // unbounded trie work.
+            let total_slots: usize = targets.iter().map(|(_, slots)| slots.len()).sum();
+            if total_slots > DEFAULT_MAX_STORAGE_VALUES_SLOTS {
+                return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
+                    format!(
+                        "total slot count {total_slots} exceeds limit {DEFAULT_MAX_STORAGE_VALUES_SLOTS}",
+                    ),
+                )));
+            }
+
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 


### PR DESCRIPTION
## Summary

`eth_getMultiProof` takes a caller-supplied `Vec<(Address, Vec<B256>)>` of proof targets with no bound. Multiproof generation walks the trie per target — far more expensive than a plain storage read — so one unauthenticated request can drive unbounded blocking-IO compute (asymmetric DoS).

The sibling multi-target method `eth_getStorageValues` in the same file already enforces `DEFAULT_MAX_STORAGE_VALUES_SLOTS` (1024) on the sum of all slot arrays for exactly this input shape (`crates/rpc/rpc-eth-api/src/helpers/state.rs:125`).

## Fix

Apply the same total-slot cap in `get_multi_proof`, before any trie work starts. Same constant, same error shape (`EthApiError::InvalidParams`), same message format as the sibling.

## Testing

- `cargo check -p reth-rpc-eth-api` passes.

Made with Cursor

Made with [Cursor](https://cursor.com)