### PR TITLE
feat(network): ingress limits

### DIFF
--- a/crates/net/eth-wire/src/errors/eth.rs
+++ b/crates/net/eth-wire/src/errors/eth.rs
@@ -83,6 +83,7 @@ impl EthStreamError {
                         P2PStreamError::Snap(_) |
                         P2PStreamError::MessageTooBig { .. } |
                         P2PStreamError::UnknownReservedMessageId(_) |
+                        P2PStreamError::UnknownSubprotocolMessageId(_) |
                         P2PStreamError::EmptyProtocolMessage |
                         P2PStreamError::UnknownDisconnectReason(_)
                 )

--- a/crates/net/eth-wire/src/errors/p2p.rs
+++ b/crates/net/eth-wire/src/errors/p2p.rs
@@ -5,7 +5,7 @@ use std::io;
 use reth_eth_wire_types::{DisconnectReason, UnknownDisconnectReason};
 use reth_primitives_traits::GotExpected;
 
-use crate::{capability::SharedCapabilityError, ProtocolVersion};
+use crate::{capability::SharedCapabilityError, Capability, ProtocolVersion};
 
 /// Errors when sending/receiving p2p messages. These should result in kicking the peer.
 #[derive(thiserror::Error, Debug)]
@@ -34,6 +34,30 @@ pub enum P2PStreamError {
         /// The maximum allowed size for the message.
         max_size: usize,
     },
+
+    /// A subprotocol message exceeds the limit declared by its local handler.
+    #[error(
+        "message for subprotocol {capability} has size {message_size}, exceeding max length {max_size}"
+    )]
+    SubprotocolMessageTooBig {
+        /// The negotiated capability whose limit was exceeded.
+        capability: Capability,
+        /// The frame size, including the capability-local message ID.
+        message_size: usize,
+        /// The maximum frame size declared by the protocol handler.
+        max_size: usize,
+    },
+
+    /// A subprotocol's bounded inbound queue has no remaining capacity.
+    #[error("inbound buffer for subprotocol {capability} is full")]
+    SubprotocolInboundBufferFull {
+        /// The negotiated capability whose queue is full.
+        capability: Capability,
+    },
+
+    /// An incoming message ID is outside all negotiated subprotocol ranges.
+    #[error("unknown subprotocol message id: {0:#04x}")]
+    UnknownSubprotocolMessageId(u8),
 
     /// Unknown reserved P2P message ID error.
     #[error("unknown reserved p2p message id: {0}")]

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -240,7 +240,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
                     inbound_messages += 1;
                     if inbound_messages == MAX_INBOUND_MESSAGES_PER_POLL {
                         inbound_messages = 0;
-                        tokio::task::yield_now().await;
+                        yield_once().await;
                     }
                 }
             }
@@ -577,7 +577,7 @@ impl InboundBudget {
     fn try_reserve(budget: &Arc<Self>, size: usize) -> Option<InboundBudgetGuard> {
         budget
             .used
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
                 used.checked_add(size).filter(|next| *next <= budget.max)
             })
             .ok()
@@ -1017,6 +1017,19 @@ impl<'a> Future for ProtocolsPoller<'a> {
         // All protocols processed, nothing ready
         Poll::Pending
     }
+}
+
+fn yield_once() -> impl Future<Output = ()> {
+    let mut yielded = false;
+    std::future::poll_fn(move |cx| {
+        if yielded {
+            Poll::Ready(())
+        } else {
+            yielded = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    })
 }
 
 /// Aggregate byte budget for inbound messages queued across all protocols on one connection.

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -13,7 +13,10 @@ use std::{
     future::Future,
     io,
     pin::{pin, Pin},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     task::{ready, Context, Poll},
 };
 
@@ -22,6 +25,7 @@ use crate::{
     errors::{EthStreamError, P2PStreamError},
     handshake::EthRlpxHandshake,
     p2pstream::DisconnectP2P,
+    protocol::ProtocolIngressLimits,
     CanDisconnect, Capability, DisconnectReason, EthStream, P2PStream, UnifiedStatus,
     HANDSHAKE_TIMEOUT,
 };
@@ -29,8 +33,9 @@ use bytes::{Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream, StreamExt, TryStream, TryStreamExt};
 use reth_eth_wire_types::NetworkPrimitives;
 use reth_ethereum_forks::ForkFilter;
+use reth_metrics::metrics::counter;
 use tokio::sync::{mpsc, mpsc::UnboundedSender};
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
 
 /// A Stream and Sink type that wraps a raw rlpx stream [`P2PStream`] and handles message ID
 /// multiplexing.
@@ -47,6 +52,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
                 conn,
                 protocols: Default::default(),
                 out_buffer: Default::default(),
+                inbound_budget: Arc::new(InboundBudget::new(MAX_MUX_IN_BUFFER_BYTES)),
             },
         }
     }
