### PR TITLE
feat(downloader): add snap account range downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8277,6 +8277,7 @@ dependencies = [
  "reth-chainspec",
  "reth-config",
  "reth-consensus",
+ "reth-eth-wire-types",
  "reth-ethereum-primitives",
  "reth-metrics",
  "reth-network-p2p",
@@ -8287,6 +8288,7 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "reth-tracing",
+ "reth-trie-common",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -10697,6 +10699,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -38,7 +38,7 @@ alloy-rlp.workspace = true
 futures.workspace = true
 futures-util.workspace = true
 pin-project.workspace = true
-tokio = { workspace = true, features = ["sync", "fs", "io-util"] }
+tokio = { workspace = true, features = ["sync", "fs", "io-util", "rt"] }
 tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["codec"] }
 async-compression = { workspace = true, features = ["gzip", "tokio"], optional = true }

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -15,11 +15,13 @@ workspace = true
 # reth
 reth-config.workspace = true
 reth-consensus.workspace = true
+reth-eth-wire-types.workspace = true
 reth-network-p2p.workspace = true
 reth-network-peers.workspace = true
 reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-tasks.workspace = true
+reth-trie-common.workspace = true
 
 # optional deps for the test-utils feature
 reth-ethereum-primitives = { workspace = true, optional = true }
@@ -30,7 +32,7 @@ reth-testing-utils = { workspace = true, optional = true }
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
-alloy-rlp = { workspace = true, optional = true }
+alloy-rlp.workspace = true
 
 # async
 futures.workspace = true
@@ -72,7 +74,7 @@ itertools.workspace = true
 
 [features]
 default = []
-file-client = ["dep:async-compression", "dep:alloy-rlp", "dep:itertools"]
+file-client = ["dep:async-compression", "dep:itertools"]
 test-utils = [
     "tempfile",
     "reth-consensus/test-utils",
@@ -84,4 +86,5 @@ test-utils = [
     "dep:reth-ethereum-primitives",
     "reth-ethereum-primitives?/test-utils",
     "reth-tasks/test-utils",
+    "reth-trie-common/test-utils",
 ]

--- a/crates/net/downloaders/src/lib.rs
+++ b/crates/net/downloaders/src/lib.rs
@@ -25,6 +25,9 @@ pub mod headers;
 /// Common downloader metrics.
 pub mod metrics;
 
+/// Downloaders for authenticated snap state ranges.
+pub mod snap;
+
 /// Module managing file-based data retrieval and buffering.
 ///
 /// Contains [`FileClient`](file_client::FileClient) to read block data from files,

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -1,14 +1,13 @@
-//! Downloads and authenticates snap/2 account ranges against [EIP-8189] pivot state roots.
-//! Verified ranges report whether another request is needed for the requested interval;
-//! persistence and sync orchestration are handled by callers.
+//! Downloads and verifies snap/2 account ranges against [EIP-8189] pivot state roots.
+//! Persistence and range selection are handled by the snap sync orchestrator.
 //!
 //! [EIP-8189]: https://eips.ethereum.org/EIPS/eip-8189
 
 use alloy_primitives::B256;
 use futures::{Future, FutureExt};
-use reth_eth_wire_types::snap::GetAccountRangeMessage;
+use reth_eth_wire_types::snap::{AccountData, AccountRangeMessage, GetAccountRangeMessage};
 use reth_network_p2p::{
-    error::RequestError,
+    error::{PeerRequestResult, RequestError},
     priority::Priority,
     snap::client::{SnapClient, SnapResponse},
 };
@@ -20,18 +19,12 @@ use std::{
 };
 use tracing::debug;
 
-/// Number of retry attempts after the initial account-range request fails.
 const MAX_RETRIES: u8 = 2;
 
 /// Downloads and verifies one account range against its requested state root.
 ///
-/// Invalid peer responses are reported and the same request is reissued at high priority. The
-/// client picks the peer, so a retry can land on the same one; only its falling reputation moves
-/// the request elsewhere. Polling verifies the range proof inline, which costs work proportional
-/// to the response.
-///
-/// The future is storage agnostic: persisting a verified range and choosing the next range are
-/// left to the snap sync orchestrator.
+/// Invalid responses penalize their peer and retry at high priority. Proof verification runs
+/// inline while polling.
 #[derive(Debug)]
 pub struct AccountRangeDownloader<C: SnapClient> {
     client: C,
@@ -53,7 +46,6 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         Ok(Self { client, request, fut, retries: 0 })
     }
 
-    /// Reissues the request at high priority if its retry budget is not exhausted.
     fn retry(&mut self) -> bool {
         if self.retries >= MAX_RETRIES {
             return false
@@ -64,12 +56,31 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         true
     }
 
-    /// Decodes and verifies a response from a peer.
     fn verify_response(
         &self,
         peer_id: PeerId,
         response: SnapResponse,
     ) -> Result<AccountRangeOutcome, RequestError> {
+        let response = self.account_range_response(response)?;
+
+        if response.accounts.is_empty() && response.proof.is_empty() {
+            return if self.request.root_hash == EMPTY_ROOT_HASH {
+                Ok(AccountRangeOutcome::Verified(VerifiedAccountRange {
+                    accounts: Vec::new(),
+                    has_more: false,
+                }))
+            } else {
+                Ok(AccountRangeOutcome::Unavailable { peer_id })
+            }
+        }
+
+        self.verify_account_range(response).map(AccountRangeOutcome::Verified)
+    }
+
+    fn account_range_response(
+        &self,
+        response: SnapResponse,
+    ) -> Result<AccountRangeMessage, RequestError> {
         let SnapResponse::AccountRange(response) = response else {
             debug!(target: "downloaders::snap", "Expected account range response");
             return Err(RequestError::BadResponse)
@@ -83,63 +94,83 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
             );
             return Err(RequestError::BadResponse)
         }
+        Ok(response)
+    }
 
-        if response.accounts.is_empty() && response.proof.is_empty() {
-            return if self.request.root_hash == EMPTY_ROOT_HASH {
-                Ok(AccountRangeOutcome::Verified(VerifiedAccountRange {
-                    accounts: Vec::new(),
-                    has_more: false,
-                }))
-            } else {
-                Ok(AccountRangeOutcome::Unavailable { peer_id })
-            }
-        }
+    fn verify_account_range(
+        &self,
+        response: AccountRangeMessage,
+    ) -> Result<VerifiedAccountRange, RequestError> {
+        self.validate_account_limit(&response.accounts)?;
 
-        // A responder appends the first account past the limit to prove the interval is complete.
-        // Anything beyond that was not requested, so it is rejected before the range is decoded
-        // and hashed rather than trimmed away after the work is done.
-        if response
-            .accounts
-            .iter()
-            .filter(|data| data.hash > self.request.limit_hash)
-            .nth(1)
-            .is_some()
-        {
+        let mut accounts = Self::decode_accounts(response.accounts)?;
+        let next = self.verify_proof(&accounts, &response.proof)?;
+
+        // Authenticate the boundary account before removing it from the requested range.
+        accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= self.request.limit_hash));
+        let has_more = next.is_some_and(|next| next <= self.request.limit_hash);
+
+        Ok(VerifiedAccountRange { accounts, has_more })
+    }
+
+    fn validate_account_limit(&self, accounts: &[AccountData]) -> Result<(), RequestError> {
+        // Only the first account past the limit is needed to prove the interval is complete.
+        if accounts.iter().filter(|data| data.hash > self.request.limit_hash).nth(1).is_some() {
             debug!(target: "downloaders::snap", "Account range runs past the requested limit");
             return Err(RequestError::BadResponse)
         }
+        Ok(())
+    }
 
-        let mut accounts = Vec::with_capacity(response.accounts.len());
-        for data in response.accounts {
-            let hash = data.hash;
-            let account = data.trie_account().map_err(|error| {
-                debug!(target: "downloaders::snap", %error, "Invalid account data");
-                RequestError::BadResponse
-            })?;
-            accounts.push((hash, account));
-        }
-
+    fn verify_proof(
+        &self,
+        accounts: &[(B256, TrieAccount)],
+        proof: &[alloy_primitives::Bytes],
+    ) -> Result<Option<B256>, RequestError> {
         let leaves = accounts.iter().map(|(hash, account)| (*hash, alloy_rlp::encode(account)));
-        let next = verify_range_proof(
-            self.request.root_hash,
-            self.request.starting_hash,
-            leaves,
-            &response.proof,
-        )
-        .map_err(|error| {
-            debug!(target: "downloaders::snap", %error, "Invalid account range proof");
-            RequestError::BadResponse
-        })?;
+        verify_range_proof(self.request.root_hash, self.request.starting_hash, leaves, proof)
+            .map_err(|error| {
+                debug!(target: "downloaders::snap", %error, "Invalid account range proof");
+                RequestError::BadResponse
+            })
+    }
 
-        // Responders append the boundary account before checking the requested limit. Authenticate
-        // an overshooting account as part of the response before removing it.
-        accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= self.request.limit_hash));
+    fn decode_accounts(data: Vec<AccountData>) -> Result<Vec<(B256, TrieAccount)>, RequestError> {
+        data.into_iter()
+            .map(|data| {
+                let hash = data.hash;
+                let account = data.trie_account().map_err(|error| {
+                    debug!(target: "downloaders::snap", %error, "Invalid account data");
+                    RequestError::BadResponse
+                })?;
+                Ok((hash, account))
+            })
+            .collect()
+    }
 
-        // The proof pins where the trie continues, so the interval is complete unless a key the
-        // response did not cover can still fall inside it.
-        let has_more = next.is_some_and(|next| next <= self.request.limit_hash);
-
-        Ok(AccountRangeOutcome::Verified(VerifiedAccountRange { accounts, has_more }))
+    fn handle_response(
+        &mut self,
+        response: PeerRequestResult<SnapResponse>,
+    ) -> Result<Option<AccountRangeOutcome>, RequestError> {
+        match response {
+            Ok(response) => {
+                let (peer_id, response) = response.split();
+                match self.verify_response(peer_id, response) {
+                    Ok(outcome) => Ok(Some(outcome)),
+                    Err(error) => {
+                        debug!(target: "downloaders::snap", ?peer_id, %error, "Invalid account range response");
+                        self.client.report_bad_message(peer_id);
+                        self.retry().then_some(None).ok_or(error)
+                    }
+                }
+            }
+            // A wrong wire response is already penalized by the session.
+            Err(error) if error.is_retryable() || error == RequestError::BadResponse => {
+                debug!(target: "downloaders::snap", %error, "Account range request failed, retrying");
+                self.retry().then_some(None).ok_or(error)
+            }
+            Err(error) => Err(error),
+        }
     }
 }
 
