### PR TITLE
refactor: default unspecified payload attributes

### DIFF
--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -228,7 +228,7 @@ where
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
                 slot_number: None,
-                target_gas_limit: None,
+                ..Default::default()
             };
 
             env.active_node_state_mut()?
@@ -302,7 +302,7 @@ where
                     withdrawals: Some(vec![]),
                     parent_beacon_block_root: Some(B256::ZERO),
                     slot_number: None,
-                    target_gas_limit: None,
+                    ..Default::default()
                 };
 
                 let fresh_fcu_result = EngineApiClient::<Engine>::fork_choice_updated_v3(

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -270,7 +270,7 @@ where
             withdrawals: Some(vec![]),
             parent_beacon_block_root: Some(B256::ZERO),
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         };
 
         crate::setup_import::setup_engine_with_chain_import(
@@ -298,7 +298,7 @@ where
                 withdrawals: Some(vec![]),
                 parent_beacon_block_root: Some(B256::ZERO),
                 slot_number: None,
-                target_gas_limit: None,
+                ..Default::default()
             }
             .into()
         }

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -161,7 +161,7 @@ async fn test_testsuite_assert_mine_block() -> Result<()> {
                 withdrawals: None,
                 parent_beacon_block_root: None,
                 slot_number: None,
-                target_gas_limit: None,
+                ..Default::default()
             },
         ));
 

--- a/crates/e2e-test-utils/tests/rocksdb/main.rs
+++ b/crates/e2e-test-utils/tests/rocksdb/main.rs
@@ -83,7 +83,7 @@ fn test_chain_spec() -> Arc<ChainSpec> {
 }
 
 /// Returns test payload attributes for the given timestamp.
-const fn test_attributes_generator(timestamp: u64) -> PayloadAttributes {
+fn test_attributes_generator(timestamp: u64) -> PayloadAttributes {
     PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
@@ -91,7 +91,7 @@ const fn test_attributes_generator(timestamp: u64) -> PayloadAttributes {
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     }
 }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -900,7 +900,7 @@ fn process_payload_attributes_shares_sparse_trie_during_validation_fallback() {
             withdrawals: None,
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         },
         &head,
         state,
@@ -1682,7 +1682,7 @@ async fn test_fcu_with_canonical_ancestor_below_finalized_is_rejected() {
         withdrawals: None,
         parent_beacon_block_root: None,
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     };
     for attrs in [Some(payload_attributes), None] {
         let err = test_harness
@@ -1716,7 +1716,7 @@ async fn test_fcu_with_canonical_ancestor_below_finalized_is_rejected() {
         withdrawals: None,
         parent_beacon_block_root: None,
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     };
     let outcome = test_harness
         .tree
@@ -1759,7 +1759,7 @@ async fn test_fcu_with_canonical_ancestor_above_finalized_starts_payload_build()
         withdrawals: None,
         parent_beacon_block_root: None,
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     };
     let outcome = test_harness
         .tree

--- a/crates/ethereum/node/src/engine_ssz_containers.rs
+++ b/crates/ethereum/node/src/engine_ssz_containers.rs
@@ -491,7 +491,7 @@ impl From<PayloadAttributesParis> for LegacyPayloadAttributes {
             withdrawals: None,
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         }
     }
 }
@@ -521,7 +521,7 @@ impl From<PayloadAttributesShanghai> for LegacyPayloadAttributes {
             withdrawals: Some(value.withdrawals),
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         }
     }
 }
@@ -551,7 +551,7 @@ impl From<PayloadAttributesCancun> for LegacyPayloadAttributes {
             withdrawals: Some(value.withdrawals),
             parent_beacon_block_root: Some(value.parent_beacon_block_root),
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         }
     }
 }
@@ -576,6 +576,7 @@ impl TryFrom<LegacyPayloadAttributes> for PayloadAttributesCancun {
 }
 
 impl From<PayloadAttributesAmsterdam> for LegacyPayloadAttributes {
+    #[allow(clippy::needless_update)]
     fn from(value: PayloadAttributesAmsterdam) -> Self {
         Self {
             timestamp: value.timestamp,
@@ -585,6 +586,7 @@ impl From<PayloadAttributesAmsterdam> for LegacyPayloadAttributes {
             parent_beacon_block_root: Some(value.parent_beacon_block_root),
             slot_number: Some(value.slot_number),
             target_gas_limit: Some(value.target_gas_limit),
+            ..Default::default()
         }
     }
 }

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -244,7 +244,7 @@ async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     };
 
     let request = TestingBuildBlockRequestV1 {
@@ -333,7 +333,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     };
 
     let envelope = node

--- a/crates/ethereum/node/tests/e2e/utils.rs
+++ b/crates/ethereum/node/tests/e2e/utils.rs
@@ -17,7 +17,7 @@ use reth_node_ethereum::EthereumNode;
 use reth_provider::FullProvider;
 
 /// Helper function to create a new eth payload attributes
-pub(crate) const fn eth_payload_attributes(timestamp: u64) -> PayloadAttributes {
+pub(crate) fn eth_payload_attributes(timestamp: u64) -> PayloadAttributes {
     PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
@@ -25,13 +25,13 @@ pub(crate) const fn eth_payload_attributes(timestamp: u64) -> PayloadAttributes 
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     }
 }
 
 /// Helper function to create pre-Cancun (Shanghai) payload attributes.
 /// No `parent_beacon_block_root` field.
