### PR TITLE
chore(deps): bump alloy-hardforks to 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+checksum = "865371fb677c005f7cb0ea9c2847a1ba4fdb042caf6428b1769fee20368bbfc7"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -7735,7 +7735,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
@@ -8648,7 +8648,7 @@ dependencies = [
  "alloy-eip7928",
  "alloy-eips",
  "alloy-genesis",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -8767,7 +8767,7 @@ name = "reth-ethereum-forks"
 version = "2.5.0"
 dependencies = [
  "alloy-eip2124",
- "alloy-hardforks 0.4.7",
+ "alloy-hardforks 0.4.8",
  "alloy-primitives",
  "arbitrary",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -447,7 +447,7 @@ alloy-evm = { version = "0.38.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
 
-alloy-hardforks = "0.4.7"
+alloy-hardforks = "0.4.8"
 
 alloy-consensus = { version = "2.4.0", default-features = false }
 alloy-contract = { version = "2.4.0", default-features = false }


### PR DESCRIPTION
Updates `alloy-hardforks` from 0.4.7 to 0.4.8 and refreshes the corresponding lockfile entries. This picks up the latest compatible patch release without changing other dependency resolutions.
