### PR TITLE
fix(rpc): honor targetGasLimit in testing_buildBlockV1

### DIFF
--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -133,6 +133,7 @@ async fn testing_rpc_commit_block_works() -> eyre::Result<()> {
 
             let chain = ctx.config().chain.clone();
             let timestamp = chain.genesis().timestamp + 1;
+            let target_gas_limit = chain.genesis().gas_limit - 100;
             let payload_attributes = EthPayloadAttributes {
                 timestamp,
                 prev_randao: B256::ZERO,
@@ -140,7 +141,7 @@ async fn testing_rpc_commit_block_works() -> eyre::Result<()> {
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
                 slot_number: Some(timestamp),
-                target_gas_limit: None,
+                target_gas_limit: Some(target_gas_limit),
             };
 
             tokio::spawn(async move {
@@ -163,6 +164,10 @@ async fn testing_rpc_commit_block_works() -> eyre::Result<()> {
                         latest.get("hash").and_then(Value::as_str).expect("latest block hash");
                     assert_eq!(latest_hash, block_hash.to_string());
                     assert_eq!(latest.get("extraData"), Some(&serde_json::to_value(extra_data)?));
+                    assert_eq!(
+                        latest.get("gasLimit").and_then(Value::as_str),
+                        Some(format!("{target_gas_limit:#x}").as_str())
+                    );
                     assert!(latest
                         .get("transactions")
                         .and_then(Value::as_array)

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -152,7 +152,13 @@ where
                     suggested_fee_recipient: request.payload_attributes.suggested_fee_recipient,
                     prev_randao: request.payload_attributes.prev_randao,
                     gas_limit: gas_limit_override.unwrap_or_else(|| {
-                        calculate_block_gas_limit(parent.gas_limit(), desired_gas_limit)
+                        calculate_block_gas_limit(
+                            parent.gas_limit(),
+                            request
+                                .payload_attributes
+                                .target_gas_limit
+                                .unwrap_or(desired_gas_limit),
+                        )
                     }),
                     parent_beacon_block_root: request.payload_attributes.parent_beacon_block_root,
                     withdrawals: withdrawals.map(Into::into),


### PR DESCRIPTION
`testing_buildBlockV1` read `slotNumber` from the raw payload attributes but dropped `targetGasLimit`. It always passed the node's static gas ceiling to `BuildPayloadArgs`, so post-Amsterdam attributes could not steer the built block's gas limit. The engine path already uses the attribute: `build_payload_v4` sets `gas_ceil` from `attributes.target_gas_limit`.

This change reads `targetGasLimit` from the attributes object, the same way the handler reads `slotNumber`, and uses it as the gas ceiling when present. When the field is absent, the handler keeps the node's static ceiling, so pre-Amsterdam calls do not change.

Adds a parse test and a handler test. The handler test passes a `targetGasLimit` equal to the parent's gas limit and asserts the built block keeps that gas limit; it fails without the fix.

go-ethereum had the same bug and fixed it in ethereum/go-ethereum#35501. See also ethereum/execution-apis#857 and ethereum/execution-apis#862.
