### PR TITLE
fix(net): make eth/72 announcements interoperable with geth

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -794,8 +794,13 @@ pub struct NewPooledTransactionHashes72 {
     ///
     /// Per [EIP-8070](https://eips.ethereum.org/EIPS/eip-8070), this is a `B_16`
     /// bitarray over `CELLS_PER_EXT_BLOB`; bit `i` is set when the announcer has column
-    /// `i` available for every type 3 transaction in the message. `None` encodes as RLP
-    /// `nil` and must be used when no type 3 transactions are announced.
+    /// `i` available for every type 3 transaction in the message.
+    ///
+    /// On the wire this field is always encoded as a 16 byte string, zero-filled when no
+    /// type 3 transactions are announced: go-ethereum decodes the mask into a fixed
+    /// `[16]byte` and rejects the RLP `nil` encoding the EIP text describes, so the
+    /// always-present form is the de facto network format. `None` is equivalent to a zero
+    /// mask; decoding additionally accepts the spec's `nil` encoding for compatibility.
     pub cell_mask: Option<B128>,
 }
 
@@ -831,6 +836,12 @@ impl proptest::prelude::Arbitrary for NewPooledTransactionHashes72 {
 }
 
 impl NewPooledTransactionHashes72 {
+    /// Cell mask advertising availability of every cell.
+    ///
+    /// Used when announcing blob transactions whose full sidecar is available locally, since
+    /// every cell can be computed from the complete blob data.
+    pub const ALL_CELLS_MASK: B128 = B128::repeat_byte(0xff);
+
     /// Returns a new instance with capacity for `capacity` entries and no cell mask.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -851,6 +862,9 @@ impl NewPooledTransactionHashes72 {
         self.hashes.push(*tx.tx_hash());
         self.sizes.push(tx.encode_2718_len());
         self.types.push(tx.ty());
+        if tx.is_eip4844() {
+            self.cell_mask = Some(Self::ALL_CELLS_MASK);
+        }
     }
 
     /// Appends the provided transactions
@@ -886,7 +900,7 @@ impl NewPooledTransactionHashes72 {
         self.types.as_slice().length() +
             self.sizes.length() +
             self.hashes.length() +
-            self.cell_mask.as_ref().map_or(1, Encodable::length)
+            self.cell_mask.unwrap_or_default().length()
     }
 }
 
