### PR TITLE
refactor(engine): merge StateProviderBuilder into OverlayStateProviderFactory

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -13,8 +13,7 @@ use alloy_rpc_types_engine::{
 };
 use error::{InsertBlockError, InsertBlockFatalError, InsertBlockValidationError};
 use reth_chain_state::{
-    CanonicalInMemoryState, ExecutedBlock, ExecutionTimingStats, MemoryOverlayStateProvider,
-    NewCanonicalChain,
+    CanonicalInMemoryState, ExecutedBlock, ExecutionTimingStats, NewCanonicalChain,
 };
 use reth_consensus::{Consensus, FullConsensus};
 use reth_engine_primitives::{
@@ -29,15 +28,14 @@ use reth_primitives_traits::{
     FastInstant as Instant, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 use reth_provider::{
-    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockNumReader, BlockReader,
-    ChangeSetReader, DatabaseProviderFactory, LatestStateProvider, ProviderError,
-    PruneCheckpointReader, SaveBlocksInput, StageCheckpointReader, StateProviderBox,
-    StateProviderFactory, StateReader, StorageChangeSetReader, StorageSettingsCache,
-    TransactionVariant, TryIntoHistoricalStateProvider,
+    BalProvider, BlockExecutionOutput, BlockExecutionResult, BlockReader, ChangeSetReader,
+    DatabaseProviderFactory, ProviderError, PruneCheckpointReader, SaveBlocksInput,
+    StageCheckpointReader, StateProviderFactory, StateReader, StorageChangeSetReader,
+    StorageSettingsCache, TransactionVariant, TryIntoHistoricalStateProvider,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::ControlFlow;
-use reth_storage_overlay::OverlayManager;
+use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie::ComputedTrieData;
 use revm::interpreter::debug_unreachable;
@@ -111,67 +109,6 @@ pub(crate) const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = EPOCH_SLOTS;
 /// This ensures that recent changesets are kept in memory for potential reorgs,
 /// even when the finalized block is not set (e.g., on L2s like Optimism).
 const CHANGESET_CACHE_RETENTION_BLOCKS: u64 = 64;
-
-/// A builder for creating state providers that can be used across threads.
-#[derive(Clone, Debug)]
-pub struct StateProviderBuilder<N: NodePrimitives, P> {
-    /// The provider factory used to create providers.
-    provider_factory: P,
-    /// Hash of the block whose state to provide.
-    parent_hash: B256,
-    /// Tracks the in-memory parent chain and its overlays.
-    overlay_manager: OverlayManager<N>,
-}
-
-impl<N: NodePrimitives, P> StateProviderBuilder<N, P> {
-    /// Creates a new state provider builder for `parent_hash`.
-    pub const fn new(
-        provider_factory: P,
-        parent_hash: B256,
-        overlay_manager: OverlayManager<N>,
-    ) -> Self {
-        Self { provider_factory, parent_hash, overlay_manager }
-    }
-}
-
-impl<N: NodePrimitives, P> StateProviderBuilder<N, P>
-where
-    P: DatabaseProviderFactory,
-    P::Provider: BlockNumReader
-        + PruneCheckpointReader
-        + StageCheckpointReader
-        + StorageSettingsCache
-        + TryIntoHistoricalStateProvider
-        + 'static,
-{
-    /// Creates a new state provider from this builder.
-    pub fn build(&self) -> ProviderResult<StateProviderBox> {
-        let overlay_builder = self.overlay_manager.overlay_builder(self.parent_hash);
-        let provider = self.provider_factory.database_provider_ro()?;
-        let anchor = overlay_builder.anchor_at_parent(&provider)?;
-        let (provider, overlay): (StateProviderBox, _) = match anchor {
-            reth_storage_overlay::AnchorForParent::NoReverts { anchor, overlay } => {
-                debug!(
-                    target: "engine::tree",
-                    parent_hash = %self.parent_hash,
-                    ?anchor,
-                    "creating state provider from latest state"
-                );
-                (Box::new(LatestStateProvider::new(provider)), overlay)
-            }
-            reth_storage_overlay::AnchorForParent::RevertsRequired { anchor, overlay, .. } => {
-                debug!(
-                    target: "engine::tree",
-                    parent_hash = %self.parent_hash,
-                    ?anchor,
-                    "creating state provider from historical state"
-                );
-                (provider.try_into_history_at_block(anchor.number)?, overlay)
-            }
-        };
-        Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
-    }
-}
 
 /// Tracks the state of the engine api internals.
 ///
@@ -3185,7 +3122,7 @@ where
         }
 
         // Ensure that the parent state is available.
-        match self.state_provider_builder(block_id.parent) {
+        match self.overlay_factory(block_id.parent) {
             Err(err) => {
                 let block = convert_to_block(self, input)?;
                 return Err(InsertBlockError::new(block, err.into()).into());
@@ -3565,14 +3502,14 @@ where
         Ok(())
     }
 
-    /// Returns a builder for creating state providers for the given hash.
+    /// Returns an [`OverlayStateProviderFactory`] for the given hash.
     ///
     /// This is an optimization for parallel execution contexts where we want to avoid
     /// creating state providers in the critical path.
-    pub fn state_provider_builder(
+    pub fn overlay_factory(
         &self,
         hash: B256,
-    ) -> ProviderResult<Option<StateProviderBuilder<N, P>>>
+    ) -> ProviderResult<Option<OverlayStateProviderFactory<P, N>>>
     where
         P: BlockReader + StateProviderFactory + StateReader + Clone,
     {
@@ -3581,10 +3518,9 @@ where
             return Ok(None)
         }
 
-        Ok(Some(StateProviderBuilder::new(
+        Ok(Some(OverlayStateProviderFactory::new(
             self.provider.clone(),
-            hash,
-            self.state.tree_state.overlay_manager.clone(),
+            self.state.tree_state.overlay_manager.overlay_builder(hash),
         )))
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -68,8 +68,8 @@ impl BalPrewarmPool {
         Arc::new(Self { workers, next: AtomicUsize::new(0), _handles: handles })
     }
 
-    /// Begins a block: hands every worker the provider builder and shared cache so each opens its
-    /// own read txn over the parent state. Pair with [`end_block`](Self::end_block).
+    /// Begins a block: hands every worker the provider-building closure and shared cache so each
+    /// opens its own read txn over the parent state. Pair with [`end_block`](Self::end_block).
     pub(crate) fn begin_block(
         &self,
         build: Arc<BuildProviderFn>,

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -4,7 +4,7 @@ use super::precompile_cache::PrecompileCacheMap;
 use crate::tree::{
     payload_processor::prewarm::{PrewarmCacheTask, PrewarmContext, PrewarmMode, PrewarmTaskEvent},
     CachedStateCacheMetrics, CachedStateMetrics, CachedStateMetricsSource, ExecutionCache,
-    ExecutionEnv, PayloadExecutionCache, SavedCache, StateProviderBuilder, TreeConfig,
+    ExecutionEnv, PayloadExecutionCache, SavedCache, TreeConfig,
 };
 use alloy_eips::eip1898::BlockWithParent;
 use alloy_primitives::B256;
@@ -18,10 +18,11 @@ use reth_evm::{
 };
 use reth_primitives_traits::{FastInstant as Instant, NodePrimitives};
 use reth_provider::{
-    BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory, PruneCheckpointReader,
-    StageCheckpointReader, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory, IntoLatestStateProvider,
+    PruneCheckpointReader, StageCheckpointReader, TryIntoHistoricalStateProvider,
 };
 use reth_revm::db::BundleState;
+use reth_storage_overlay::OverlayStateProviderFactory;
 use reth_tasks::Runtime;
 pub use reth_trie_parallel::{
     error::StateRootTaskError,
@@ -169,7 +170,7 @@ where
         &self,
         env: ExecutionEnv<Evm>,
         transactions: I,
-        provider_builder: StateProviderBuilder<Evm::Primitives, P>,
+        overlay_factory: OverlayStateProviderFactory<P, Evm::Primitives>,
         hint_stream: Option<StateRootHintStream>,
         hashed_update_stream: Option<StateRootUpdateStream>,
         parallel_bal_execution: bool,
@@ -179,7 +180,7 @@ where
         P::Provider: BlockNumReader
             + PruneCheckpointReader
             + StageCheckpointReader
-            + StorageSettingsCache
+            + IntoLatestStateProvider
             + TryIntoHistoricalStateProvider
             + 'static,
     {
@@ -188,7 +189,7 @@ where
         let prewarm_handle = self.spawn_caching_with(
             env,
             prewarm_rx,
-            provider_builder,
+            overlay_factory,
             hint_stream,
             hashed_update_stream,
             parallel_bal_execution,
@@ -339,7 +340,7 @@ where
         &self,
         env: ExecutionEnv<Evm>,
         transactions: mpsc::Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
-        provider_builder: StateProviderBuilder<Evm::Primitives, P>,
+        overlay_factory: OverlayStateProviderFactory<P, Evm::Primitives>,
         hint_stream: Option<StateRootHintStream>,
         hashed_update_stream: Option<StateRootUpdateStream>,
         parallel_bal_execution: bool,
@@ -349,7 +350,7 @@ where
         P::Provider: BlockNumReader
             + PruneCheckpointReader
             + StageCheckpointReader
-            + StorageSettingsCache
+            + IntoLatestStateProvider
             + TryIntoHistoricalStateProvider
             + 'static,
     {
@@ -375,7 +376,7 @@ where
             env,
             evm_config: self.evm_config.clone(),
             saved_cache: saved_cache.clone(),
-            provider: provider_builder,
+            provider: overlay_factory,
             bal_prewarm_pool: parallel_bal_execution.then(|| self.bal_prewarm_pool()),
             metrics: PrewarmMetrics::default(),
             cache_metrics: self.cache_metrics.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -376,7 +376,7 @@ where
             env,
             evm_config: self.evm_config.clone(),
             saved_cache: saved_cache.clone(),
-            provider: overlay_factory,
+            overlay_factory,
             bal_prewarm_pool: parallel_bal_execution.then(|| self.bal_prewarm_pool()),
             metrics: PrewarmMetrics::default(),
             cache_metrics: self.cache_metrics.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -15,7 +15,7 @@ use super::{bal_prewarm_pool::BalPrewarmPool, StateRootHintStream, StateRootUpda
 use crate::tree::{
     precompile_cache::{CachedPrecompile, PrecompileCacheMap},
     CachedStateCacheMetrics, CachedStateMetrics, CachedStateProvider, ExecutionEnv,
-    PayloadExecutionCache, SavedCache, StateProviderBuilder,
+    PayloadExecutionCache, SavedCache,
 };
 use alloy_consensus::transaction::TxHashRef;
 use alloy_eip7928::bal::DecodedBal;
@@ -28,10 +28,11 @@ use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
     AccountReader, BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory,
-    PruneCheckpointReader, StageCheckpointReader, StorageSettingsCache,
+    IntoLatestStateProvider, PruneCheckpointReader, StageCheckpointReader,
     TryIntoHistoricalStateProvider,
 };
 use reth_revm::database::StateProviderDatabase;
+use reth_storage_overlay::OverlayStateProviderFactory;
 use reth_tasks::{pool::WorkerPool, Runtime};
 use reth_trie_common::MultiProofTargetsV2;
 use std::sync::{
@@ -96,7 +97,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
@@ -418,8 +419,8 @@ where
             // This runs side-by-side with the parallel transaction execution reducing the time it
             // spends blocking on the data.
             let caches = saved_cache.cache().clone();
-            let provider_builder = ctx.provider.clone();
-            let build = Arc::new(move || provider_builder.build());
+            let overlay_factory = ctx.provider.clone();
+            let build = Arc::new(move || overlay_factory.state_provider());
 
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
             for account in prefetch_bal.as_bal() {
@@ -533,7 +534,7 @@ where
     /// The saved cache.
     pub saved_cache: Option<SavedCache>,
     /// Provider to obtain the state
-    pub provider: StateProviderBuilder<N, P>,
+    pub provider: OverlayStateProviderFactory<P, N>,
     /// Dedicated blocking pool for warming the BAL read-set. `Some` only on the BAL parallel
     /// execution path; the pool is owned by the [`PayloadProcessor`](super::PayloadProcessor).
     pub(crate) bal_prewarm_pool: Option<Arc<BalPrewarmPool>>,
@@ -573,7 +574,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
@@ -581,7 +582,7 @@ where
     /// Creates a per-thread EVM for prewarming.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn evm_for_ctx(&self) -> PrewarmEvmState<Evm> {
-        let mut state_provider = match self.provider.build() {
+        let mut state_provider = match self.provider.state_provider() {
             Ok(provider) => provider,
             Err(err) => {
                 trace!(
@@ -701,7 +702,7 @@ where
                 )
                 .entered();
 
-                let inner = match self.provider.build() {
+                let inner = match self.provider.state_provider() {
                     Ok(p) => p,
                     Err(err) => {
                         warn!(

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -419,7 +419,7 @@ where
             // This runs side-by-side with the parallel transaction execution reducing the time it
             // spends blocking on the data.
             let caches = saved_cache.cache().clone();
-            let overlay_factory = ctx.provider.clone();
+            let overlay_factory = ctx.overlay_factory.clone();
             let build = Arc::new(move || overlay_factory.state_provider());
 
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
@@ -533,8 +533,8 @@ where
     pub evm_config: Evm,
     /// The saved cache.
     pub saved_cache: Option<SavedCache>,
-    /// Provider to obtain the state
-    pub provider: OverlayStateProviderFactory<P, N>,
+    /// Factory for creating state providers over the parent state.
+    pub overlay_factory: OverlayStateProviderFactory<P, N>,
     /// Dedicated blocking pool for warming the BAL read-set. `Some` only on the BAL parallel
     /// execution path; the pool is owned by the [`PayloadProcessor`](super::PayloadProcessor).
     pub(crate) bal_prewarm_pool: Option<Arc<BalPrewarmPool>>,
@@ -582,7 +582,7 @@ where
     /// Creates a per-thread EVM for prewarming.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn evm_for_ctx(&self) -> PrewarmEvmState<Evm> {
-        let mut state_provider = match self.provider.state_provider() {
+        let mut state_provider = match self.overlay_factory.state_provider() {
             Ok(provider) => provider,
             Err(err) => {
                 trace!(
@@ -702,7 +702,7 @@ where
                 )
                 .entered();
 
-                let inner = match self.provider.state_provider() {
+                let inner = match self.overlay_factory.state_provider() {
                     Ok(p) => p,
                     Err(err) => {
                         warn!(

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -103,7 +103,7 @@ use crate::tree::{
     txpool_prewarm,
     types::{InsertPayloadResult, ValidationOutput},
     CacheWaitDurations, CachedStateProvider, EngineApiMetrics, EngineApiTreeState, ExecutionEnv,
-    PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
+    PayloadHandle, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
 use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash, BlockAccessList};
@@ -147,9 +147,9 @@ use reth_primitives_traits::{
 };
 use reth_provider::{
     BlockExecutionOutput, BlockReader, ChangeSetReader, DatabaseProviderFactory,
-    DatabaseProviderROFactory, ProviderError, PruneCheckpointReader, StageCheckpointReader,
-    StateProvider, StateProviderBox, StateProviderFactory, StateReader, StorageChangeSetReader,
-    StorageSettingsCache, TryIntoHistoricalStateProvider,
+    DatabaseProviderROFactory, IntoLatestStateProvider, ProviderError, PruneCheckpointReader,
+    StageCheckpointReader, StateProvider, StateProviderBox, StateProviderFactory, StateReader,
+    StorageChangeSetReader, StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
 use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
 use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
@@ -307,6 +307,7 @@ where
                           + ChangeSetReader
                           + StorageChangeSetReader
                           + StorageSettingsCache
+                          + IntoLatestStateProvider
                           + TryIntoHistoricalStateProvider
                           + 'static,
         > + BlockReader<Header = N::BlockHeader>
@@ -546,8 +547,7 @@ where
         trace!(target: "engine::tree::payload_validator", "Fetching block state provider");
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "state_provider").entered();
-        let Some(provider_builder) =
-            ensure_ok!(self.state_provider_builder(parent_hash, ctx.state()))
+        let Some(overlay_factory) = ensure_ok!(self.overlay_factory(parent_hash, ctx.state()))
         else {
             // this is pre-validated in the tree
             return Err(InsertBlockError::new(
@@ -591,11 +591,6 @@ where
         // Get an iterator over the transactions in the payload
         let txs = self.tx_iterator_for(&input)?;
 
-        // Create overlay factory for state-root tasks that need multiproofs.
-        let provider_factory = self.provider.clone();
-        let overlay_builder = ctx.state().tree_state.overlay_manager.overlay_builder(parent_hash);
-        let overlay_factory = OverlayStateProviderFactory::new(provider_factory, overlay_builder);
-
         let parallel_bal_execution = ensure_ok!(self.bal_path_eligible(env.decoded_bal.as_deref()));
 
         // Prepare the state-root job before execution so it can provide streaming hooks.
@@ -605,8 +600,7 @@ where
                 &self.overlay_manager,
                 &env,
                 &parent_block,
-                provider_builder.clone(),
-                overlay_factory,
+                overlay_factory.clone(),
                 &self.config,
                 parallel_bal_execution,
                 ctx.state_mut(),
@@ -631,7 +625,7 @@ where
         let mut handle = ensure_ok!(self.spawn_payload_processor(
             env.clone(),
             txs,
-            provider_builder.clone(),
+            overlay_factory.clone(),
             hint_stream,
             hashed_update_stream,
             parallel_bal_execution,
@@ -667,7 +661,7 @@ where
         // The second parameter `instrument_state_provider` controls whether we should
         // instrument the state provider with metrics.
         let make_state_provider = |fill_on_miss: bool| -> ProviderResult<StateProviderBox> {
-            let provider = provider_builder.build()?;
+            let provider = overlay_factory.state_provider()?;
             let mut provider = if let Some((caches, cache_metrics)) = &execution_cache {
                 let fill_mode = if fill_on_miss {
                     CacheFillMode::FillOnMiss
@@ -806,7 +800,7 @@ where
                 || hashed_state.get(),
                 &block,
                 &parent_block,
-                || provider_builder.build(),
+                || overlay_factory.state_provider(),
             )
         });
 
@@ -842,7 +836,7 @@ where
                     || hashed_state.get(),
                     &block,
                     &parent_block,
-                    || provider_builder.build(),
+                    || overlay_factory.state_provider(),
                 )
             });
         }
@@ -1364,7 +1358,7 @@ where
         &self,
         env: ExecutionEnv<Evm>,
         txs: T,
-        provider_builder: StateProviderBuilder<N, P>,
+        overlay_factory: OverlayStateProviderFactory<P, N>,
         hint_stream: Option<StateRootHintStream>,
         hashed_update_stream: Option<StateRootUpdateStream>,
         parallel_bal_execution: bool,
@@ -1380,7 +1374,7 @@ where
         let handle = self.payload_processor.spawn_with_state_root_streams(
             env,
             txs,
-            provider_builder,
+            overlay_factory,
             hint_stream,
             hashed_update_stream,
             parallel_bal_execution,
@@ -1391,23 +1385,22 @@ where
         Ok(handle)
     }
 
-    /// Creates a `StateProviderBuilder` for the given parent hash.
+    /// Creates an [`OverlayStateProviderFactory`] for the given parent hash.
     ///
     /// Returns `None` when the parent is neither in memory nor persisted.
-    fn state_provider_builder(
+    fn overlay_factory(
         &self,
         hash: B256,
         state: &EngineApiTreeState<N>,
-    ) -> ProviderResult<Option<StateProviderBuilder<N, P>>> {
+    ) -> ProviderResult<Option<OverlayStateProviderFactory<P, N>>> {
         if !state.tree_state.contains_hash(&hash) && self.provider.header(hash)?.is_none() {
             debug!(target: "engine::tree::payload_validator", %hash, "no canonical state found for block");
             return Ok(None)
         }
 
-        Ok(Some(StateProviderBuilder::new(
+        Ok(Some(OverlayStateProviderFactory::new(
             self.provider.clone(),
-            hash,
-            state.tree_state.overlay_manager.clone(),
+            state.tree_state.overlay_manager.overlay_builder(hash),
         )))
     }
 
@@ -1436,8 +1429,8 @@ where
         timestamp: u64,
         state: &mut EngineApiTreeState<N>,
     ) -> Option<PayloadStateRootHandle> {
-        let provider_builder = match self.state_provider_builder(parent_hash, state) {
-            Ok(Some(provider_builder)) => provider_builder,
+        let overlay_factory = match self.overlay_factory(parent_hash, state) {
+            Ok(Some(overlay_factory)) => overlay_factory,
             Ok(None) => return None,
             Err(err) => {
                 warn!(
@@ -1449,10 +1442,6 @@ where
                 return None
             }
         };
-        let overlay_factory = OverlayStateProviderFactory::new(
-            self.provider.clone(),
-            state.tree_state.overlay_manager.overlay_builder(parent_hash),
-        );
 
         match self.state_root_strategy.prepare_payload_builder(PayloadStateRootJobContext::new(
             &self.runtime,
@@ -1461,7 +1450,6 @@ where
             parent_header,
             timestamp,
             state,
-            provider_builder,
             overlay_factory,
             &self.config,
         )) {
@@ -1780,6 +1768,7 @@ where
                           + ChangeSetReader
                           + StorageChangeSetReader
                           + StorageSettingsCache
+                          + IntoLatestStateProvider
                           + TryIntoHistoricalStateProvider
                           + 'static,
         > + BlockReader<Header = N::BlockHeader>
@@ -1879,8 +1868,8 @@ where
             }
         };
 
-        let provider_builder = match self.state_provider_builder(parent.hash(), state) {
-            Ok(Some(provider_builder)) => provider_builder,
+        let overlay_factory = match self.overlay_factory(parent.hash(), state) {
+            Ok(Some(overlay_factory)) => overlay_factory,
             Ok(None) => return,
             Err(err) => {
                 trace!(
@@ -1892,7 +1881,7 @@ where
                 return
             }
         };
-        txpool_prewarm.start(parent.hash(), evm_env, provider_builder)
+        txpool_prewarm.start(parent.hash(), evm_env, overlay_factory)
     }
 
     fn payload_builder_resources(

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -56,10 +56,7 @@
 mod sparse_trie;
 
 use self::sparse_trie::{SparseTrieCacheTask, SparseTrieTaskMetrics};
-use crate::tree::{
-    metrics::BlockValidationMetrics, EngineApiTreeState, ExecutionEnv, StateProviderBuilder,
-    TreeConfig,
-};
+use crate::tree::{metrics::BlockValidationMetrics, EngineApiTreeState, ExecutionEnv, TreeConfig};
 use alloy_primitives::B256;
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
@@ -70,8 +67,8 @@ use reth_primitives_traits::{
 };
 use reth_provider::{
     BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory, DatabaseProviderROFactory,
-    HashedPostStateProvider, ProviderError, PruneCheckpointReader, StageCheckpointReader,
-    StateRootProvider, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    HashedPostStateProvider, IntoLatestStateProvider, ProviderError, PruneCheckpointReader,
+    StageCheckpointReader, StateRootProvider, TryIntoHistoricalStateProvider,
 };
 use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
 use reth_tasks::utils::increase_thread_priority;
@@ -146,7 +143,6 @@ where
     parent_header: &'a N::BlockHeader,
     timestamp: u64,
     state: &'a mut EngineApiTreeState<N>,
-    provider_builder: StateProviderBuilder<N, P>,
     overlay_factory: OverlayStateProviderFactory<P, N>,
     config: &'a TreeConfig,
 }
@@ -178,7 +174,6 @@ where
         parent_header: &'a N::BlockHeader,
         timestamp: u64,
         state: &'a mut EngineApiTreeState<N>,
-        provider_builder: StateProviderBuilder<N, P>,
         overlay_factory: OverlayStateProviderFactory<P, N>,
         config: &'a TreeConfig,
     ) -> Self {
@@ -189,7 +184,6 @@ where
             parent_header,
             timestamp,
             state,
-            provider_builder,
             overlay_factory,
             config,
         }
@@ -225,12 +219,12 @@ where
         self.executor
     }
 
-    /// Returns a clone of the state provider builder.
-    pub fn provider_builder(&self) -> StateProviderBuilder<N, P>
+    /// Returns a clone of the overlay state provider factory.
+    pub fn overlay_factory(&self) -> OverlayStateProviderFactory<P, N>
     where
         P: Clone,
     {
-        self.provider_builder.clone()
+        self.overlay_factory.clone()
     }
 
     /// Consumes the pending sparse trie prune request as in-memory parent-chain blocks, if any.
@@ -252,7 +246,6 @@ where
     overlay_manager: &'a OverlayManager<N>,
     env: &'a ExecutionEnv<Evm>,
     parent_header: &'a SealedHeader<N::BlockHeader>,
-    provider_builder: StateProviderBuilder<N, P>,
     overlay_factory: OverlayStateProviderFactory<P, N>,
     config: &'a TreeConfig,
     parallel_bal_execution: bool,
@@ -284,7 +277,6 @@ where
         overlay_manager: &'a OverlayManager<N>,
         env: &'a ExecutionEnv<Evm>,
         parent_header: &'a SealedHeader<N::BlockHeader>,
-        provider_builder: StateProviderBuilder<N, P>,
         overlay_factory: OverlayStateProviderFactory<P, N>,
         config: &'a TreeConfig,
         parallel_bal_execution: bool,
@@ -295,7 +287,6 @@ where
             overlay_manager,
             env,
             parent_header,
-            provider_builder,
             overlay_factory,
             config,
             parallel_bal_execution,
@@ -323,12 +314,12 @@ where
         self.parallel_bal_execution
     }
 
-    /// Returns a clone of the state provider builder.
-    pub fn provider_builder(&self) -> StateProviderBuilder<N, P>
+    /// Returns a clone of the overlay state provider factory.
+    pub fn overlay_factory(&self) -> OverlayStateProviderFactory<P, N>
     where
         P: Clone,
     {
-        self.provider_builder.clone()
+        self.overlay_factory.clone()
     }
 
     /// Consumes the pending sparse trie prune request as in-memory parent-chain blocks, if any.
@@ -823,7 +814,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -841,7 +832,7 @@ where
 
         if !ctx.config.use_state_root_task() {
             return Ok(PreparedStateRootJob::new(
-                Box::new(SynchronousStateRootJob { provider_builder: ctx.provider_builder }),
+                Box::new(SynchronousStateRootJob { overlay_factory: ctx.overlay_factory }),
                 None,
             ))
         }
@@ -852,7 +843,6 @@ where
             overlay_manager,
             env,
             parent_header,
-            provider_builder,
             overlay_factory,
             config,
             parallel_bal_execution,
@@ -900,7 +890,6 @@ where
         let mut prepared = PreparedStateRootJob::new(
             Box::new(SparseTrieStateRootJob {
                 handle,
-                provider_builder,
                 overlay_factory,
                 executor: executor.clone(),
                 timeout: config.state_root_task_timeout(),
@@ -984,7 +973,7 @@ impl<N: NodePrimitives> StateRootJob<N> for SkippedStateRootJob {
 
 #[derive(Debug)]
 struct SynchronousStateRootJob<N: NodePrimitives, P> {
-    provider_builder: StateProviderBuilder<N, P>,
+    overlay_factory: OverlayStateProviderFactory<P, N>,
 }
 
 impl<N, P> StateRootJob<N> for SynchronousStateRootJob<N, P>
@@ -994,7 +983,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
 {
@@ -1008,7 +997,7 @@ where
         _output: Arc<BlockExecutionOutput<N::Receipt>>,
         hashed_state: &LazyHashedPostState,
     ) -> ProviderResult<StateRootJobOutcome> {
-        let provider = self.provider_builder.clone().build()?;
+        let provider = self.overlay_factory.state_provider()?;
         let (state_root, trie_updates) =
             provider.state_root_with_updates(hashed_state.get().as_ref().clone())?;
         Ok(StateRootJobOutcome::new(state_root, Arc::new(trie_updates)))
@@ -1018,7 +1007,6 @@ where
 #[derive(Debug)]
 struct SparseTrieStateRootJob<N: NodePrimitives, P> {
     handle: StateRootHandle,
-    provider_builder: StateProviderBuilder<N, P>,
     overlay_factory: OverlayStateProviderFactory<P, N>,
     executor: reth_tasks::Runtime,
     timeout: Option<Duration>,
@@ -1033,7 +1021,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -1042,10 +1030,10 @@ where
 {
     fn serial_fallback(
         executor: &reth_tasks::Runtime,
-        provider_builder: StateProviderBuilder<N, P>,
+        overlay_factory: OverlayStateProviderFactory<P, N>,
         output: Arc<BlockExecutionOutput<N::Receipt>>,
     ) -> ProviderResult<SerialFallbackRx> {
-        let provider = provider_builder.build()?;
+        let provider = overlay_factory.state_provider()?;
         let (fallback_tx, fallback_rx) = mpsc::channel();
         executor.spawn_blocking_named("serial-root", move || {
             let result = (|| {
@@ -1068,7 +1056,7 @@ where
         &self,
         output: &BlockExecutionOutput<N::Receipt>,
     ) -> ProviderResult<StateRootJobOutcome> {
-        let provider = self.provider_builder.clone().build()?;
+        let provider = self.overlay_factory.state_provider()?;
         let hashed_state = Arc::new(provider.hashed_post_state(&output.state)?);
         let (state_root, trie_updates) =
             provider.state_root_with_updates(hashed_state.as_ref().clone())?;
@@ -1116,7 +1104,6 @@ where
 
         if self.compare_trie_updates {
             let _has_diff = compare_trie_updates_with_serial(
-                self.provider_builder.clone(),
                 self.overlay_factory.clone(),
                 output,
                 trie_updates.as_ref().clone(),
@@ -1143,7 +1130,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     OverlayStateProviderFactory<P, N>: DatabaseProviderROFactory<Provider: TrieCursorFactory + HashedCursorFactory>
@@ -1176,28 +1163,16 @@ where
             Ok(Ok(outcome)) => return self.verified_sparse_outcome(block, &output, outcome),
             Ok(Err(err)) => {
                 debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");
-                Self::serial_fallback(
-                    &self.executor,
-                    self.provider_builder.clone(),
-                    output.clone(),
-                )?
+                Self::serial_fallback(&self.executor, self.overlay_factory.clone(), output.clone())?
             }
             Err(RecvTimeoutError::Timeout) => {
                 warn!(target: "engine::tree::state_root_strategy", ?timeout, "State root task timed out, racing serial fallback");
                 self.metrics.state_root_task_timeout_total.increment(1);
-                Self::serial_fallback(
-                    &self.executor,
-                    self.provider_builder.clone(),
-                    output.clone(),
-                )?
+                Self::serial_fallback(&self.executor, self.overlay_factory.clone(), output.clone())?
             }
             Err(RecvTimeoutError::Disconnected) => {
                 debug!(target: "engine::tree::state_root_strategy", "State root task dropped, falling back to serial root");
-                Self::serial_fallback(
-                    &self.executor,
-                    self.provider_builder.clone(),
-                    output.clone(),
-                )?
+                Self::serial_fallback(&self.executor, self.overlay_factory.clone(), output.clone())?
             }
         };
 
@@ -1237,7 +1212,6 @@ where
 }
 
 fn compare_trie_updates_with_serial<N, P>(
-    state_provider_builder: StateProviderBuilder<N, P>,
     overlay_factory: OverlayStateProviderFactory<P, N>,
     output: &BlockExecutionOutput<N::Receipt>,
     task_trie_updates: TrieUpdates,
@@ -1248,7 +1222,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     OverlayStateProviderFactory<P, N>:
@@ -1256,7 +1230,7 @@ where
 {
     debug!(target: "engine::tree::state_root_strategy", "Comparing trie updates with serial computation");
 
-    match state_provider_builder.build().and_then(|provider| {
+    match overlay_factory.state_provider().and_then(|provider| {
         let hashed_state = provider.hashed_post_state(&output.state)?;
         provider.state_root_with_updates(hashed_state)
     }) {

--- a/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/mod.rs
@@ -4,15 +4,16 @@ mod control;
 mod worker;
 
 use self::control::Control;
-use crate::tree::{StateProviderBuilder, TxPoolPrewarmCacheSnapshot};
+use crate::tree::TxPoolPrewarmCacheSnapshot;
 use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{Address, B256};
 use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::{NodePrimitives, TxTy};
 use reth_provider::{
-    BlockNumReader, DatabaseProviderFactory, PruneCheckpointReader, StageCheckpointReader,
-    StorageSettingsCache, TryIntoHistoricalStateProvider,
+    BlockNumReader, DatabaseProviderFactory, IntoLatestStateProvider, PruneCheckpointReader,
+    StageCheckpointReader, TryIntoHistoricalStateProvider,
 };
+use reth_storage_overlay::OverlayStateProviderFactory;
 use std::{fmt::Debug, sync::Arc};
 
 /// Coordinates a long-lived worker and the latest completed immutable snapshot.
@@ -41,7 +42,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     Evm: ConfigureEvm<Primitives = N> + 'static,
@@ -84,9 +85,9 @@ where
         &self,
         parent_hash: B256,
         evm_env: EvmEnvFor<Evm>,
-        provider_builder: StateProviderBuilder<N, P>,
+        overlay_factory: OverlayStateProviderFactory<P, N>,
     ) {
-        self.control.start(parent_hash, Job { evm_env, provider_builder });
+        self.control.start(parent_hash, Job { evm_env, overlay_factory });
     }
 }
 
@@ -120,5 +121,5 @@ pub trait Source<N: NodePrimitives>: Send + Sync + Debug {
 /// A request to warm txpool transactions against one fully validated parent state.
 struct Job<N: NodePrimitives, P, Evm: ConfigureEvm<Primitives = N>> {
     evm_env: EvmEnvFor<Evm>,
-    provider_builder: StateProviderBuilder<N, P>,
+    overlay_factory: OverlayStateProviderFactory<P, N>,
 }

--- a/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
+++ b/crates/engine/tree/src/tree/txpool_prewarm/worker.rs
@@ -9,8 +9,8 @@ use crossbeam_channel::{Receiver, RecvTimeoutError, TryRecvError};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
-    BlockNumReader, DatabaseProviderFactory, PruneCheckpointReader, StageCheckpointReader,
-    StorageSettingsCache, TryIntoHistoricalStateProvider,
+    BlockNumReader, DatabaseProviderFactory, IntoLatestStateProvider, PruneCheckpointReader,
+    StageCheckpointReader, TryIntoHistoricalStateProvider,
 };
 use reth_revm::{cached::CachedReads, db::State};
 use std::{
@@ -70,7 +70,7 @@ where
     P::Provider: BlockNumReader
         + PruneCheckpointReader
         + StageCheckpointReader
-        + StorageSettingsCache
+        + IntoLatestStateProvider
         + TryIntoHistoricalStateProvider
         + 'static,
     Evm: ConfigureEvm<Primitives = N>,
@@ -184,7 +184,7 @@ where
             return BatchEnd::GoAgain
         }
 
-        let state_provider = match job.provider_builder.build() {
+        let state_provider = match job.overlay_factory.state_provider() {
             Ok(provider) => provider,
             Err(err) => {
                 trace!(
@@ -316,7 +316,6 @@ fn entry_counts(reads: &CachedReads) -> (usize, usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::{super::Transaction as PoolTransaction, *};
-    use crate::tree::StateProviderBuilder;
     use alloy_consensus::{transaction::Recovered, Signed, TxLegacy};
     use alloy_primitives::{Address, Signature, TxKind, U256};
     use crossbeam_channel::{unbounded, Sender};
@@ -376,10 +375,9 @@ mod tests {
             provider.add_stage_checkpoint(StageId::Finish, StageCheckpoint::new(0));
             let job = Job {
                 evm_env: Default::default(),
-                provider_builder: StateProviderBuilder::new(
+                overlay_factory: reth_storage_overlay::OverlayStateProviderFactory::new(
                     provider,
-                    parent_hash,
-                    reth_storage_overlay::OverlayManager::default(),
+                    reth_storage_overlay::OverlayManager::default().overlay_builder(parent_hash),
                 ),
             };
             self.commands.send(Command::Start { parent_hash, job }).unwrap();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -62,9 +62,10 @@ use reth_prune_types::{
 use reth_stages_types::{FinishCheckpoint, StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
-    BlockBodyIndicesProvider, BlockBodyReader, MetadataProvider, MetadataWriter,
-    NodePrimitivesProvider, StateProvider, StateReader, StateWriteConfig, StorageChangeSetReader,
-    StoragePath, StorageSettingsCache, TryIntoHistoricalStateProvider, WriteStateInput,
+    BlockBodyIndicesProvider, BlockBodyReader, IntoLatestStateProvider, MetadataProvider,
+    MetadataWriter, NodePrimitivesProvider, StateProvider, StateReader, StateWriteConfig,
+    StorageChangeSetReader, StoragePath, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    WriteStateInput,
 };
 use reth_storage_errors::provider::{ProviderResult, StaticFileWriterError};
 use reth_storage_overlay::OverlayManager;
@@ -1051,6 +1052,12 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         }
 
         Ok(Box::new(state_provider))
+    }
+}
+
+impl<TX: DbTx + 'static, N: NodeTypes> IntoLatestStateProvider for DatabaseProvider<TX, N> {
+    fn into_latest(self) -> StateProviderBox {
+        Box::new(LatestStateProvider::new(self))
     }
 }
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -1253,6 +1253,8 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> IntoLat
     for MockEthProvider<T, ChainSpec>
 {
     fn into_latest(self) -> StateProviderBox {
+        // Matches `StateProviderFactory::latest` for this mock: state reads are served from the
+        // scripted account/storage maps rather than the empty `TxMock` database.
         Box::new(self)
     }
 }

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -36,9 +36,9 @@ use reth_prune_types::{PruneCheckpoint, PruneModes, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_storage_api::{
     BlockBodyIndicesProvider, BytecodeReader, DBProvider, DatabaseProviderFactory, DbTxProvider,
-    HashedPostStateProvider, NodePrimitivesProvider, StageCheckpointReader, StateProofProvider,
-    StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
-    TryIntoHistoricalStateProvider,
+    HashedPostStateProvider, IntoLatestStateProvider, NodePrimitivesProvider,
+    StageCheckpointReader, StateProofProvider, StorageChangeSetReader, StorageRootProvider,
+    StorageSettingsCache, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::{ConsistentViewError, ProviderError, ProviderResult};
 use reth_trie::{
@@ -1246,6 +1246,14 @@ impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static>
         block_number: BlockNumber,
     ) -> ProviderResult<StateProviderBox> {
         self.history_by_block_number(block_number)
+    }
+}
+
+impl<T: NodePrimitives, ChainSpec: EthChainSpec + Send + Sync + 'static> IntoLatestStateProvider
+    for MockEthProvider<T, ChainSpec>
+{
+    fn into_latest(self) -> StateProviderBox {
+        Box::new(self)
     }
 }
 

--- a/crates/storage/provider/src/traits/full.rs
+++ b/crates/storage/provider/src/traits/full.rs
@@ -10,7 +10,7 @@ use reth_chain_state::{
 };
 use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_storage_api::{
-    NodePrimitivesProvider, StorageChangeSetReader, StorageSettingsCache,
+    IntoLatestStateProvider, NodePrimitivesProvider, StorageChangeSetReader, StorageSettingsCache,
     TryIntoHistoricalStateProvider,
 };
 use std::fmt::Debug;
@@ -25,6 +25,7 @@ pub trait FullProvider<N: NodeTypesWithDB>:
                       + ChangeSetReader
                       + StorageChangeSetReader
                       + StorageSettingsCache
+                      + IntoLatestStateProvider
                       + TryIntoHistoricalStateProvider
                       + 'static,
     > + NodePrimitivesProvider<Primitives = N::Primitives>
@@ -63,6 +64,7 @@ impl<T, N: NodeTypesWithDB> FullProvider<N> for T where
                           + ChangeSetReader
                           + StorageChangeSetReader
                           + StorageSettingsCache
+                          + IntoLatestStateProvider
                           + TryIntoHistoricalStateProvider
                           + 'static,
         > + NodePrimitivesProvider<Primitives = N::Primitives>

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -5,11 +5,12 @@ pub use crate::bal::NoopBalStore;
 use crate::{
     AccountReader, BalProvider, BalStoreHandle, BlockBodyIndicesProvider, BlockHashReader,
     BlockIdReader, BlockNumReader, BlockReader, BlockReaderIdExt, BlockSource, BytecodeReader,
-    ChangeSetReader, HashedPostStateProvider, HeaderProvider, NodePrimitivesProvider,
-    PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt, StageCheckpointReader,
-    StateProofProvider, StateProvider, StateProviderBox, StateProviderFactory,
-    StateRangeProviderFactory, StateRangeView, StateReader, StateRootProvider, StorageRootProvider,
-    TransactionVariant, TransactionsProvider, TryIntoHistoricalStateProvider,
+    ChangeSetReader, HashedPostStateProvider, HeaderProvider, IntoLatestStateProvider,
+    NodePrimitivesProvider, PruneCheckpointReader, ReceiptProvider, ReceiptProviderIdExt,
+    StageCheckpointReader, StateProofProvider, StateProvider, StateProviderBox,
+    StateProviderFactory, StateRangeProviderFactory, StateRangeView, StateReader,
+    StateRootProvider, StorageRootProvider, TransactionVariant, TransactionsProvider,
+    TryIntoHistoricalStateProvider,
 };
 
 #[cfg(feature = "db-api")]
@@ -637,6 +638,12 @@ impl<C: Send + Sync + 'static, N: NodePrimitives> TryIntoHistoricalStateProvider
         block_number: BlockNumber,
     ) -> ProviderResult<StateProviderBox> {
         self.history_by_block_number(block_number)
+    }
+}
+
+impl<C: Send + Sync + 'static, N: NodePrimitives> IntoLatestStateProvider for NoopProvider<C, N> {
+    fn into_latest(self) -> StateProviderBox {
+        Box::new(self)
     }
 }
 

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -121,6 +121,13 @@ pub trait TryIntoHistoricalStateProvider {
     ) -> ProviderResult<StateProviderBox>;
 }
 
+/// Trait implemented for database providers that can be converted into a state provider for the
+/// latest database state.
+pub trait IntoLatestStateProvider {
+    /// Returns a [`StateProvider`] for the latest database state.
+    fn into_latest(self) -> StateProviderBox;
+}
+
 /// Light wrapper that returns `StateProvider` implementations that correspond to the given
 /// `BlockNumber`, the latest state, or the pending state.
 ///

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -89,6 +89,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         }
     }
 
+    /// Returns the parent hash this builder targets.
+    pub const fn parent_hash(&self) -> B256 {
+        self.parent_hash
+    }
+
     /// Set the overlay source.
     ///
     /// This overlay will be applied on top of any reverts.

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -94,6 +94,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         self.parent_hash
     }
 
+    /// Returns true if this builder resolves overlays through the [`OverlayManager`].
+    pub(crate) const fn is_managed(&self) -> bool {
+        matches!(self.overlay_source, Some(OverlaySource::Managed))
+    }
+
     /// Set the overlay source.
     ///
     /// This overlay will be applied on top of any reverts.

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -1,6 +1,7 @@
-use crate::{database_state_frontiers, Overlay, OverlayBuilder};
+use crate::{database_state_frontiers, AnchorForParent, Overlay, OverlayBuilder};
 use alloy_primitives::{BlockHash, B256};
 use metrics::{Counter, Histogram};
+use reth_chain_state::MemoryOverlayStateProvider;
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
 use reth_errors::ProviderResult;
 use reth_ethereum_primitives::EthPrimitives;
@@ -11,8 +12,9 @@ use reth_primitives_traits::{
 };
 use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-    DatabaseProviderROFactory, DbTxProvider, PruneCheckpointReader, StageCheckpointReader,
-    StorageChangeSetReader, StorageSettingsCache,
+    DatabaseProviderROFactory, DbTxProvider, IntoLatestStateProvider, PruneCheckpointReader,
+    StageCheckpointReader, StateProviderBox, StorageChangeSetReader, StorageSettingsCache,
+    TryIntoHistoricalStateProvider,
 };
 use reth_trie::{
     hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
@@ -24,7 +26,7 @@ use reth_trie_db::{
     LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter, PackedStoragesTrie,
 };
 use std::{sync::Arc, time::Instant};
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 /// Metrics for overlay state provider factory operations.
 #[derive(Clone, Metrics)]
@@ -108,6 +110,46 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
             };
 
         Ok(overlay)
+    }
+}
+
+impl<F, N> OverlayStateProviderFactory<F, N>
+where
+    N: NodePrimitives,
+    F: DatabaseProviderFactory,
+    F::Provider: BlockNumReader
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + IntoLatestStateProvider
+        + TryIntoHistoricalStateProvider,
+{
+    /// Creates a [`reth_storage_api::StateProvider`] for this factory's parent block by layering
+    /// the in-memory parent chain on top of the latest or historical database state.
+    #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
+    pub fn state_provider(&self) -> ProviderResult<StateProviderBox> {
+        let provider = self.factory.database_provider_ro()?;
+        let anchor = self.overlay_builder.anchor_at_parent(&provider)?;
+        let (provider, overlay): (StateProviderBox, _) = match anchor {
+            AnchorForParent::NoReverts { anchor, overlay } => {
+                debug!(
+                    target: "providers::state::overlay",
+                    parent_hash = %self.overlay_builder.parent_hash(),
+                    ?anchor,
+                    "creating state provider from latest state"
+                );
+                (provider.into_latest(), overlay)
+            }
+            AnchorForParent::RevertsRequired { anchor, overlay, .. } => {
+                debug!(
+                    target: "providers::state::overlay",
+                    parent_hash = %self.overlay_builder.parent_hash(),
+                    ?anchor,
+                    "creating state provider from historical state"
+                );
+                (provider.try_into_history_at_block(anchor.number)?, overlay)
+            }
+        };
+        Ok(Box::new(MemoryOverlayStateProvider::new(provider, overlay)))
     }
 }
 

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{BlockHash, B256};
 use metrics::{Counter, Histogram};
 use reth_chain_state::MemoryOverlayStateProvider;
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
-use reth_errors::ProviderResult;
+use reth_errors::{ProviderError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_metrics::Metrics;
 use reth_primitives_traits::{
@@ -125,8 +125,15 @@ where
 {
     /// Creates a [`reth_storage_api::StateProvider`] for this factory's parent block by layering
     /// the in-memory parent chain on top of the latest or historical database state.
+    ///
+    /// Only supported for manager-backed factories: immediate overlays carry pre-merged
+    /// hashed-state/trie data for trie cursors and are not applied to state reads, so building a
+    /// state provider from such a factory would silently serve stale state.
     #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
     pub fn state_provider(&self) -> ProviderResult<StateProviderBox> {
+        if !self.overlay_builder.is_managed() {
+            return Err(ProviderError::UnsupportedProvider)
+        }
         let provider = self.factory.database_provider_ro()?;
         let anchor = self.overlay_builder.anchor_at_parent(&provider)?;
         let (provider, overlay): (StateProviderBox, _) = match anchor {


### PR DESCRIPTION
The engine tree carried two types capturing the same data: `StateProviderBuilder` (provider factory + parent hash + overlay manager) for building EVM state providers, and `OverlayStateProviderFactory` (provider factory + `OverlayBuilder`, which is parent hash + overlay manager) for building trie cursor providers. Payload validation constructed both from the same triple and threaded them side by side through the state-root strategy contexts and jobs.

This merges them: `OverlayStateProviderFactory` gains a `state_provider()` method that subsumes `StateProviderBuilder::build()`, and the engine tree passes a single factory everywhere. The latest-state conversion needed by the no-reverts path is expressed through a new `IntoLatestStateProvider` trait in `reth-storage-api`, mirroring the existing `TryIntoHistoricalStateProvider` that the reverts path already uses. `StateProviderBuilder` is removed.

No behavior change: the skip-overlay-for-reused-sparse-trie flag only affects overlay construction for trie cursors (`build_overlay_at_frontiers`), not the anchor resolution that `state_provider()` uses, so sharing one factory instance for both purposes yields the same providers as before.