@@ -64,7 +70,21 @@ impl<St> RlpxProtocolMultiplexer<St> {
         F: FnOnce(ProtocolConnection) -> Proto,
         Proto: Stream<Item = BytesMut> + Send + 'static,
     {
-        self.inner.install_protocol(cap, f)
+        self.inner.install_protocol(cap, ProtocolIngressLimits::default(), f)
+    }
+
+    /// Installs a new protocol with local limits for inbound messages.
+    pub fn install_protocol_with_limits<F, Proto>(
+        &mut self,
+        cap: &Capability,
+        limits: ProtocolIngressLimits,
+        f: F,
+    ) -> Result<(), UnsupportedCapabilityError>
+    where
+        F: FnOnce(ProtocolConnection) -> Proto,
+        Proto: Stream<Item = BytesMut> + Send + 'static,
+    {
+        self.inner.install_protocol(cap, limits, f)
     }
 
     /// Returns the [`SharedCapabilities`] of the underlying raw p2p stream
@@ -86,13 +106,10 @@ impl<St> RlpxProtocolMultiplexer<St> {
             return Err(P2PStreamError::CapabilityNotShared)
         };
 
-        let (to_primary, from_wire) = mpsc::unbounded_channel();
+        let (to_primary, from_wire) =
+            self.inner.inbound_channel(&shared_cap, ProtocolIngressLimits::default());
         let (to_wire, from_primary) = mpsc::unbounded_channel();
-        let proxy = ProtocolProxy {
-            shared_cap: shared_cap.clone(),
-            from_wire: UnboundedReceiverStream::new(from_wire),
-            to_wire,
-        };
+        let proxy = ProtocolProxy { shared_cap: shared_cap.clone(), from_wire, to_wire };
 
         let st = primary(proxy);
         Ok(RlpxSatelliteStream {
@@ -155,47 +172,20 @@ impl<St> RlpxProtocolMultiplexer<St> {
             return Err(P2PStreamError::CapabilityNotShared.into())
         };
 
-        let (to_primary, from_wire) = mpsc::unbounded_channel();
+        let (to_primary, from_wire) =
+            self.inner.inbound_channel(&shared_cap, ProtocolIngressLimits::default());
         let (to_wire, mut from_primary) = mpsc::unbounded_channel();
-        let proxy = ProtocolProxy {
-            shared_cap: shared_cap.clone(),
-            from_wire: UnboundedReceiverStream::new(from_wire),
-            to_wire,
-        };
+        let proxy = ProtocolProxy { shared_cap: shared_cap.clone(), from_wire, to_wire };
 
         let f = handshake(proxy);
         let mut f = pin!(f);
+        let mut inbound_messages = 0;
 
         // this polls the connection and the primary stream concurrently until the handshake is
         // complete
         loop {
             tokio::select! {
                 biased;
-                Some(Ok(msg)) = self.inner.conn.next() => {
-                    // Ensure the message belongs to the primary protocol
-                    let Some(offset) = msg.first().copied()
-                    else {
-                        return Err(P2PStreamError::EmptyProtocolMessage.into())
-                    };
-                    if let Some(cap) = self.shared_capabilities().find_by_relative_offset(offset).cloned() {
-                            if cap == shared_cap {
-                                // delegate to primary
-                                let _ = to_primary.send(msg);
-                            } else {
-                                // delegate to satellite
-                                self.inner.delegate_message(&cap, msg);
-                            }
-                        } else {
-                           return Err(P2PStreamError::UnknownReservedMessageId(offset).into())
-                        }
-                }
-                Some(msg) = from_primary.recv() => {
-                    self.inner.conn.send(msg).await.map_err(Into::into)?;
-                }
-                // Poll all subprotocols for new messages
-                msg = ProtocolsPoller::new(&mut self.inner.protocols) => {
-                     self.inner.conn.send(msg.map_err(Into::into)?).await.map_err(Into::into)?;
-                }
                 res = &mut f => {
                     let (st, extra) = res?;
                     return Ok((
@@ -211,6 +201,45 @@ impl<St> RlpxProtocolMultiplexer<St> {
                         },
                         extra,
                     ))
+                }
+                Some(msg) = from_primary.recv() => {
+                    self.inner.conn.send(msg).await.map_err(Into::into)?;
+                }
+                // Polling a satellite drives its inbound consumer even when it has no outbound
+                // message. This must happen before reading another frame from the socket.
+                msg = ProtocolsPoller::new(&mut self.inner.protocols) => {
+                     self.inner.conn.send(msg.map_err(Into::into)?).await.map_err(Into::into)?;
+                }
+                incoming = self.inner.conn.next() => {
+                    let msg = match incoming {
+                        Some(Ok(msg)) => msg,
+                        Some(Err(err)) => return Err(err.into()),
+                        None => {
+                            return Err(P2PStreamError::Io(io::ErrorKind::UnexpectedEof.into()).into())
+                        }
+                    };
+                    // Ensure the message belongs to the primary protocol
+                    let Some(offset) = msg.first().copied()
+                    else {
+                        return Err(P2PStreamError::EmptyProtocolMessage.into())
+                    };
+                    if let Some(cap) = self.shared_capabilities().find_by_relative_offset(offset).cloned() {
+                            if cap == shared_cap {
+                                // delegate to primary
+                                to_primary.try_send(msg).map_err(Into::into)?;
+                            } else {
+                                // delegate to satellite
+                                self.inner.delegate_message(&cap, msg).map_err(Into::into)?;
+                            }
+                        } else {
+                           return Err(P2PStreamError::UnknownReservedMessageId(offset).into())
+                        }
+
+                    inbound_messages += 1;
+                    if inbound_messages == MAX_INBOUND_MESSAGES_PER_POLL {
+                        inbound_messages = 0;
+                        tokio::task::yield_now().await;
+                    }
                 }
             }
         }
@@ -257,6 +286,8 @@ struct MultiplexInner<St> {
     protocols: VecDeque<ProtocolStream>,
     /// Buffer for outgoing messages on the wire.
     out_buffer: OutBuffer,
+    /// Byte budget shared by every inbound protocol queue on this connection.
+    inbound_budget: Arc<InboundBudget>,
 }
 
 impl<St> MultiplexInner<St> {
@@ -265,19 +296,24 @@ impl<St> MultiplexInner<St> {
     }
 
     /// Delegates a message to the matching protocol.
-    fn delegate_message(&self, cap: &SharedCapability, msg: BytesMut) -> bool {
+    fn delegate_message(
+        &self,
+        cap: &SharedCapability,
+        msg: BytesMut,
+    ) -> Result<bool, P2PStreamError> {
         for proto in &self.protocols {
             if proto.shared_cap == *cap {
-                proto.send_raw(msg);
-                return true
+                proto.send_raw(msg)?;
+                return Ok(true)
             }
         }
-        false
+        Ok(false)
     }
 
     fn install_protocol<F, Proto>(
         &mut self,
         cap: &Capability,
+        limits: ProtocolIngressLimits,
         f: F,
     ) -> Result<(), UnsupportedCapabilityError>
     where
@@ -286,12 +322,21 @@ impl<St> MultiplexInner<St> {
     {
         let shared_cap =
             self.conn.shared_capabilities().ensure_matching_capability(cap).cloned()?;
-        let (to_satellite, rx) = mpsc::unbounded_channel();
-        let proto_conn = ProtocolConnection { from_wire: UnboundedReceiverStream::new(rx) };
+        self.conn.set_protocol_ingress_limits(&shared_cap, limits);
+        let (to_satellite, from_wire) = self.inbound_channel(&shared_cap, limits);
+        let proto_conn = ProtocolConnection { from_wire };
         let st = f(proto_conn);
         let st = ProtocolStream { shared_cap, to_satellite, satellite_st: Box::pin(st) };
         self.protocols.push_back(st);
         Ok(())
+    }
+
+    fn inbound_channel(
+        &self,
+        capability: &SharedCapability,
+        limits: ProtocolIngressLimits,
+    ) -> (InboundSender, InboundReceiver) {
+        inbound_channel(capability, limits, Arc::clone(&self.inbound_budget))
     }
 }
 
@@ -299,7 +344,7 @@ impl<St> MultiplexInner<St> {
 #[derive(Debug)]
 struct PrimaryProtocol<Primary> {
     /// Channel to send messages to the primary protocol.
-    to_primary: UnboundedSender<BytesMut>,
+    to_primary: InboundSender,
     /// Receiver for messages from the primary protocol.
     from_primary: UnboundedReceiverStream<Bytes>,
     /// Shared capability of the primary protocol.
@@ -315,7 +360,7 @@ struct PrimaryProtocol<Primary> {
 pub struct ProtocolProxy {
     shared_cap: SharedCapability,
     /// Receives _non-empty_ messages from the wire
-    from_wire: UnboundedReceiverStream<BytesMut>,
+    from_wire: InboundReceiver,
     /// Sends _non-empty_ messages from the wire
     to_wire: UnboundedSender<Bytes>,
 }
@@ -451,12 +496,127 @@ impl CanDisconnect<Bytes> for UnauthProxy {
     }
 }
 
+#[derive(Debug)]
+struct InboundSender {
+    inner: mpsc::Sender<BudgetedInbound>,
+    connection_budget: Arc<InboundBudget>,
+    protocol_budget: Arc<InboundBudget>,
+    capability: Capability,
+}
+
+impl InboundSender {
+    fn try_send(&self, frame: BytesMut) -> Result<(), P2PStreamError> {
+        let size = frame.capacity().max(frame.len());
+        let Some(connection_guard) = InboundBudget::try_reserve(&self.connection_budget, size)
+        else {
+            return Err(self.buffer_full())
+        };
+        let Some(protocol_guard) = InboundBudget::try_reserve(&self.protocol_budget, size) else {
+            return Err(self.buffer_full())
+        };
+
+        let frame = BudgetedInbound {
+            frame,
+            _connection_guard: connection_guard,
+            _protocol_guard: protocol_guard,
+        };
+        self.inner.try_send(frame).map_err(|err| match err {
+            mpsc::error::TrySendError::Full(_) => self.buffer_full(),
+            mpsc::error::TrySendError::Closed(_) => {
+                P2PStreamError::Io(io::ErrorKind::BrokenPipe.into())
+            }
+        })
+    }
+
+    fn buffer_full(&self) -> P2PStreamError {
+        counter!("p2pstream.subprotocol_inbound_buffer_full").increment(1);
+        P2PStreamError::SubprotocolInboundBufferFull { capability: self.capability.clone() }
+    }
+}
+
+#[derive(Debug)]
+struct InboundReceiver {
+    inner: ReceiverStream<BudgetedInbound>,
+}
+
+impl Stream for InboundReceiver {
+    type Item = BytesMut;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx).map(|frame| frame.map(BudgetedInbound::into_frame))
+    }
+}
+
+#[derive(Debug)]
+struct BudgetedInbound {
+    frame: BytesMut,
+    _connection_guard: InboundBudgetGuard,
+    _protocol_guard: InboundBudgetGuard,
+}
+
+impl BudgetedInbound {
+    fn into_frame(self) -> BytesMut {
+        let Self { frame, _connection_guard, _protocol_guard } = self;
+        frame
+    }
+}
+
+#[derive(Debug)]
+struct InboundBudget {
+    used: AtomicUsize,
+    max: usize,
+}
+
+impl InboundBudget {
+    const fn new(max: usize) -> Self {
+        Self { used: AtomicUsize::new(0), max }
+    }
+
+    fn try_reserve(budget: &Arc<Self>, size: usize) -> Option<InboundBudgetGuard> {
+        budget
+            .used
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
+                used.checked_add(size).filter(|next| *next <= budget.max)
+            })
+            .ok()
+            .map(|_| InboundBudgetGuard { size, budget: Arc::clone(budget) })
+    }
+}
+
+#[derive(Debug)]
+struct InboundBudgetGuard {
+    size: usize,
+    budget: Arc<InboundBudget>,
+}
+
+impl Drop for InboundBudgetGuard {
+    fn drop(&mut self) {
+        self.budget.used.fetch_sub(self.size, Ordering::Relaxed);
+    }
+}
+
+fn inbound_channel(
+    capability: &SharedCapability,
+    limits: ProtocolIngressLimits,
+    connection_budget: Arc<InboundBudget>,
+) -> (InboundSender, InboundReceiver) {
+    let (tx, rx) = mpsc::channel(limits.max_buffered_messages());
+    let sender = InboundSender {
+        inner: tx,
+        connection_budget,
+        protocol_budget: Arc::new(InboundBudget::new(limits.max_buffered_bytes())),
+        capability: capability.capability().into_owned(),
+    };
+    let receiver = InboundReceiver { inner: ReceiverStream::new(rx) };
+    (sender, receiver)
+}
+
 /// A connection channel to receive _`non_empty`_ messages for the negotiated protocol.
 ///
 /// This is a [Stream] that returns raw bytes of the received messages for this protocol.
 #[derive(Debug)]
 pub struct ProtocolConnection {
-    from_wire: UnboundedReceiverStream<BytesMut>,
+    from_wire: InboundReceiver,
 }
 
 impl Stream for ProtocolConnection {
@@ -491,7 +651,21 @@ impl<St, Primary> RlpxSatelliteStream<St, Primary> {
         F: FnOnce(ProtocolConnection) -> Proto,
         Proto: Stream<Item = BytesMut> + Send + 'static,
     {
-        self.inner.install_protocol(cap, f)
+        self.inner.install_protocol(cap, ProtocolIngressLimits::default(), f)
+    }
+
+    /// Installs a new protocol with local limits for inbound messages.
+    pub fn install_protocol_with_limits<F, Proto>(
+        &mut self,
+        cap: &Capability,
+        limits: ProtocolIngressLimits,
+        f: F,
+    ) -> Result<(), UnsupportedCapabilityError>
+    where
+        F: FnOnce(ProtocolConnection) -> Proto,
+        Proto: Stream<Item = BytesMut> + Send + 'static,
+    {
+        self.inner.install_protocol(cap, limits, f)
     }
 
     /// Returns the primary protocol.
@@ -588,6 +762,7 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+        let mut inbound_messages = 0;
 
         loop {
             // first drain the primary stream
@@ -640,46 +815,45 @@ where
             }
 
             let mut delegated = false;
-            loop {
-                // pull messages from connection
-                match this.inner.conn.poll_next_unpin(cx) {
-                    Poll::Ready(Some(Ok(msg))) => {
-                        delegated = true;
-                        let Some(offset) = msg.first().copied() else {
-                            return Poll::Ready(Some(Err(
-                                P2PStreamError::EmptyProtocolMessage.into()
-                            )))
-                        };
-                        // delegate the multiplexed message to the correct protocol
-                        if let Some(cap) =
-                            this.inner.conn.shared_capabilities().find_by_relative_offset(offset)
-                        {
-                            if cap == &this.primary.shared_cap {
-                                // delegate to primary
-                                let _ = this.primary.to_primary.send(msg);
-                            } else {
-                                // delegate to installed satellite if any
-                                for proto in &this.inner.protocols {
-                                    if proto.shared_cap == *cap {
-                                        proto.send_raw(msg);
-                                        break
-                                    }
-                                }
-                            }
-                        } else {
-                            return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(
-                                offset,
-                            )
-                            .into())))
-                        }
+            // Pull one message before returning to the top of the loop, where every protocol gets
+            // another chance to consume its inbound queue.
+            match this.inner.conn.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(msg))) => {
+                    delegated = true;
+                    let Some(offset) = msg.first().copied() else {
+                        return Poll::Ready(Some(Err(P2PStreamError::EmptyProtocolMessage.into())))
+                    };
+                    let Some(cap) = this
+                        .inner
+                        .conn
+                        .shared_capabilities()
+                        .find_by_relative_offset(offset)
+                        .cloned()
+                    else {
+                        return Poll::Ready(Some(Err(P2PStreamError::UnknownReservedMessageId(
+                            offset,
+                        )
+                        .into())))
+                    };
+
+                    let result = if cap == this.primary.shared_cap {
+                        this.primary.to_primary.try_send(msg)
+                    } else {
+                        this.inner.delegate_message(&cap, msg).map(|_| ())
+                    };
+                    if let Err(err) = result {
+                        return Poll::Ready(Some(Err(err.into())))
                     }
-                    Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err.into()))),
-                    Poll::Ready(None) => {
-                        // connection closed
-                        return Poll::Ready(None)
+
+                    inbound_messages += 1;
+                    if inbound_messages == MAX_INBOUND_MESSAGES_PER_POLL {
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending
                     }
-                    Poll::Pending => break,
                 }
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err.into()))),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => {}
             }
 
             if !conn_ready || (!delegated && this.inner.out_buffer.is_empty()) {
@@ -725,7 +899,7 @@ where
 struct ProtocolStream {
     shared_cap: SharedCapability,
     /// the channel shared with the satellite stream
-    to_satellite: UnboundedSender<BytesMut>,
+    to_satellite: InboundSender,
     satellite_st: Pin<Box<dyn Stream<Item = BytesMut> + Send>>,
 }
 
@@ -757,8 +931,9 @@ impl ProtocolStream {
     }
 
     /// Sends the message to the satellite stream.
-    fn send_raw(&self, msg: BytesMut) {
-        let _ = self.unmask_id(msg).map(|msg| self.to_satellite.send(msg));
+    fn send_raw(&self, msg: BytesMut) -> Result<(), P2PStreamError> {
+        let msg = self.unmask_id(msg).map_err(P2PStreamError::from)?;
+        self.to_satellite.try_send(msg)
     }
 }
 
@@ -817,6 +992,12 @@ impl<'a> Future for ProtocolsPoller<'a> {
         Poll::Pending
     }
 }
