### PR TITLE
fix(chainspec): honor genesis slotNumber instead of hardcoding 0 (EIP-7843)

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -82,11 +82,11 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
         .active_at_timestamp(genesis.timestamp)
         .then_some(EMPTY_BLOCK_ACCESS_LIST_HASH);
 
-    // If Amsterdam is activated at genesis we set slot number to 0
+    // If Amsterdam is activated at genesis we set slot number to the provided genesis or 0
     let slot_number = hardforks
         .fork(EthereumHardfork::Amsterdam)
         .active_at_timestamp(genesis.timestamp)
-        .then_some(0);
+        .then_some(genesis.slot_number.unwrap_or(0));
 
     Header {
         number: genesis.number.unwrap_or_default(),
@@ -2654,6 +2654,28 @@ Post-merge hard forks (timestamp based):
         // check that the forkhash is correct
         let expected_forkhash = ForkHash(hex!("0x8062457a"));
         assert_eq!(ForkHash::from(genesis_hash), expected_forkhash);
+    }
+
+    #[test]
+    fn test_amsterdam_genesis_slot_number() {
+        // a genesis-provided slot number is used as-is
+        let genesis =
+            Genesis { gas_limit: 0x2fefd8u64, ..Default::default() }.with_slot_number(Some(999));
+        let chainspec = ChainSpecBuilder::default()
+            .chain(Chain::from_id(1337))
+            .genesis(genesis)
+            .amsterdam_activated()
+            .build();
+        assert_eq!(chainspec.genesis_header().slot_number, Some(999));
+
+        // an omitted slot number defaults to 0
+        let genesis = Genesis { gas_limit: 0x2fefd8u64, ..Default::default() };
+        let chainspec = ChainSpecBuilder::default()
+            .chain(Chain::from_id(1337))
+            .genesis(genesis)
+            .amsterdam_activated()
+            .build();
+        assert_eq!(chainspec.genesis_header().slot_number, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
`make_genesis_header` set `slot_number` to `Some(0)` whenever Amsterdam is active at genesis, ignoring the value in the genesis JSON. Any fixture with a nonzero genesis slot number fails: hive glamsterdam-quick `test_slotnum_genesis` (fixtures `tests-glamsterdam-devnet@v8.1.0`) reports `slot_number: expected 0x03e7, got 0x00` on consume-rlp and a genesis forkchoice update stuck `SYNCING` on consume-engine.

Example run: https://hive.ethpandaops.io/#/test/glamsterdam-quick/1786549384-264b0fb999b2d081299a3f589120dd18

Fix: read `genesis.slot_number.unwrap_or(0)`, mirroring the `blob_gas_used`/`excess_blob_gas` handling a few lines above.

`alloy_genesis::Genesis::slot_number` is available since alloy 2.4.1, which main already uses, so no dependency changes are needed.