### PR TITLE
ci: allow transitive bitmaps advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,8 @@ ignore = [
     "RUSTSEC-2023-0089",
     # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
     "RUSTSEC-2026-0173",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0247 bitmaps is unmaintained, transitive dep via imbl
+    "RUSTSEC-2026-0247",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Cargo deny now rejects the locked `bitmaps 3.2.1` dependency because RUSTSEC-2026-0247 marks every release unmaintained. Reth pulls the crate transitively through `imbl`, and the advisory provides no safe upgrade.

Add a documented temporary advisory exception so fresh lint runs remain usable until the upstream dependency can be replaced.