+
+/// Aggregate byte budget for inbound messages queued across all protocols on one connection.
+const MAX_MUX_IN_BUFFER_BYTES: usize = 32 * 1024 * 1024;
+
+/// Maximum network messages delegated before yielding the connection task.
+const MAX_INBOUND_MESSAGES_PER_POLL: usize = 32;
 
 /// Soft cap for per-connection outbound `RLPx` messages waiting in the multiplexer.
 ///
@@ -943,6 +1124,229 @@ mod tests {
         ) -> Poll<Result<(), Self::Error>> {
             Poll::Pending
         }
+    }
+
+    #[derive(Debug)]
+    struct InboundFramesTransport {
+        frames: VecDeque<BytesMut>,
+    }
+
+    impl Stream for InboundFramesTransport {
+        type Item = io::Result<BytesMut>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.frames.pop_front().map(Ok))
+        }
+    }
+
+    impl Sink<Bytes> for InboundFramesTransport {
+        type Error = io::Error;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Bytes) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[derive(Debug)]
+    struct HoldingProtocol {
+        _conn: ProtocolConnection,
+    }
+
+    impl Stream for HoldingProtocol {
+        type Item = BytesMut;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Pending
+        }
+    }
+
+    #[derive(Debug)]
+    struct DrainingProtocol {
+        conn: ProtocolConnection,
+    }
+
+    impl Stream for DrainingProtocol {
+        type Item = BytesMut;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            while matches!(self.conn.poll_next_unpin(cx), Poll::Ready(Some(_))) {}
+            Poll::Pending
+        }
+    }
+
+    #[derive(Debug)]
+    struct SignalingDrainingProtocol {
+        conn: ProtocolConnection,
+        drained: Option<oneshot::Sender<()>>,
+    }
+
+    impl Stream for SignalingDrainingProtocol {
+        type Item = BytesMut;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if matches!(self.conn.poll_next_unpin(cx), Poll::Ready(Some(_))) &&
+                let Some(drained) = self.drained.take()
+            {
+                let _ = drained.send(());
+            }
+            Poll::Pending
+        }
+    }
+
+    fn compressed_frame(message_id: u8, payload: &[u8]) -> BytesMut {
+        let mut encoded = vec![0; snap::raw::max_compress_len(payload.len()) + 1];
+        encoded[0] = message_id;
+        let len = snap::raw::Encoder::new().compress(payload, &mut encoded[1..]).unwrap();
+        encoded.truncate(len + 1);
+        BytesMut::from(encoded.as_slice())
+    }
+
+    fn test_multiplexer(
+        frame_count: usize,
+    ) -> (RlpxProtocolMultiplexer<InboundFramesTransport>, SharedCapability, SharedCapability) {
+        let (hello, _) = test_hello();
+        let shared_capabilities =
+            SharedCapabilities::try_new(hello.protocols.clone(), hello.message().capabilities)
+                .unwrap();
+        let eth = shared_capabilities.eth().unwrap().clone();
+        let test = shared_capabilities.find(&TestProtoMessage::capability()).unwrap().clone();
+        let frames =
+            (0..frame_count).map(|_| compressed_frame(test.message_id_offset(), &[0])).collect();
+        let conn = P2PStream::new(InboundFramesTransport { frames }, shared_capabilities);
+        (RlpxProtocolMultiplexer::new(conn), eth, test)
+    }
+
+    fn shared_test_capability(name: &'static str, offset: u8) -> SharedCapability {
+        SharedCapability::UnknownCapability {
+            cap: Capability::new_static(name, 1),
+            offset,
+            messages: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn inbound_channel_enforces_and_releases_protocol_limits() {
+        let capability = shared_test_capability("test", 0x10);
+        let limits =
+            ProtocolIngressLimits::new(16).with_max_buffered_bytes(4).with_max_buffered_messages(1);
+        let aggregate = Arc::new(InboundBudget::new(16));
+        let (sender, mut receiver) = inbound_channel(&capability, limits, aggregate);
+
+        sender.try_send(BytesMut::zeroed(4)).unwrap();
+        assert!(matches!(
+            sender.try_send(BytesMut::zeroed(1)),
+            Err(P2PStreamError::SubprotocolInboundBufferFull { .. })
+        ));
+
+        assert_eq!(receiver.next().await.unwrap().len(), 4);
+        sender.try_send(BytesMut::zeroed(1)).unwrap();
+    }
+
+    #[tokio::test]
+    async fn inbound_channels_share_connection_byte_budget() {
+        let aggregate = Arc::new(InboundBudget::new(6));
+        let limits = ProtocolIngressLimits::new(16)
+            .with_max_buffered_bytes(16)
+            .with_max_buffered_messages(2);
+        let (first, mut first_receiver) =
+            inbound_channel(&shared_test_capability("aaa", 0x10), limits, Arc::clone(&aggregate));
+        let (second, _second_receiver) =
+            inbound_channel(&shared_test_capability("bbb", 0x11), limits, aggregate);
+
+        first.try_send(BytesMut::zeroed(4)).unwrap();
+        assert!(matches!(
+            second.try_send(BytesMut::zeroed(4)),
+            Err(P2PStreamError::SubprotocolInboundBufferFull { .. })
+        ));
+
+        let _ = first_receiver.next().await.unwrap();
+        second.try_send(BytesMut::zeroed(4)).unwrap();
+    }
+
+    #[tokio::test]
+    async fn stalled_satellite_fails_when_its_inbound_queue_is_full() {
+        let (mut mux, eth, test) = test_multiplexer(2);
+        let limits =
+            ProtocolIngressLimits::new(2).with_max_buffered_bytes(2).with_max_buffered_messages(1);
+        mux.install_protocol_with_limits(&TestProtoMessage::capability(), limits, |conn| {
+            HoldingProtocol { _conn: conn }
+        })
+        .unwrap();
+        let mut stream = mux
+            .into_satellite_stream(eth.capability().as_ref(), |proxy| PendingPrimary {
+                _proxy: proxy,
+            })
+            .unwrap();
+
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(matches!(
+            Pin::new(&mut stream).poll_next(&mut cx),
+            Poll::Ready(Some(Err(P2PStreamError::SubprotocolInboundBufferFull {
+                capability,
+            }))) if capability == test.capability().into_owned()
+        ));
+    }
+
+    #[tokio::test]
+    async fn satellite_is_polled_between_inbound_frames() {
+        let (mut mux, eth, _) = test_multiplexer(2 * MAX_INBOUND_MESSAGES_PER_POLL);
+        let limits =
+            ProtocolIngressLimits::new(2).with_max_buffered_bytes(2).with_max_buffered_messages(1);
+        mux.install_protocol_with_limits(&TestProtoMessage::capability(), limits, |conn| {
+            DrainingProtocol { conn }
+        })
+        .unwrap();
+        let mut stream = mux
+            .into_satellite_stream(eth.capability().as_ref(), |proxy| PendingPrimary {
+                _proxy: proxy,
+            })
+            .unwrap();
+
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(Pin::new(&mut stream).poll_next(&mut cx).is_pending());
+        assert_eq!(stream.inner.conn.inner().frames.len(), MAX_INBOUND_MESSAGES_PER_POLL);
+    }
+
+    #[tokio::test]
+    async fn satellite_is_polled_between_frames_during_primary_handshake() {
+        let (mut mux, eth, _) = test_multiplexer(2);
+        let limits =
+            ProtocolIngressLimits::new(2).with_max_buffered_bytes(2).with_max_buffered_messages(1);
+        let (drained_tx, drained_rx) = oneshot::channel();
+        mux.install_protocol_with_limits(&TestProtoMessage::capability(), limits, |conn| {
+            SignalingDrainingProtocol { conn, drained: Some(drained_tx) }
+        })
+        .unwrap();
+
+        let stream = mux
+            .into_satellite_stream_with_handshake(eth.capability().as_ref(), async move |proxy| {
+                drained_rx.await.unwrap();
+                Ok::<_, P2PStreamError>(PendingPrimary { _proxy: proxy })
+            })
+            .await;
+
+        assert!(stream.is_ok());
     }
 
     #[tokio::test]

--- a/crates/net/eth-wire/src/multiplex.rs
+++ b/crates/net/eth-wire/src/multiplex.rs
@@ -121,6 +121,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
                 shared_cap,
             },
             next_outbound: 0,
+            producer_polls_since_inbound: 0,
         })
     }
 
