### PR TITLE
refactor(network): assert negotiated protocol installation

### DIFF
--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1247,11 +1247,14 @@ async fn authenticate_stream<N: NetworkPrimitives>(
             let cap = handler.protocol().cap;
             let remote_peer_id = authenticated_peer_id;
 
+            // The unsupported-handler pass above guarantees that every remaining handler has a
+            // matching negotiated capability. The multiplexer retains the same immutable set of
+            // shared capabilities, so installing one of these handlers cannot fail.
             multiplex_stream
                 .install_protocol(&cap, move |conn| {
                     handler.into_connection(direction, remote_peer_id, conn)
                 })
-                .ok();
+                .expect("remaining handler capability was negotiated");
         }
 
         let (multiplex_stream, their_status) = match multiplex_stream


### PR DESCRIPTION
Replace the discarded protocol installation result with an assertion and document why the negotiated-capability invariant makes failure unreachable.

Prompted by: @pepyakin