### PR TITLE
docs(engine): clarify BlockStatus::Valid does not imply canonical

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3667,7 +3667,11 @@ impl Drop for PayloadBuildLease {
 /// is valid or not.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockStatus {
-    /// The block is valid and block extends canonical chain.
+    /// The block is valid: its parent state was available, so it was executed and inserted into
+    /// the tree.
+    ///
+    /// Note: this does not imply the block extends the canonical chain. Blocks on a fork are
+    /// executed and inserted the same way and report this status as well.
     Valid,
     /// The block may be valid and has an unknown missing ancestor.
     Disconnected {


### PR DESCRIPTION
`BlockStatus::Valid` is documented as "the block is valid and block extends canonical chain", but `insert_block_or_payload` computes `is_fork` and emits `ForkBlockAdded` for fork blocks while still returning `BlockStatus::Valid`.
Its own doc comment already says it "handles both canonical and fork chain insertions".