### PR TITLE
ci(docker): build partial persistence nightly image

### DIFF
--- a/.github/scripts/verify_image_arch.sh
+++ b/.github/scripts/verify_image_arch.sh
@@ -42,6 +42,7 @@ verify_image() {
 
 if [[ "$TARGETS" == *"nightly"* ]]; then
     verify_image "${REGISTRY}/reth:nightly" amd64 arm64
+    verify_image "${REGISTRY}/reth:nightly-partial-persistence" amd64 arm64
     verify_image "${REGISTRY}/reth:nightly-profiling" amd64
     verify_image "${REGISTRY}/reth:nightly-edge-profiling" amd64
 else

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,6 +96,7 @@ jobs:
               echo "ethereum.tags=${REGISTRY}/reth:nightly"
               echo "ethereum.args.RETH_ENGINE_TXPOOL_PREWARMING=true"
               echo "ethereum.args.RETH_ENGINE_SENDER_RECOVERY_CACHE=true"
+              echo "ethereum-partial-persistence.tags=${REGISTRY}/reth:nightly-partial-persistence"
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,7 +35,7 @@ group "default" {
 }
 
 group "nightly" {
-  targets = ["ethereum", "ethereum-profiling"]
+  targets = ["ethereum", "ethereum-profiling", "ethereum-partial-persistence"]
 }
 
 // Base target with shared configuration
@@ -69,6 +69,16 @@ target "ethereum" {
     MANIFEST_PATH = "bin/reth"
   }
   tags = ["${REGISTRY}/reth:${TAG}"]
+}
+
+target "ethereum-partial-persistence" {
+  inherits = ["_base"]
+  args = {
+    BINARY        = "reth"
+    MANIFEST_PATH = "bin/reth"
+    FEATURES      = "partial-persistence"
+  }
+  tags = ["${REGISTRY}/reth:nightly-partial-persistence"]
 }
 
 target "ethereum-profiling" {


### PR DESCRIPTION
## Summary

- add a `nightly-partial-persistence` reth image to the scheduled nightly Bake group
- compile the image with the `partial-persistence` Cargo feature
- verify both amd64 and arm64 manifests after publishing

Prompted by: @shekhirin
