### PR TITLE
fix(txpool): include blob pool in queued transactions

### DIFF
--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -73,13 +73,16 @@ impl<T: PoolTransaction> BlobTransactions<T> {
         self.by_id.values().map(|tx| tx.transaction.clone())
     }
 
-    /// Returns all transactions for the given sender, using a `BTree` range query.
-    pub(crate) fn txs_by_sender(&self, sender: SenderId) -> Vec<Arc<ValidPoolTransaction<T>>> {
+    /// Returns an iterator over all transactions for the given sender, using a `BTree` range
+    /// query.
+    pub(crate) fn txs_by_sender(
+        &self,
+        sender: SenderId,
+    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T>>> + '_ {
         self.by_id
             .range((sender.start_bound(), Unbounded))
             .take_while(move |(other, _)| sender == other.sender)
             .map(|(_, tx)| Arc::clone(&tx.transaction))
-            .collect()
     }
 
     /// Removes the transaction from the pool

--- a/crates/transaction-pool/src/pool/blob.rs
+++ b/crates/transaction-pool/src/pool/blob.rs
@@ -1,11 +1,14 @@
 use super::txpool::PendingFees;
 use crate::{
-    identifier::TransactionId, pool::size::SizeTracker, traits::BestTransactionsAttributes,
+    identifier::{SenderId, TransactionId},
+    pool::size::SizeTracker,
+    traits::BestTransactionsAttributes,
     PoolTransaction, SubPoolLimit, ValidPoolTransaction,
 };
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
+    ops::Bound::Unbounded,
     sync::Arc,
 };
 
@@ -63,6 +66,20 @@ impl<T: PoolTransaction> BlobTransactions<T> {
         let id = self.submission_id;
         self.submission_id = self.submission_id.wrapping_add(1);
         id
+    }
+
+    /// Returns an iterator over all transactions in the pool
+    pub(crate) fn all(&self) -> impl ExactSizeIterator<Item = Arc<ValidPoolTransaction<T>>> + '_ {
+        self.by_id.values().map(|tx| tx.transaction.clone())
+    }
+
+    /// Returns all transactions for the given sender, using a `BTree` range query.
+    pub(crate) fn txs_by_sender(&self, sender: SenderId) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        self.by_id
+            .range((sender.start_bound(), Unbounded))
+            .take_while(move |(other, _)| sender == other.sender)
+            .map(|(_, tx)| Arc::clone(&tx.transaction))
+            .collect()
     }
 
     /// Removes the transaction from the pool

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -499,7 +499,7 @@ impl<T: TransactionOrdering> TxPool<T> {
 
     /// Returns all transactions from parked pools
     pub(crate) fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        self.basefee_pool.all().chain(self.queued_pool.all()).collect()
+        self.basefee_pool.all().chain(self.queued_pool.all()).chain(self.blob_pool.all()).collect()
     }
 
     /// Returns the number of transactions in parked pools
@@ -522,6 +522,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         let mut txs = self.basefee_pool.txs_by_sender(sender);
         txs.extend(self.queued_pool.txs_by_sender(sender));
+        txs.extend(self.blob_pool.txs_by_sender(sender));
         txs
     }
 
@@ -3644,6 +3645,34 @@ mod tests {
         assert_eq!(tx_meta.subpool, SubPool::Pending);
         assert!(tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
         assert!(tx_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn queued_transactions_include_blob_pool() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let initial_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+        let tx = MockTransaction::eip4844()
+            .with_max_fee(500)
+            .with_priority_fee(1)
+            .with_blob_fee(initial_blob_fee + 100);
+        let validated = f.validated(tx);
+        let id = *validated.id();
+        let sender = validated.sender_id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+
+        // Raise the base fee beyond the transaction's cap so it gets parked in the blob pool.
+        pool.update_basefee(600, |_| {});
+        assert_eq!(pool.blob_pool.len(), 1);
+
+        let queued = pool.queued_transactions();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].id(), &id);
+
+        let by_sender = pool.queued_txs_by_sender(sender);
+        assert_eq!(by_sender.len(), 1);
+        assert_eq!(by_sender[0].id(), &id);
     }
 
     #[test]


### PR DESCRIPTION
Companion to #26677.

All non-pending blob transactions are routed to the blob sub-pool, so `queued_transactions()` and `queued_txs_by_sender()` omitted them entirely. This made them invisible to `txpool_content`, `txpool_inspect` and `txpool_contentFrom`, which would disagree with the `txpool_status.queued` count once #26677 lands, and it also excluded them from stale-transaction eviction in `maintain.rs` — whose existing `is_eip4844` sidecar cleanup branch was unreachable as a result, so parked blob transactions and their sidecars were never dropped after `max_tx_lifetime`.

Adds `all()` and `txs_by_sender()` accessors to `BlobTransactions` mirroring the `ParkedPool` ones and chains the blob pool into both queued getters. Local transactions remain exempt from lifetime eviction via the existing origin check.