### PR TITLE
refactor(txpool): return iterators from txs_by_sender accessors

### DIFF
--- a/crates/transaction-pool/src/pool/parked.rs
+++ b/crates/transaction-pool/src/pool/parked.rs
@@ -151,16 +151,16 @@ impl<T: ParkedOrd> ParkedPool<T> {
             .collect()
     }
 
-    /// Returns all transactions for the given sender, using a `BTree` range query.
+    /// Returns an iterator over all transactions for the given sender, using a `BTree` range
+    /// query.
     pub(crate) fn txs_by_sender(
         &self,
         sender: SenderId,
-    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T::Transaction>>> + '_ {
         self.by_id
             .range((sender.start_bound(), Unbounded))
             .take_while(move |(other, _)| sender == other.sender)
             .map(|(_, tx)| Arc::clone(&tx.transaction))
-            .collect()
     }
 
     #[cfg(test)]

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -583,16 +583,16 @@ impl<T: TransactionOrdering> PendingPool<T> {
             .map(|(tx_id, _)| tx_id)
     }
 
-    /// Returns all transactions for the given sender, using a `BTree` range query.
+    /// Returns an iterator over all transactions for the given sender, using a `BTree` range
+    /// query.
     pub(crate) fn txs_by_sender(
         &self,
         sender: SenderId,
-    ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+    ) -> impl Iterator<Item = Arc<ValidPoolTransaction<T::Transaction>>> + '_ {
         self.by_id
             .range((sender.start_bound(), Unbounded))
             .take_while(move |(other, _)| sender == other.sender)
             .map(|(_, tx)| tx.transaction.clone())
-            .collect()
     }
 
     /// Retrieves a transaction with the given ID from the pool, if it exists.

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -494,7 +494,7 @@ impl<T: TransactionOrdering> TxPool<T> {
         &self,
         sender: SenderId,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        self.pending_pool.txs_by_sender(sender)
+        self.pending_pool.txs_by_sender(sender).collect()
     }
 
     /// Returns all transactions from parked pools
@@ -520,10 +520,11 @@ impl<T: TransactionOrdering> TxPool<T> {
         &self,
         sender: SenderId,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let mut txs = self.basefee_pool.txs_by_sender(sender);
-        txs.extend(self.queued_pool.txs_by_sender(sender));
-        txs.extend(self.blob_pool.txs_by_sender(sender));
-        txs
+        self.basefee_pool
+            .txs_by_sender(sender)
+            .chain(self.queued_pool.txs_by_sender(sender))
+            .chain(self.blob_pool.txs_by_sender(sender))
+            .collect()
     }
 
     /// Returns `true` if the transaction with the given hash is already included in this pool.


### PR DESCRIPTION
Follow-up to #26679.

The per-sub-pool `txs_by_sender` accessors each collected into an intermediate `Vec` even though callers only iterate or extend. They now return iterators; `queued_txs_by_sender` chains the basefee, queued and blob pool iterators and collects once, and `pending_txs_by_sender` collects at the call site.

Based on #26679 since it builds on the blob pool accessor added there.