-pub(crate) const fn eth_payload_attributes_shanghai(timestamp: u64) -> PayloadAttributes {
+pub(crate) fn eth_payload_attributes_shanghai(timestamp: u64) -> PayloadAttributes {
     PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
@@ -39,7 +39,7 @@ pub(crate) const fn eth_payload_attributes_shanghai(timestamp: u64) -> PayloadAt
         withdrawals: Some(vec![]),
         parent_beacon_block_root: None,
         slot_number: None,
-        target_gas_limit: None,
+        ..Default::default()
     }
 }
 
@@ -49,7 +49,7 @@ pub(crate) const fn eth_payload_attributes_shanghai(timestamp: u64) -> PayloadAt
 /// `slot_number` in the attributes once Amsterdam is active. Tests use the timestamp as a
 /// deterministic dummy slot because the exact beacon slot is irrelevant for these local e2e
 /// payloads.
-pub(crate) const fn eth_payload_attributes_amsterdam(timestamp: u64) -> PayloadAttributes {
+pub(crate) fn eth_payload_attributes_amsterdam(timestamp: u64) -> PayloadAttributes {
     PayloadAttributes {
         timestamp,
         prev_randao: B256::ZERO,
@@ -57,7 +57,7 @@ pub(crate) const fn eth_payload_attributes_amsterdam(timestamp: u64) -> PayloadA
         withdrawals: Some(vec![]),
         parent_beacon_block_root: Some(B256::ZERO),
         slot_number: Some(timestamp),
-        target_gas_limit: None,
+        ..Default::default()
     }
 }
 

--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -60,7 +60,7 @@ async fn testing_rpc_build_block_works() -> eyre::Result<()> {
                 withdrawals: None,
                 parent_beacon_block_root: None,
                 slot_number: None,
-                target_gas_limit: None,
+                ..Default::default()
             };
 
             let request = TestingBuildBlockRequestV1 {
@@ -134,6 +134,7 @@ async fn testing_rpc_commit_block_works() -> eyre::Result<()> {
             let chain = ctx.config().chain.clone();
             let timestamp = chain.genesis().timestamp + 1;
             let target_gas_limit = chain.genesis().gas_limit - 100;
+            #[allow(clippy::needless_update)]
             let payload_attributes = EthPayloadAttributes {
                 timestamp,
                 prev_randao: B256::ZERO,
@@ -142,6 +143,7 @@ async fn testing_rpc_commit_block_works() -> eyre::Result<()> {
                 parent_beacon_block_root: Some(B256::ZERO),
                 slot_number: Some(timestamp),
                 target_gas_limit: Some(target_gas_limit),
+                ..Default::default()
             };
 
             tokio::spawn(async move {

--- a/crates/payload/builder/src/service.rs
+++ b/crates/payload/builder/src/service.rs
@@ -693,7 +693,7 @@ mod tests {
                     withdrawals: None,
                     parent_beacon_block_root: None,
                     slot_number: None,
-                    target_gas_limit: None,
+                    ..Default::default()
                 },
                 parent_hash: B256::ZERO,
                 resources: PayloadBuilderResources::default().with_lease(lease),

--- a/crates/payload/primitives/src/traits.rs
+++ b/crates/payload/primitives/src/traits.rs
@@ -253,7 +253,7 @@ mod tests {
             withdrawals: None,
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         };
 
         // Verify that the generated payload ID matches the expected value
@@ -292,7 +292,7 @@ mod tests {
             ]),
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         };
 
         // Verify that the generated payload ID matches the expected value
@@ -326,7 +326,7 @@ mod tests {
                 .unwrap(),
             ),
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         };
 
         // Verify that the generated payload ID matches the expected value
@@ -351,7 +351,7 @@ mod tests {
             withdrawals: Some(vec![]),
             parent_beacon_block_root: Some(B256::from_slice(&[2; 32])),
             slot_number: Some(1),
-            target_gas_limit: None,
+            ..Default::default()
         };
 
         let first = payload_id(&parent, &attributes);
@@ -365,6 +365,7 @@ mod tests {
         let parent =
             B256::from_str("0x9876543210abcdef9876543210abcdef9876543210abcdef9876543210abcdef")
                 .unwrap();
+        #[allow(clippy::needless_update)]
         let mut attributes = EthPayloadAttributes {
             timestamp: 1622553200,
             prev_randao: B256::from_slice(&[1; 32]),
@@ -376,6 +377,7 @@ mod tests {
             parent_beacon_block_root: Some(B256::from_slice(&[2; 32])),
             slot_number: Some(1),
             target_gas_limit: Some(30_000_000),
+            ..Default::default()
         };
 
         let first = payload_id(&parent, &attributes);

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -2141,7 +2141,7 @@ mod tests {
             withdrawals: Some(vec![]),
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         };
         let custody_columns = B128::from(0b1010u128.to_le_bytes());
         let expected_custody_columns = B128::from(0b1010u128);
@@ -2198,7 +2198,7 @@ mod tests {
             // Invalid for V3/Cancun, but should be ignored if forkchoice is SYNCING.
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         };
 
         let api_task = tokio::spawn(async move {
@@ -2247,7 +2247,7 @@ mod tests {
             withdrawals: Some(vec![]),
             parent_beacon_block_root: None,
             slot_number: None,
-            target_gas_limit: None,
+            ..Default::default()
         };
 
         let api_task = tokio::spawn(async move {


### PR DESCRIPTION
Uses `..Default::default()` for Alloy `PayloadAttributes` construction across SSZ conversions and test helpers, preserving explicit fork-specific values. This keeps Reth compiling when Alloy adds defaulted payload-attribute fields instead of requiring every literal to be updated.