@@ -198,6 +199,7 @@ impl<St> RlpxProtocolMultiplexer<St> {
                                 shared_cap,
                             },
                             next_outbound: 0,
+                            producer_polls_since_inbound: 0,
                         },
                         extra,
                     ))
@@ -635,6 +637,8 @@ pub struct RlpxSatelliteStream<St, Primary> {
     primary: PrimaryProtocol<Primary>,
     /// Round-robin cursor for the next outbound producer to poll.
     next_outbound: usize,
+    /// Number of round-robin producers polled since the last inbound frame.
+    producer_polls_since_inbound: usize,
 }
 
 impl<St, Primary> RlpxSatelliteStream<St, Primary> {
@@ -651,7 +655,11 @@ impl<St, Primary> RlpxSatelliteStream<St, Primary> {
         F: FnOnce(ProtocolConnection) -> Proto,
         Proto: Stream<Item = BytesMut> + Send + 'static,
     {
-        self.inner.install_protocol(cap, ProtocolIngressLimits::default(), f)
+        let result = self.inner.install_protocol(cap, ProtocolIngressLimits::default(), f);
+        if result.is_ok() {
+            self.producer_polls_since_inbound = 0;
+        }
+        result
     }
 
     /// Installs a new protocol with local limits for inbound messages.
@@ -665,7 +673,11 @@ impl<St, Primary> RlpxSatelliteStream<St, Primary> {
         F: FnOnce(ProtocolConnection) -> Proto,
         Proto: Stream<Item = BytesMut> + Send + 'static,
     {
-        self.inner.install_protocol(cap, limits, f)
+        let result = self.inner.install_protocol(cap, limits, f);
+        if result.is_ok() {
+            self.producer_polls_since_inbound = 0;
+        }
+        result
     }
 
     /// Returns the primary protocol.
@@ -718,6 +730,9 @@ impl<St, Primary> RlpxSatelliteStream<St, Primary> {
 
             let producer = self.next_outbound;
             self.next_outbound = (self.next_outbound + 1) % producers;
+            if self.producer_polls_since_inbound < producers {
+                self.producer_polls_since_inbound += 1;
+            }
 
             let msg = if producer == 0 {
                 match self.primary.from_primary.poll_next_unpin(cx) {
@@ -809,6 +824,16 @@ where
             }
 
             match this.poll_outbound_producers(cx) {
+                Ok(ProducerPoll::Full)
+                    if this.producer_polls_since_inbound < this.inner.protocols.len() + 1 =>
+                {
+                    // A full buffer prevents protocol streams from being polled. Pause ingress
+                    // until every consumer has had a chance to drain the previous frame.
+                    if conn_ready {
+                        cx.waker().wake_by_ref();
+                    }
+                    return Poll::Pending
+                }
                 Ok(ProducerPoll::Pending | ProducerPoll::Full) => {}
                 Ok(ProducerPoll::Closed) => return Poll::Ready(None),
                 Err(err) => return Poll::Ready(Some(Err(P2PStreamError::Io(err).into()))),
@@ -844,6 +869,7 @@ where
                     if let Err(err) = result {
                         return Poll::Ready(Some(Err(err.into())))
                     }
+                    this.producer_polls_since_inbound = 0;
 
                     inbound_messages += 1;
                     if inbound_messages == MAX_INBOUND_MESSAGES_PER_POLL {
@@ -1069,7 +1095,7 @@ mod tests {
     };
     use futures::{stream, task::noop_waker_ref};
     use reth_eth_wire_types::EthNetworkPrimitives;
-    use std::task::Poll;
+    use std::{sync::atomic::AtomicBool, task::Poll};
     use tokio::{net::TcpListener, sync::oneshot};
     use tokio_util::codec::Decoder;
 
@@ -1082,6 +1108,24 @@ mod tests {
         type Item = Result<(), P2PStreamError>;
 
         fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Pending
+        }
+    }
+
+    #[derive(Debug)]
+    struct BurstingPrimary {
+        proxy: ProtocolProxy,
+        remaining: usize,
+    }
+
+    impl Stream for BurstingPrimary {
+        type Item = Result<(), P2PStreamError>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                self.proxy.try_send(Bytes::from_static(&[0, 0])).unwrap();
+            }
             Poll::Pending
         }
     }
@@ -1129,6 +1173,7 @@ mod tests {
     #[derive(Debug)]
     struct InboundFramesTransport {
         frames: VecDeque<BytesMut>,
+        writable: AtomicBool,
     }
 
     impl Stream for InboundFramesTransport {
@@ -1146,25 +1191,23 @@ mod tests {
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
         ) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
+            if self.writable.load(Ordering::Relaxed) {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
         }
 
         fn start_send(self: Pin<&mut Self>, _item: Bytes) -> Result<(), Self::Error> {
             Ok(())
         }
 
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.poll_ready(cx)
         }
 
-        fn poll_close(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.poll_ready(cx)
         }
     }
 
@@ -1233,7 +1276,10 @@ mod tests {
         let test = shared_capabilities.find(&TestProtoMessage::capability()).unwrap().clone();
         let frames =
             (0..frame_count).map(|_| compressed_frame(test.message_id_offset(), &[0])).collect();
-        let conn = P2PStream::new(InboundFramesTransport { frames }, shared_capabilities);
+        let conn = P2PStream::new(
+            InboundFramesTransport { frames, writable: AtomicBool::new(true) },
+            shared_capabilities,
+        );
         (RlpxProtocolMultiplexer::new(conn), eth, test)
     }
 
@@ -1326,6 +1372,54 @@ mod tests {
         let mut cx = Context::from_waker(noop_waker_ref());
         assert!(Pin::new(&mut stream).poll_next(&mut cx).is_pending());
         assert_eq!(stream.inner.conn.inner().frames.len(), MAX_INBOUND_MESSAGES_PER_POLL);
+    }
+
+    #[tokio::test]
+    async fn outbound_backpressure_preserves_inbound_fairness() {
+        let (hello, _) = test_hello();
+        let shared_capabilities =
+            SharedCapabilities::try_new(hello.protocols.clone(), hello.message().capabilities)
+                .unwrap();
+        let eth = shared_capabilities.eth().unwrap().clone();
+        let test = shared_capabilities.find(&TestProtoMessage::capability()).unwrap().clone();
+        let frames = (0..2)
+            .map(|_| compressed_frame(test.message_id_offset(), &[0]))
+            .collect::<VecDeque<_>>();
+        let conn = P2PStream::new(
+            InboundFramesTransport { frames, writable: AtomicBool::new(false) },
+            shared_capabilities,
+        );
+        let mut mux = RlpxProtocolMultiplexer::new(conn);
+        let limits =
+            ProtocolIngressLimits::new(2).with_max_buffered_bytes(2).with_max_buffered_messages(1);
+        mux.install_protocol_with_limits(&TestProtoMessage::capability(), limits, |conn| {
+            DrainingProtocol { conn }
+        })
+        .unwrap();
+        let mut stream = mux
+            .into_satellite_stream(eth.capability().as_ref(), |proxy| BurstingPrimary {
+                proxy,
+                remaining: 3,
+            })
+            .unwrap();
+        stream.inner.conn.start_send_unpin(Bytes::from_static(&[0, 0])).unwrap();
+        stream.inner.conn.start_send_unpin(Bytes::from_static(&[0, 0])).unwrap();
+        stream.inner.out_buffer.max_bytes = 1;
+        stream.inner.out_buffer.push_back(Bytes::from_static(&[0, 0]));
+
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(Pin::new(&mut stream).poll_next(&mut cx).is_pending());
+        assert_eq!(stream.inner.conn.inner().frames.len(), 2);
+
+        assert!(Pin::new(&mut stream).poll_next(&mut cx).is_pending());
+        assert_eq!(stream.inner.conn.inner().frames.len(), 2);
+
+        stream.inner.conn.inner().writable.store(true, Ordering::Relaxed);
+        assert!(Pin::new(&mut stream).poll_next(&mut cx).is_pending());
+        assert_eq!(stream.inner.conn.inner().frames.len(), 2);
+
+        assert!(matches!(Pin::new(&mut stream).poll_next(&mut cx), Poll::Ready(None)));
+        assert_eq!(stream.inner.conn.inner().frames.len(), 0);
     }
 
     #[tokio::test]

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -351,6 +351,10 @@ impl<S> P2PStream<S> {
         limits: ProtocolIngressLimits,
     ) {
         let Some(max_frame_bytes) = limits.max_frame_bytes() else { return };
+        if capability.num_messages() == 0 {
+            return
+        }
+
         let start = capability.message_id_offset();
         let end = u16::from(start) + u16::from(capability.num_messages());
         let configured = InboundProtocolLimit {
@@ -360,8 +364,10 @@ impl<S> P2PStream<S> {
             max_frame_bytes,
         };
 
-        if let Some(current) =
-            self.inbound_protocol_limits.iter_mut().find(|current| current.start == start)
+        if let Some(current) = self
+            .inbound_protocol_limits
+            .iter_mut()
+            .find(|current| current.capability == configured.capability)
         {
             *current = configured;
         } else {
@@ -1052,6 +1058,40 @@ mod tests {
                 message_size: 5,
                 max_size: 4,
             } if capability == cap
+        ));
+    }
+
+    #[tokio::test]
+    async fn zero_message_protocol_does_not_replace_neighboring_frame_limit() {
+        let zero = Capability::new_static("aaa", 1);
+        let limited = Capability::new_static("bbb", 1);
+        let shared_capabilities = SharedCapabilities::try_new(
+            vec![Protocol::new(zero.clone(), 0), Protocol::new(limited.clone(), 1)],
+            vec![zero.clone(), limited.clone()],
+        )
+        .unwrap();
+        let zero_shared = shared_capabilities.find(&zero).unwrap().clone();
+        let limited_shared = shared_capabilities.find(&limited).unwrap().clone();
+        assert_eq!(zero_shared.message_id_offset(), limited_shared.message_id_offset());
+
+        let mut encoder = snap::raw::Encoder::new();
+        let mut scratch = Vec::new();
+        let oversized =
+            compress_frame(&mut encoder, &mut scratch, limited_shared.message_id_offset(), &[0; 4])
+                .unwrap();
+        let transport =
+            InboundTransport { incoming: VecDeque::from([BytesMut::from(oversized.as_ref())]) };
+        let mut stream = P2PStream::new(transport, shared_capabilities);
+        stream.set_protocol_ingress_limits(&limited_shared, ProtocolIngressLimits::new(4));
+        stream.set_protocol_ingress_limits(&zero_shared, ProtocolIngressLimits::new(1));
+
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap_err(),
+            P2PStreamError::SubprotocolMessageTooBig {
+                capability,
+                message_size: 5,
+                max_size: 4,
+            } if capability == limited
         ));
     }
 

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -3,6 +3,7 @@ use crate::{
     disconnect::CanDisconnect,
     errors::{P2PHandshakeError, P2PStreamError},
     pinger::{Pinger, PingerEvent},
+    protocol::ProtocolIngressLimits,
     DisconnectReason, HelloMessage, HelloMessageWithProtocols,
 };
 use alloy_primitives::{
@@ -278,6 +279,9 @@ pub struct P2PStream<S> {
     /// The supported capability for this stream.
     shared_capabilities: SharedCapabilities,
 
+    /// Explicit frame limits registered by installed subprotocol handlers.
+    inbound_protocol_limits: Vec<InboundProtocolLimit>,
+
     /// Outgoing messages buffered for sending to the underlying stream.
     outgoing_messages: VecDeque<Bytes>,
 
@@ -309,6 +313,7 @@ impl<S> P2PStream<S> {
             decoder: snap::raw::Decoder::new(),
             pinger: Pinger::new(PING_INTERVAL, PING_TIMEOUT),
             shared_capabilities,
+            inbound_protocol_limits: Vec::new(),
             outgoing_messages: VecDeque::new(),
             outgoing_message_buffer_capacity: MAX_P2P_CAPACITY,
             disconnecting: false,
@@ -340,6 +345,34 @@ impl<S> P2PStream<S> {
         &self.shared_capabilities
     }
 
+    pub(crate) fn set_protocol_ingress_limits(
+        &mut self,
+        capability: &crate::capability::SharedCapability,
+        limits: ProtocolIngressLimits,
+    ) {
+        let Some(max_frame_bytes) = limits.max_frame_bytes() else { return };
+        let start = capability.message_id_offset();
+        let end = u16::from(start) + u16::from(capability.num_messages());
+        let configured = InboundProtocolLimit {
+            capability: capability.capability().into_owned(),
+            start,
+            end,
+            max_frame_bytes,
+        };
+
+        if let Some(current) =
+            self.inbound_protocol_limits.iter_mut().find(|current| current.start == start)
+        {
+            *current = configured;
+        } else {
+            self.inbound_protocol_limits.push(configured);
+        }
+    }
+
+    fn inbound_protocol_limit(&self, message_id: u8) -> Option<&InboundProtocolLimit> {
+        self.inbound_protocol_limits.iter().find(|limit| limit.contains(message_id))
+    }
+
     /// Returns `true` if the stream has outgoing capacity.
     fn has_outgoing_capacity(&self) -> bool {
         self.outgoing_messages.len() < self.outgoing_message_buffer_capacity
@@ -355,6 +388,20 @@ impl<S> P2PStream<S> {
     pub fn send_ping(&mut self) {
         self.outgoing_messages.push_back(Bytes::from_static(SNAPPY_PING_MESSAGE));
         self.needs_control_flush = true;
+    }
+}
+
+#[derive(Debug)]
+struct InboundProtocolLimit {
+    capability: crate::Capability,
+    start: u8,
+    end: u16,
+    max_frame_bytes: usize,
+}
+
+impl InboundProtocolLimit {
+    const fn contains(&self, message_id: u8) -> bool {
+        message_id >= self.start && (message_id as u16) < self.end
     }
 }
 
@@ -495,6 +542,11 @@ where
                 }
             }
 
+            if id > MAX_RESERVED_MESSAGE_ID && this.shared_capabilities.find_by_offset(id).is_none()
+            {
+                return Poll::Ready(Some(Err(P2PStreamError::UnknownSubprotocolMessageId(id))))
+            }
+
             // first check that the compressed message length does not exceed the max
             // payload size
             let decompressed_len = snap::raw::decompress_len(&bytes[1..])?;
@@ -505,9 +557,21 @@ where
                 })))
             }
 
