### PR TITLE
fix(rpc): keep simulated transfer logs out of receipts

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -203,9 +203,9 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                     };
 
                     let (result, results) = if trace_transfers {
-                        // prepare inspector to capture transfer inside the evm so they are recorded
-                        // and included in logs
-                        let inspector = TransferInspector::new(false).with_logs(true);
+                        // Collect transfer operations without inserting synthetic logs into the
+                        // journal; they are appended only to the RPC simulation result.
+                        let inspector = TransferInspector::new(false);
                         let evm = this
                             .evm_config()
                             .evm_with_env_and_inspector(&mut db, evm_env, inspector);
@@ -219,7 +219,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                             .map_err(|e| Self::Error::from_eth_err(EthApiError::other(e)))?;
                         }
 
-                        simulate::execute_transactions(
+                        simulate::execute_transactions_with_transfer_logs(
                             builder,
                             &state_provider,
                             calls,

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -7,13 +7,18 @@ use crate::{
 use alloy_chains::Chain;
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
-use alloy_evm::{block::TxResult, precompiles::PrecompilesMap};
+use alloy_evm::{
+    block::TxResult,
+    precompiles::{DynPrecompile, Precompile, PrecompilesMap},
+};
 use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
+use alloy_primitives::{Log, LogData, B256};
 use alloy_rpc_types_eth::{
     simulate::{SimBlock, SimCallResult, SimulateError, SimulatedBlock},
     state::StateOverride,
     BlockId, BlockOverrides, BlockTransactionsKind,
 };
+use alloy_sol_types::SolValue;
 use jsonrpsee_types::{error::INTERNAL_ERROR_CODE, ErrorObject};
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutor},
@@ -31,6 +36,10 @@ use revm::{
     primitives::{Address, Bytes, TxKind, U256},
     Database,
 };
+use revm_inspectors::transfer::{
+    TransferInspector, TransferOperation, TRANSFER_EVENT_TOPIC, TRANSFER_LOG_EMITTER,
+};
+use std::{collections::HashMap, sync::Arc};
 
 /// Fallback seconds added between simulated block timestamps when neither the user nor the chain
 /// hint provides a value.
@@ -255,9 +264,9 @@ where
 
 /// Applies precompile move overrides from state overrides to the EVM's precompiles map.
 ///
-/// This function processes `movePrecompileToAddress` entries from the state overrides and
-/// moves precompiles from their original addresses to new addresses. The original address
-/// is cleared (precompile removed) and the precompile is installed at the destination address.
+/// Moved destinations are resolved dynamically instead of being added to the map's address set.
+/// This keeps them callable while preventing the pre-execution warmup from treating them as
+/// canonical precompiles.
 pub fn apply_precompile_overrides(
     state_overrides: &StateOverride,
     precompiles: &mut PrecompilesMap,
@@ -278,13 +287,80 @@ pub fn apply_precompile_overrides(
         }
     }
 
-    precompiles.move_precompiles(moves).map_err(
-        |alloy_evm::precompiles::MovePrecompileError::NotAPrecompile(addr)| {
-            EthSimulateError::NotAPrecompile(addr)
-        },
-    )?;
+    for (source, _) in &moves {
+        if precompiles.get(source).is_none() {
+            return Err(EthSimulateError::NotAPrecompile(*source))
+        }
+    }
+
+    let mut extracted = Vec::with_capacity(moves.len());
+    for (source, dest) in moves {
+        let mut moved_precompile = None;
+        precompiles.apply_precompile(&source, |existing| {
+            moved_precompile = existing;
+            None
+        });
+        if let Some(precompile) = moved_precompile {
+            extracted.push((dest, precompile));
+        }
+    }
+
+    if !extracted.is_empty() {
+        let mut moved_precompiles = HashMap::with_capacity(extracted.len());
+        for (dest, precompile) in extracted {
+            // Dynamic lookups are only consulted for addresses absent from the main map.
+            precompiles.apply_precompile(&dest, |_| None);
+            moved_precompiles.insert(dest, Arc::new(precompile));
+        }
+
+        precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
+            moved_precompiles
+                .get(address)
+                .map(|precompile| shared_precompile(Arc::clone(precompile)))
+        });
+    }
 
     Ok(())
+}
+
+fn shared_precompile(precompile: Arc<DynPrecompile>) -> DynPrecompile {
+    let id = precompile.precompile_id().clone();
+    if precompile.supports_caching() {
+        DynPrecompile::new(id, move |input| precompile.call(input))
+    } else {
+        DynPrecompile::new_stateful(id, move |input| precompile.call(input))
+    }
+}
+
+/// Appends synthetic ETH-transfer logs to the RPC result without adding them to the EVM journal.
+pub fn append_transfer_logs<HaltReasonTy>(
+    inspector: &TransferInspector,
+    result: &mut ExecutionResult<HaltReasonTy>,
+    next_transfer: &mut usize,
+) {
+    let transfers = inspector.transfers();
+    if *next_transfer >= transfers.len() {
+        return
+    }
+
+    let ExecutionResult::Success { logs, .. } = result else {
+        *next_transfer = transfers.len();
+        return
+    };
+
+    logs.extend(transfers[*next_transfer..].iter().map(transfer_to_log));
+    *next_transfer = transfers.len();
+}
+
+fn transfer_to_log(transfer: &TransferOperation) -> Log {
+    let from = B256::from_slice(&transfer.from.abi_encode());
+    let to = B256::from_slice(&transfer.to.abi_encode());
+    let data = transfer.value.abi_encode();
+
+    Log {
+        address: TRANSFER_LOG_EMITTER,
+        data: LogData::new_unchecked(vec![TRANSFER_EVENT_TOPIC, from, to], data.into()),
+    }
 }
 
 /// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the
