### PR TITLE
fix(rpc): cap debug_traceCallMany and trace_callMany floods

### DIFF
--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -385,6 +385,23 @@ where
             return Err(EthApiError::InvalidParams(String::from("bundles are empty.")).into())
         }
 
+        // Match eth_simulateV1 / eth_callMany budgets: tracing is heavier per tx.
+        let max_call_many = self.eth_api().max_simulate_blocks() as usize;
+        if bundles.len() > max_call_many {
+            return Err(EthApiError::InvalidParams(format!(
+                "bundle count {} exceeds limit {max_call_many}",
+                bundles.len(),
+            ))
+            .into())
+        }
+        let total_txs: usize = bundles.iter().map(|b| b.transactions.len()).sum();
+        if total_txs > max_call_many {
+            return Err(EthApiError::InvalidParams(format!(
+                "transaction count {total_txs} exceeds limit {max_call_many}",
+            ))
+            .into())
+        }
+
         let StateContext { transaction_index, block_number } = state_context.unwrap_or_default();
         let transaction_index = transaction_index.unwrap_or_default();
 

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -151,6 +151,16 @@ where
         calls: Vec<(RpcTxReq<Eth::NetworkTypes>, HashSet<TraceType>)>,
         block_id: Option<BlockId>,
     ) -> Result<Vec<TraceResults>, Eth::Error> {
+        // Match eth_simulateV1 / eth_callMany budgets for sequential replay floods.
+        let max_call_many = self.eth_api().max_simulate_blocks() as usize;
+        if calls.len() > max_call_many {
+            return Err(EthApiError::InvalidParams(format!(
+                "call count {} exceeds limit {max_call_many}",
+                calls.len(),
+            ))
+            .into())
+        }
+
         let at = block_id.unwrap_or(BlockId::pending());
         let (evm_env, at) = self.eth_api().evm_env_at(at).await?;
 


### PR DESCRIPTION
## Summary
- `debug_traceCallMany` previously only rejected empty bundles, then sequentially traced every bundle/tx while holding blocking work. Same class as `eth_callMany` (#26624).
- `trace_callMany` similarly accepted unbounded sequential call lists.
- Cap both to `max_simulate_blocks` (default 256), matching `eth_simulateV1` / proposed `eth_callMany` budgets.

## Attack / impact
Unauthenticated (or broadly exposed) RPC client can submit huge `debug_traceCallMany` / `trace_callMany` payloads. Tracing is heavier than plain `eth_callMany`, so the missing budget is a DoS amplification relative to the eth namespace fix.

## Test plan
- [x] `cargo check -p reth-rpc --lib`
- [ ] CI
- Tip: `c7d94e622e` · commit: `c7926cf564`

Sibling of #26624 / #26623.

Made with [Cursor](https://cursor.com)