+            let frame_len = decompressed_len + 1;
+            if let Some(limit) = this.inbound_protocol_limit(id) &&
+                frame_len > limit.max_frame_bytes
+            {
+                counter!("p2pstream.subprotocol_message_too_big").increment(1);
+                return Poll::Ready(Some(Err(P2PStreamError::SubprotocolMessageTooBig {
+                    capability: limit.capability.clone(),
+                    message_size: frame_len,
+                    max_size: limit.max_frame_bytes,
+                })))
+            }
+
             // create a buffer to hold the decompressed message, adding a byte to the length for
             // the message ID byte, which is the first byte in this buffer
-            let mut decompress_buf = BytesMut::zeroed(decompressed_len + 1);
+            let mut decompress_buf = BytesMut::zeroed(frame_len);
 
             // each message following a successful handshake is compressed with snappy, so we need
             // to decompress the message before we can decode it.
@@ -869,8 +933,8 @@ fn compress_frame(
 mod tests {
     use super::*;
     use crate::{
-        capability::SharedCapability, test_utils::eth_hello, Capability, EthVersion,
-        ProtocolVersion,
+        capability::SharedCapability, protocol::Protocol, test_utils::eth_hello, Capability,
+        EthVersion, ProtocolVersion,
     };
     use futures::task::noop_waker_ref;
     use tokio::net::{TcpListener, TcpStream};
@@ -881,6 +945,39 @@ mod tests {
     struct FlushCountingTransport {
         sent: Vec<Bytes>,
         flushes: usize,
+    }
+
+    #[derive(Default)]
+    struct InboundTransport {
+        incoming: VecDeque<BytesMut>,
+    }
+
+    impl Stream for InboundTransport {
+        type Item = io::Result<BytesMut>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.incoming.pop_front().map(Ok))
+        }
+    }
+
+    impl Sink<Bytes> for InboundTransport {
+        type Error = io::Error;
+
+        fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Bytes) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
     }
 
     impl Stream for FlushCountingTransport {
@@ -922,6 +1019,40 @@ mod tests {
             vec![Capability::eth(EthVersion::Eth68)],
         )
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn rejects_subprotocol_frame_before_decompression_when_declared_size_exceeds_limit() {
+        let cap = Capability::new_static("test", 1);
+        let shared_capabilities =
+            SharedCapabilities::try_new(vec![Protocol::new(cap.clone(), 1)], vec![cap.clone()])
+                .unwrap();
+        let shared_capability = shared_capabilities.find(&cap).unwrap().clone();
+        let wire_id = shared_capability.message_id_offset();
+        let mut encoder = snap::raw::Encoder::new();
+        let mut scratch = Vec::new();
+        let accepted = compress_frame(&mut encoder, &mut scratch, wire_id, &[0; 3]).unwrap();
+        let oversized = compress_frame(&mut encoder, &mut scratch, wire_id, &[0; 4]).unwrap();
+        let transport = InboundTransport {
+            incoming: [accepted, oversized]
+                .into_iter()
+                .map(|frame| BytesMut::from(frame.as_ref()))
+                .collect(),
+        };
+        let mut stream = P2PStream::new(transport, shared_capabilities);
+        stream.set_protocol_ingress_limits(&shared_capability, ProtocolIngressLimits::new(4));
+
+        let frame = stream.next().await.unwrap().unwrap();
+        assert_eq!(frame.len(), 4);
+
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap_err(),
+            P2PStreamError::SubprotocolMessageTooBig {
+                capability,
+                message_size: 5,
+                max_size: 4,
+            } if capability == cap
+        ));
     }
 
     #[tokio::test]

