### PR TITLE
chore: expose blob cell availability on pooled transactions

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1552,7 +1552,7 @@ pub struct EthPooledTransaction<T = TransactionSigned> {
     /// Cached blob cell availability for this transaction.
     ///
     /// This is shared with the blob sidecar so that availability updates are reflected here.
-    blob_cell_availability: Option<BlobCellAvailability>,
+    pub blob_cell_availability: Option<BlobCellAvailability>,
 }
 
 impl<T: SignedTransaction> EthPooledTransaction<T> {


### PR DESCRIPTION
## Summary

Expose `EthPooledTransaction::blob_cell_availability` publicly so callers can construct the struct directly.
## Testing

Not run (not requested)