### PR TITLE
fix(rpc): cap eth_getProof keys and multiproof address floods

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -172,6 +172,17 @@ pub trait EthState: LoadState + SpawnBlocking {
                 .map_err(RethError::other)
                 .map_err(EthApiError::Internal)?;
 
+            // Same total-slot budget as `storage_values` / `get_multi_proof`: each
+            // key triggers storage-trie proof work on the blocking IO pool.
+            if keys.len() > DEFAULT_MAX_STORAGE_VALUES_SLOTS {
+                return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
+                    format!(
+                        "storage key count {} exceeds limit {DEFAULT_MAX_STORAGE_VALUES_SLOTS}",
+                        keys.len(),
+                    ),
+                )));
+            }
+
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 
@@ -205,6 +216,20 @@ pub trait EthState: LoadState + SpawnBlocking {
                 .await
                 .map_err(RethError::other)
                 .map_err(EthApiError::Internal)?;
+
+            // Multiproof retains every target address in the account trie even
+            // when that address's slot list is empty. A slot-sum-only cap (see
+            // open #26619) therefore fails open on `[(addr, []); N]`. Charge
+            // max(1, slots.len()) per target and reuse the storage_values budget.
+            let proof_units: usize =
+                targets.iter().map(|(_, slots)| slots.len().max(1)).sum();
+            if proof_units > DEFAULT_MAX_STORAGE_VALUES_SLOTS {
+                return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
+                    format!(
+                        "proof target units {proof_units} exceeds limit {DEFAULT_MAX_STORAGE_VALUES_SLOTS}",
+                    ),
+                )));
+            }
 
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;

--- a/crates/rpc/rpc/src/eth/helpers/state.rs
+++ b/crates/rpc/rpc/src/eth/helpers/state.rs
@@ -103,4 +103,43 @@ mod tests {
         let account = eth_api.get_account(address, Default::default()).await.unwrap();
         assert!(account.is_none());
     }
+
+    #[tokio::test]
+    async fn test_get_proof_rejects_oversized_key_list() {
+        use reth_rpc_server_types::constants::DEFAULT_MAX_STORAGE_VALUES_SLOTS;
+
+        let eth_api = noop_eth_api();
+        let keys = vec![U256::ZERO.into(); DEFAULT_MAX_STORAGE_VALUES_SLOTS + 1];
+        let err = EthState::get_proof(&eth_api, Address::ZERO, keys, None).unwrap().await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("storage key count") && msg.contains("exceeds limit"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_multi_proof_rejects_empty_slot_address_flood() {
+        use alloy_primitives::B256;
+        use reth_rpc_server_types::constants::DEFAULT_MAX_STORAGE_VALUES_SLOTS;
+
+        let eth_api = noop_eth_api();
+        // Slot-sum is 0, so a slots-only cap would admit this. Each address still
+        // forces account-trie retention, so proof-units must reject it.
+        let targets = (0..=DEFAULT_MAX_STORAGE_VALUES_SLOTS)
+            .map(|i| {
+                let mut raw = [0u8; 20];
+                raw[12..].copy_from_slice(&(i as u64).to_be_bytes());
+                (Address::from(raw), Vec::<B256>::new())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(targets.iter().map(|(_, s)| s.len()).sum::<usize>(), 0);
+
+        let err = EthState::get_multi_proof(&eth_api, targets, None).unwrap().await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("proof target units") && msg.contains("exceeds limit"),
+            "unexpected error: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`eth_getMultiProof` and `eth_getProof` accept caller-supplied proof targets with no size budget. Proof generation walks the account/storage tries on the blocking IO pool, so one unauthenticated request can drive asymmetric DoS.

Open PR #26619 adds a total-slot sum cap for `eth_getMultiProof`. That is necessary but not sufficient: each target address is retained in the account trie even when its slot list is empty, so `[(addr, []); N]` has `total_slots == 0` and still forces unbounded account-trie work. This PR charges `max(1, slots.len())` per target against the same `DEFAULT_MAX_STORAGE_VALUES_SLOTS` (1024) budget used by `eth_getStorageValues`, and applies the same key-count budget to `eth_getProof`.

## Fix

- `get_multi_proof`: reject when `sum(max(1, slots.len())) > 1024`
- `get_proof`: reject when `keys.len() > 1024`
- Same `EthApiError::InvalidParams` shape as the storage_values sibling

## Testing

```
cargo test -p reth-rpc --lib test_get_proof_rejects_oversized_key_list
cargo test -p reth-rpc --lib test_get_multi_proof_rejects_empty_slot_address_flood
```

Both new unit tests pass (including an explicit `total_slots == 0` empty-slot flood that a slot-sum-only cap would admit).

## Relation to #26619

This supersedes the slot-sum-only approach in #26619. Happy to close #26619 in favor of this, or fold these changes into that PR if maintainers prefer.


Made with [Cursor](https://cursor.com)