@@ -300,7 +376,7 @@ pub fn apply_precompile_overrides(
 /// [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 #[expect(clippy::type_complexity)]
 pub fn execute_transactions<S, T>(
-    mut builder: S,
+    builder: S,
     state_provider: impl StateProvider,
     calls: Vec<RpcTxReq<T::Network>>,
     remaining_call_gas_limit: &mut Option<u64>,
@@ -317,6 +393,78 @@ pub fn execute_transactions<S, T>(
 where
     S: BlockBuilder<Executor: BlockExecutor<Evm: Evm<DB: Database<Error: Into<EthApiError>>>>>,
     T: RpcConvert<Primitives = S::Primitives>,
+{
+    execute_transactions_with_result_hook(
+        builder,
+        state_provider,
+        calls,
+        remaining_call_gas_limit,
+        chain_id,
+        compute_state_root,
+        converter,
+        |_, _| {},
+    )
+}
+
+/// Executes transactions and appends synthetic ETH-transfer logs to the RPC results.
+#[expect(clippy::type_complexity)]
+pub fn execute_transactions_with_transfer_logs<S, T>(
+    builder: S,
+    state_provider: impl StateProvider,
+    calls: Vec<RpcTxReq<T::Network>>,
+    remaining_call_gas_limit: &mut Option<u64>,
+    chain_id: u64,
+    compute_state_root: bool,
+    converter: &T,
+) -> Result<
+    (
+        BlockBuilderOutcome<S::Primitives>,
+        Vec<ExecutionResult<<<S::Executor as BlockExecutor>::Evm as Evm>::HaltReason>>,
+    ),
+    EthApiError,
+>
+where
+    S: BlockBuilder<Executor: BlockExecutor<Evm: Evm<DB: Database<Error: Into<EthApiError>>>>>,
+    <S::Executor as BlockExecutor>::Evm: Evm<Inspector = TransferInspector>,
+    T: RpcConvert<Primitives = S::Primitives>,
+{
+    let mut next_transfer = 0;
+    execute_transactions_with_result_hook(
+        builder,
+        state_provider,
+        calls,
+        remaining_call_gas_limit,
+        chain_id,
+        compute_state_root,
+        converter,
+        |evm, result| append_transfer_logs(evm.inspector(), result, &mut next_transfer),
+    )
+}
+
+#[expect(clippy::type_complexity)]
+fn execute_transactions_with_result_hook<S, T, F>(
+    mut builder: S,
+    state_provider: impl StateProvider,
+    calls: Vec<RpcTxReq<T::Network>>,
+    remaining_call_gas_limit: &mut Option<u64>,
+    chain_id: u64,
+    compute_state_root: bool,
+    converter: &T,
+    mut process_result: F,
+) -> Result<
+    (
+        BlockBuilderOutcome<S::Primitives>,
+        Vec<ExecutionResult<<<S::Executor as BlockExecutor>::Evm as Evm>::HaltReason>>,
+    ),
+    EthApiError,
+>
+where
+    S: BlockBuilder<Executor: BlockExecutor<Evm: Evm<DB: Database<Error: Into<EthApiError>>>>>,
+    T: RpcConvert<Primitives = S::Primitives>,
+    F: FnMut(
+        &<S::Executor as BlockExecutor>::Evm,
+        &mut ExecutionResult<<<S::Executor as BlockExecutor>::Evm as Evm>::HaltReason>,
+    ),
 {
     builder.apply_pre_execution_changes()?;
 
@@ -383,6 +531,10 @@ where
             tx_regular_gas_used = result.result().result.gas().block_regular_gas_used();
             results.push(result.result().result.clone())
         })?;
+
+        if let Some(result) = results.last_mut() {
+            process_result(builder.evm(), result);
+        }
 
         let gas_used = gas_output.tx_gas_used();
         if let Some(remaining_call_gas_limit) = remaining_call_gas_limit.as_mut() {

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -39,7 +39,7 @@ use revm::{
 use revm_inspectors::transfer::{
     TransferInspector, TransferOperation, TRANSFER_EVENT_TOPIC, TRANSFER_LOG_EMITTER,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, rc::Rc};
 
 /// Fallback seconds added between simulated block timestamps when neither the user nor the chain
 /// hint provides a value.
@@ -310,12 +310,12 @@ pub fn apply_precompile_overrides(
         for (dest, precompile) in extracted {
             // Dynamic lookups are only consulted for addresses absent from the main map.
             precompiles.apply_precompile(&dest, |_| None);
-            moved_precompiles.insert(dest, Arc::new(precompile));
+            moved_precompiles.insert(dest, Rc::new(precompile));
         }
 
         precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
             moved_precompiles.get(address).map(|precompile| {
-                let precompile = Arc::clone(precompile);
+                let precompile = Rc::clone(precompile);
                 let id = precompile.precompile_id().clone();
                 if precompile.supports_caching() {
                     DynPrecompile::new(id, move |input| precompile.call(input))
@@ -395,10 +395,12 @@ where
         builder,
         state_provider,
         calls,
-        remaining_call_gas_limit,
-        chain_id,
-        compute_state_root,
-        converter,
+        TransactionExecutionConfig {
+            remaining_call_gas_limit,
+            chain_id,
+            compute_state_root,
+            converter,
+        },
         |_, _| {},
     )
 }
@@ -430,12 +432,21 @@ where
         builder,
         state_provider,
         calls,
-        remaining_call_gas_limit,
-        chain_id,
-        compute_state_root,
-        converter,
+        TransactionExecutionConfig {
+            remaining_call_gas_limit,
+            chain_id,
+            compute_state_root,
+            converter,
+        },
         |evm, result| append_transfer_logs(evm.inspector(), result, &mut next_transfer),
     )
+}
+
+struct TransactionExecutionConfig<'a, T> {
+    remaining_call_gas_limit: &'a mut Option<u64>,
+    chain_id: u64,
+    compute_state_root: bool,
+    converter: &'a T,
 }
 
 #[expect(clippy::type_complexity)]
@@ -443,10 +454,7 @@ fn execute_transactions_with_result_hook<S, T, F>(
     mut builder: S,
     state_provider: impl StateProvider,
     calls: Vec<RpcTxReq<T::Network>>,
-    remaining_call_gas_limit: &mut Option<u64>,
-    chain_id: u64,
-    compute_state_root: bool,
-    converter: &T,
+    config: TransactionExecutionConfig<'_, T>,
     mut process_result: F,
 ) -> Result<
     (
@@ -498,7 +506,7 @@ where
             }
         }
 
-        if let Some(remaining_call_gas_limit) = *remaining_call_gas_limit {
+        if let Some(remaining_call_gas_limit) = *config.remaining_call_gas_limit {
             if let Some(gas_limit) = call.as_ref().gas_limit() {
                 if gas_limit > remaining_call_gas_limit {
                     call.as_mut().set_gas_limit(remaining_call_gas_limit);
@@ -514,10 +522,10 @@ where
             call,
             default_gas_limit,
             builder.evm().block().basefee(),
-            chain_id,
+            config.chain_id,
             builder.evm().cfg_env().disable_nonce_check,
             builder.evm_mut().db_mut(),
-            converter,
+            config.converter,
         )?;
         // Create transaction with an empty envelope.
         // The effect for a layer-2 execution client is that it does not charge L1 cost.
@@ -534,7 +542,7 @@ where
         }
 
         let gas_used = gas_output.tx_gas_used();
-        if let Some(remaining_call_gas_limit) = remaining_call_gas_limit.as_mut() {
+        if let Some(remaining_call_gas_limit) = config.remaining_call_gas_limit.as_mut() {
             if gas_used > *remaining_call_gas_limit {
                 return Err(EthApiError::other(EthSimulateError::GasLimitReached))
             }
@@ -546,7 +554,7 @@ where
         block_state_gas_used = block_state_gas_used.saturating_add(gas_output.state_gas_used());
     }
 
-    let result = if compute_state_root {
+    let result = if config.compute_state_root {
         builder.finish(state_provider, None)?
     } else {
         builder.finish(NoopProvider::default(), None)?

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -314,22 +314,19 @@ pub fn apply_precompile_overrides(
         }
 
         precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
-            moved_precompiles
-                .get(address)
-                .map(|precompile| shared_precompile(Arc::clone(precompile)))
+            moved_precompiles.get(address).map(|precompile| {
+                let precompile = Arc::clone(precompile);
+                let id = precompile.precompile_id().clone();
+                if precompile.supports_caching() {
+                    DynPrecompile::new(id, move |input| precompile.call(input))
+                } else {
+                    DynPrecompile::new_stateful(id, move |input| precompile.call(input))
+                }
+            })
         });
     }
 
     Ok(())
-}
-
-fn shared_precompile(precompile: Arc<DynPrecompile>) -> DynPrecompile {
-    let id = precompile.precompile_id().clone();
-    if precompile.supports_caching() {
-        DynPrecompile::new(id, move |input| precompile.call(input))
-    } else {
-        DynPrecompile::new_stateful(id, move |input| precompile.call(input))
-    }
 }
 
 /// Appends synthetic ETH-transfer logs to the RPC result without adding them to the EVM journal.


### PR DESCRIPTION
Append trace transfer logs only to eth_simulate call results and keep moved precompile destinations out of the warm address set.