@@ -153,28 +184,10 @@ where
         let this = self.get_mut();
 
         loop {
-            match ready!(this.fut.poll_unpin(cx)) {
-                Ok(response) => {
-                    let (peer_id, response) = response.split();
-                    match this.verify_response(peer_id, response) {
-                        Ok(outcome) => return Poll::Ready(Ok(outcome)),
-                        Err(error) => {
-                            debug!(target: "downloaders::snap", ?peer_id, %error, "Invalid account range response");
-                            this.client.report_bad_message(peer_id);
-                            if !this.retry() {
-                                return Poll::Ready(Err(error))
-                            }
-                        }
-                    }
-                }
-                // A wrong wire response is already attributed and penalized by the session, so the
-                // request is reissued without reporting the peer a second time.
-                Err(error) if error.is_retryable() || error == RequestError::BadResponse => {
-                    debug!(target: "downloaders::snap", %error, "Account range request failed, retrying");
-                    if !this.retry() {
-                        return Poll::Ready(Err(error))
-                    }
-                }
+            let response = ready!(this.fut.poll_unpin(cx));
+            match this.handle_response(response) {
+                Ok(Some(outcome)) => return Poll::Ready(Ok(outcome)),
+                Ok(None) => {}
                 Err(error) => return Poll::Ready(Err(error)),
             }
         }
@@ -184,12 +197,9 @@ where
 /// The result of an authenticated account-range request.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AccountRangeOutcome {
-    /// The selected peer does not have the requested state root.
-    ///
-    /// This is not a protocol violation and does not affect peer reputation. The peer is named so
-    /// the orchestrator can retry elsewhere, deprioritize it, or advance its pivot.
+    /// The peer does not have the requested state root and was not penalized.
     Unavailable {
-        /// Peer that answered without the requested state.
+        /// The peer that answered.
         peer_id: PeerId,
     },
     /// An account range authenticated against the requested state root.
@@ -205,7 +215,7 @@ pub struct VerifiedAccountRange {
     pub has_more: bool,
 }
 
-/// Error returned when an account-range request has reversed bounds.
+/// An account-range request whose origin exceeds its limit.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 #[error("account range origin {origin} exceeds limit {limit}")]
 pub struct InvalidAccountRange {
@@ -219,10 +229,9 @@ mod tests {
     use alloy_primitives::{Bytes, KECCAK256_EMPTY, U256};
     use futures::future::{ready, Ready};
     use reth_eth_wire_types::snap::{
-        AccountData, AccountRangeMessage, ByteCodesMessage, GetBlockAccessListsMessage,
-        GetByteCodesMessage, GetStorageRangesMessage,
+        ByteCodesMessage, GetBlockAccessListsMessage, GetByteCodesMessage, GetStorageRangesMessage,
     };
-    use reth_network_p2p::{download::DownloadClient, error::PeerRequestResult};
+    use reth_network_p2p::download::DownloadClient;
     use reth_network_peers::WithPeerId;
     use reth_trie_common::{proof::ProofRetainer, HashBuilder, Nibbles};
     use std::{
@@ -535,8 +544,7 @@ mod tests {
         assert!(client.reported.lock().unwrap().is_empty());
     }
 
-    /// snap/2 requires a peer with no account inside `[origin, limit]` to return the first account
-    /// after `limit`, so the sole returned account authenticates the interval and then trims away.
+    // The first account after the limit proves an empty interval.
     #[tokio::test]
     async fn empty_interval_is_proven_by_the_first_account_after_the_limit() {
         let accounts = vec![(key(1), account(7)), (key(9), account(8))];
@@ -565,8 +573,7 @@ mod tests {
         assert!(client.reported.lock().unwrap().is_empty());
     }
 
-    /// A response cut short by the responder's byte budget completes the interval anyway when the
-    /// proof shows the trie continues past the limit.
+    // A proof that continues past the limit completes the requested interval.
     #[tokio::test]
     async fn range_ending_before_the_limit_needs_no_further_request() {
         let accounts = vec![(key(1), account(7)), (key(9), account(8))];

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -12,6 +12,7 @@ use reth_network_p2p::{
     priority::Priority,
     snap::client::{SnapClient, SnapResponse},
 };
+use reth_network_peers::PeerId;
 use reth_trie_common::{range_proof::verify_range_proof, TrieAccount, EMPTY_ROOT_HASH};
 use std::{
     pin::Pin,
@@ -60,7 +61,11 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
     }
 
     /// Decodes and verifies a response from a peer.
-    fn verify_response(&self, response: SnapResponse) -> Result<AccountRangeOutcome, RequestError> {
+    fn verify_response(
+        &self,
+        peer_id: PeerId,
+        response: SnapResponse,
+    ) -> Result<AccountRangeOutcome, RequestError> {
         let SnapResponse::AccountRange(response) = response else {
             debug!(target: "downloaders::snap", "Expected account range response");
             return Err(RequestError::BadResponse)
@@ -82,7 +87,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
                     has_more: false,
                 }))
             } else {
-                Ok(AccountRangeOutcome::Unavailable)
+                Ok(AccountRangeOutcome::Unavailable { peer_id })
             }
         }
 
@@ -147,7 +152,7 @@ where
             match ready!(this.fut.poll_unpin(cx)) {
                 Ok(response) => {
                     let (peer_id, response) = response.split();
-                    match this.verify_response(response) {
+                    match this.verify_response(peer_id, response) {
                         Ok(outcome) => return Poll::Ready(Ok(outcome)),
                         Err(error) => {
                             debug!(target: "downloaders::snap", ?peer_id, %error, "Invalid account range response");
@@ -177,9 +182,12 @@ where
 pub enum AccountRangeOutcome {
     /// The selected peer does not have the requested state root.
     ///
-    /// This is not a protocol violation and does not affect peer reputation. The orchestrator can
-    /// retry elsewhere or advance its pivot.
-    Unavailable,
+    /// This is not a protocol violation and does not affect peer reputation. The peer is named so
+    /// the orchestrator can retry elsewhere, deprioritize it, or advance its pivot.
+    Unavailable {
+        /// Peer that answered without the requested state.
+        peer_id: PeerId,
+    },
     /// An account range authenticated against the requested state root.
     Verified(VerifiedAccountRange),
 }
@@ -211,7 +219,7 @@ mod tests {
         GetByteCodesMessage, GetStorageRangesMessage,
     };
     use reth_network_p2p::{download::DownloadClient, error::PeerRequestResult};
-    use reth_network_peers::{PeerId, WithPeerId};
+    use reth_network_peers::WithPeerId;
     use reth_trie_common::{proof::ProofRetainer, HashBuilder, Nibbles};
     use std::{
         collections::VecDeque,
@@ -418,7 +426,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        assert_eq!(outcome, AccountRangeOutcome::Unavailable);
+        assert_eq!(outcome, AccountRangeOutcome::Unavailable { peer_id: peer });
         assert!(client.reported.lock().unwrap().is_empty());
     }
 

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -1,11 +1,11 @@
-//! Downloads and verifies snap/2 account ranges against [EIP-8189] pivot state roots.
-//! Persistence and range selection are handled by the snap sync orchestrator.
+//! Downloads and verifies snap/2 account ranges against
+//! [EIP-8189](https://eips.ethereum.org/EIPS/eip-8189) pivot state roots.
 //!
-//! [EIP-8189]: https://eips.ethereum.org/EIPS/eip-8189
+//! Persistence and range selection are handled by the snap sync orchestrator.
 
 use alloy_primitives::B256;
 use futures::{Future, FutureExt};
-use reth_eth_wire_types::snap::{AccountData, AccountRangeMessage, GetAccountRangeMessage};
+use reth_eth_wire_types::snap::{AccountRangeMessage, GetAccountRangeMessage};
 use reth_network_p2p::{
     error::{PeerRequestResult, RequestError},
     priority::Priority,
@@ -24,7 +24,7 @@ const MAX_RETRIES: u8 = 2;
 /// Downloads and verifies one account range against its requested state root.
 ///
 /// Invalid responses penalize their peer and retry at high priority. Proof verification runs on
-/// Tokio's blocking pool.
+/// the blocking pool.
 #[derive(Debug)]
 pub struct AccountRangeDownloader<C: SnapClient> {
     client: C,
@@ -35,7 +35,9 @@ pub struct AccountRangeDownloader<C: SnapClient> {
 }
 
 impl<C: SnapClient> AccountRangeDownloader<C> {
-    /// Validates the range, then creates a downloader and submits `request` at normal priority.
+    /// Creates a downloader and submits the initial request at normal priority.
+    ///
+    /// Returns an error when the origin exceeds the limit because such a range cannot be proven.
     pub fn new(client: C, request: GetAccountRangeMessage) -> Result<Self, InvalidAccountRange> {
         if request.starting_hash > request.limit_hash {
             return Err(InvalidAccountRange {
@@ -47,6 +49,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         Ok(Self { client, request, fut, verification: None, retries: 0 })
     }
 
+    // Raise retry priority so transient failures cannot leave range progress behind new work.
     fn retry(&mut self) -> bool {
         if self.retries >= MAX_RETRIES {
             return false
@@ -57,6 +60,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         true
     }
 
+    // Verify peer-controlled proofs off the async worker while retaining peer attribution.
     fn start_verification(
         &mut self,
         peer_id: PeerId,
@@ -76,12 +80,12 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         }
 
         let request = self.request.clone();
-        let fut =
-            tokio::task::spawn_blocking(move || Self::verify_account_range(&request, response));
+        let fut = tokio::task::spawn_blocking(move || verify_account_range(&request, response));
         self.verification = Some(VerificationTask { peer_id, fut });
         Ok(None)
     }
 
+    // Bind replies to the expected request before trusting peer-supplied data.
     fn account_range_response(
         &self,
         response: SnapResponse,
@@ -102,58 +106,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         Ok(response)
     }
 
-    fn verify_account_range(
-        request: &GetAccountRangeMessage,
-        response: AccountRangeMessage,
-    ) -> Result<VerifiedAccountRange, RequestError> {
-        Self::validate_account_limit(request.limit_hash, &response.accounts)?;
-
-        let mut accounts = Self::decode_accounts(response.accounts)?;
-        let next = Self::verify_proof(request, &accounts, &response.proof)?;
-
-        // Authenticate the boundary account before removing it from the requested range.
-        accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= request.limit_hash));
-        let has_more = next.is_some_and(|next| next <= request.limit_hash);
-
-        Ok(VerifiedAccountRange { accounts, has_more })
-    }
-
-    fn validate_account_limit(limit: B256, accounts: &[AccountData]) -> Result<(), RequestError> {
-        // Only the first account past the limit is needed to prove the interval is complete.
-        if accounts.iter().filter(|data| data.hash > limit).nth(1).is_some() {
-            debug!(target: "downloaders::snap", "Account range runs past the requested limit");
-            return Err(RequestError::BadResponse)
-        }
-        Ok(())
-    }
-
-    fn verify_proof(
-        request: &GetAccountRangeMessage,
-        accounts: &[(B256, TrieAccount)],
-        proof: &[alloy_primitives::Bytes],
-    ) -> Result<Option<B256>, RequestError> {
-        let leaves = accounts.iter().map(|(hash, account)| (*hash, alloy_rlp::encode(account)));
-        verify_range_proof(request.root_hash, request.starting_hash, leaves, proof).map_err(
-            |error| {
-                debug!(target: "downloaders::snap", %error, "Invalid account range proof");
-                RequestError::BadResponse
-            },
-        )
-    }
-
-    fn decode_accounts(data: Vec<AccountData>) -> Result<Vec<(B256, TrieAccount)>, RequestError> {
-        data.into_iter()
-            .map(|data| {
-                let hash = data.hash;
-                let account = data.trie_account().map_err(|error| {
-                    debug!(target: "downloaders::snap", %error, "Invalid account data");
-                    RequestError::BadResponse
-                })?;
-                Ok((hash, account))
-            })
-            .collect()
-    }
-
+    // Keep validation and retry accounting together so peers are penalized exactly once.
     fn handle_response(
         &mut self,
         response: PeerRequestResult<SnapResponse>,
@@ -179,6 +132,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         }
     }
 
+    // Preserve peer attribution until blocking verification finishes.
     fn poll_verification(
         &mut self,
         cx: &mut Context<'_>,
@@ -209,6 +163,7 @@ where
 {
     type Output = Result<AccountRangeOutcome, RequestError>;
 
+    // Finish an active verification before accepting another response.
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 
@@ -243,6 +198,15 @@ pub enum AccountRangeOutcome {
     Verified(VerifiedAccountRange),
 }
 
+// Couples blocking proof work with its responder so failures remain attributable.
+#[derive(Debug)]
+struct VerificationTask {
+    // Identifies the responder to penalize if verification rejects the range.
+    peer_id: PeerId,
+    // Carries the verified result back without blocking the async worker.
+    fut: tokio::task::JoinHandle<Result<VerifiedAccountRange, RequestError>>,
+}
+
 /// A decoded account range authenticated against a state root.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VerifiedAccountRange {
@@ -250,6 +214,50 @@ pub struct VerifiedAccountRange {
     pub accounts: Vec<(B256, TrieAccount)>,
     /// Whether another request is needed to complete the requested interval.
     pub has_more: bool,
+}
+
+// Authenticate the full response before trimming its optional boundary account.
+fn verify_account_range(
+    request: &GetAccountRangeMessage,
+    response: AccountRangeMessage,
+) -> Result<VerifiedAccountRange, RequestError> {
+    // Allow only the single out-of-range account needed as a boundary witness.
+    if response.accounts.iter().filter(|data| data.hash > request.limit_hash).nth(1).is_some() {
+        debug!(target: "downloaders::snap", "Account range runs past the requested limit");
+        return Err(RequestError::BadResponse)
+    }
+
+    // Decode first so malformed account values are attributed to the responder.
+    let mut accounts = response
+        .accounts
+        .into_iter()
+        .map(|data| {
+            data.into_trie_entry().map_err(|error| {
+                debug!(target: "downloaders::snap", %error, "Invalid account data");
+                RequestError::BadResponse
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let next = verify_proof(request, &accounts, &response.proof)?;
+
+    // Authenticate the boundary account before removing it from the requested range.
+    accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= request.limit_hash));
+    let has_more = next.is_some_and(|next| next <= request.limit_hash);
+
+    Ok(VerifiedAccountRange { accounts, has_more })
+}
+
+// Re-encode decoded accounts so the proof authenticates their canonical trie values.
+fn verify_proof(
+    request: &GetAccountRangeMessage,
+    accounts: &[(B256, TrieAccount)],
+    proof: &[alloy_primitives::Bytes],
+) -> Result<Option<B256>, RequestError> {
+    let leaves = accounts.iter().map(|(hash, account)| (*hash, alloy_rlp::encode(account)));
+    verify_range_proof(request.root_hash, request.starting_hash, leaves, proof).map_err(|error| {
+        debug!(target: "downloaders::snap", %error, "Invalid account range proof");
+        RequestError::BadResponse
+    })
 }
 
 /// An account-range request whose origin exceeds its limit.
@@ -260,19 +268,14 @@ pub struct InvalidAccountRange {
     limit: B256,
 }
 
-#[derive(Debug)]
-struct VerificationTask {
-    peer_id: PeerId,
-    fut: tokio::task::JoinHandle<Result<VerifiedAccountRange, RequestError>>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloy_primitives::{Bytes, KECCAK256_EMPTY, U256};
     use futures::future::{ready, Ready};
     use reth_eth_wire_types::snap::{
-        ByteCodesMessage, GetBlockAccessListsMessage, GetByteCodesMessage, GetStorageRangesMessage,
+        AccountData, ByteCodesMessage, GetBlockAccessListsMessage, GetByteCodesMessage,
+        GetStorageRangesMessage,
     };
     use reth_network_p2p::download::DownloadClient;
     use reth_network_peers::WithPeerId;

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -1,0 +1,575 @@
+//! Downloads and authenticates snap/2 account ranges against [EIP-8189] pivot state roots.
+//! Verified ranges report whether another request is needed for the requested interval;
+//! persistence and sync orchestration are handled by callers.
+//!
+//! [EIP-8189]: https://eips.ethereum.org/EIPS/eip-8189
+
+use alloy_primitives::B256;
+use futures::{Future, FutureExt};
+use reth_eth_wire_types::snap::GetAccountRangeMessage;
+use reth_network_p2p::{
+    error::RequestError,
+    priority::Priority,
+    snap::client::{SnapClient, SnapResponse},
+};
+use reth_trie_common::{range_proof::verify_range_proof, TrieAccount, EMPTY_ROOT_HASH};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Context, Poll},
+};
+use tracing::debug;
+
+/// Number of retry attempts after the initial account-range request fails.
+const MAX_RETRIES: u8 = 2;
+
+/// Downloads and verifies one account range against its requested state root.
+///
+/// Invalid peer responses are reported and the same request is retried with high priority. The
+/// future is storage agnostic: persisting a verified range and choosing the next range are left to
+/// the snap sync orchestrator.
+#[derive(Debug)]
+pub struct AccountRangeDownloader<C: SnapClient> {
+    client: Arc<C>,
+    request: GetAccountRangeMessage,
+    fut: C::Output,
+    retries: u8,
+}
+
+impl<C: SnapClient> AccountRangeDownloader<C> {
+    /// Validates the range, then creates a downloader and submits `request` at normal priority.
+    pub fn new(
+        client: Arc<C>,
+        request: GetAccountRangeMessage,
+    ) -> Result<Self, InvalidAccountRange> {
+        if request.starting_hash > request.limit_hash {
+            return Err(InvalidAccountRange {
+                origin: request.starting_hash,
+                limit: request.limit_hash,
+            })
+        }
+        let fut = client.get_account_range(request.clone());
+        Ok(Self { client, request, fut, retries: 0 })
+    }
+
+    /// Reissues the request at high priority if its retry budget is not exhausted.
+    fn retry(&mut self) -> bool {
+        if self.retries >= MAX_RETRIES {
+            return false
+        }
+        self.retries += 1;
+        self.fut =
+            self.client.get_account_range_with_priority(self.request.clone(), Priority::High);
+        true
+    }
+
+    /// Decodes and verifies a response from a peer.
+    fn verify_response(&self, response: SnapResponse) -> Result<AccountRangeOutcome, RequestError> {
+        let SnapResponse::AccountRange(response) = response else {
+            debug!(target: "downloaders::snap", "Expected account range response");
+            return Err(RequestError::BadResponse)
+        };
+        if response.request_id != self.request.request_id {
+            debug!(
+                target: "downloaders::snap",
+                expected = self.request.request_id,
+                got = response.request_id,
+                "Account range response id mismatch"
+            );
+            return Err(RequestError::BadResponse)
+        }
+
+        if response.accounts.is_empty() && response.proof.is_empty() {
+            return if self.request.root_hash == EMPTY_ROOT_HASH {
+                Ok(AccountRangeOutcome::Verified(VerifiedAccountRange {
+                    accounts: Vec::new(),
+                    has_more: false,
+                }))
+            } else {
+                Ok(AccountRangeOutcome::Unavailable)
+            }
+        }
+
+        let mut accounts = Vec::with_capacity(response.accounts.len());
+        for data in response.accounts {
+            let hash = data.hash;
+            let account = data.trie_account().map_err(|error| {
+                debug!(target: "downloaders::snap", %error, "Invalid account data");
+                RequestError::BadResponse
+            })?;
+            accounts.push((hash, account));
+        }
+
+        let leaves = accounts.iter().map(|(hash, account)| (*hash, alloy_rlp::encode(account)));
+        let mut has_more = verify_range_proof(
+            self.request.root_hash,
+            self.request.starting_hash,
+            leaves,
+            &response.proof,
+        )
+        .map_err(|error| {
+            debug!(target: "downloaders::snap", %error, "Invalid account range proof");
+            RequestError::BadResponse
+        })?;
+
+        // Responders append the boundary account before checking the requested limit. Authenticate
+        // an overshooting account as part of the response before removing it.
+        let reached_limit =
+            accounts.last().is_some_and(|(hash, _)| *hash >= self.request.limit_hash);
+        let retained = accounts.partition_point(|(hash, _)| *hash <= self.request.limit_hash);
+        if retained < accounts.len() {
+            accounts.truncate(retained);
+        }
+        if reached_limit {
+            has_more = false;
+        }
+
+        Ok(AccountRangeOutcome::Verified(VerifiedAccountRange { accounts, has_more }))
+    }
+}
+
+impl<C> Future for AccountRangeDownloader<C>
+where
+    C: SnapClient + 'static,
+{
+    type Output = Result<AccountRangeOutcome, RequestError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        loop {
+            match ready!(this.fut.poll_unpin(cx)) {
+                Ok(response) => {
+                    let (peer_id, response) = response.split();
+                    match this.verify_response(response) {
+                        Ok(outcome) => return Poll::Ready(Ok(outcome)),
+                        Err(error) => {
+                            debug!(target: "downloaders::snap", ?peer_id, %error, "Invalid account range response");
+                            this.client.report_bad_message(peer_id);
+                            if !this.retry() {
+                                return Poll::Ready(Err(error))
+                            }
+                        }
+                    }
+                }
+                // A wrong wire response is already attributed and penalized by the session. It is
+                // still safe to retry the request with another snap peer.
+                Err(error) if error.is_retryable() || error == RequestError::BadResponse => {
+                    debug!(target: "downloaders::snap", %error, "Account range request failed, retrying");
+                    if !this.retry() {
+                        return Poll::Ready(Err(error))
+                    }
+                }
+                Err(error) => return Poll::Ready(Err(error)),
+            }
+        }
+    }
+}
+
+/// The result of an authenticated account-range request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AccountRangeOutcome {
+    /// The selected peer does not have the requested state root.
+    ///
+    /// This is not a protocol violation and does not affect peer reputation. The orchestrator can
+    /// retry elsewhere or advance its pivot.
+    Unavailable,
+    /// An account range authenticated against the requested state root.
+    Verified(VerifiedAccountRange),
+}
+
+/// A decoded account range authenticated against a state root.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedAccountRange {
+    /// Accounts in strictly increasing hashed-key order.
+    pub accounts: Vec<(B256, TrieAccount)>,
+    /// Whether another request is needed to complete the requested interval.
+    pub has_more: bool,
+}
+
+/// Error returned when an account-range request has reversed bounds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("account range origin {origin} exceeds limit {limit}")]
+pub struct InvalidAccountRange {
+    origin: B256,
+    limit: B256,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, KECCAK256_EMPTY, U256};
+    use futures::future::{ready, Ready};
+    use reth_eth_wire_types::snap::{
+        AccountData, AccountRangeMessage, ByteCodesMessage, GetBlockAccessListsMessage,
+        GetByteCodesMessage, GetStorageRangesMessage,
+    };
+    use reth_network_p2p::{download::DownloadClient, error::PeerRequestResult};
+    use reth_network_peers::{PeerId, WithPeerId};
+    use reth_trie_common::{proof::ProofRetainer, HashBuilder, Nibbles};
+    use std::{collections::VecDeque, sync::Mutex};
+
+    const MAX_HASH: B256 = B256::new([0xff; B256::len_bytes()]);
+
+    #[derive(Debug)]
+    struct TestSnapClient {
+        responses: Mutex<VecDeque<PeerRequestResult<SnapResponse>>>,
+        reported: Mutex<Vec<PeerId>>,
+        priorities: Mutex<Vec<Priority>>,
+    }
+
+    impl TestSnapClient {
+        fn new(responses: impl IntoIterator<Item = PeerRequestResult<SnapResponse>>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into_iter().collect()),
+                reported: Mutex::new(Vec::new()),
+                priorities: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn next(&self, priority: Priority) -> Ready<PeerRequestResult<SnapResponse>> {
+            self.priorities.lock().unwrap().push(priority);
+            ready(self.responses.lock().unwrap().pop_front().expect("test response available"))
+        }
+    }
+
+    impl DownloadClient for TestSnapClient {
+        fn report_bad_message(&self, peer_id: PeerId) {
+            self.reported.lock().unwrap().push(peer_id);
+        }
+
+        fn num_connected_peers(&self) -> usize {
+            1
+        }
+    }
+
+    impl SnapClient for TestSnapClient {
+        type Output = Ready<PeerRequestResult<SnapResponse>>;
+
+        fn get_account_range_with_priority(
+            &self,
+            _request: GetAccountRangeMessage,
+            priority: Priority,
+        ) -> Self::Output {
+            self.next(priority)
+        }
+
+        fn get_storage_ranges(&self, _request: GetStorageRangesMessage) -> Self::Output {
+            ready(Err(RequestError::UnsupportedCapability))
+        }
+
+        fn get_storage_ranges_with_priority(
+            &self,
+            _request: GetStorageRangesMessage,
+            _priority: Priority,
+        ) -> Self::Output {
+            ready(Err(RequestError::UnsupportedCapability))
+        }
+
+        fn get_byte_codes(&self, _request: GetByteCodesMessage) -> Self::Output {
+            ready(Err(RequestError::UnsupportedCapability))
+        }
+
+        fn get_byte_codes_with_priority(
+            &self,
+            _request: GetByteCodesMessage,
+            _priority: Priority,
+        ) -> Self::Output {
+            ready(Err(RequestError::UnsupportedCapability))
+        }
+
+        fn get_block_access_lists_with_priority(
+            &self,
+            _request: GetBlockAccessListsMessage,
+            _priority: Priority,
+        ) -> Self::Output {
+            ready(Err(RequestError::UnsupportedCapability))
+        }
+    }
+
+    fn key(value: u64) -> B256 {
+        B256::left_padding_from(&value.to_be_bytes())
+    }
+
+    fn account(nonce: u64) -> TrieAccount {
+        TrieAccount {
+            nonce,
+            balance: U256::from(1),
+            storage_root: EMPTY_ROOT_HASH,
+            code_hash: KECCAK256_EMPTY,
+        }
+    }
+
+    fn root(accounts: &[(B256, TrieAccount)]) -> B256 {
+        let mut builder = HashBuilder::default();
+        for (key, account) in accounts {
+            builder.add_leaf(Nibbles::unpack(*key), &alloy_rlp::encode(account));
+        }
+        builder.root()
+    }
+
+    fn root_and_proof(accounts: &[(B256, TrieAccount)], targets: &[B256]) -> (B256, Vec<Bytes>) {
+        let targets = targets.iter().copied().map(Nibbles::unpack).collect();
+        let mut builder = HashBuilder::default().with_proof_retainer(ProofRetainer::new(targets));
+        for (key, account) in accounts {
+            builder.add_leaf(Nibbles::unpack(*key), &alloy_rlp::encode(account));
+        }
+        let root = builder.root();
+        let proof = builder
+            .take_proof_nodes()
+            .into_nodes_sorted()
+            .into_iter()
+            .map(|(_, node)| node)
+            .collect();
+        (root, proof)
+    }
+
+    fn request(root_hash: B256) -> GetAccountRangeMessage {
+        GetAccountRangeMessage {
+            request_id: 1,
+            root_hash,
+            starting_hash: B256::ZERO,
+            limit_hash: MAX_HASH,
+            response_bytes: 512 * 1024,
+        }
+    }
+
+    fn response(peer: PeerId, message: AccountRangeMessage) -> PeerRequestResult<SnapResponse> {
+        Ok(WithPeerId::new(peer, SnapResponse::AccountRange(message)))
+    }
+
+    #[tokio::test]
+    async fn verifies_and_decodes_a_complete_account_range() {
+        let accounts = vec![(key(1), account(7)), (key(2), account(8))];
+        let root_hash = root(&accounts);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage {
+            request_id: 1,
+            accounts: accounts
+                .iter()
+                .map(|(key, account)| AccountData::from_trie_account(*key, account))
+                .collect(),
+            proof: Vec::new(),
+        };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+
+        let outcome = AccountRangeDownloader::new(Arc::clone(&client), request(root_hash))
+            .unwrap()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            AccountRangeOutcome::Verified(VerifiedAccountRange { accounts, has_more: false })
+        );
+        assert!(client.reported.lock().unwrap().is_empty());
+        assert_eq!(*client.priorities.lock().unwrap(), [Priority::Normal]);
+    }
+
+    #[tokio::test]
+    async fn invalid_peer_is_reported_and_request_is_retried_at_high_priority() {
+        let accounts = vec![(key(1), account(7))];
+        let root_hash = root(&accounts);
+        let bad_peer = PeerId::random();
+        let good_peer = PeerId::random();
+        let bad = Ok(WithPeerId::new(
+            bad_peer,
+            SnapResponse::ByteCodes(ByteCodesMessage { request_id: 1, codes: Vec::new() }),
+        ));
+        let good = response(
+            good_peer,
+            AccountRangeMessage {
+                request_id: 1,
+                accounts: vec![AccountData::from_trie_account(accounts[0].0, &accounts[0].1)],
+                proof: Vec::new(),
+            },
+        );
+        let client = Arc::new(TestSnapClient::new([bad, good]));
+
+        let outcome = AccountRangeDownloader::new(Arc::clone(&client), request(root_hash))
+            .unwrap()
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, AccountRangeOutcome::Verified(_)));
+        assert_eq!(*client.reported.lock().unwrap(), [bad_peer]);
+        assert_eq!(*client.priorities.lock().unwrap(), [Priority::Normal, Priority::High]);
+    }
+
+    #[tokio::test]
+    async fn unavailable_state_is_not_a_bad_peer_response() {
+        let peer = PeerId::random();
+        let message =
+            AccountRangeMessage { request_id: 1, accounts: Vec::new(), proof: Vec::new() };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+
+        let outcome =
+            AccountRangeDownloader::new(Arc::clone(&client), request(B256::repeat_byte(0x11)))
+                .unwrap()
+                .await
+                .unwrap();
+
+        assert_eq!(outcome, AccountRangeOutcome::Unavailable);
+        assert!(client.reported.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn invalid_request_range_is_rejected_before_submission() {
+        let client = Arc::new(TestSnapClient::new(std::iter::empty()));
+        let mut request = request(B256::repeat_byte(0x11));
+        request.starting_hash = key(2);
+        request.limit_hash = key(1);
+
+        assert!(matches!(
+            AccountRangeDownloader::new(Arc::clone(&client), request),
+            Err(InvalidAccountRange { .. })
+        ));
+        assert!(client.priorities.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn authenticates_then_trims_an_account_past_the_limit() {
+        let accounts = vec![(key(1), account(7)), (key(3), account(8)), (key(4), account(9))];
+        let (root_hash, proof) = root_and_proof(&accounts, &[key(1), key(3)]);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage {
+            request_id: 1,
+            accounts: accounts[..2]
+                .iter()
+                .map(|(key, account)| AccountData::from_trie_account(*key, account))
+                .collect(),
+            proof,
+        };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+        let mut request = request(root_hash);
+        request.limit_hash = key(2);
+
+        let outcome =
+            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            AccountRangeOutcome::Verified(VerifiedAccountRange {
+                accounts: vec![accounts[0]],
+                has_more: false,
+            })
+        );
+        assert!(client.reported.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn account_at_the_limit_completes_the_requested_interval() {
+        let accounts = vec![(key(1), account(7)), (key(2), account(8)), (key(3), account(9))];
+        let (root_hash, proof) = root_and_proof(&accounts, &[key(1), key(2)]);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage {
+            request_id: 1,
+            accounts: accounts[..2]
+                .iter()
+                .map(|(key, account)| AccountData::from_trie_account(*key, account))
+                .collect(),
+            proof,
+        };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+        let mut request = request(root_hash);
+        request.limit_hash = key(2);
+
+        let outcome =
+            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            AccountRangeOutcome::Verified(VerifiedAccountRange {
+                accounts: accounts[..2].to_vec(),
+                has_more: false,
+            })
+        );
+        assert!(client.reported.lock().unwrap().is_empty());
+    }
+
+    /// snap/2 requires a peer with no account inside `[origin, limit]` to return the first account
+    /// after `limit`, so the sole returned account authenticates the interval and then trims away.
+    #[tokio::test]
+    async fn empty_interval_is_proven_by_the_first_account_after_the_limit() {
+        let accounts = vec![(key(1), account(7)), (key(9), account(8))];
+        let (root_hash, proof) = root_and_proof(&accounts, &[key(3), key(9)]);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage {
+            request_id: 1,
+            accounts: vec![AccountData::from_trie_account(accounts[1].0, &accounts[1].1)],
+            proof,
+        };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+        let mut request = request(root_hash);
+        request.starting_hash = key(3);
+        request.limit_hash = key(5);
+
+        let outcome =
+            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            AccountRangeOutcome::Verified(VerifiedAccountRange {
+                accounts: Vec::new(),
+                has_more: false,
+            })
+        );
+        assert!(client.reported.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn request_errors_retry_without_duplicate_peer_penalties() {
+        let accounts = vec![(key(1), account(7))];
+        let root_hash = root(&accounts);
+        let peer = PeerId::random();
+        let good = response(
+            peer,
+            AccountRangeMessage {
+                request_id: 1,
+                accounts: vec![AccountData::from_trie_account(accounts[0].0, &accounts[0].1)],
+                proof: Vec::new(),
+            },
+        );
+        let client = Arc::new(TestSnapClient::new([
+            Err(RequestError::Timeout),
+            Err(RequestError::BadResponse),
+            good,
+        ]));
+
+        AccountRangeDownloader::new(Arc::clone(&client), request(root_hash))
+            .unwrap()
+            .await
+            .unwrap();
+
+        assert!(client.reported.lock().unwrap().is_empty());
+        assert_eq!(
+            *client.priorities.lock().unwrap(),
+            [Priority::Normal, Priority::High, Priority::High]
+        );
+    }
+
+    #[tokio::test]
+    async fn stops_after_the_retry_budget_is_exhausted() {
+        let peers = [PeerId::random(), PeerId::random(), PeerId::random()];
+        let responses = peers.map(|peer| {
+            Ok(WithPeerId::new(
+                peer,
+                SnapResponse::ByteCodes(ByteCodesMessage { request_id: 1, codes: Vec::new() }),
+            ))
+        });
+        let client = Arc::new(TestSnapClient::new(responses));
+
+        let error =
+            AccountRangeDownloader::new(Arc::clone(&client), request(B256::repeat_byte(0x11)))
+                .unwrap()
+                .await
+                .unwrap_err();
+
+        assert_eq!(error, RequestError::BadResponse);
+        assert_eq!(*client.reported.lock().unwrap(), peers);
+        assert_eq!(
+            *client.priorities.lock().unwrap(),
+            [Priority::Normal, Priority::High, Priority::High]
+        );
+    }
+}

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -15,7 +15,6 @@ use reth_network_p2p::{
 use reth_trie_common::{range_proof::verify_range_proof, TrieAccount, EMPTY_ROOT_HASH};
 use std::{
     pin::Pin,
-    sync::Arc,
     task::{ready, Context, Poll},
 };
 use tracing::debug;
@@ -30,7 +29,7 @@ const MAX_RETRIES: u8 = 2;
 /// the snap sync orchestrator.
 #[derive(Debug)]
 pub struct AccountRangeDownloader<C: SnapClient> {
-    client: Arc<C>,
+    client: C,
     request: GetAccountRangeMessage,
     fut: C::Output,
     retries: u8,
@@ -38,10 +37,7 @@ pub struct AccountRangeDownloader<C: SnapClient> {
 
 impl<C: SnapClient> AccountRangeDownloader<C> {
     /// Validates the range, then creates a downloader and submits `request` at normal priority.
-    pub fn new(
-        client: Arc<C>,
-        request: GetAccountRangeMessage,
-    ) -> Result<Self, InvalidAccountRange> {
+    pub fn new(client: C, request: GetAccountRangeMessage) -> Result<Self, InvalidAccountRange> {
         if request.starting_hash > request.limit_hash {
             return Err(InvalidAccountRange {
                 origin: request.starting_hash,
@@ -126,7 +122,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
 
 impl<C> Future for AccountRangeDownloader<C>
 where
-    C: SnapClient + 'static,
+    C: SnapClient + Unpin + 'static,
 {
     type Output = Result<AccountRangeOutcome, RequestError>;
 
@@ -203,7 +199,10 @@ mod tests {
     use reth_network_p2p::{download::DownloadClient, error::PeerRequestResult};
     use reth_network_peers::{PeerId, WithPeerId};
     use reth_trie_common::{proof::ProofRetainer, HashBuilder, Nibbles};
-    use std::{collections::VecDeque, sync::Mutex};
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
 
     const MAX_HASH: B256 = B256::new([0xff; B256::len_bytes()]);
 

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -23,13 +23,14 @@ const MAX_RETRIES: u8 = 2;
 
 /// Downloads and verifies one account range against its requested state root.
 ///
-/// Invalid responses penalize their peer and retry at high priority. Proof verification runs
-/// inline while polling.
+/// Invalid responses penalize their peer and retry at high priority. Proof verification runs on
+/// Tokio's blocking pool.
 #[derive(Debug)]
 pub struct AccountRangeDownloader<C: SnapClient> {
     client: C,
     request: GetAccountRangeMessage,
     fut: C::Output,
+    verification: Option<VerificationTask>,
     retries: u8,
 }
 
@@ -43,7 +44,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
             })
         }
         let fut = client.get_account_range(request.clone());
-        Ok(Self { client, request, fut, retries: 0 })
+        Ok(Self { client, request, fut, verification: None, retries: 0 })
     }
 
     fn retry(&mut self) -> bool {
@@ -56,25 +57,29 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         true
     }
 
-    fn verify_response(
-        &self,
+    fn start_verification(
+        &mut self,
         peer_id: PeerId,
         response: SnapResponse,
-    ) -> Result<AccountRangeOutcome, RequestError> {
+    ) -> Result<Option<AccountRangeOutcome>, RequestError> {
         let response = self.account_range_response(response)?;
 
         if response.accounts.is_empty() && response.proof.is_empty() {
             return if self.request.root_hash == EMPTY_ROOT_HASH {
-                Ok(AccountRangeOutcome::Verified(VerifiedAccountRange {
+                Ok(Some(AccountRangeOutcome::Verified(VerifiedAccountRange {
                     accounts: Vec::new(),
                     has_more: false,
-                }))
+                })))
             } else {
-                Ok(AccountRangeOutcome::Unavailable { peer_id })
+                Ok(Some(AccountRangeOutcome::Unavailable { peer_id }))
             }
         }
 
-        self.verify_account_range(response).map(AccountRangeOutcome::Verified)
+        let request = self.request.clone();
+        let fut =
+            tokio::task::spawn_blocking(move || Self::verify_account_range(&request, response));
+        self.verification = Some(VerificationTask { peer_id, fut });
+        Ok(None)
     }
 
     fn account_range_response(
@@ -98,24 +103,24 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
     }
 
     fn verify_account_range(
-        &self,
+        request: &GetAccountRangeMessage,
         response: AccountRangeMessage,
     ) -> Result<VerifiedAccountRange, RequestError> {
-        self.validate_account_limit(&response.accounts)?;
+        Self::validate_account_limit(request.limit_hash, &response.accounts)?;
 
         let mut accounts = Self::decode_accounts(response.accounts)?;
-        let next = self.verify_proof(&accounts, &response.proof)?;
+        let next = Self::verify_proof(request, &accounts, &response.proof)?;
 
         // Authenticate the boundary account before removing it from the requested range.
-        accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= self.request.limit_hash));
-        let has_more = next.is_some_and(|next| next <= self.request.limit_hash);
+        accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= request.limit_hash));
+        let has_more = next.is_some_and(|next| next <= request.limit_hash);
 
         Ok(VerifiedAccountRange { accounts, has_more })
     }
 
-    fn validate_account_limit(&self, accounts: &[AccountData]) -> Result<(), RequestError> {
+    fn validate_account_limit(limit: B256, accounts: &[AccountData]) -> Result<(), RequestError> {
         // Only the first account past the limit is needed to prove the interval is complete.
-        if accounts.iter().filter(|data| data.hash > self.request.limit_hash).nth(1).is_some() {
+        if accounts.iter().filter(|data| data.hash > limit).nth(1).is_some() {
             debug!(target: "downloaders::snap", "Account range runs past the requested limit");
             return Err(RequestError::BadResponse)
         }
@@ -123,16 +128,17 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
     }
 
     fn verify_proof(
-        &self,
+        request: &GetAccountRangeMessage,
         accounts: &[(B256, TrieAccount)],
         proof: &[alloy_primitives::Bytes],
     ) -> Result<Option<B256>, RequestError> {
         let leaves = accounts.iter().map(|(hash, account)| (*hash, alloy_rlp::encode(account)));
-        verify_range_proof(self.request.root_hash, self.request.starting_hash, leaves, proof)
-            .map_err(|error| {
+        verify_range_proof(request.root_hash, request.starting_hash, leaves, proof).map_err(
+            |error| {
                 debug!(target: "downloaders::snap", %error, "Invalid account range proof");
                 RequestError::BadResponse
-            })
+            },
+        )
     }
 
     fn decode_accounts(data: Vec<AccountData>) -> Result<Vec<(B256, TrieAccount)>, RequestError> {
@@ -155,8 +161,8 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         match response {
             Ok(response) => {
                 let (peer_id, response) = response.split();
-                match self.verify_response(peer_id, response) {
-                    Ok(outcome) => Ok(Some(outcome)),
+                match self.start_verification(peer_id, response) {
+                    Ok(outcome) => Ok(outcome),
                     Err(error) => {
                         debug!(target: "downloaders::snap", ?peer_id, %error, "Invalid account range response");
                         self.client.report_bad_message(peer_id);
@@ -172,6 +178,29 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
             Err(error) => Err(error),
         }
     }
+
+    fn poll_verification(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<AccountRangeOutcome>, RequestError>> {
+        let verification = self.verification.as_mut().expect("verification task is present");
+        let result = ready!(verification.fut.poll_unpin(cx));
+        let peer_id = verification.peer_id;
+        self.verification = None;
+
+        match result {
+            Ok(Ok(range)) => Poll::Ready(Ok(Some(AccountRangeOutcome::Verified(range)))),
+            Ok(Err(error)) => {
+                debug!(target: "downloaders::snap", ?peer_id, %error, "Invalid account range response");
+                self.client.report_bad_message(peer_id);
+                Poll::Ready(self.retry().then_some(None).ok_or(error))
+            }
+            Err(error) => {
+                debug!(target: "downloaders::snap", %error, "Account range verification task failed");
+                Poll::Ready(Err(RequestError::ChannelClosed))
+            }
+        }
+    }
 }
 
 impl<C> Future for AccountRangeDownloader<C>
@@ -184,6 +213,14 @@ where
         let this = self.get_mut();
 
         loop {
+            if this.verification.is_some() {
+                match ready!(this.poll_verification(cx)) {
+                    Ok(Some(outcome)) => return Poll::Ready(Ok(outcome)),
+                    Ok(None) => {}
+                    Err(error) => return Poll::Ready(Err(error)),
+                }
+            }
+
             let response = ready!(this.fut.poll_unpin(cx));
             match this.handle_response(response) {
                 Ok(Some(outcome)) => return Poll::Ready(Ok(outcome)),
@@ -221,6 +258,12 @@ pub struct VerifiedAccountRange {
 pub struct InvalidAccountRange {
     origin: B256,
     limit: B256,
+}
+
+#[derive(Debug)]
+struct VerificationTask {
+    peer_id: PeerId,
+    fut: tokio::task::JoinHandle<Result<VerifiedAccountRange, RequestError>>,
 }
 
 #[cfg(test)]

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -12,6 +12,7 @@ use reth_network_p2p::{
     snap::client::{SnapClient, SnapResponse},
 };
 use reth_network_peers::PeerId;
+use reth_tasks::Runtime;
 use reth_trie_common::{range_proof::verify_range_proof, TrieAccount, EMPTY_ROOT_HASH};
 use std::{
     pin::Pin,
@@ -28,6 +29,7 @@ const MAX_RETRIES: u8 = 2;
 #[derive(Debug)]
 pub struct AccountRangeDownloader<C: SnapClient> {
     client: C,
+    runtime: Runtime,
     request: GetAccountRangeMessage,
     fut: C::Output,
     verification: Option<VerificationTask>,
@@ -35,10 +37,13 @@ pub struct AccountRangeDownloader<C: SnapClient> {
 }
 
 impl<C: SnapClient> AccountRangeDownloader<C> {
-    /// Creates a downloader and submits the initial request at normal priority.
-    ///
-    /// Returns an error when the origin exceeds the limit because such a range cannot be proven.
-    pub fn new(client: C, request: GetAccountRangeMessage) -> Result<Self, InvalidAccountRange> {
+    /// Creates a downloader using `runtime` for proof verification and submits the initial request.
+    /// Returns an error when the origin exceeds the limit.
+    pub fn new(
+        client: C,
+        request: GetAccountRangeMessage,
+        runtime: Runtime,
+    ) -> Result<Self, InvalidAccountRange> {
         if request.starting_hash > request.limit_hash {
             return Err(InvalidAccountRange {
                 origin: request.starting_hash,
@@ -46,7 +51,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
             })
         }
         let fut = client.get_account_range(request.clone());
-        Ok(Self { client, request, fut, verification: None, retries: 0 })
+        Ok(Self { client, runtime, request, fut, verification: None, retries: 0 })
     }
 
     // Raise retry priority so transient failures cannot leave range progress behind new work.
@@ -80,7 +85,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         }
 
         let request = self.request.clone();
-        let fut = tokio::task::spawn_blocking(move || verify_account_range(&request, response));
+        let fut = self.runtime.spawn_blocking(move || verify_account_range(&request, response));
         self.verification = Some(VerificationTask { peer_id, fut });
         Ok(None)
     }
@@ -414,8 +419,15 @@ mod tests {
         Ok(WithPeerId::new(peer, SnapResponse::AccountRange(message)))
     }
 
-    #[tokio::test]
-    async fn verifies_and_decodes_a_complete_account_range() {
+    fn downloader(
+        client: Arc<TestSnapClient>,
+        request: GetAccountRangeMessage,
+    ) -> Result<AccountRangeDownloader<Arc<TestSnapClient>>, InvalidAccountRange> {
+        AccountRangeDownloader::new(client, request, Runtime::test())
+    }
+
+    #[test]
+    fn verifies_and_decodes_without_an_ambient_runtime() {
         let accounts = vec![(key(1), account(7)), (key(2), account(8))];
         let root_hash = root(&accounts);
         let peer = PeerId::random();
@@ -429,10 +441,8 @@ mod tests {
         };
         let client = Arc::new(TestSnapClient::new([response(peer, message)]));
 
-        let outcome = AccountRangeDownloader::new(Arc::clone(&client), request(root_hash))
-            .unwrap()
-            .await
-            .unwrap();
+        let downloader = downloader(Arc::clone(&client), request(root_hash)).unwrap();
+        let outcome = futures::executor::block_on(downloader).unwrap();
 
         assert_eq!(
             outcome,
@@ -462,10 +472,7 @@ mod tests {
         );
         let client = Arc::new(TestSnapClient::new([bad, good]));
 
-        let outcome = AccountRangeDownloader::new(Arc::clone(&client), request(root_hash))
-            .unwrap()
-            .await
-            .unwrap();
+        let outcome = downloader(Arc::clone(&client), request(root_hash)).unwrap().await.unwrap();
 
         assert!(matches!(outcome, AccountRangeOutcome::Verified(_)));
         assert_eq!(*client.reported.lock().unwrap(), [bad_peer]);
@@ -479,11 +486,10 @@ mod tests {
             AccountRangeMessage { request_id: 1, accounts: Vec::new(), proof: Vec::new() };
         let client = Arc::new(TestSnapClient::new([response(peer, message)]));
 
-        let outcome =
-            AccountRangeDownloader::new(Arc::clone(&client), request(B256::repeat_byte(0x11)))
-                .unwrap()
-                .await
-                .unwrap();
+        let outcome = downloader(Arc::clone(&client), request(B256::repeat_byte(0x11)))
+            .unwrap()
+            .await
+            .unwrap();
 
         assert_eq!(outcome, AccountRangeOutcome::Unavailable { peer_id: peer });
         assert!(client.reported.lock().unwrap().is_empty());
@@ -497,7 +503,7 @@ mod tests {
         request.limit_hash = key(1);
 
         assert!(matches!(
-            AccountRangeDownloader::new(Arc::clone(&client), request),
+            downloader(Arc::clone(&client), request),
             Err(InvalidAccountRange { .. })
         ));
         assert!(client.priorities.lock().unwrap().is_empty());
@@ -520,8 +526,7 @@ mod tests {
         let mut request = request(root_hash);
         request.limit_hash = key(2);
 
-        let outcome =
-            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+        let outcome = downloader(Arc::clone(&client), request).unwrap().await.unwrap();
 
         assert_eq!(
             outcome,
@@ -553,8 +558,7 @@ mod tests {
         let mut request = request(root_hash);
         request.limit_hash = key(2);
 
-        let error =
-            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap_err();
+        let error = downloader(Arc::clone(&client), request).unwrap().await.unwrap_err();
 
         assert_eq!(error, RequestError::BadResponse);
         assert_eq!(client.reported.lock().unwrap().len(), attempts);
@@ -577,8 +581,7 @@ mod tests {
         let mut request = request(root_hash);
         request.limit_hash = key(2);
 
-        let outcome =
-            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+        let outcome = downloader(Arc::clone(&client), request).unwrap().await.unwrap();
 
         assert_eq!(
             outcome,
@@ -606,8 +609,7 @@ mod tests {
         request.starting_hash = key(3);
         request.limit_hash = key(5);
 
-        let outcome =
-            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+        let outcome = downloader(Arc::clone(&client), request).unwrap().await.unwrap();
 
         assert_eq!(
             outcome,
@@ -634,8 +636,7 @@ mod tests {
         let mut request = request(root_hash);
         request.limit_hash = key(5);
 
-        let outcome =
-            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+        let outcome = downloader(Arc::clone(&client), request).unwrap().await.unwrap();
 
         assert_eq!(
             outcome,
@@ -660,8 +661,7 @@ mod tests {
         let mut request = request(root_hash);
         request.limit_hash = key(5);
 
-        let outcome =
-            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+        let outcome = downloader(Arc::clone(&client), request).unwrap().await.unwrap();
 
         assert_eq!(
             outcome,
@@ -691,10 +691,7 @@ mod tests {
             good,
         ]));
 
-        AccountRangeDownloader::new(Arc::clone(&client), request(root_hash))
-            .unwrap()
-            .await
-            .unwrap();
+        downloader(Arc::clone(&client), request(root_hash)).unwrap().await.unwrap();
 
         assert!(client.reported.lock().unwrap().is_empty());
         assert_eq!(
@@ -714,11 +711,10 @@ mod tests {
         });
         let client = Arc::new(TestSnapClient::new(responses));
 
-        let error =
-            AccountRangeDownloader::new(Arc::clone(&client), request(B256::repeat_byte(0x11)))
-                .unwrap()
-                .await
-                .unwrap_err();
+        let error = downloader(Arc::clone(&client), request(B256::repeat_byte(0x11)))
+            .unwrap()
+            .await
+            .unwrap_err();
 
         assert_eq!(error, RequestError::BadResponse);
         assert_eq!(*client.reported.lock().unwrap(), peers);

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -86,6 +86,20 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
             }
         }
 
+        // A responder appends the first account past the limit to prove the interval is complete.
+        // Anything beyond that was not requested, so it is rejected before the range is decoded
+        // and hashed rather than trimmed away after the work is done.
+        if response
+            .accounts
+            .iter()
+            .filter(|data| data.hash > self.request.limit_hash)
+            .nth(1)
+            .is_some()
+        {
+            debug!(target: "downloaders::snap", "Account range runs past the requested limit");
+            return Err(RequestError::BadResponse)
+        }
+
         let mut accounts = Vec::with_capacity(response.accounts.len());
         for data in response.accounts {
             let hash = data.hash;
@@ -450,6 +464,33 @@ mod tests {
             })
         );
         assert!(client.reported.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn range_running_past_the_limit_is_rejected() {
+        let accounts = vec![(key(1), account(7)), (key(3), account(8)), (key(4), account(9))];
+        let (root_hash, proof) = root_and_proof(&accounts, &[key(1), key(4)]);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage {
+            request_id: 1,
+            accounts: accounts
+                .iter()
+                .map(|(key, account)| AccountData::from_trie_account(*key, account))
+                .collect(),
+            proof,
+        };
+        let attempts = usize::from(MAX_RETRIES) + 1;
+        let client = Arc::new(TestSnapClient::new(
+            std::iter::repeat_with(|| response(peer, message.clone())).take(attempts),
+        ));
+        let mut request = request(root_hash);
+        request.limit_hash = key(2);
+
+        let error =
+            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap_err();
+
+        assert_eq!(error, RequestError::BadResponse);
+        assert_eq!(client.reported.lock().unwrap().len(), attempts);
     }
 
     #[tokio::test]

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -25,9 +25,13 @@ const MAX_RETRIES: u8 = 2;
 
 /// Downloads and verifies one account range against its requested state root.
 ///
-/// Invalid peer responses are reported and the same request is retried with high priority. The
-/// future is storage agnostic: persisting a verified range and choosing the next range are left to
-/// the snap sync orchestrator.
+/// Invalid peer responses are reported and the same request is reissued at high priority. The
+/// client picks the peer, so a retry can land on the same one; only its falling reputation moves
+/// the request elsewhere. Polling verifies the range proof inline, which costs work proportional
+/// to the response.
+///
+/// The future is storage agnostic: persisting a verified range and choosing the next range are
+/// left to the snap sync orchestrator.
 #[derive(Debug)]
 pub struct AccountRangeDownloader<C: SnapClient> {
     client: C,
@@ -163,8 +167,8 @@ where
                         }
                     }
                 }
-                // A wrong wire response is already attributed and penalized by the session. It is
-                // still safe to retry the request with another snap peer.
+                // A wrong wire response is already attributed and penalized by the session, so the
+                // request is reissued without reporting the peer a second time.
                 Err(error) if error.is_retryable() || error == RequestError::BadResponse => {
                     debug!(target: "downloaders::snap", %error, "Account range request failed, retrying");
                     if !this.retry() {

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -101,7 +101,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
         }
 
         let leaves = accounts.iter().map(|(hash, account)| (*hash, alloy_rlp::encode(account)));
-        let mut has_more = verify_range_proof(
+        let next = verify_range_proof(
             self.request.root_hash,
             self.request.starting_hash,
             leaves,
@@ -114,15 +114,11 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
 
         // Responders append the boundary account before checking the requested limit. Authenticate
         // an overshooting account as part of the response before removing it.
-        let reached_limit =
-            accounts.last().is_some_and(|(hash, _)| *hash >= self.request.limit_hash);
-        let retained = accounts.partition_point(|(hash, _)| *hash <= self.request.limit_hash);
-        if retained < accounts.len() {
-            accounts.truncate(retained);
-        }
-        if reached_limit {
-            has_more = false;
-        }
+        accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= self.request.limit_hash));
+
+        // The proof pins where the trie continues, so the interval is complete unless a key the
+        // response did not cover can still fall inside it.
+        let has_more = next.is_some_and(|next| next <= self.request.limit_hash);
 
         Ok(AccountRangeOutcome::Verified(VerifiedAccountRange { accounts, has_more }))
     }
@@ -515,6 +511,60 @@ mod tests {
             })
         );
         assert!(client.reported.lock().unwrap().is_empty());
+    }
+
+    /// A response cut short by the responder's byte budget completes the interval anyway when the
+    /// proof shows the trie continues past the limit.
+    #[tokio::test]
+    async fn range_ending_before_the_limit_needs_no_further_request() {
+        let accounts = vec![(key(1), account(7)), (key(9), account(8))];
+        let (root_hash, proof) = root_and_proof(&accounts, &[key(1)]);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage {
+            request_id: 1,
+            accounts: vec![AccountData::from_trie_account(accounts[0].0, &accounts[0].1)],
+            proof,
+        };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+        let mut request = request(root_hash);
+        request.limit_hash = key(5);
+
+        let outcome =
+            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            AccountRangeOutcome::Verified(VerifiedAccountRange {
+                accounts: vec![accounts[0]],
+                has_more: false,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn range_ending_before_a_covered_key_reports_more() {
+        let accounts = vec![(key(1), account(7)), (key(3), account(8))];
+        let (root_hash, proof) = root_and_proof(&accounts, &[key(1)]);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage {
+            request_id: 1,
+            accounts: vec![AccountData::from_trie_account(accounts[0].0, &accounts[0].1)],
+            proof,
+        };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+        let mut request = request(root_hash);
+        request.limit_hash = key(5);
+
+        let outcome =
+            AccountRangeDownloader::new(Arc::clone(&client), request).unwrap().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            AccountRangeOutcome::Verified(VerifiedAccountRange {
+                accounts: vec![accounts[0]],
+                has_more: true,
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -140,6 +140,12 @@ impl AccountData {
             code_hash: SlimAccountBody::restore(&slim.code_hash, KECCAK256_EMPTY)?,
         })
     }
+
+    /// Consumes the wire value and returns its hashed key with the decoded trie account.
+    pub fn into_trie_entry(self) -> alloy_rlp::Result<(B256, TrieAccount)> {
+        let account = self.trie_account()?;
+        Ok((self.hash, account))
+    }
 }
 
 /// Response containing a number of consecutive accounts and the Merkle proofs for the entire range.
@@ -885,12 +891,14 @@ mod tests {
     #[test]
     fn slim_body_elides_empty_storage_and_code() {
         let account = trie_account(EMPTY_ROOT_HASH, KECCAK256_EMPTY);
-        let encoded = AccountData::from_trie_account(B256::repeat_byte(1), &account);
+        let hash = B256::repeat_byte(1);
+        let encoded = AccountData::from_trie_account(hash, &account);
 
         let body = SlimAccountBody::decode(&mut encoded.body.as_ref()).unwrap();
         assert!(body.storage_root.is_empty());
         assert!(body.code_hash.is_empty());
         assert_eq!(encoded.trie_account().unwrap(), account);
+        assert_eq!(encoded.into_trie_entry().unwrap(), (hash, account));
     }
 
     #[test]

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 # alloy
 alloy-primitives.workspace = true
-thiserror.workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec"] }
 alloy-trie = { workspace = true, features = ["ethereum"] }
 alloy-consensus.workspace = true
@@ -29,6 +28,7 @@ bytes = { workspace = true, optional = true }
 derive_more.workspace = true
 itertools = { workspace = true, features = ["use_alloc"] }
 nybbles = { workspace = true, features = ["rlp"] }
+thiserror.workspace = true
 
 # reth
 revm.workspace = true
@@ -72,7 +72,6 @@ std = [
     "alloy-consensus/std",
     "alloy-genesis/std",
     "alloy-primitives/std",
-    "thiserror/std",
     "alloy-rlp/std",
     "alloy-rpc-types-eth?/std",
     "alloy-serde?/std",
@@ -85,6 +84,7 @@ std = [
     "serde?/std",
     "serde_with?/std",
     "serde_json/std",
+    "thiserror/std",
     "revm/std",
     "reth-codecs?/std",
     "alloy-eips/std",

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # alloy
 alloy-primitives.workspace = true
+thiserror.workspace = true
 alloy-rlp = { workspace = true, features = ["arrayvec"] }
 alloy-trie = { workspace = true, features = ["ethereum"] }
 alloy-consensus.workspace = true
@@ -71,6 +72,7 @@ std = [
     "alloy-consensus/std",
     "alloy-genesis/std",
     "alloy-primitives/std",
+    "thiserror/std",
     "alloy-rlp/std",
     "alloy-rpc-types-eth?/std",
     "alloy-serde?/std",

--- a/crates/trie/common/src/lib.rs
+++ b/crates/trie/common/src/lib.rs
@@ -63,6 +63,9 @@ pub use trie::{BranchNodeMasks, BranchNodeMasksMap, ProofTrieNode};
 mod trie_node_v2;
 pub use trie_node_v2::*;
 
+/// Merkle Patricia trie range-proof verification.
+pub mod range_proof;
+
 /// The implementation of a container for storing intermediate changes to a trie.
 /// The container indicates when the trie has been modified.
 pub mod prefix_set;

--- a/crates/trie/common/src/range_proof.rs
+++ b/crates/trie/common/src/range_proof.rs
@@ -103,9 +103,6 @@ impl<'a> RangeProofVerifier<'a> {
         prefix: Nibbles,
         reference: &RlpNode,
     ) -> Result<(), RangeProofError> {
-        if prefix.len() > KEY_NIBBLES {
-            return Err(RangeProofError::PathTooLong { path: prefix })
-        }
         if let Some(hash) = reference.as_hash() {
             self.frontier.push_subtree(prefix, hash);
             return Ok(())
@@ -351,23 +348,15 @@ where
 {
     let (frontier, last_key) = ProofFrontier::from_leaves(origin, leaves)?;
 
-    // An empty trie has no subtrie for a proof to authenticate, so the reconstructed root alone
-    // settles whether the response is the empty range the root commits to.
-    if root == EMPTY_ROOT_HASH {
+    // An empty trie has no subtrie for a proof to authenticate, and a proof is omitted only when
+    // the leaves are the entire trie. In both cases the reconstructed root alone authenticates the
+    // response, since a shorter range cannot reproduce the root.
+    if root == EMPTY_ROOT_HASH || proof.is_empty() {
         let got = frontier.root()?;
         if got != root {
             return Err(RangeProofError::RootMismatch { expected: root, got })
         }
         return Ok(false)
-    }
-
-    // A proof is omitted only when the leaves are the entire trie. A shorter range cannot
-    // reconstruct the root, so a match authenticates the range without a boundary proof.
-    if proof.is_empty() {
-        let got = frontier.root()?;
-        return (got == root)
-            .then_some(false)
-            .ok_or(RangeProofError::RootMismatch { expected: root, got })
     }
 
     RangeProofVerifier::new(origin, last_key.unwrap_or(MAX_HASH), proof, frontier).verify(root)

--- a/crates/trie/common/src/range_proof.rs
+++ b/crates/trie/common/src/range_proof.rs
@@ -1,0 +1,690 @@
+//! Merkle Patricia trie range-proof verification.
+//!
+//! Reconstructs a trie root from consecutive hashed leaves and boundary proof nodes, rejecting
+//! altered or incomplete ranges and reporting whether leaves remain to the right of the range.
+
+use crate::{HashBuilder, Nibbles, RlpNode, TrieNode, EMPTY_ROOT_HASH};
+use alloc::vec::Vec;
+use alloy_primitives::{keccak256, map::B256Map, Bytes, B256};
+use alloy_rlp::Decodable;
+
+const KEY_NIBBLES: usize = B256::len_bytes() * 2;
+const MAX_HASH: B256 = B256::new([0xff; B256::len_bytes()]);
+
+/// Reconstructs the parts of a trie outside an authenticated leaf range.
+struct RangeProofVerifier<'a> {
+    /// Hashed-key bounds of the range the response is expected to cover.
+    range: ProofRange,
+    /// Boundary proof nodes the peer supplied, indexed by the hash that references them.
+    nodes: ProofNodes<'a>,
+    /// Returned leaves plus the subtries outside the range, awaiting root reconstruction.
+    frontier: ProofFrontier,
+    /// Whether a leaf right of the range was proven, meaning the trie continues past the response.
+    has_more: bool,
+}
+
+impl<'a> RangeProofVerifier<'a> {
+    /// Indexes proof nodes by hash and initializes the authenticated range boundaries.
+    fn new(left: B256, right: B256, proof: &'a [Bytes], frontier: ProofFrontier) -> Self {
+        Self {
+            range: ProofRange::new(left, right),
+            nodes: ProofNodes::new(proof),
+            frontier,
+            has_more: false,
+        }
+    }
+
+    /// Reconstructs the root from returned leaves and the proof subtries outside the range.
+    fn verify(mut self, root: B256) -> Result<bool, RangeProofError> {
+        self.visit_reference(Nibbles::new(), &RlpNode::word_rlp(&root))?;
+
+        let got = self.frontier.root()?;
+        if got != root {
+            return Err(RangeProofError::RootMismatch { expected: root, got })
+        }
+        Ok(self.has_more)
+    }
+
+    /// Traverses boundary references while retaining subtries wholly outside the returned range.
+    fn visit_reference(
+        &mut self,
+        prefix: Nibbles,
+        reference: &RlpNode,
+    ) -> Result<(), RangeProofError> {
+        match self.range.subtree_relation(&prefix)? {
+            SubtreeRelation::OutsideLeft => self.add_outside_reference(prefix, reference),
+            SubtreeRelation::OutsideRight => {
+                self.has_more = true;
+                self.add_outside_reference(prefix, reference)
+            }
+            SubtreeRelation::Inside => Ok(()),
+            SubtreeRelation::Boundary => {
+                let node = self.nodes.resolve(prefix, reference)?;
+                self.visit_node(node, prefix)
+            }
+        }
+    }
+
+    /// Expands a boundary node and records any leaf proven to lie outside the returned range.
+    fn visit_node(&mut self, node: TrieNode, prefix: Nibbles) -> Result<(), RangeProofError> {
+        match node {
+            TrieNode::EmptyRoot => Ok(()),
+            TrieNode::Leaf(leaf) => {
+                let path = prefix.descend_leaf(&leaf.key)?;
+                match self.range.key_relation(&path) {
+                    KeyRelation::Before => self.frontier.push_leaf(path, leaf.value),
+                    KeyRelation::Inside => {}
+                    KeyRelation::After => {
+                        self.has_more = true;
+                        self.frontier.push_leaf(path, leaf.value);
+                    }
+                }
+                Ok(())
+            }
+            TrieNode::Extension(extension) => {
+                self.visit_reference(prefix.descend_extension(&extension.key)?, &extension.child)
+            }
+            TrieNode::Branch(branch) => {
+                for (nibble, child) in branch
+                    .as_ref()
+                    .children()
+                    .filter_map(|(nibble, child)| child.map(|child| (nibble, child)))
+                {
+                    self.visit_reference(prefix.descend_child(nibble)?, child)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Adds an outside subtree to the frontier without expanding hashed references.
+    fn add_outside_reference(
+        &mut self,
+        prefix: Nibbles,
+        reference: &RlpNode,
+    ) -> Result<(), RangeProofError> {
+        if prefix.len() > KEY_NIBBLES {
+            return Err(RangeProofError::PathTooLong { path: prefix })
+        }
+        if let Some(hash) = reference.as_hash() {
+            self.frontier.push_subtree(prefix, hash);
+            return Ok(())
+        }
+        self.add_outside_node(TrieNode::decode(&mut reference.as_slice())?, prefix)
+    }
+
+    /// Flattens an inline outside node into frontier entries accepted by [`HashBuilder`].
+    fn add_outside_node(&mut self, node: TrieNode, prefix: Nibbles) -> Result<(), RangeProofError> {
+        match node {
+            TrieNode::EmptyRoot => Ok(()),
+            TrieNode::Leaf(leaf) => {
+                let path = prefix.descend_leaf(&leaf.key)?;
+                self.frontier.push_leaf(path, leaf.value);
+                Ok(())
+            }
+            TrieNode::Extension(extension) => self
+                .add_outside_reference(prefix.descend_extension(&extension.key)?, &extension.child),
+            TrieNode::Branch(branch) => {
+                for (nibble, child) in branch
+                    .as_ref()
+                    .children()
+                    .filter_map(|(nibble, child)| child.map(|child| (nibble, child)))
+                {
+                    self.add_outside_reference(prefix.descend_child(nibble)?, child)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Fixed hashed-key boundaries for the range being authenticated.
+struct ProofRange {
+    /// Inclusive origin requested by the downloader.
+    left: Nibbles,
+    /// Inclusive final returned key, or the maximum key for an empty response.
+    right: Nibbles,
+}
+
+impl ProofRange {
+    /// Converts the inclusive hashed-key boundaries into trie paths.
+    fn new(left: B256, right: B256) -> Self {
+        Self { left: Nibbles::unpack(left), right: Nibbles::unpack(right) }
+    }
+
+    /// Classifies a subtree as outside, inside, or intersecting a range boundary.
+    ///
+    /// A subtree holds exactly the keys starting with `prefix`, so the bounds truncated to the
+    /// same depth decide the relation. A prefix equal to a bound is treated as a boundary and
+    /// expanded; the node is always resolvable, since it sits on that bound's proof path.
+    fn subtree_relation(&self, prefix: &Nibbles) -> Result<SubtreeRelation, RangeProofError> {
+        if prefix.len() > KEY_NIBBLES {
+            return Err(RangeProofError::PathTooLong { path: *prefix })
+        }
+        let left = self.left.slice(..prefix.len());
+        let right = self.right.slice(..prefix.len());
+
+        Ok(if *prefix < left {
+            SubtreeRelation::OutsideLeft
+        } else if *prefix > right {
+            SubtreeRelation::OutsideRight
+        } else if *prefix > left && *prefix < right {
+            SubtreeRelation::Inside
+        } else {
+            SubtreeRelation::Boundary
+        })
+    }
+
+    /// Classifies a complete leaf path relative to the authenticated range.
+    fn key_relation(&self, path: &Nibbles) -> KeyRelation {
+        if path < &self.left {
+            KeyRelation::Before
+        } else if path > &self.right {
+            KeyRelation::After
+        } else {
+            KeyRelation::Inside
+        }
+    }
+}
+
+/// Proof nodes indexed by the hash used in trie references.
+struct ProofNodes<'a>(B256Map<&'a [u8]>);
+
+impl<'a> ProofNodes<'a> {
+    /// Indexes the wire proof nodes for constant-time reference resolution.
+    fn new(proof: &'a [Bytes]) -> Self {
+        Self(proof.iter().map(|node| (keccak256(node), node.as_ref())).collect())
+    }
+
+    /// Resolves a hashed reference from the proof, or decodes an inline trie node directly.
+    fn resolve(&self, path: Nibbles, reference: &RlpNode) -> Result<TrieNode, RangeProofError> {
+        let Some(hash) = reference.as_hash() else {
+            return Ok(TrieNode::decode(&mut reference.as_slice())?)
+        };
+        let node = self.0.get(&hash).ok_or(RangeProofError::MissingProofNode { path })?;
+        Ok(TrieNode::decode(&mut &node[..])?)
+    }
+}
+
+/// Ordered leaves and opaque subtries used to reconstruct a trie root.
+#[derive(Default)]
+struct ProofFrontier(Vec<FrontierEntry>);
+
+impl ProofFrontier {
+    /// Builds the initial frontier from returned leaves and validates their ordering.
+    fn from_leaves<I, V>(origin: B256, leaves: I) -> Result<(Self, Option<B256>), RangeProofError>
+    where
+        I: IntoIterator<Item = (B256, V)>,
+        V: Into<Vec<u8>>,
+    {
+        let mut frontier = Self::default();
+        let mut previous = None;
+
+        for (key, value) in leaves {
+            let value = value.into();
+            if key < origin {
+                return Err(RangeProofError::LeafBeforeOrigin { key, origin })
+            }
+            if previous.is_some_and(|previous| key <= previous) {
+                return Err(RangeProofError::NonMonotonicLeaves)
+            }
+            if value.is_empty() {
+                return Err(RangeProofError::EmptyLeafValue { key })
+            }
+            previous = Some(key);
+            frontier.push_leaf(Nibbles::unpack(key), value);
+        }
+
+        Ok((frontier, previous))
+    }
+
+    /// Adds a complete trie leaf to the root reconstruction frontier.
+    fn push_leaf(&mut self, path: Nibbles, value: Vec<u8>) {
+        debug_assert_eq!(path.len(), KEY_NIBBLES);
+        self.0.push(FrontierEntry::Leaf { path, value });
+    }
+
+    /// Adds an opaque subtree hash to the root reconstruction frontier.
+    fn push_subtree(&mut self, path: Nibbles, hash: B256) {
+        debug_assert!(path.len() <= KEY_NIBBLES);
+        self.0.push(FrontierEntry::Subtree { path, hash });
+    }
+
+    /// Sorts the frontier and reconstructs its Merkle Patricia trie root.
+    fn root(mut self) -> Result<B256, RangeProofError> {
+        // Outside subtries are disjoint from returned leaves, so sorting produces the strict path
+        // order required by HashBuilder. Reject duplicates before they reach its assertion.
+        self.0.sort_unstable_by_key(FrontierEntry::path);
+        let mut builder = HashBuilder::default();
+        let mut previous = None;
+
+        for entry in self.0 {
+            let path = entry.path();
+            if previous.is_some_and(|previous| path <= previous) {
+                return Err(RangeProofError::DuplicateFrontierPath { path })
+            }
+            previous = Some(path);
+            match entry {
+                FrontierEntry::Leaf { path, value } => builder.add_leaf(path, &value),
+                FrontierEntry::Subtree { path, hash } => builder.add_branch(path, hash, false),
+            }
+        }
+        Ok(builder.root())
+    }
+}
+
+/// Error returned when a trie range proof is invalid.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RangeProofError {
+    /// The response leaves are not strictly increasing.
+    #[error("range leaves are not strictly increasing")]
+    NonMonotonicLeaves,
+    /// A returned leaf precedes the requested origin.
+    #[error("range leaf {key} precedes origin {origin}")]
+    LeafBeforeOrigin {
+        /// Hashed key of the offending leaf.
+        key: B256,
+        /// Inclusive origin the range was requested from.
+        origin: B256,
+    },
+    /// A returned leaf has no value and would represent a deletion.
+    #[error("range leaf {key} has an empty value")]
+    EmptyLeafValue {
+        /// Hashed key of the valueless leaf.
+        key: B256,
+    },
+    /// A proof node required on a range boundary is missing.
+    #[error("missing proof node at path {path:?}")]
+    MissingProofNode {
+        /// Trie path the missing node was referenced from.
+        path: Nibbles,
+    },
+    /// An extension node consumes no nibble, so a crafted chain could recurse without descending.
+    #[error("extension node at path {path:?} has an empty key")]
+    EmptyExtensionKey {
+        /// Trie path the extension was reached at.
+        path: Nibbles,
+    },
+    /// A proof path exceeds a hashed key's fixed length.
+    #[error("proof path {path:?} exceeds hashed key length")]
+    PathTooLong {
+        /// Trie path that could not be descended any further.
+        path: Nibbles,
+    },
+    /// A leaf does not resolve to a complete hashed key.
+    #[error("leaf path {path:?} does not resolve to a hashed key")]
+    InvalidLeafPath {
+        /// Incomplete trie path the leaf terminated at.
+        path: Nibbles,
+    },
+    /// Two reconstructed trie entries occupy the same path.
+    #[error("duplicate range-proof frontier path {path:?}")]
+    DuplicateFrontierPath {
+        /// Trie path claimed by more than one entry.
+        path: Nibbles,
+    },
+    /// The reconstructed trie does not match the requested root.
+    #[error("range proof root mismatch: expected {expected}, got {got}")]
+    RootMismatch {
+        /// Root the range was requested against.
+        expected: B256,
+        /// Root reconstructed from the response.
+        got: B256,
+    },
+    /// A trie node failed to decode.
+    #[error(transparent)]
+    Rlp(#[from] alloy_rlp::Error),
+}
+
+/// Verifies a consecutive leaf range against `root`, starting at `origin`.
+///
+/// Returns whether the trie holds a leaf to the right of the last verified leaf.
+pub fn verify_range_proof<I, V>(
+    root: B256,
+    origin: B256,
+    leaves: I,
+    proof: &[Bytes],
+) -> Result<bool, RangeProofError>
+where
+    I: IntoIterator<Item = (B256, V)>,
+    V: Into<Vec<u8>>,
+{
+    let (frontier, last_key) = ProofFrontier::from_leaves(origin, leaves)?;
+
+    // An empty trie has no subtrie for a proof to authenticate, so the reconstructed root alone
+    // settles whether the response is the empty range the root commits to.
+    if root == EMPTY_ROOT_HASH {
+        let got = frontier.root()?;
+        if got != root {
+            return Err(RangeProofError::RootMismatch { expected: root, got })
+        }
+        return Ok(false)
+    }
+
+    // A proof is omitted only when the leaves are the entire trie. A shorter range cannot
+    // reconstruct the root, so a match authenticates the range without a boundary proof.
+    if proof.is_empty() {
+        let got = frontier.root()?;
+        return (got == root)
+            .then_some(false)
+            .ok_or(RangeProofError::RootMismatch { expected: root, got })
+    }
+
+    RangeProofVerifier::new(origin, last_key.unwrap_or(MAX_HASH), proof, frontier).verify(root)
+}
+
+/// Depth-checked descents along a hashed-key trie path.
+///
+/// [`Nibbles`] holds at most [`KEY_NIBBLES`] nibbles and panics when extended past that, corrupting
+/// its length in release builds, so every descent is bounded before the path is appended to.
+trait TriePath: Sized {
+    /// Descends through an extension node's key.
+    fn descend_extension(self, key: &Nibbles) -> Result<Self, RangeProofError>;
+
+    /// Descends into a branch node's child.
+    fn descend_child(self, nibble: u8) -> Result<Self, RangeProofError>;
+
+    /// Descends through a leaf node's key onto the complete hashed key it terminates.
+    fn descend_leaf(self, key: &Nibbles) -> Result<Self, RangeProofError>;
+
+    /// Appends a node key, rejecting one that would run past a hashed key.
+    fn join_checked(self, key: &Nibbles) -> Result<Self, RangeProofError>;
+}
+
+impl TriePath for Nibbles {
+    fn descend_extension(self, key: &Nibbles) -> Result<Self, RangeProofError> {
+        // A canonical extension always consumes a nibble. An empty key would let a crafted chain of
+        // extensions recurse at a fixed depth until the stack is exhausted.
+        if key.is_empty() {
+            return Err(RangeProofError::EmptyExtensionKey { path: self })
+        }
+        self.join_checked(key)
+    }
+
+    fn descend_child(self, nibble: u8) -> Result<Self, RangeProofError> {
+        if self.len() >= KEY_NIBBLES {
+            return Err(RangeProofError::PathTooLong { path: self })
+        }
+        let mut path = self;
+        path.push(nibble);
+        Ok(path)
+    }
+
+    fn descend_leaf(self, key: &Nibbles) -> Result<Self, RangeProofError> {
+        let path = self.join_checked(key)?;
+        if path.len() != KEY_NIBBLES {
+            return Err(RangeProofError::InvalidLeafPath { path })
+        }
+        Ok(path)
+    }
+
+    fn join_checked(self, key: &Nibbles) -> Result<Self, RangeProofError> {
+        if self.len() + key.len() > KEY_NIBBLES {
+            return Err(RangeProofError::PathTooLong { path: self })
+        }
+        Ok(self.join(key))
+    }
+}
+
+#[derive(Clone, Debug)]
+enum FrontierEntry {
+    Leaf { path: Nibbles, value: Vec<u8> },
+    Subtree { path: Nibbles, hash: B256 },
+}
+
+impl FrontierEntry {
+    /// Returns the trie path used to order entries before root reconstruction.
+    const fn path(&self) -> Nibbles {
+        match self {
+            Self::Leaf { path, .. } | Self::Subtree { path, .. } => *path,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SubtreeRelation {
+    OutsideLeft,
+    OutsideRight,
+    Boundary,
+    Inside,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KeyRelation {
+    Before,
+    Inside,
+    After,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{proof::ProofRetainer, BranchNode, ExtensionNode, TrieMask};
+    use alloc::{vec, vec::Vec};
+
+    fn key(value: u64) -> B256 {
+        B256::left_padding_from(&value.to_be_bytes())
+    }
+
+    fn encode_node(node: &TrieNode) -> Bytes {
+        alloy_rlp::encode(node).into()
+    }
+
+    fn no_leaves() -> Vec<(B256, Vec<u8>)> {
+        Vec::new()
+    }
+
+    fn value(byte: u8) -> Vec<u8> {
+        vec![byte; 64]
+    }
+
+    fn build_proof(leaves: &[(B256, Vec<u8>)], targets: &[B256]) -> (B256, Vec<Bytes>) {
+        let targets = targets.iter().copied().map(Nibbles::unpack).collect();
+        let mut builder = HashBuilder::default().with_proof_retainer(ProofRetainer::new(targets));
+        for (key, value) in leaves {
+            builder.add_leaf(Nibbles::unpack(*key), value);
+        }
+        let root = builder.root();
+        let proof = builder
+            .take_proof_nodes()
+            .into_nodes_sorted()
+            .into_iter()
+            .map(|(_, node)| node)
+            .collect();
+        (root, proof)
+    }
+
+    #[test]
+    fn partial_range_authenticates_and_reports_more() {
+        let leaves =
+            vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3)), (key(4), value(4))];
+        let (root, proof) = build_proof(&leaves, &[key(2), key(3)]);
+
+        assert!(verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap());
+    }
+
+    #[test]
+    fn inline_outside_nodes_are_reconstructed() {
+        let leaves =
+            vec![(key(1), vec![1]), (key(2), vec![2]), (key(3), vec![3]), (key(4), vec![4])];
+        let (root, proof) = build_proof(&leaves, &[key(2), key(3)]);
+
+        assert!(verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap());
+    }
+
+    #[test]
+    fn unused_proof_nodes_are_accepted() {
+        let leaves =
+            vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3)), (key(4), value(4))];
+        let (root, mut proof) = build_proof(&leaves, &[key(2), key(3)]);
+        proof.push(Bytes::from_static(&[alloy_rlp::EMPTY_STRING_CODE]));
+
+        assert!(verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap());
+    }
+
+    /// A crafted node key that would push a path past the hashed-key length must be rejected,
+    /// because `Nibbles` panics (and corrupts its length in release) when extended past capacity.
+    #[test]
+    fn node_paths_are_bounded_before_they_overflow_a_key() {
+        let dangling = RlpNode::word_rlp(&B256::repeat_byte(0xaa));
+
+        // An extension one nibble deep whose key spans a whole hashed key: 1 + 64 nibbles.
+        let overlong = encode_node(&TrieNode::Extension(ExtensionNode::new(
+            Nibbles::unpack(key(1)),
+            dangling.clone(),
+        )));
+        let branch = encode_node(&TrieNode::Branch(BranchNode::new(
+            vec![RlpNode::word_rlp(&keccak256(&overlong))],
+            TrieMask::new(1),
+        )));
+        let proof = vec![branch.clone(), overlong];
+
+        assert!(matches!(
+            verify_range_proof(keccak256(&branch), key(1), no_leaves(), &proof),
+            Err(RangeProofError::PathTooLong { .. })
+        ));
+
+        // A branch sitting at the full hashed-key depth, which has no room for a child.
+        let deep_branch =
+            encode_node(&TrieNode::Branch(BranchNode::new(vec![dangling], TrieMask::new(1))));
+        let reach = encode_node(&TrieNode::Extension(ExtensionNode::new(
+            Nibbles::unpack(key(1)),
+            RlpNode::word_rlp(&keccak256(&deep_branch)),
+        )));
+        let proof = vec![reach.clone(), deep_branch];
+
+        assert!(matches!(
+            verify_range_proof(keccak256(&reach), key(1), no_leaves(), &proof),
+            Err(RangeProofError::PathTooLong { .. })
+        ));
+    }
+
+    /// An extension consuming no nibble leaves the depth unchanged, so a chain of them would
+    /// recurse until the stack is exhausted rather than hitting the hashed-key bound.
+    #[test]
+    fn empty_extension_keys_are_rejected() {
+        let empty_key = Nibbles::new();
+        let mut proof = Vec::new();
+        let mut child = RlpNode::word_rlp(&B256::repeat_byte(0xaa));
+
+        for _ in 0..64 {
+            let node = encode_node(&TrieNode::Extension(ExtensionNode::new(empty_key, child)));
+            child = RlpNode::word_rlp(&keccak256(&node));
+            proof.push(node);
+        }
+        let root = keccak256(proof.last().unwrap());
+
+        assert!(matches!(
+            verify_range_proof(root, key(1), no_leaves(), &proof),
+            Err(RangeProofError::EmptyExtensionKey { .. })
+        ));
+    }
+
+    #[test]
+    fn missing_boundary_node_is_rejected() {
+        let leaves =
+            vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3)), (key(4), value(4))];
+        let (root, _) = build_proof(&leaves, &[key(2), key(3)]);
+        let unrelated = [Bytes::from_static(&[alloy_rlp::EMPTY_STRING_CODE])];
+
+        assert!(matches!(
+            verify_range_proof(root, key(2), leaves[1..3].to_vec(), &unrelated),
+            Err(RangeProofError::MissingProofNode { .. })
+        ));
+    }
+
+    #[test]
+    fn boundary_proof_can_authenticate_an_exhausted_range() {
+        let leaves =
+            vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3)), (key(4), value(4))];
+        let (root, proof) = build_proof(&leaves, &[key(2), key(4)]);
+
+        assert!(!verify_range_proof(root, key(2), leaves[1..].to_vec(), &proof).unwrap());
+    }
+
+    #[test]
+    fn proof_free_full_trie_is_exhausted() {
+        let leaves = vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3))];
+        let (root, _) = build_proof(&leaves, &[]);
+
+        assert!(!verify_range_proof(root, B256::ZERO, leaves, &[]).unwrap());
+    }
+
+    #[test]
+    fn omitted_interior_leaf_changes_root() {
+        let leaves =
+            vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3)), (key(4), value(4))];
+        let (root, proof) = build_proof(&leaves, &[key(2), key(4)]);
+        let returned = vec![(key(2), value(2)), (key(4), value(4))];
+
+        assert!(matches!(
+            verify_range_proof(root, key(2), returned, &proof),
+            Err(RangeProofError::RootMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn mutated_leaf_changes_root() {
+        let leaves = vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3))];
+        let (root, proof) = build_proof(&leaves, &[key(2), key(3)]);
+        let returned = vec![(key(2), value(9)), (key(3), value(3))];
+
+        assert!(matches!(
+            verify_range_proof(root, key(2), returned, &proof),
+            Err(RangeProofError::RootMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_tail_is_authenticated() {
+        let leaves = vec![(key(1), value(1)), (key(2), value(2))];
+        let (root, proof) = build_proof(&leaves, &[key(3)]);
+
+        assert!(!verify_range_proof(root, key(3), core::iter::empty::<(B256, Vec<u8>)>(), &proof,)
+            .unwrap());
+    }
+
+    #[test]
+    fn empty_range_cannot_hide_a_right_leaf() {
+        let leaves = vec![(key(1), value(1)), (key(3), value(3))];
+        let (root, proof) = build_proof(&leaves, &[key(2)]);
+
+        assert!(matches!(
+            verify_range_proof(root, key(2), core::iter::empty::<(B256, Vec<u8>)>(), &proof,),
+            Err(RangeProofError::RootMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_monotonic_leaves_and_leaves_before_origin() {
+        let leaves = vec![(key(2), value(2)), (key(1), value(1))];
+
+        assert_eq!(
+            verify_range_proof(B256::ZERO, B256::ZERO, leaves, &[]),
+            Err(RangeProofError::NonMonotonicLeaves)
+        );
+        assert!(matches!(
+            verify_range_proof(B256::ZERO, key(2), [(key(1), value(1))], &[],),
+            Err(RangeProofError::LeafBeforeOrigin { .. })
+        ));
+        assert_eq!(
+            verify_range_proof(B256::ZERO, B256::ZERO, [(key(1), Vec::new())], &[]),
+            Err(RangeProofError::EmptyLeafValue { key: key(1) })
+        );
+    }
+
+    #[test]
+    fn empty_root_accepts_only_an_empty_range() {
+        assert!(!verify_range_proof(
+            EMPTY_ROOT_HASH,
+            B256::ZERO,
+            core::iter::empty::<(B256, Vec<u8>)>(),
+            &[],
+        )
+        .unwrap());
+        assert!(matches!(
+            verify_range_proof(EMPTY_ROOT_HASH, B256::ZERO, [(key(1), value(1))], &[],),
+            Err(RangeProofError::RootMismatch { .. })
+        ));
+    }
+}

--- a/crates/trie/common/src/range_proof.rs
+++ b/crates/trie/common/src/range_proof.rs
@@ -11,20 +11,14 @@ use alloy_rlp::Decodable;
 const KEY_NIBBLES: usize = B256::len_bytes() * 2;
 const MAX_HASH: B256 = B256::new([0xff; B256::len_bytes()]);
 
-/// Reconstructs the parts of a trie outside an authenticated leaf range.
 struct RangeProofVerifier<'a> {
-    /// Hashed-key bounds of the range the response is expected to cover.
     range: ProofRange,
-    /// Boundary proof nodes the peer supplied, indexed by the hash that references them.
     nodes: ProofNodes<'a>,
-    /// Returned leaves plus the subtries outside the range, awaiting root reconstruction.
     frontier: ProofFrontier,
-    /// Leftmost path proven to lie right of the range, if the trie continues past the response.
     next: Option<Nibbles>,
 }
 
 impl<'a> RangeProofVerifier<'a> {
-    /// Indexes proof nodes by hash and initializes the authenticated range boundaries.
     fn new(left: B256, right: B256, proof: &'a [Bytes], frontier: ProofFrontier) -> Self {
         Self {
             range: ProofRange::new(left, right),
@@ -34,7 +28,6 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
-    /// Reconstructs the root from returned leaves and the proof subtries outside the range.
     fn verify(mut self, root: B256) -> Result<Option<B256>, RangeProofError> {
         self.visit_reference(Nibbles::new(), &RlpNode::word_rlp(&root))?;
 
@@ -45,7 +38,6 @@ impl<'a> RangeProofVerifier<'a> {
         Ok(self.next.as_ref().map(TriePath::lowest_key))
     }
 
-    /// Traverses boundary references while retaining subtries wholly outside the returned range.
     fn visit_reference(
         &mut self,
         prefix: Nibbles,
@@ -65,7 +57,6 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
-    /// Expands a boundary node and records any leaf proven to lie outside the returned range.
     fn visit_node(&mut self, node: TrieNode, prefix: Nibbles) -> Result<(), RangeProofError> {
         match node {
             TrieNode::EmptyRoot => Ok(()),
@@ -97,7 +88,6 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
-    /// Adds an outside subtree to the frontier without expanding hashed references.
     fn add_outside_reference(
         &mut self,
         prefix: Nibbles,
@@ -110,7 +100,6 @@ impl<'a> RangeProofVerifier<'a> {
         self.add_outside_node(TrieNode::decode(&mut reference.as_slice())?, prefix)
     }
 
-    /// Flattens an inline outside node into frontier entries accepted by [`HashBuilder`].
     fn add_outside_node(&mut self, node: TrieNode, prefix: Nibbles) -> Result<(), RangeProofError> {
         match node {
             TrieNode::EmptyRoot => Ok(()),
@@ -134,7 +123,6 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
-    /// Keeps the leftmost of the paths proven to lie right of the authenticated range.
     fn note_next(&mut self, path: Nibbles) {
         if self.next.is_none_or(|next| path < next) {
             self.next = Some(path);
@@ -142,25 +130,16 @@ impl<'a> RangeProofVerifier<'a> {
     }
 }
 
-/// Fixed hashed-key boundaries for the range being authenticated.
 struct ProofRange {
-    /// Inclusive origin requested by the downloader.
     left: Nibbles,
-    /// Inclusive final returned key, or the maximum key for an empty response.
     right: Nibbles,
 }
 
 impl ProofRange {
-    /// Converts the inclusive hashed-key boundaries into trie paths.
     fn new(left: B256, right: B256) -> Self {
         Self { left: Nibbles::unpack(left), right: Nibbles::unpack(right) }
     }
 
-    /// Classifies a subtree as outside, inside, or intersecting a range boundary.
-    ///
-    /// A subtree holds exactly the keys starting with `prefix`, so the bounds truncated to the
-    /// same depth decide the relation. A prefix equal to a bound is treated as a boundary and
-    /// expanded; the node is always resolvable, since it sits on that bound's proof path.
     fn subtree_relation(&self, prefix: &Nibbles) -> Result<SubtreeRelation, RangeProofError> {
         if prefix.len() > KEY_NIBBLES {
             return Err(RangeProofError::PathTooLong { path: *prefix })
@@ -179,7 +158,6 @@ impl ProofRange {
         })
     }
 
-    /// Classifies a complete leaf path relative to the authenticated range.
     fn key_relation(&self, path: &Nibbles) -> KeyRelation {
         if path < &self.left {
             KeyRelation::Before
@@ -191,16 +169,13 @@ impl ProofRange {
     }
 }
 
-/// Proof nodes indexed by the hash used in trie references.
 struct ProofNodes<'a>(B256Map<&'a [u8]>);
 
 impl<'a> ProofNodes<'a> {
-    /// Indexes the wire proof nodes for constant-time reference resolution.
     fn new(proof: &'a [Bytes]) -> Self {
         Self(proof.iter().map(|node| (keccak256(node), node.as_ref())).collect())
     }
 
-    /// Resolves a hashed reference from the proof, or decodes an inline trie node directly.
     fn resolve(&self, path: Nibbles, reference: &RlpNode) -> Result<TrieNode, RangeProofError> {
         let Some(hash) = reference.as_hash() else {
             return Ok(TrieNode::decode(&mut reference.as_slice())?)
@@ -210,12 +185,10 @@ impl<'a> ProofNodes<'a> {
     }
 }
 
-/// Ordered leaves and opaque subtries used to reconstruct a trie root.
 #[derive(Default)]
 struct ProofFrontier(Vec<FrontierEntry>);
 
 impl ProofFrontier {
-    /// Builds the initial frontier from returned leaves and validates their ordering.
     fn from_leaves<I, V>(origin: B256, leaves: I) -> Result<(Self, Option<B256>), RangeProofError>
     where
         I: IntoIterator<Item = (B256, V)>,
@@ -242,19 +215,16 @@ impl ProofFrontier {
         Ok((frontier, previous))
     }
 
-    /// Adds a complete trie leaf to the root reconstruction frontier.
     fn push_leaf(&mut self, path: Nibbles, value: Vec<u8>) {
         debug_assert_eq!(path.len(), KEY_NIBBLES);
         self.0.push(FrontierEntry::Leaf { path, value });
     }
 
-    /// Adds an opaque subtree hash to the root reconstruction frontier.
     fn push_subtree(&mut self, path: Nibbles, hash: B256) {
         debug_assert!(path.len() <= KEY_NIBBLES);
         self.0.push(FrontierEntry::Subtree { path, hash });
     }
 
-    /// Sorts the frontier and reconstructs its Merkle Patricia trie root.
     fn root(mut self) -> Result<B256, RangeProofError> {
         // Outside subtries are disjoint from returned leaves, so sorting produces the strict path
         // order required by HashBuilder. Reject duplicates before they reach its assertion.
@@ -342,9 +312,7 @@ pub enum RangeProofError {
 
 /// Verifies a consecutive leaf range against `root`, starting at `origin`.
 ///
-/// Returns the lowest key the trie can still hold to the right of the last verified leaf, or
-/// `None` when the range exhausts the trie. A subtree the boundary proof leaves unexpanded pins
-/// only a prefix, so the key is a lower bound rather than the exact next key.
+/// Returns a lower bound for the next key, or `None` if the range exhausts the trie.
 pub fn verify_range_proof<I, V>(
     root: B256,
     origin: B256,
@@ -357,9 +325,7 @@ where
 {
     let (frontier, last_key) = ProofFrontier::from_leaves(origin, leaves)?;
 
-    // An empty trie has no subtrie for a proof to authenticate, and a proof is omitted only when
-    // the leaves are the entire trie. In both cases the reconstructed root alone authenticates the
-    // response, since a shorter range cannot reproduce the root.
+    // Empty tries and proof-free ranges are authenticated by their reconstructed root.
     if root == EMPTY_ROOT_HASH || proof.is_empty() {
         let got = frontier.root()?;
         if got != root {
@@ -371,24 +337,15 @@ where
     RangeProofVerifier::new(origin, last_key.unwrap_or(MAX_HASH), proof, frontier).verify(root)
 }
 
-/// Depth-checked descents along a hashed-key trie path.
-///
-/// [`Nibbles`] holds at most [`KEY_NIBBLES`] nibbles and panics when extended past that, corrupting
-/// its length in release builds, so every descent is bounded before the path is appended to.
 trait TriePath: Sized {
-    /// Lowest hashed key the subtree at this path can hold.
     fn lowest_key(&self) -> B256;
 
-    /// Descends through an extension node's key.
     fn descend_extension(self, key: &Nibbles) -> Result<Self, RangeProofError>;
 
-    /// Descends into a branch node's child.
     fn descend_child(self, nibble: u8) -> Result<Self, RangeProofError>;
 
-    /// Descends through a leaf node's key onto the complete hashed key it terminates.
     fn descend_leaf(self, key: &Nibbles) -> Result<Self, RangeProofError>;
 
-    /// Appends a node key, rejecting one that would run past a hashed key.
     fn join_checked(self, key: &Nibbles) -> Result<Self, RangeProofError>;
 }
 
@@ -439,7 +396,6 @@ enum FrontierEntry {
 }
 
 impl FrontierEntry {
-    /// Returns the trie path used to order entries before root reconstruction.
     const fn path(&self) -> Nibbles {
         match self {
             Self::Leaf { path, .. } | Self::Subtree { path, .. } => *path,
@@ -512,8 +468,7 @@ mod tests {
         );
     }
 
-    /// A subtree the proof leaves unexpanded pins only a prefix, so the reported key is the lowest
-    /// key that subtree can hold rather than the next leaf itself.
+    // An unexpanded subtree reports its lowest possible key.
     #[test]
     fn unexpanded_right_subtree_reports_a_prefix_bound() {
         let right = |tail: u8| {
@@ -561,8 +516,7 @@ mod tests {
         );
     }
 
-    /// A crafted node key that would push a path past the hashed-key length must be rejected,
-    /// because `Nibbles` panics (and corrupts its length in release) when extended past capacity.
+    // Reject paths before they exceed the fixed hashed-key length.
     #[test]
     fn node_paths_are_bounded_before_they_overflow_a_key() {
         let dangling = RlpNode::word_rlp(&B256::repeat_byte(0xaa));
@@ -598,8 +552,7 @@ mod tests {
         ));
     }
 
-    /// An extension consuming no nibble leaves the depth unchanged, so a chain of them would
-    /// recurse until the stack is exhausted rather than hitting the hashed-key bound.
+    // Empty extensions could recurse indefinitely without increasing the path depth.
     #[test]
     fn empty_extension_keys_are_rejected() {
         let empty_key = Nibbles::new();

--- a/crates/trie/common/src/range_proof.rs
+++ b/crates/trie/common/src/range_proof.rs
@@ -1,7 +1,7 @@
 //! Merkle Patricia trie range-proof verification.
 //!
 //! Reconstructs a trie root from consecutive hashed leaves and boundary proof nodes, rejecting
-//! altered or incomplete ranges and reporting whether leaves remain to the right of the range.
+//! altered or incomplete ranges and reporting where the trie continues past the range.
 
 use crate::{HashBuilder, Nibbles, RlpNode, TrieNode, EMPTY_ROOT_HASH};
 use alloc::vec::Vec;
@@ -19,8 +19,8 @@ struct RangeProofVerifier<'a> {
     nodes: ProofNodes<'a>,
     /// Returned leaves plus the subtries outside the range, awaiting root reconstruction.
     frontier: ProofFrontier,
-    /// Whether a leaf right of the range was proven, meaning the trie continues past the response.
-    has_more: bool,
+    /// Leftmost path proven to lie right of the range, if the trie continues past the response.
+    next: Option<Nibbles>,
 }
 
 impl<'a> RangeProofVerifier<'a> {
@@ -30,19 +30,19 @@ impl<'a> RangeProofVerifier<'a> {
             range: ProofRange::new(left, right),
             nodes: ProofNodes::new(proof),
             frontier,
-            has_more: false,
+            next: None,
         }
     }
 
     /// Reconstructs the root from returned leaves and the proof subtries outside the range.
-    fn verify(mut self, root: B256) -> Result<bool, RangeProofError> {
+    fn verify(mut self, root: B256) -> Result<Option<B256>, RangeProofError> {
         self.visit_reference(Nibbles::new(), &RlpNode::word_rlp(&root))?;
 
         let got = self.frontier.root()?;
         if got != root {
             return Err(RangeProofError::RootMismatch { expected: root, got })
         }
-        Ok(self.has_more)
+        Ok(self.next.as_ref().map(TriePath::lowest_key))
     }
 
     /// Traverses boundary references while retaining subtries wholly outside the returned range.
@@ -54,7 +54,7 @@ impl<'a> RangeProofVerifier<'a> {
         match self.range.subtree_relation(&prefix)? {
             SubtreeRelation::OutsideLeft => self.add_outside_reference(prefix, reference),
             SubtreeRelation::OutsideRight => {
-                self.has_more = true;
+                self.note_next(prefix);
                 self.add_outside_reference(prefix, reference)
             }
             SubtreeRelation::Inside => Ok(()),
@@ -75,7 +75,7 @@ impl<'a> RangeProofVerifier<'a> {
                     KeyRelation::Before => self.frontier.push_leaf(path, leaf.value),
                     KeyRelation::Inside => {}
                     KeyRelation::After => {
-                        self.has_more = true;
+                        self.note_next(path);
                         self.frontier.push_leaf(path, leaf.value);
                     }
                 }
@@ -131,6 +131,13 @@ impl<'a> RangeProofVerifier<'a> {
                 }
                 Ok(())
             }
+        }
+    }
+
+    /// Keeps the leftmost of the paths proven to lie right of the authenticated range.
+    fn note_next(&mut self, path: Nibbles) {
+        if self.next.is_none_or(|next| path < next) {
+            self.next = Some(path);
         }
     }
 }
@@ -335,13 +342,15 @@ pub enum RangeProofError {
 
 /// Verifies a consecutive leaf range against `root`, starting at `origin`.
 ///
-/// Returns whether the trie holds a leaf to the right of the last verified leaf.
+/// Returns the lowest key the trie can still hold to the right of the last verified leaf, or
+/// `None` when the range exhausts the trie. A subtree the boundary proof leaves unexpanded pins
+/// only a prefix, so the key is a lower bound rather than the exact next key.
 pub fn verify_range_proof<I, V>(
     root: B256,
     origin: B256,
     leaves: I,
     proof: &[Bytes],
-) -> Result<bool, RangeProofError>
+) -> Result<Option<B256>, RangeProofError>
 where
     I: IntoIterator<Item = (B256, V)>,
     V: Into<Vec<u8>>,
@@ -356,7 +365,7 @@ where
         if got != root {
             return Err(RangeProofError::RootMismatch { expected: root, got })
         }
-        return Ok(false)
+        return Ok(None)
     }
 
     RangeProofVerifier::new(origin, last_key.unwrap_or(MAX_HASH), proof, frontier).verify(root)
@@ -367,6 +376,9 @@ where
 /// [`Nibbles`] holds at most [`KEY_NIBBLES`] nibbles and panics when extended past that, corrupting
 /// its length in release builds, so every descent is bounded before the path is appended to.
 trait TriePath: Sized {
+    /// Lowest hashed key the subtree at this path can hold.
+    fn lowest_key(&self) -> B256;
+
     /// Descends through an extension node's key.
     fn descend_extension(self, key: &Nibbles) -> Result<Self, RangeProofError>;
 
@@ -381,6 +393,11 @@ trait TriePath: Sized {
 }
 
 impl TriePath for Nibbles {
+    // Packing zero-fills the nibbles the path leaves free, which is the key it bounds.
+    fn lowest_key(&self) -> B256 {
+        B256::right_padding_from(&self.pack())
+    }
+
     fn descend_extension(self, key: &Nibbles) -> Result<Self, RangeProofError> {
         // A canonical extension always consumes a nibble. An empty key would let a crafted chain of
         // extensions recurse at a fixed depth until the stack is exhausted.
@@ -484,12 +501,39 @@ mod tests {
     }
 
     #[test]
-    fn partial_range_authenticates_and_reports_more() {
+    fn partial_range_authenticates_and_reports_the_next_key() {
         let leaves =
             vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3)), (key(4), value(4))];
         let (root, proof) = build_proof(&leaves, &[key(2), key(3)]);
 
-        assert!(verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap());
+        assert_eq!(
+            verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap(),
+            Some(key(4))
+        );
+    }
+
+    /// A subtree the proof leaves unexpanded pins only a prefix, so the reported key is the lowest
+    /// key that subtree can hold rather than the next leaf itself.
+    #[test]
+    fn unexpanded_right_subtree_reports_a_prefix_bound() {
+        let right = |tail: u8| {
+            let mut key = B256::ZERO;
+            key.0[0] = 0x40;
+            key.0[31] = tail;
+            key
+        };
+        let leaves = vec![
+            (key(1), value(1)),
+            (key(2), value(2)),
+            (right(1), value(3)),
+            (right(2), value(4)),
+        ];
+        let (root, proof) = build_proof(&leaves, &[key(1), key(2)]);
+
+        assert_eq!(
+            verify_range_proof(root, key(1), leaves[..2].to_vec(), &proof).unwrap(),
+            Some(B256::right_padding_from(&[0x40]))
+        );
     }
 
     #[test]
@@ -498,7 +542,10 @@ mod tests {
             vec![(key(1), vec![1]), (key(2), vec![2]), (key(3), vec![3]), (key(4), vec![4])];
         let (root, proof) = build_proof(&leaves, &[key(2), key(3)]);
 
-        assert!(verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap());
+        assert_eq!(
+            verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap(),
+            Some(key(4))
+        );
     }
 
     #[test]
@@ -508,7 +555,10 @@ mod tests {
         let (root, mut proof) = build_proof(&leaves, &[key(2), key(3)]);
         proof.push(Bytes::from_static(&[alloy_rlp::EMPTY_STRING_CODE]));
 
-        assert!(verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap());
+        assert_eq!(
+            verify_range_proof(root, key(2), leaves[1..3].to_vec(), &proof).unwrap(),
+            Some(key(4))
+        );
     }
 
     /// A crafted node key that would push a path past the hashed-key length must be rejected,
@@ -588,7 +638,7 @@ mod tests {
             vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3)), (key(4), value(4))];
         let (root, proof) = build_proof(&leaves, &[key(2), key(4)]);
 
-        assert!(!verify_range_proof(root, key(2), leaves[1..].to_vec(), &proof).unwrap());
+        assert_eq!(verify_range_proof(root, key(2), leaves[1..].to_vec(), &proof).unwrap(), None);
     }
 
     #[test]
@@ -596,7 +646,7 @@ mod tests {
         let leaves = vec![(key(1), value(1)), (key(2), value(2)), (key(3), value(3))];
         let (root, _) = build_proof(&leaves, &[]);
 
-        assert!(!verify_range_proof(root, B256::ZERO, leaves, &[]).unwrap());
+        assert_eq!(verify_range_proof(root, B256::ZERO, leaves, &[]).unwrap(), None);
     }
 
     #[test]
@@ -629,8 +679,11 @@ mod tests {
         let leaves = vec![(key(1), value(1)), (key(2), value(2))];
         let (root, proof) = build_proof(&leaves, &[key(3)]);
 
-        assert!(!verify_range_proof(root, key(3), core::iter::empty::<(B256, Vec<u8>)>(), &proof,)
-            .unwrap());
+        assert_eq!(
+            verify_range_proof(root, key(3), core::iter::empty::<(B256, Vec<u8>)>(), &proof)
+                .unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -664,13 +717,16 @@ mod tests {
 
     #[test]
     fn empty_root_accepts_only_an_empty_range() {
-        assert!(!verify_range_proof(
-            EMPTY_ROOT_HASH,
-            B256::ZERO,
-            core::iter::empty::<(B256, Vec<u8>)>(),
-            &[],
-        )
-        .unwrap());
+        assert_eq!(
+            verify_range_proof(
+                EMPTY_ROOT_HASH,
+                B256::ZERO,
+                core::iter::empty::<(B256, Vec<u8>)>(),
+                &[]
+            )
+            .unwrap(),
+            None
+        );
         assert!(matches!(
             verify_range_proof(EMPTY_ROOT_HASH, B256::ZERO, [(key(1), value(1))], &[],),
             Err(RangeProofError::RootMismatch { .. })

--- a/crates/trie/common/src/range_proof.rs
+++ b/crates/trie/common/src/range_proof.rs
@@ -2,8 +2,10 @@
 //!
 //! Reconstructs a trie root from consecutive hashed leaves and boundary proof nodes, rejecting
 //! altered or incomplete ranges and reporting where the trie continues past the range.
+//! Boundary paths are expanded, outside commitments are retained, and response leaves replace the
+//! covered interior before the reconstructed root is compared with the requested root.
 
-use crate::{HashBuilder, Nibbles, RlpNode, TrieNode, EMPTY_ROOT_HASH};
+use crate::{HashBuilder, Nibbles, RlpNode, TrieNode};
 use alloc::vec::Vec;
 use alloy_primitives::{keccak256, map::B256Map, Bytes, B256};
 use alloy_rlp::Decodable;
@@ -11,14 +13,20 @@ use alloy_rlp::Decodable;
 const KEY_NIBBLES: usize = B256::len_bytes() * 2;
 const MAX_HASH: B256 = B256::new([0xff; B256::len_bytes()]);
 
+// Coordinates proof traversal and root reconstruction through one shared frontier.
 struct RangeProofVerifier<'a> {
+    // Determines which trie paths belong to the response and which remain proof-owned.
     range: ProofRange,
+    // Resolves hashed boundary references without depending on proof wire order.
     nodes: ProofNodes<'a>,
+    // Accumulates the disjoint entries needed to reconstruct the requested root.
     frontier: ProofFrontier,
+    // Tracks the lowest known path after the response to report whether the trie continues.
     next: Option<Nibbles>,
 }
 
 impl<'a> RangeProofVerifier<'a> {
+    // Creates a verifier with fixed bounds so traversal cannot drift from the supplied leaf range.
     fn new(left: B256, right: B256, proof: &'a [Bytes], frontier: ProofFrontier) -> Self {
         Self {
             range: ProofRange::new(left, right),
@@ -28,6 +36,8 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
+    // Verifies the range by rebuilding its root, making omitted or altered leaves change the
+    // result.
     fn verify(mut self, root: B256) -> Result<Option<B256>, RangeProofError> {
         self.visit_reference(Nibbles::new(), &RlpNode::word_rlp(&root))?;
 
@@ -38,6 +48,8 @@ impl<'a> RangeProofVerifier<'a> {
         Ok(self.next.as_ref().map(TriePath::lowest_key))
     }
 
+    // Visits a trie reference, expanding only boundaries because response leaves replace the
+    // interior.
     fn visit_reference(
         &mut self,
         prefix: Nibbles,
@@ -57,6 +69,7 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
+    // Visits a boundary node to expose the disjoint commitments needed for root reconstruction.
     fn visit_node(&mut self, node: TrieNode, prefix: Nibbles) -> Result<(), RangeProofError> {
         match node {
             TrieNode::EmptyRoot => Ok(()),
@@ -88,6 +101,7 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
+    // Adds an outside reference without expanding hashes because returned leaves cannot overlap it.
     fn add_outside_reference(
         &mut self,
         prefix: Nibbles,
@@ -100,6 +114,7 @@ impl<'a> RangeProofVerifier<'a> {
         self.add_outside_node(TrieNode::decode(&mut reference.as_slice())?, prefix)
     }
 
+    // Adds an inline outside node by descending until a retainable leaf or hashed child is reached.
     fn add_outside_node(&mut self, node: TrieNode, prefix: Nibbles) -> Result<(), RangeProofError> {
         match node {
             TrieNode::EmptyRoot => Ok(()),
@@ -123,6 +138,7 @@ impl<'a> RangeProofVerifier<'a> {
         }
     }
 
+    // Records the lowest right-side path needed to determine whether the interval is covered.
     fn note_next(&mut self, path: Nibbles) {
         if self.next.is_none_or(|next| path < next) {
             self.next = Some(path);
@@ -130,16 +146,21 @@ impl<'a> RangeProofVerifier<'a> {
     }
 }
 
+// Stores unpacked range bounds so recursive comparisons avoid repeatedly expanding hashed keys.
 struct ProofRange {
+    // Inclusive origin paired with the proof's left boundary path.
     left: Nibbles,
+    // Inclusive last leaf, or the maximum key when an empty response proves exhaustion.
     right: Nibbles,
 }
 
 impl ProofRange {
+    // Creates range bounds in the nibble representation used throughout trie traversal.
     fn new(left: B256, right: B256) -> Self {
         Self { left: Nibbles::unpack(left), right: Nibbles::unpack(right) }
     }
 
+    // Classifies a subtree prefix to avoid resolving subtries that cannot cross a boundary.
     fn subtree_relation(&self, prefix: &Nibbles) -> Result<SubtreeRelation, RangeProofError> {
         if prefix.len() > KEY_NIBBLES {
             return Err(RangeProofError::PathTooLong { path: *prefix })
@@ -158,6 +179,7 @@ impl ProofRange {
         })
     }
 
+    // Classifies a complete key because boundary proof leaves may sit outside the supplied range.
     fn key_relation(&self, path: &Nibbles) -> KeyRelation {
         if path < &self.left {
             KeyRelation::Before
@@ -169,13 +191,41 @@ impl ProofRange {
     }
 }
 
+// Prevents proof-owned subtries from being discarded or expanded unnecessarily by making each
+// prefix's relationship to the requested range explicit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SubtreeRelation {
+    // Retains a subtree that lies entirely before the requested range.
+    OutsideLeft,
+    // Retains a subtree after the range and uses its prefix to bound the next key.
+    OutsideRight,
+    // Expands a subtree because it may contain both proof-owned and response-owned paths.
+    Boundary,
+    // Replaces a wholly covered subtree with the response leaves being authenticated.
+    Inside,
+}
+
+// Prevents boundary proof leaves from being confused with response-owned interior leaves.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KeyRelation {
+    // Retains a proof leaf needed to reconstruct the trie before the response range.
+    Before,
+    // Defers to the response value so the reconstructed root authenticates the supplied leaf.
+    Inside,
+    // Retains a proof leaf and records that the trie continues beyond the response range.
+    After,
+}
+
+// Indexes proof blobs by commitment because proof wire order has no semantic meaning.
 struct ProofNodes<'a>(B256Map<&'a [u8]>);
 
 impl<'a> ProofNodes<'a> {
+    // Builds the proof index once to avoid rescanning it for every boundary reference.
     fn new(proof: &'a [Bytes]) -> Self {
         Self(proof.iter().map(|node| (keccak256(node), node.as_ref())).collect())
     }
 
+    // Resolves inline references directly and requires proof backing for hashed references.
     fn resolve(&self, path: Nibbles, reference: &RlpNode) -> Result<TrieNode, RangeProofError> {
         let Some(hash) = reference.as_hash() else {
             return Ok(TrieNode::decode(&mut reference.as_slice())?)
@@ -185,10 +235,12 @@ impl<'a> ProofNodes<'a> {
     }
 }
 
+// Collects disjoint leaves and subtree commitments for canonical root reconstruction.
 #[derive(Default)]
 struct ProofFrontier(Vec<FrontierEntry>);
 
 impl ProofFrontier {
+    // Builds a frontier from validated leaves before HashBuilder enforces ordering with assertions.
     fn from_leaves<I, V>(origin: B256, leaves: I) -> Result<(Self, Option<B256>), RangeProofError>
     where
         I: IntoIterator<Item = (B256, V)>,
@@ -215,16 +267,19 @@ impl ProofFrontier {
         Ok((frontier, previous))
     }
 
+    // Adds a leaf only at the fixed depth required by secure-trie hashed keys.
     fn push_leaf(&mut self, path: Nibbles, value: Vec<u8>) {
         debug_assert_eq!(path.len(), KEY_NIBBLES);
         self.0.push(FrontierEntry::Leaf { path, value });
     }
 
+    // Adds an opaque subtree at any prefix within the fixed hashed-key depth.
     fn push_subtree(&mut self, path: Nibbles, hash: B256) {
         debug_assert!(path.len() <= KEY_NIBBLES);
         self.0.push(FrontierEntry::Subtree { path, hash });
     }
 
+    // Reconstructs the root after sorting leaves and subtries into HashBuilder's strict path order.
     fn root(mut self) -> Result<B256, RangeProofError> {
         // Outside subtries are disjoint from returned leaves, so sorting produces the strict path
         // order required by HashBuilder. Reject duplicates before they reach its assertion.
@@ -244,6 +299,25 @@ impl ProofFrontier {
             }
         }
         Ok(builder.root())
+    }
+}
+
+// Unifies supplied leaves and proof-owned subtrees so HashBuilder receives one globally ordered
+// stream without losing which payload each path carries.
+#[derive(Clone, Debug)]
+enum FrontierEntry {
+    // Carries a response value so root reconstruction authenticates the supplied leaf.
+    Leaf { path: Nibbles, value: Vec<u8> },
+    // Carries an opaque commitment so proof-owned state outside the range remains unchanged.
+    Subtree { path: Nibbles, hash: B256 },
+}
+
+impl FrontierEntry {
+    // Exposes the common ordering key because HashBuilder requires strictly increasing paths.
+    const fn path(&self) -> Nibbles {
+        match self {
+            Self::Leaf { path, .. } | Self::Subtree { path, .. } => *path,
+        }
     }
 }
 
@@ -325,8 +399,8 @@ where
 {
     let (frontier, last_key) = ProofFrontier::from_leaves(origin, leaves)?;
 
-    // Empty tries and proof-free ranges are authenticated by their reconstructed root.
-    if root == EMPTY_ROOT_HASH || proof.is_empty() {
+    // Without boundary nodes, only the complete leaf set can reproduce the requested root.
+    if proof.is_empty() {
         let got = frontier.root()?;
         if got != root {
             return Err(RangeProofError::RootMismatch { expected: root, got })
@@ -337,33 +411,40 @@ where
     RangeProofVerifier::new(origin, last_key.unwrap_or(MAX_HASH), proof, frontier).verify(root)
 }
 
+// Keeps path mutation behind one checked API because external `Nibbles` cannot have inherent
+// methods and malformed proofs must not bypass secure-trie depth invariants.
 trait TriePath: Sized {
+    // Produces the conservative bound needed when an opaque subtree hides its first exact key.
     fn lowest_key(&self) -> B256;
 
+    // Requires extensions to consume bounded path space so hostile proofs cannot recurse in place.
     fn descend_extension(self, key: &Nibbles) -> Result<Self, RangeProofError>;
 
+    // Rejects branches beyond the key depth before mutating the path.
     fn descend_child(self, nibble: u8) -> Result<Self, RangeProofError>;
 
+    // Requires leaves to resolve to one full hashed key before entering the frontier.
     fn descend_leaf(self, key: &Nibbles) -> Result<Self, RangeProofError>;
 
+    // Shares the overflow guard used by extension and leaf descent.
     fn join_checked(self, key: &Nibbles) -> Result<Self, RangeProofError>;
 }
 
 impl TriePath for Nibbles {
-    // Packing zero-fills the nibbles the path leaves free, which is the key it bounds.
+    // Returns the subtree's lowest possible key because packing zero-fills unconsumed nibbles.
     fn lowest_key(&self) -> B256 {
         B256::right_padding_from(&self.pack())
     }
 
+    // Descends an extension while rejecting empty keys that could recurse without consuming space.
     fn descend_extension(self, key: &Nibbles) -> Result<Self, RangeProofError> {
-        // A canonical extension always consumes a nibble. An empty key would let a crafted chain of
-        // extensions recurse at a fixed depth until the stack is exhausted.
         if key.is_empty() {
             return Err(RangeProofError::EmptyExtensionKey { path: self })
         }
         self.join_checked(key)
     }
 
+    // Descends one branch nibble while rejecting nodes below the fixed hashed-key depth.
     fn descend_child(self, nibble: u8) -> Result<Self, RangeProofError> {
         if self.len() >= KEY_NIBBLES {
             return Err(RangeProofError::PathTooLong { path: self })
@@ -373,6 +454,7 @@ impl TriePath for Nibbles {
         Ok(path)
     }
 
+    // Completes a leaf path while rejecting leaves that do not resolve to one full hashed key.
     fn descend_leaf(self, key: &Nibbles) -> Result<Self, RangeProofError> {
         let path = self.join_checked(key)?;
         if path.len() != KEY_NIBBLES {
@@ -381,6 +463,7 @@ impl TriePath for Nibbles {
         Ok(path)
     }
 
+    // Joins path segments while rejecting proof nodes that exceed the fixed hashed-key depth.
     fn join_checked(self, key: &Nibbles) -> Result<Self, RangeProofError> {
         if self.len() + key.len() > KEY_NIBBLES {
             return Err(RangeProofError::PathTooLong { path: self })
@@ -389,39 +472,10 @@ impl TriePath for Nibbles {
     }
 }
 
-#[derive(Clone, Debug)]
-enum FrontierEntry {
-    Leaf { path: Nibbles, value: Vec<u8> },
-    Subtree { path: Nibbles, hash: B256 },
-}
-
-impl FrontierEntry {
-    const fn path(&self) -> Nibbles {
-        match self {
-            Self::Leaf { path, .. } | Self::Subtree { path, .. } => *path,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SubtreeRelation {
-    OutsideLeft,
-    OutsideRight,
-    Boundary,
-    Inside,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum KeyRelation {
-    Before,
-    Inside,
-    After,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{proof::ProofRetainer, BranchNode, ExtensionNode, TrieMask};
+    use crate::{proof::ProofRetainer, BranchNode, ExtensionNode, TrieMask, EMPTY_ROOT_HASH};
     use alloc::{vec, vec::Vec};
 
     fn key(value: u64) -> B256 {
@@ -684,5 +738,8 @@ mod tests {
             verify_range_proof(EMPTY_ROOT_HASH, B256::ZERO, [(key(1), value(1))], &[],),
             Err(RangeProofError::RootMismatch { .. })
         ));
+        assert!(
+            verify_range_proof(EMPTY_ROOT_HASH, B256::ZERO, no_leaves(), &[Bytes::new()]).is_err()
+        );
     }
 }


### PR DESCRIPTION
Adds a storage-agnostic account-range downloader and moves reusable Merkle range-proof verification into `reth-trie-common`. Each verified response returns decoded `TrieAccount`s and whether the requested interval requires another request.

In EIP-8189, this authenticates account batches downloaded at the selected pivot before their storage and bytecode are fetched and BALs advance the state toward the chain head.

The next PR will use the verified account hashes and storage roots to download storage ranges, reusing the shared range-proof verifier for partial responses.