@@ -896,11 +910,8 @@ impl Encodable for NewPooledTransactionHashes72 {
         self.types.as_slice().encode(out);
         self.sizes.encode(out);
         self.hashes.encode(out);
-        if let Some(cell_mask) = &self.cell_mask {
-            cell_mask.encode(out);
-        } else {
-            out.put_u8(alloy_rlp::EMPTY_STRING_CODE);
-        }
+        // A zero-filled mask when no cells are available, see the `cell_mask` field docs.
+        self.cell_mask.unwrap_or_default().encode(out);
     }
 
     fn length(&self) -> usize {
@@ -924,10 +935,13 @@ impl Decodable for NewPooledTransactionHashes72 {
             return Err(alloy_rlp::Error::InputTooShort)
         };
         let cell_mask = if first_byte == alloy_rlp::EMPTY_STRING_CODE {
+            // The EIP-8070 `nil` encoding, tolerated for compatibility.
             payload = &payload[1..];
             None
         } else {
-            Some(B128::decode(&mut payload)?)
+            // A zero mask is the wire representation of "no cells available", see the
+            // `cell_mask` field docs.
+            Some(B128::decode(&mut payload)?).filter(|mask| !mask.is_zero())
         };
 
         if !payload.is_empty() {
@@ -1658,6 +1672,8 @@ mod tests {
     #[test]
     fn eth_72_tx_hash_roundtrip() {
         let vectors = vec![
+            // `None` is always encoded as a zero-filled 16 byte mask, matching go-ethereum's
+            // non-optional `[16]byte` field.
             (
                 NewPooledTransactionHashes72 {
                     types: vec![],
@@ -1665,7 +1681,7 @@ mod tests {
                     hashes: vec![],
                     cell_mask: None,
                 },
-                &hex!("c480c0c080")[..],
+                &hex!("d480c0c09000000000000000000000000000000000")[..],
             ),
             (
                 NewPooledTransactionHashes72 {
@@ -1681,6 +1697,17 @@ mod tests {
         for vector in vectors {
             test_encoding_vector(vector);
         }
+    }
+
+    #[test]
+    fn eth_72_decodes_spec_nil_cell_mask() {
+        // The EIP-8070 text encodes an absent mask as the RLP empty string; decoding stays
+        // lenient even though reth never produces this form.
+        let encoded = hex!("c480c0c080");
+
+        let decoded = NewPooledTransactionHashes72::decode(&mut encoded.as_ref()).unwrap();
+
+        assert_eq!(decoded.cell_mask, None);
     }
 
     #[test]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1,6 +1,6 @@
 //! Transactions management for the p2p network.
 
-use alloy_consensus::transaction::TxHashRef;
+use alloy_consensus::{constants::EIP4844_TX_TYPE_ID, transaction::TxHashRef};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use smallvec::SmallVec;
 
@@ -517,8 +517,19 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             // Blob sidecar errors: penalize but do NOT cache the hash as bad.
             // The transaction may be valid — only the sidecar from this peer was wrong.
             // Using regular penalties means repeated offenders still get disconnected.
+            //
+            // Eth/72 peers are exempt: they elide blob payloads from `PooledTransactions`
+            // responses per EIP-8070 (cells are fetched separately), so a sidecar validation
+            // failure is expected rather than evidence of misbehavior.
             if let Some(peers) = peers {
                 for peer_id in peers {
+                    if self
+                        .peers
+                        .get(&peer_id)
+                        .is_some_and(|peer| peer.version() == EthVersion::Eth72)
+                    {
+                        continue
+                    }
                     self.report_peer_bad_transactions(peer_id);
                 }
             }
@@ -2058,7 +2069,12 @@ impl PooledTransactionsHashesBuilder {
             Self::Eth72(msg) => {
                 msg.hashes.push(*pooled_tx.hash());
                 msg.sizes.push(pooled_tx.encoded_length());
-                msg.types.push(pooled_tx.transaction.ty());
+                let ty = pooled_tx.transaction.ty();
+                msg.types.push(ty);
+                if ty == EIP4844_TX_TYPE_ID {
+                    // The pool holds the full sidecar, so every cell can be served.
+                    msg.cell_mask = Some(NewPooledTransactionHashes72::ALL_CELLS_MASK);
+                }
             }
         }
     }
@@ -2099,7 +2115,12 @@ impl PooledTransactionsHashesBuilder {
             Self::Eth72(msg) => {
                 msg.hashes.push(*tx.tx_hash());
                 msg.sizes.push(tx.propagation_size());
-                msg.types.push(tx.tx_type());
+                let ty = tx.tx_type();
+                msg.types.push(ty);
+                if ty == EIP4844_TX_TYPE_ID {
+                    // The pool holds the full sidecar, so every cell can be served.
+                    msg.cell_mask = Some(NewPooledTransactionHashes72::ALL_CELLS_MASK);
+                }
             }
         }
     }
@@ -3331,6 +3352,31 @@ mod tests {
             PropagationMode::Basic,
         );
         assert!(propagated.is_empty());
+    }
+
+    #[test]
+    fn test_eth72_hashes_builder_sets_cell_mask_for_blob_txs() {
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+
+        // no blob transactions: the mask stays unset and encodes as a zero mask
+        let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
+        builder.push(&PropagateTransaction::pool_tx(valid_eth_pool_transaction(
+            tx_gen.gen_eip1559_pooled(),
+        )));
+        let msg = builder.build();
+        assert_eq!(msg.as_eth72().unwrap().cell_mask, None);
+
+        // announcing a blob transaction advertises every cell as available
+        let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
+        builder.push(&PropagateTransaction::pool_tx(valid_eth_pool_transaction(
+            tx_gen.gen_eip1559_pooled(),
+        )));
+        builder.push_pooled(valid_eth_pool_transaction(tx_gen.gen_eip4844_pooled()));
+        let msg = builder.build();
+        assert_eq!(
+            msg.as_eth72().unwrap().cell_mask,
+            Some(NewPooledTransactionHashes72::ALL_CELLS_MASK)
+        );
     }
 
     #[tokio::test]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -518,18 +518,11 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             // The transaction may be valid — only the sidecar from this peer was wrong.
             // Using regular penalties means repeated offenders still get disconnected.
             //
-            // Eth/72 peers are exempt: they elide blob payloads from `PooledTransactions`
-            // responses per EIP-8070 (cells are fetched separately), so a sidecar validation
-            // failure is expected rather than evidence of misbehavior.
+            // Eth/72 peers cannot reach this path with an elided sidecar: their blob
+            // transactions are dropped before import in `import_transactions`, so any sidecar
+            // failure here means actual blob data failed validation.
             if let Some(peers) = peers {
                 for peer_id in peers {
-                    if self
-                        .peers
-                        .get(&peer_id)
-                        .is_some_and(|peer| peer.version() == EthVersion::Eth72)
-                    {
-                        continue
-                    }
                     self.report_peer_bad_transactions(peer_id);
                 }
             }
@@ -1434,6 +1427,23 @@ where
         for tx in &transactions {
             if source.is_broadcast() && !peer.seen_transactions.insert(*tx.tx_hash()) {
                 num_already_seen_by_peer += 1;
+            }
+        }
+
+        // Eth/72 `PooledTransactions` responses elide blob payloads from type 3 transactions per
+        // EIP-8070, so their sidecars can never validate. Drop them before touching the pool;
+        // geth equivalently diverts these bodies into a buffer that is completed with cells
+        // fetched via `GetCells`, which is not implemented yet.
+        if peer.version() == EthVersion::Eth72 {
+            let len_before = transactions.len();
+            transactions.retain(|tx| !tx.is_eip4844());
+            let dropped = len_before - transactions.len();
+            if dropped > 0 {
+                trace!(target: "net::tx",
+                    peer_id=format!("{peer_id:#}"),
+                    dropped,
+                    "dropped blob transactions from eth72 response, cell fetching not implemented"
+                );
             }
         }
 

--- a/crates/net/network/tests/it/eth72.rs
+++ b/crates/net/network/tests/it/eth72.rs
@@ -1,0 +1,210 @@
+//! Eth/72 interop tests.
+//!
+//! A raw peer speaking the go-ethereum eth/72 wire format connects to a node and exercises the
+//! announcement cell mask in both directions as well as a blob-elided `PooledTransactions`
+//! response per [EIP-8070](https://eips.ethereum.org/EIPS/eip-8070).
+
+use alloy_consensus::{
+    constants::EIP4844_TX_TYPE_ID, transaction::TxEip4844WithSidecar, Header, SignableTransaction,
+    TxEip4844,
+};
+use alloy_eips::{
+    eip2718::Encodable2718,
+    eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant},
+};
+use alloy_primitives::{Address, B256, U256};
+use futures::{SinkExt, StreamExt};
+use reth_chainspec::MAINNET;
+use reth_ecies::stream::ECIESStream;
+use reth_eth_wire::{
+    EthMessage, EthNetworkPrimitives, EthStream, EthVersion, HelloMessageWithProtocols,
+    NewPooledTransactionHashes72, P2PStream, StatusBuilder, UnauthedEthStream, UnauthedP2PStream,
+};
+use reth_eth_wire_types::{message::RequestPair, PooledTransactions};
+use reth_ethereum_forks::EthereumHardfork;
+use reth_ethereum_primitives::{Block, PooledTransactionVariant};
+use reth_network::{
+    test_utils::{NetworkEventStream, PeerConfig, Testnet},
+    transactions::config::{TransactionPropagationMode, TransactionsManagerConfig},
+    NetworkEventListenerProvider, PeersInfo,
+};
+use reth_network_peers::pk2id;
+use reth_primitives_traits::{crypto::secp256k1::sign_message, SignerRecoverable};
+use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
+use reth_transaction_pool::{
+    test_utils::TransactionGenerator, AddedTransactionOutcome, PoolTransaction, TransactionPool,
+};
+use secp256k1::{SecretKey, SECP256K1};
+use std::time::Duration;
+use tokio::net::TcpStream;
+
+type RawEthStream = EthStream<P2PStream<ECIESStream<TcpStream>>, EthNetworkPrimitives>;
+
+/// Returns the next eth message from the raw peer's stream, skipping unrelated traffic such as
+/// block range updates.
+async fn next_message(stream: &mut RawEthStream) -> EthMessage<EthNetworkPrimitives> {
+    loop {
+        let message = tokio::time::timeout(Duration::from_secs(30), stream.next())
+            .await
+            .expect("timed out awaiting eth message")
+            .expect("stream terminated")
+            .expect("stream errored");
+        if !matches!(message, EthMessage::BlockRangeUpdate(_)) {
+            return message
+        }
+    }
+}
+
+/// A signed EIP-4844 pooled transaction in the eth/72 shape: the sidecar keeps commitments and
+/// cell proof metadata while the blob payloads are elided (fetched separately via `GetCells`).
+fn blob_tx_without_blobs() -> PooledTransactionVariant {
+    let mut versioned_hash = B256::random();
+    versioned_hash.0[0] = 0x01;
+
+    let tx = TxEip4844 {
+        chain_id: 1,
+        nonce: 0,
+        gas_limit: 100_000,
+        max_fee_per_gas: 20_000_000_000,
+        max_priority_fee_per_gas: 1_000_000_000,
+        to: Address::random(),
+        value: U256::ZERO,
+        access_list: Default::default(),
+        blob_versioned_hashes: vec![versioned_hash],
+        max_fee_per_blob_gas: 20_000_000_000,
+        input: Default::default(),
+    };
+
+    let signature = sign_message(B256::random(), tx.signature_hash()).unwrap();
+    let sidecar = BlobTransactionSidecarVariant::Eip7594(BlobTransactionSidecarEip7594 {
+        blobs: vec![],
+        commitments: vec![Default::default()],
+        cell_proofs: vec![],
+    });
+
+    PooledTransactionVariant::Eip4844(
+        TxEip4844WithSidecar::from_tx_and_sidecar(tx, sidecar).into_signed(signature),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth72_blob_announcements_and_elided_pooled_response() {
+    reth_tracing::init_test_tracing();
+
+    let provider = MockEthProvider::default().with_genesis_block();
+
+    // A recent tip so the pool validator activates the blob fork checks; the network status
+    // itself stays at the genesis head.
+    let tip = Header {
+        number: 1,
+        parent_hash: MAINNET.genesis_hash(),
+        timestamp: 1_750_000_000,
+        gas_limit: 30_000_000,
+        base_fee_per_gas: Some(7),
+        excess_blob_gas: Some(0),
+        blob_gas_used: Some(0),
+        ..Default::default()
+    };
+    provider.add_block(tip.hash_slow(), Block { header: tip, body: Default::default() });
+
+    let mut net = Testnet::create_with(0, provider.clone()).await;
+    net.add_peer_with_config(PeerConfig::with_protocols(
+        provider.clone(),
+        Some(EthVersion::Eth72.into()),
+    ))
+    .await
+    .unwrap();
+
+    // Announce hashes to every peer instead of broadcasting transactions in full, so the raw
+    // peer receives `NewPooledTransactionHashes` for non-blob transactions as well.
+    let tx_manager_config = TransactionsManagerConfig {
+        propagation_mode: TransactionPropagationMode::Max(0),
+        ..Default::default()
+    };
+    let net = net.with_eth_pool_config(tx_manager_config);
+    let handle = net.spawn();
+
+    let node = &handle.peers()[0];
+    let node_id = *node.peer_id();
+    let node_pool = node.pool().unwrap();
+    let mut events = NetworkEventStream::new(node.network().event_listener());
+
+    // connect a raw eth/72 peer
+    let raw_key = SecretKey::new(&mut rand_08::thread_rng());
+    let raw_id = pk2id(&raw_key.public_key(SECP256K1));
+
+    let tcp = TcpStream::connect(node.local_addr()).await.unwrap();
+    let ecies = ECIESStream::connect(tcp, raw_key, node_id).await.unwrap();
+    let hello = HelloMessageWithProtocols::builder(raw_id)
+        .protocols(vec![EthVersion::Eth72.into()])
+        .build();
+    let (p2p, _their_hello) = UnauthedP2PStream::new(ecies).handshake(hello).await.unwrap();
+    let version = p2p.shared_capabilities().eth_version().unwrap();
+    assert_eq!(version, EthVersion::Eth72);
+
+    let mut status = StatusBuilder::default().build();
+    status.set_eth_version(version);
+    let fork_filter = MAINNET.hardfork_fork_filter(EthereumHardfork::Frontier).unwrap();
+    let (mut eth_stream, _their_status) = UnauthedEthStream::new(p2p)
+        .handshake::<EthNetworkPrimitives>(status, fork_filter)
+        .await
+        .unwrap();
+
+    assert_eq!(events.next_session_established().await.unwrap(), raw_id);
+    let baseline_reputation = node.peer_handle().peer_by_id(raw_id).await.unwrap().reputation();
+
+    // 1) node -> raw peer: a plain pending transaction is announced with the eth/72 message
+    let mut tx_gen = TransactionGenerator::new(rand::rng());
+    let tx = tx_gen.gen_eip1559_pooled();
+    provider.add_account(tx.sender(), ExtendedAccount::new(0, U256::from(100_000_000u64)));
+    let AddedTransactionOutcome { hash: pending_hash, .. } =
+        node_pool.add_external_transaction(tx).await.unwrap();
+
+    let announcement = match next_message(&mut eth_stream).await {
+        EthMessage::NewPooledTransactionHashes72(announcement) => announcement,
+        message => panic!("unexpected message {message:?}"),
+    };
+    assert_eq!(announcement.hashes, vec![pending_hash]);
+    // no blob transactions were announced: the zero cell mask on the wire decodes to `None`
+    assert_eq!(announcement.cell_mask, None);
+
+    // 2) raw peer -> node: a geth style blob announcement carrying the custody mask
+    let pooled = blob_tx_without_blobs();
+    let blob_tx_hash = *pooled.tx_hash();
+    let sender = pooled.recover_signer().unwrap();
+    provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(19))));
+
+    let announcement = NewPooledTransactionHashes72 {
+        types: vec![EIP4844_TX_TYPE_ID],
+        sizes: vec![pooled.encode_2718_len()],
+        hashes: vec![blob_tx_hash],
+        cell_mask: Some(NewPooledTransactionHashes72::ALL_CELLS_MASK),
+    };
+    eth_stream.send(EthMessage::NewPooledTransactionHashes72(announcement)).await.unwrap();
+
+    // the node must fetch the announced blob transaction
+    let request = match next_message(&mut eth_stream).await {
+        EthMessage::GetPooledTransactions(request) => request,
+        message => panic!("unexpected message {message:?}"),
+    };
+    assert_eq!(request.message.0, vec![blob_tx_hash]);
+
+    // 3) raw peer -> node: the eth/72 response elides the blob payloads
+    eth_stream
+        .send(EthMessage::PooledTransactions(RequestPair {
+            request_id: request.request_id,
+            message: PooledTransactions(vec![pooled]),
+        }))
+        .await
+        .unwrap();
+
+    // The import fails because the blob payloads are missing (cell fetching is not implemented
+    // yet), but the eth/72 peer served a spec compliant response and must not be penalized.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    assert!(!node_pool.contains(&blob_tx_hash));
+    let reputation = node.peer_handle().peer_by_id(raw_id).await.unwrap().reputation();
+    assert_eq!(reputation, baseline_reputation);
+    // the session survives serving the blob-elided response
+    assert_eq!(node.network().num_connected_peers(), 1);
+}

--- a/crates/net/network/tests/it/eth72.rs
+++ b/crates/net/network/tests/it/eth72.rs
@@ -198,8 +198,8 @@ async fn test_eth72_blob_announcements_and_elided_pooled_response() {
         .await
         .unwrap();
 
-    // The import fails because the blob payloads are missing (cell fetching is not implemented
-    // yet), but the eth/72 peer served a spec compliant response and must not be penalized.
+    // The blob-elided body is dropped before the pool import (cell fetching is not implemented
+    // yet), and the eth/72 peer served a spec compliant response so it must not be penalized.
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     assert!(!node_pool.contains(&blob_tx_hash));

--- a/crates/net/network/tests/it/main.rs
+++ b/crates/net/network/tests/it/main.rs
@@ -2,6 +2,7 @@
 
 mod big_pooled_txs_req;
 mod connect;
+mod eth72;
 mod multiplex;
 mod requests;
 mod session;


### PR DESCRIPTION
Devnet-8 peering breaks on eth/72 because the announcement cell mask reth sends is undecodable for geth: EIP-8070's text encodes an absent mask as RLP nil, but geth's `NewPooledTransactionHashesPacket72.Mask` is a fixed `[16]byte` whose RLP decoder rejects the nil encoding, so every reth `NewPooledTransactionHashes` on an eth/72 session failed to decode and dropped the session. Reth also never populated the mask when announcing blob transactions, and penalized eth/72 peers that correctly served blob transactions with elided blob payloads.

This switches the wire encoding to the de facto geth format: the mask is always encoded as a 16 byte string, zero-filled when no type-3 transactions are announced, while decoding stays lenient and also accepts the spec's nil form. Blob transaction announcements now advertise an all-cells mask since the pool holds the full sidecar.

Blob transactions in eth/72 fetch responses are dropped before the pool import: their blob payloads are elided per EIP-8070, so the sidecar can never validate, and importing them only produced a guaranteed failure that penalized a spec-compliant peer. This mirrors geth, which diverts these bodies into a buffer completed with cells fetched via `GetCells` instead of importing them; the buffer/cell-fetching part is not implemented yet, so until then blob transactions cannot be imported from eth/72 peers.

The new interop test connects a raw eth/72 peer speaking the geth wire format to a node, verifies announcements in both directions, and serves a blob-elided `PooledTransactions` response, asserting the peer is neither penalized nor disconnected.

Related follow-ups: the serving side (eliding blobs from our own responses) is #26574, announced sizes for blob transactions still need to switch to the blob-elided size to match geth's `SizeWithoutBlob` semantics once serving lands, and `GetCells` based cell fetching plus blob reconstruction is needed before blob transactions can actually be imported from eth/72 peers. The EIP text and geth's implementation genuinely disagree on the nil mask encoding; worth raising upstream.