### PR TITLE
feat(engine): add inclusion list rpc stub

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -229,6 +229,12 @@ pub trait EngineApi<Engine: EngineTypes> {
         payload_id: PayloadId,
     ) -> RpcResult<Engine::ExecutionPayloadEnvelopeV6>;
 
+    /// Returns transactions selected from the local transaction pool for the FOCIL inclusion list.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/pull/609>.
+    #[method(name = "getInclusionListV1")]
+    async fn get_inclusion_list_v1(&self) -> RpcResult<Vec<Bytes>>;
+
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1>
     #[method(name = "getPayloadBodiesByHashV1")]
     async fn get_payload_bodies_by_hash_v1(

--- a/crates/rpc/rpc-builder/tests/it/auth.rs
+++ b/crates/rpc/rpc-builder/tests/it/auth.rs
@@ -110,6 +110,7 @@ where
     EngineApiClient::fork_choice_updated_v1(client, ForkchoiceState::default(), None).await;
     EngineApiClient::get_payload_v1(client, PayloadId::new([0, 0, 0, 0, 0, 0, 0, 0])).await;
     EngineApiClient::get_payload_v2(client, PayloadId::new([0, 0, 0, 0, 0, 0, 0, 0])).await;
+    EngineApiClient::get_inclusion_list_v1(client).await;
     EngineApiClient::get_payload_bodies_by_hash_v1(client, vec![]).await;
     EngineApiClient::get_payload_bodies_by_range_v1(client, U64::ZERO, U64::from(1u64)).await;
     EngineApiClient::exchange_capabilities(client, vec![]).await;

--- a/crates/rpc/rpc-engine-api/src/capabilities.rs
+++ b/crates/rpc/rpc-engine-api/src/capabilities.rs
@@ -29,6 +29,7 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getPayloadV4",
     "engine_getPayloadV5",
     "engine_getPayloadV6",
+    "engine_getInclusionListV1",
     "engine_newPayloadV1",
     "engine_newPayloadV2",
     "engine_newPayloadV3",
@@ -250,6 +251,7 @@ mod tests {
         assert!(!is_critical_method("engine_getPayloadBodiesByHashV1"));
         assert!(!is_critical_method("engine_getPayloadBodiesByRangeV1"));
         assert!(!is_critical_method("engine_getClientVersionV1"));
+        assert!(!is_critical_method("engine_getInclusionListV1"));
     }
 
     #[test]

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -1432,6 +1432,14 @@ where
         Ok(self.get_payload_v6_metered(payload_id).await?)
     }
 
+    /// Handler for `engine_getInclusionListV1`.
+    ///
+    /// See also <https://github.com/ethereum/execution-apis/pull/609>.
+    async fn get_inclusion_list_v1(&self) -> RpcResult<Vec<Bytes>> {
+        trace!(target: "rpc::engine", "Serving engine_getInclusionListV1");
+        Ok(Vec::new())
+    }
+
     /// Handler for `engine_getPayloadBodiesByHashV1`
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1>
     async fn get_payload_bodies_by_hash_v1(
@@ -1688,6 +1696,14 @@ mod tests {
         let (_, api) = setup_engine_api();
         let res = api.get_client_version_v1(client.clone());
         assert_eq!(res.unwrap(), vec![client]);
+    }
+
+    #[tokio::test]
+    async fn get_inclusion_list_v1_returns_empty_list() {
+        let (_, api) = setup_engine_api();
+
+        let res = EngineApiServer::get_inclusion_list_v1(&api).await.unwrap();
+        assert!(res.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds the engine_getInclusionListV1 RPC and advertises it through Engine API capability exchange. The handler returns an empty list for now, allowing FOCIL client integration to begin while transaction selection remains follow-up work.

Tracks ethereum/execution-apis#609.