### PR TITLE
fix(rpc): cap eth_callMany bundle and transaction floods

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -309,6 +309,24 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into());
             }
 
+            // Match eth_simulateV1 budgets: unbounded eth_callMany holds one blocking-IO
+            // permit while each tx can consume a full call gas cap.
+            let max_call_many = self.max_simulate_blocks() as usize;
+            if bundles.len() > max_call_many {
+                return Err(EthApiError::InvalidParams(format!(
+                    "bundle count {} exceeds limit {max_call_many}",
+                    bundles.len(),
+                ))
+                .into());
+            }
+            let total_txs: usize = bundles.iter().map(|b| b.transactions.len()).sum();
+            if total_txs > max_call_many {
+                return Err(EthApiError::InvalidParams(format!(
+                    "transaction count {total_txs} exceeds limit {max_call_many}",
+                ))
+                .into());
+            }
+
             let _permit = self.acquire_owned_blocking_io().await;
 
             let StateContext { transaction_index, block_number } =

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -824,6 +824,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_call_many_rejects_oversized_transaction_flood() {
+        use reth_rpc_server_types::constants::DEFAULT_MAX_SIMULATE_BLOCKS;
+
+        let eth_api = build_test_eth_api(NoopProvider::default());
+        let bundles = vec![Bundle {
+            transactions: vec![
+                TransactionRequest::default();
+                DEFAULT_MAX_SIMULATE_BLOCKS as usize + 1
+            ],
+            block_override: None,
+        }];
+
+        let response = <EthApi<_, _> as EthApiServer<_, _, _, _, _, _>>::call_many(
+            &eth_api, bundles, None, None,
+        )
+        .await;
+
+        let err = response.expect_err("call_many should reject oversized transaction floods");
+        let message = err.message().to_ascii_lowercase();
+        assert!(
+            message.contains("transaction count") && message.contains("exceeds limit"),
+            "unexpected error: {message}"
+        );
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    }
+
+    #[tokio::test]
     /// Requesting no block should result in a default response
     async fn test_fee_history_no_block_requested() {
         let block_count = 10;


### PR DESCRIPTION
## Summary
- `eth_callMany` only rejected empty bundles; bundle/tx counts were unbounded.
- Each request holds one blocking-IO permit while every tx can consume a full call gas cap, so a flood is asymmetric DoS (sibling class of #26619/#26623).
- Cap both `bundles.len()` and total transactions to `max_simulate_blocks()` (same budget as `eth_simulateV1`).

## Test plan
- [x] `cargo test -p reth-rpc --lib eth::core::tests::test_call_many_rejects_oversized_transaction_flood`


Made with [Cursor](https://cursor.com)