### PR TITLE
fix(stages): validate block access list hash on import path (EIP-7928)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7843,6 +7843,7 @@ version = "2.5.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
@@ -10241,6 +10242,7 @@ name = "reth-stages"
 version = "2.5.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -59,6 +59,7 @@ reth-discv4.workspace = true
 reth-discv5.workspace = true
 
 # ethereum
+alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -5,6 +5,7 @@ use crate::common::{
     EnvironmentArgs,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
+use alloy_eip7928::compute_block_access_list_hash;
 use alloy_primitives::{Address, B256, U256};
 use clap::Parser;
 use eyre::WrapErr;
@@ -199,8 +200,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
                         };
 
+                        let bal_hash = executor
+                            .take_bal()
+                            .as_ref()
+                            .map(|bal| compute_block_access_list_hash(bal.as_slice()));
+
                         if let Err(err) = consensus
-                            .validate_block_post_execution(&block, &result, None,None)
+                            .validate_block_post_execution(&block, &result, None, bal_hash)
                             .wrap_err_with(|| {
                                 format!(
                                     "Failed to validate block {} {}",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -45,6 +45,7 @@ reth-trie-db = { workspace = true, features = ["metrics"] }
 
 reth-testing-utils = { workspace = true, optional = true }
 
+alloy-eip7928.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -1,5 +1,9 @@
 use crate::stages::MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD;
 use alloy_consensus::BlockHeader;
+use alloy_eip7928::{
+    compute_block_access_list_hash, constants::ITEM_COST, total_bal_items,
+    BlockAccessListGasError,
+};
 use alloy_primitives::BlockNumber;
 use num_traits::Zero;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
@@ -359,8 +363,24 @@ where
                 })
             })?;
 
+            let built_bal = executor.take_bal();
+            if let Some(bal) = &built_bal {
+                let gas_limit = block.header().gas_limit();
+                let items = total_bal_items(bal);
+                if items > gas_limit / ITEM_COST as u64 {
+                    return Err(StageError::Block {
+                        block: Box::new(block.block_with_parent()),
+                        error: BlockErrorKind::Validation(
+                            BlockAccessListGasError::new(items, gas_limit).into(),
+                        ),
+                    })
+                }
+            }
+            let bal_hash =
+                built_bal.as_ref().map(|bal| compute_block_access_list_hash(bal.as_slice()));
+
             if let Err(err) =
-                self.consensus.validate_block_post_execution(&block, &result, None, None)
+                self.consensus.validate_block_post_execution(&block, &result, None, bal_hash)
             {
                 return Err(StageError::Block {
                     block: Box::new(block.block_with_parent()),


### PR DESCRIPTION
`reth import` executed blocks without validating the EIP-7928 block access list, so blocks with invalid BAL contents or an over-limit BAL item cost were accepted on the RLP-import path (the engine path already validates both). Fixes the consume-rlp fails of `tests/amsterdam/eip7928_block_level_access_lists/` (`test_block_access_lists_invalid.py`, `test_bal_gas_limit_boundary`, `test_fork_transition_bal_size_constraint`) on [hive glamsterdam-quick](https://hive.ethpandaops.io/#/test/glamsterdam-quick/1786545713-b58ee7108bac1061a0e86683cb053c10).
