### PR TITLE
chore(trie): implement `Clone` for `SparseStateTrie`

### DIFF
--- a/crates/trie/sparse/src/metrics.rs
+++ b/crates/trie/sparse/src/metrics.rs
@@ -3,7 +3,7 @@
 use reth_metrics::{metrics::Histogram, Metrics};
 
 /// Metrics for the sparse state trie
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct SparseStateTrieMetrics {
     /// Number of total account nodes, including those that were skipped.
     pub(crate) multiproof_total_account_nodes: u64,
@@ -37,7 +37,7 @@ impl SparseStateTrieMetrics {
 }
 
 /// Metrics for the sparse state trie
-#[derive(Metrics)]
+#[derive(Metrics, Clone)]
 #[metrics(scope = "sparse_state_trie")]
 pub(crate) struct SparseStateTrieInnerMetrics {
     /// Histogram of total account nodes, including those that were skipped.

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -508,6 +508,18 @@ where
     }
 }
 
+impl Clone for SparseStateTrie {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            storage: self.storage.clone(),
+            retain_updates: self.retain_updates,
+            deferred_drops: DeferredDrops::default(),
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
 /// The fields of [`SparseStateTrie`] related to storage tries. This is kept separate from the rest
 /// of [`SparseStateTrie`] to help enforce allocation re-use.
 #[derive(Debug, Default)]
@@ -585,6 +597,16 @@ impl<S: SparseTrieTrait + Clone> StorageTries<S> {
         self.tries.entry(address).or_insert_with(|| {
             self.cleared_tries.pop().unwrap_or_else(|| self.default_trie.clone())
         })
+    }
+}
+
+impl<S: Clone> Clone for StorageTries<S> {
+    fn clone(&self) -> Self {
+        Self {
+            tries: self.tries.clone(),
+            cleared_tries: Vec::new(),
+            default_trie: self.default_trie.clone(),
+        }
     }
 }
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -515,6 +515,7 @@ impl Clone for SparseStateTrie {
             storage: self.storage.clone(),
             retain_updates: self.retain_updates,
             deferred_drops: DeferredDrops::default(),
+            #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),
         }
     }


### PR DESCRIPTION
Can't derive because we don't need to clone buffer and deferred drop fields.