### PR TITLE
refactor(rpc): use Alloy trace chain result type

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -15,7 +15,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadV3, PraguePayloadFields,
 };
 use alloy_rpc_types_eth::TransactionRequest;
-use alloy_rpc_types_trace::geth::GethDebugTracingOptions;
+use alloy_rpc_types_trace::geth::{ChainBlockTraceResult, GethDebugTracingOptions};
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
@@ -29,7 +29,7 @@ use reth_node_core::{
 use reth_node_ethereum::EthereumNode;
 use reth_payload_primitives::BuiltPayload;
 use reth_primitives_traits::Block as _;
-use reth_rpc_api::{servers::AdminApiServer, ChainBlockTraceResult};
+use reth_rpc_api::servers::AdminApiServer;
 use reth_rpc_server_types::RpcModuleSelection;
 use reth_tasks::Runtime;
 use std::{

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -1,15 +1,15 @@
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
-use alloy_primitives::{Address, Bytes, B256, U256, U64};
+use alloy_primitives::{Address, Bytes, B256, U64};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_eth::{Account, AccountInfo, Bundle, Index, StateContext};
 use alloy_rpc_types_trace::geth::{
-    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    ChainBlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+    TraceResult,
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
-use serde::{Deserialize, Serialize};
 
 /// Debug rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
@@ -381,51 +381,4 @@ pub trait DebugApi<TxReq: RpcObject> {
         block_hash: B256,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
-}
-
-/// Results for one block emitted by a `traceChain` debug subscription.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ChainBlockTraceResult {
-    /// Block number corresponding to the trace task.
-    pub block: U256,
-    /// Block hash corresponding to the trace task.
-    pub hash: B256,
-    /// Trace results produced by the task.
-    ///
-    /// Geth leaves entries after the first transaction-level tracing failure as `null`.
-    pub traces: Vec<Option<TraceResult>>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn chain_block_trace_result_matches_geth_wire_shape() {
-        let block_hash = B256::repeat_byte(0x11);
-        let tx_hash = B256::repeat_byte(0x22);
-        let result = ChainBlockTraceResult {
-            block: U256::from(2),
-            hash: block_hash,
-            traces: vec![
-                Some(TraceResult::Error {
-                    error: "trace failed".to_string(),
-                    tx_hash: Some(tx_hash),
-                }),
-                None,
-            ],
-        };
-
-        assert_eq!(
-            serde_json::to_value(result).unwrap(),
-            serde_json::json!({
-                "block": "0x2",
-                "hash": block_hash,
-                "traces": [
-                    {"error": "trace failed", "txHash": tx_hash},
-                    null
-                ]
-            })
-        );
-    }
 }

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -32,7 +32,6 @@ mod txpool;
 mod validation;
 mod web3;
 
-pub use debug::ChainBlockTraceResult;
 pub use reth::RethJitAction;
 pub use testing::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1, TESTING_COMMIT_BLOCK_V1};
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -10,7 +10,8 @@ use alloy_rpc_types_eth::{
     state::EvmOverrides, Account, AccountInfo, BlockError, Bundle, Index, StateContext,
 };
 use alloy_rpc_types_trace::geth::{
-    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    ChainBlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+    TraceResult,
 };
 use async_trait::async_trait;
 use futures::Stream;
@@ -24,7 +25,7 @@ use reth_primitives_traits::{
     Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom, RecoveredBlock,
 };
 use reth_revm::{db::State, witness::ExecutionWitnessRecord};
-use reth_rpc_api::{ChainBlockTraceResult, DebugApiServer};
+use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},


### PR DESCRIPTION
Replaces Reth's local `ChainBlockTraceResult` with the native Alloy 2.4 type now that `debug_traceChain` has landed. This removes the duplicate wire type and keeps the RPC API, implementation, and e2e client aligned with Alloy.