--- a/crates/net/eth-wire/src/protocol.rs
+++ b/crates/net/eth-wire/src/protocol.rs
@@ -69,6 +69,87 @@ impl Protocol {
     }
 }
 
+/// Local limits for inbound messages of an `RLPx` subprotocol.
+///
+/// These limits are not advertised to the remote peer and do not affect message ID negotiation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProtocolIngressLimits {
+    max_frame_bytes: Option<usize>,
+    max_buffered_bytes: usize,
+    max_buffered_messages: usize,
+}
+
+impl ProtocolIngressLimits {
+    /// Default byte budget for messages waiting to be polled by a protocol connection.
+    pub const DEFAULT_MAX_BUFFERED_BYTES: usize = 32 * 1024 * 1024;
+
+    /// Default message budget for messages waiting to be polled by a protocol connection.
+    pub const DEFAULT_MAX_BUFFERED_MESSAGES: usize = 1024;
+
+    /// Creates limits with an explicit maximum inbound frame size.
+    ///
+    /// The frame size includes the capability-local message ID byte.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_frame_bytes` is zero.
+    pub const fn new(max_frame_bytes: usize) -> Self {
+        assert!(max_frame_bytes > 0, "maximum frame size must be non-zero");
+        Self { max_frame_bytes: Some(max_frame_bytes), ..Self::default_values() }
+    }
+
+    /// Sets the maximum number of buffered frame bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_buffered_bytes` is zero.
+    pub const fn with_max_buffered_bytes(mut self, max_buffered_bytes: usize) -> Self {
+        assert!(max_buffered_bytes > 0, "maximum buffered bytes must be non-zero");
+        self.max_buffered_bytes = max_buffered_bytes;
+        self
+    }
+
+    /// Sets the maximum number of buffered messages.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_buffered_messages` is zero.
+    pub const fn with_max_buffered_messages(mut self, max_buffered_messages: usize) -> Self {
+        assert!(max_buffered_messages > 0, "maximum buffered messages must be non-zero");
+        self.max_buffered_messages = max_buffered_messages;
+        self
+    }
+
+    /// Returns the explicit maximum inbound frame size, if configured.
+    pub const fn max_frame_bytes(&self) -> Option<usize> {
+        self.max_frame_bytes
+    }
+
+    /// Returns the maximum number of buffered frame bytes.
+    pub const fn max_buffered_bytes(&self) -> usize {
+        self.max_buffered_bytes
+    }
+
+    /// Returns the maximum number of buffered messages.
+    pub const fn max_buffered_messages(&self) -> usize {
+        self.max_buffered_messages
+    }
+
+    const fn default_values() -> Self {
+        Self {
+            max_frame_bytes: None,
+            max_buffered_bytes: Self::DEFAULT_MAX_BUFFERED_BYTES,
+            max_buffered_messages: Self::DEFAULT_MAX_BUFFERED_MESSAGES,
+        }
+    }
+}
+
+impl Default for ProtocolIngressLimits {
+    fn default() -> Self {
+        Self::default_values()
+    }
+}
+
 impl From<EthVersion> for Protocol {
     fn from(version: EthVersion) -> Self {
         Self::eth(version)

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -149,7 +149,6 @@ impl SessionError for EthStreamError {
                             )
                     ) | P2PStreamError::UnknownReservedMessageId(_) |
                         P2PStreamError::UnknownSubprotocolMessageId(_) |
-                        P2PStreamError::SubprotocolMessageTooBig { .. } |
                         P2PStreamError::EmptyProtocolMessage |
                         P2PStreamError::ParseSharedCapability(_) |
                         P2PStreamError::CapabilityNotShared |
@@ -354,17 +353,24 @@ mod tests {
     #[test]
     fn subprotocol_ingress_errors_have_distinct_reputation_outcomes() {
         let capability = reth_eth_wire::Capability::new_static("test", 1);
+        let unknown =
+            EthStreamError::P2PStreamError(P2PStreamError::UnknownSubprotocolMessageId(0xff));
+        assert!(unknown.is_protocol_breach());
+        assert!(unknown.is_fatal_protocol_error());
+
         let oversized = EthStreamError::P2PStreamError(P2PStreamError::SubprotocolMessageTooBig {
             capability: capability.clone(),
             message_size: 5,
             max_size: 4,
         });
-        assert!(oversized.is_fatal_protocol_error());
+        assert!(!oversized.is_protocol_breach());
+        assert!(!oversized.is_fatal_protocol_error());
         assert_eq!(oversized.should_backoff(), Some(BackoffKind::Medium));
 
         let full = EthStreamError::P2PStreamError(P2PStreamError::SubprotocolInboundBufferFull {
             capability,
         });
+        assert!(!full.is_protocol_breach());
         assert!(!full.is_fatal_protocol_error());
         assert_eq!(full.should_backoff(), Some(BackoffKind::Low));
     }

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -148,6 +148,8 @@ impl SessionError for EthStreamError {
                                     DisconnectReason::ProtocolBreach
                             )
                     ) | P2PStreamError::UnknownReservedMessageId(_) |
+                        P2PStreamError::UnknownSubprotocolMessageId(_) |
+                        P2PStreamError::SubprotocolMessageTooBig { .. } |
                         P2PStreamError::EmptyProtocolMessage |
                         P2PStreamError::ParseSharedCapability(_) |
                         P2PStreamError::CapabilityNotShared |
@@ -220,12 +222,17 @@ impl SessionError for EthStreamError {
             Self::P2PStreamError(
                 P2PStreamError::Rlp(_) |
                 P2PStreamError::UnknownReservedMessageId(_) |
+                P2PStreamError::UnknownSubprotocolMessageId(_) |
                 P2PStreamError::UnknownDisconnectReason(_) |
                 P2PStreamError::MessageTooBig { .. } |
+                P2PStreamError::SubprotocolMessageTooBig { .. } |
                 P2PStreamError::EmptyProtocolMessage |
                 P2PStreamError::PingerError(_) |
                 P2PStreamError::Snap(_),
             ) => Some(BackoffKind::Medium),
+            Self::P2PStreamError(P2PStreamError::SubprotocolInboundBufferFull { .. }) => {
+                Some(BackoffKind::Low)
+            }
             Self::EthHandshakeError(EthHandshakeError::InvalidFork(_)) => {
                 // the remote can come back online after updating client version, so we can back off
                 // for a bit
@@ -342,6 +349,24 @@ mod tests {
             P2PHandshakeError::NoResponse,
         ));
         assert_eq!(err.should_backoff(), Some(BackoffKind::Low));
+    }
+
+    #[test]
+    fn subprotocol_ingress_errors_have_distinct_reputation_outcomes() {
+        let capability = reth_eth_wire::Capability::new_static("test", 1);
+        let oversized = EthStreamError::P2PStreamError(P2PStreamError::SubprotocolMessageTooBig {
+            capability: capability.clone(),
+            message_size: 5,
+            max_size: 4,
+        });
+        assert!(oversized.is_fatal_protocol_error());
+        assert_eq!(oversized.should_backoff(), Some(BackoffKind::Medium));
+
+        let full = EthStreamError::P2PStreamError(P2PStreamError::SubprotocolInboundBufferFull {
+            capability,
+        });
+        assert!(!full.is_fatal_protocol_error());
+        assert_eq!(full.should_backoff(), Some(BackoffKind::Low));
     }
 
     #[test]

--- a/crates/net/network/src/protocol.rs
+++ b/crates/net/network/src/protocol.rs
@@ -5,7 +5,9 @@
 use alloy_primitives::bytes::BytesMut;
 use futures::Stream;
 use reth_eth_wire::{
-    capability::SharedCapabilities, multiplex::ProtocolConnection, protocol::Protocol,
+    capability::SharedCapabilities,
+    multiplex::ProtocolConnection,
+    protocol::{Protocol, ProtocolIngressLimits},
 };
 use reth_network_api::{Direction, PeerId};
 use std::{
@@ -49,6 +51,11 @@ pub trait ConnectionHandler: Send + Sync + 'static {
     ///
     /// This will be negotiated with the remote peer.
     fn protocol(&self) -> Protocol;
+
+    /// Returns local resource limits for inbound messages of this protocol.
+    fn inbound_limits(&self) -> ProtocolIngressLimits {
+        ProtocolIngressLimits::default()
+    }
 
     /// Invoked when the `RLPx` connection has been established by the peer does not share the
     /// protocol.
@@ -200,6 +207,8 @@ impl<T: ProtocolHandler> DynProtocolHandler for T {
 pub(crate) trait DynConnectionHandler: Send + Sync + 'static {
     fn protocol(&self) -> Protocol;
 
+    fn inbound_limits(&self) -> ProtocolIngressLimits;
+
     fn on_unsupported_by_peer(
         self: Box<Self>,
         supported: &SharedCapabilities,
@@ -218,6 +227,10 @@ pub(crate) trait DynConnectionHandler: Send + Sync + 'static {
 impl<T: ConnectionHandler> DynConnectionHandler for T {
     fn protocol(&self) -> Protocol {
         T::protocol(self)
+    }
+
+    fn inbound_limits(&self) -> ProtocolIngressLimits {
+        T::inbound_limits(self)
     }
 
     fn on_unsupported_by_peer(

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1244,11 +1244,12 @@ async fn authenticate_stream<N: NetworkPrimitives>(
 
         // install additional handlers
         for handler in extra_handlers.into_iter() {
-            let cap = handler.protocol().cap;
+            let protocol = handler.protocol();
+            let limits = handler.inbound_limits();
             let remote_peer_id = authenticated_peer_id;
 
             multiplex_stream
-                .install_protocol(&cap, move |conn| {
+                .install_protocol_with_limits(&protocol.cap, limits, move |conn| {
                     handler.into_connection(direction, remote_peer_id, conn)
                 })
                 .ok();


### PR DESCRIPTION
Limit inbound traffic for multiplexed RLPx subprotocols by replacing
unbounded channels with bounded per-protocol queues. Default each queue
to 1,024 messages and 32 MiB, enforce a shared 32 MiB byte budget across
all protocol queues on a connection, and let custom handlers configure
tighter frame and buffering limits.

Use 32 MiB to match the payload volume already accommodated by the lower
layers. RLPx caps decompressed payloads at 16 MiB, the P2P sink admits
two messages, and the multiplexer uses the same 32 MiB bound for
outbound buffering. Keep a separate message-count limit to constrain
floods of small frames.

Reject frames over an explicit protocol limit using Snappy's declared
decompressed size before allocating the output buffer. Charge queued
allocation capacity against both protocol and connection budgets, then
release those reservations when the handler receives the frame.
Register limits by capability and ignore zero-message ranges so shared
offsets cannot overwrite another protocol's policy.

Return through protocol polling between delivered subprotocol frames
during handshake and established sessions, and yield the connection
task after 32 delegated messages. Surface oversized frames, exhausted
queues, and out-of-range message IDs through dedicated P2P errors with
distinct peer backoff behavior.




---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>