### PR TITLE
fix(txpool): include blob pool in queued transactions count

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -504,7 +504,7 @@ impl<T: TransactionOrdering> TxPool<T> {
 
     /// Returns the number of transactions in parked pools
     pub(crate) fn queued_transactions_count(&self) -> usize {
-        self.basefee_pool.len() + self.queued_pool.len()
+        self.basefee_pool.len() + self.queued_pool.len() + self.blob_pool.len()
     }
 
     /// Returns queued and pending transactions for the specified sender
@@ -2513,6 +2513,29 @@ mod tests {
         // make sure the blob transaction was promoted into the pending pool
         assert_eq!(pool.pending_pool.len(), 1);
         assert!(pool.blob_pool.is_empty());
+    }
+
+    #[test]
+    fn test_queued_count_includes_blob_pool() {
+        let on_chain_balance = U256::MAX;
+        let on_chain_nonce = 0;
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+        let tx = MockTransaction::eip4844().inc_price().inc_limit();
+
+        // set block info so the tx is underpriced w.r.t. blob fee and lands in the blob pool
+        let mut block_info = pool.block_info();
+        block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap() + 1);
+        pool.set_block_info(block_info);
+
+        let validated = f.validated(tx);
+        pool.add_transaction(validated, on_chain_balance, on_chain_nonce, None).unwrap();
+
+        assert_eq!(pool.blob_pool.len(), 1);
+        assert!(pool.pending_pool.is_empty());
+
+        // blob pool transactions are parked and must be reported as queued
+        assert_eq!(pool.queued_transactions_count(), 1);
     }
 
     /// A struct representing a txpool promotion test instance


### PR DESCRIPTION
Closes #26676, supersedes #26677 (credit to @SnowingFox for the report and initial patch).

Blob transactions parked in the blob pool because the current blob fee is too high are future-eligible just like basefee/queued-pool transactions, but `queued_transactions_count()` only summed `basefee_pool` and `queued_pool`, so `txpool_status.queued` undercounted them. Adds the blob pool to the count and a test that parks an underpriced EIP-4844 transaction and asserts it is reported as queued.