### PR TITLE
fix(storage): roll back RocksDB BAL storage

### DIFF
--- a/crates/cli/commands/src/common.rs
+++ b/crates/cli/commands/src/common.rs
@@ -27,7 +27,8 @@ use reth_provider::{
         BlockchainProvider, NodeTypesForProvider, RocksDBProvider, StaticFileProvider,
         StaticFileProviderBuilder,
     },
-    BalStoreHandle, ProviderFactory, RocksDBBalStore, StaticFileProviderFactory, StorageSettings,
+    BalConfig, BalStoreHandle, InMemoryBalStore, ProviderFactory, StaticFileProviderFactory,
+    StorageSettings,
 };
 use reth_stages::{sets::DefaultStages, Pipeline, PipelineTarget};
 use reth_static_file::StaticFileProducer;
@@ -195,14 +196,11 @@ impl<C: ChainSpecParser> EnvironmentArgs<C> {
     where
         C: ChainSpecParser<ChainSpec = N::ChainSpec>,
     {
-        let bal_store = self
-            .db
-            .balstore_cache_size
-            .map(|distance| {
-                RocksDBBalStore::with_buffer_retention_distance(rocksdb_provider.clone(), distance)
-            })
-            .unwrap_or_else(|| RocksDBBalStore::new(rocksdb_provider.clone()));
-        let bal_store = BalStoreHandle::new(bal_store);
+        let balstore_cache_size =
+            self.db.balstore_cache_size.unwrap_or(BalConfig::DEFAULT_IN_MEMORY_RETENTION_DISTANCE);
+        let bal_store = BalStoreHandle::new(InMemoryBalStore::new(
+            BalConfig::with_in_memory_retention_distance(balstore_cache_size),
+        ));
         let factory = ProviderFactory::<NodeTypesWithDBAdapter<N, DatabaseEnv>>::new(
             db,
             self.chain.clone(),

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -567,43 +567,6 @@ mod tests {
     }
 
     #[test]
-    fn test_save_blocks_flushes_bal_store() {
-        use reth_provider::{RocksDBBalStore, RocksDBProviderFactory};
-
-        reth_tracing::init_test_tracing();
-        let provider = create_test_provider_factory();
-        let bal_store = BalStoreHandle::new(RocksDBBalStore::new(provider.rocksdb_provider()));
-        let provider = provider.with_bal_store(bal_store);
-        init_genesis(&provider).unwrap();
-
-        let mut test_block_builder = TestBlockBuilder::eth();
-        let executed = test_block_builder.get_executed_block_with_number(1, B256::random());
-        let num_hash = executed.recovered_block().num_hash();
-        let raw_bal = Bytes::from_static(&[0xc0]);
-
-        provider.bal_store().insert(num_hash, RawBal::new(raw_bal.clone())).unwrap();
-
-        let (_finished_exex_height_tx, finished_exex_height_rx) =
-            tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
-        let pruner =
-            Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
-        let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
-        let handle = PersistenceHandle::<EthPrimitives>::spawn_service(
-            provider.clone(),
-            pruner,
-            sync_metrics_tx,
-        );
-        let (tx, rx) = crossbeam_channel::bounded(1);
-
-        handle.save_blocks(full_save_input(vec![executed]), tx).unwrap();
-
-        let result = rx.recv_timeout(std::time::Duration::from_secs(10)).expect("test timed out");
-        assert_eq!(result.last_block, num_hash);
-        let persisted_store = RocksDBBalStore::new(provider.rocksdb_provider());
-        assert_eq!(persisted_store.get_by_hash(num_hash.hash).unwrap(), Some(raw_bal));
-    }
-
-    #[test]
     fn test_save_blocks_multiple_blocks() {
         reth_tracing::init_test_tracing();
         let handle = default_persistence_handle();

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -71,10 +71,10 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BalStoreHandle, BlockHashReader, BlockNumReader, DBProvider, DatabaseProviderFactory,
-    MetadataProvider, MetadataWriter, ProviderError, ProviderFactory, ProviderResult,
-    RocksDBBalStore, RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
-    StaticFileProviderFactory, StorageSettingsCache,
+    BalConfig, BalStoreHandle, BlockHashReader, BlockNumReader, DBProvider,
+    DatabaseProviderFactory, InMemoryBalStore, MetadataProvider, MetadataWriter, ProviderError,
+    ProviderFactory, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
+    StaticFileProviderBuilder, StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_prune::{PruneMode, PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
@@ -524,15 +524,14 @@ where
                 .build()?
         };
 
-        let bal_store = self
+        let balstore_cache_size = self
             .node_config()
             .db
             .balstore_cache_size
-            .map(|distance| {
-                RocksDBBalStore::with_buffer_retention_distance(rocksdb_provider.clone(), distance)
-            })
-            .unwrap_or_else(|| RocksDBBalStore::new(rocksdb_provider.clone()));
-        let bal_store = BalStoreHandle::new(bal_store);
+            .unwrap_or(BalConfig::DEFAULT_IN_MEMORY_RETENTION_DISTANCE);
+        let bal_store = BalStoreHandle::new(InMemoryBalStore::new(
+            BalConfig::with_in_memory_retention_distance(balstore_cache_size),
+        ));
         let factory = ProviderFactory::new(
             self.right().clone(),
             self.chain_spec(),

--- a/crates/storage/provider/src/bal/rocksdb.rs
+++ b/crates/storage/provider/src/bal/rocksdb.rs
@@ -352,13 +352,21 @@ struct RocksDBBalEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::providers::RocksDBBuilder;
+    use crate::providers::{RocksDBBuilder, RocksDBProvider};
     use alloy_primitives::B256;
     use tokio_stream::StreamExt;
 
+    fn test_rocksdb(dir: &tempfile::TempDir) -> RocksDBProvider {
+        RocksDBBuilder::new(dir.path())
+            .with_table::<tables::BlockAccessLists>()
+            .with_table::<tables::BlockAccessListBlockNumbers>()
+            .build()
+            .unwrap()
+    }
+
     fn test_store() -> (tempfile::TempDir, RocksDBBalStore) {
         let dir = tempfile::tempdir().unwrap();
-        let rocksdb = RocksDBBuilder::new(dir.path()).with_default_tables().build().unwrap();
+        let rocksdb = test_rocksdb(&dir);
         (dir, RocksDBBalStore::new(rocksdb))
     }
 
@@ -447,7 +455,7 @@ mod tests {
     #[test]
     fn configured_buffer_retention_distance_is_used() {
         let dir = tempfile::tempdir().unwrap();
-        let rocksdb = RocksDBBuilder::new(dir.path()).with_default_tables().build().unwrap();
+        let rocksdb = test_rocksdb(&dir);
         let store = RocksDBBalStore::with_buffer_retention_distance(rocksdb, 64);
         let old = NumHash::new(1, B256::with_last_byte(1));
         let tip = NumHash::new(34, B256::with_last_byte(2));

--- a/crates/storage/provider/src/providers/rocksdb/metrics.rs
+++ b/crates/storage/provider/src/providers/rocksdb/metrics.rs
@@ -8,8 +8,6 @@ use strum::{EnumIter, IntoEnumIterator};
 
 pub(super) const ROCKSDB_TABLES: &[&str] = &[
     Tables::TransactionHashNumbers.name(),
-    Tables::BlockAccessLists.name(),
-    Tables::BlockAccessListBlockNumbers.name(),
     Tables::StoragesHistory.name(),
     Tables::AccountsHistory.name(),
 ];

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -315,14 +315,10 @@ impl RocksDBBuilder {
     /// - [`tables::TransactionHashNumbers`] - Transaction hash to number mapping
     /// - [`tables::AccountsHistory`] - Account history index
     /// - [`tables::StoragesHistory`] - Storage history index
-    /// - [`tables::BlockAccessLists`] - Block access list payloads
-    /// - [`tables::BlockAccessListBlockNumbers`] - Block access list hash index
     pub fn with_default_tables(self) -> Self {
         self.with_table::<tables::TransactionHashNumbers>()
             .with_table::<tables::AccountsHistory>()
             .with_table::<tables::StoragesHistory>()
-            .with_table::<tables::BlockAccessLists>()
-            .with_table::<tables::BlockAccessListBlockNumbers>()
     }
 
     /// Enables metrics.
@@ -2892,25 +2888,22 @@ mod tests {
         provider.put::<tables::StoragesHistory>(key.clone(), &value).unwrap();
         assert!(provider.get::<tables::StoragesHistory>(key).unwrap().is_some());
 
-        let bal_key =
-            reth_db_api::models::StoredBlockAccessListKey::new(1, B256::with_last_byte(1));
-        let bal_value =
-            reth_db_api::models::StoredBlockAccessList::new(Bytes::from_static(&[0xc0]));
-        provider.put::<tables::BlockAccessLists>(bal_key, &bal_value).unwrap();
-        assert_eq!(provider.get::<tables::BlockAccessLists>(bal_key).unwrap(), Some(bal_value));
-        provider
-            .put::<tables::BlockAccessListBlockNumbers>(bal_key.hash(), &bal_key.number())
-            .unwrap();
-        assert_eq!(
-            provider.get::<tables::BlockAccessListBlockNumbers>(bal_key.hash()).unwrap(),
-            Some(bal_key.number())
-        );
+        drop(provider);
+
+        let column_families = DB::list_cf(&Options::default(), temp_dir.path()).unwrap();
+        assert!(!column_families.iter().any(|name| name == tables::BlockAccessLists::NAME));
+        assert!(!column_families
+            .iter()
+            .any(|name| name == tables::BlockAccessListBlockNumbers::NAME));
     }
 
     #[test]
     fn block_access_lists_store_large_payloads_in_blob_files() {
         let temp_dir = TempDir::new().unwrap();
-        let provider = RocksDBBuilder::new(temp_dir.path()).with_default_tables().build().unwrap();
+        let provider = RocksDBBuilder::new(temp_dir.path())
+            .with_table::<tables::BlockAccessLists>()
+            .build()
+            .unwrap();
         let bal_key =
             reth_db_api::models::StoredBlockAccessListKey::new(1, B256::with_last_byte(1));
         let bal_value = reth_db_api::models::StoredBlockAccessList::new(Bytes::from(vec![


### PR DESCRIPTION
Restores the in-memory BAL store and stops the default RocksDB configuration from registering or managing BAL column families.

This rolls back disk-backed BAL activation without deleting existing on-disk data; compatibility for databases that already contain those families is handled in #26647.
