### PR TITLE
fix(engine): consensus-correct verdicts for payloads that diverge from their BAL

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -14,7 +14,10 @@
 //! validation. This module only logs the first divergence between the received BAL and the BAL
 //! rebuilt from canonical execution.
 
-use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError};
+use super::{
+    ordered_outputs::{ordered_worker_outputs, OrderedWorkerOutputError},
+    worker, BalExecutionError,
+};
 use alloy_eip7928::{
     bal::{Bal as AlloyBal, DecodedBal},
     compute_block_access_list_hash, BlockAccessList,
@@ -145,7 +148,22 @@ where
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
-            let output = output?;
+            let output = match output {
+                Ok(output) => output,
+                Err(err) => {
+                    // Block-level admission is the consensus verdict for a transaction
+                    // that cannot fit the remaining block gas; only a transaction that
+                    // passes admission surfaces its speculative execution failure.
+                    if let OrderedWorkerOutputError::Worker(worker::BalWorkerError::Execution {
+                        tx_gas_limit,
+                        ..
+                    }) = &err
+                    {
+                        gas_tracker.validate_tx_limit(*tx_gas_limit)?;
+                    }
+                    return Err(err.into());
+                }
+            };
 
             gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
             gas_tracker.record_result(output.result.result());
@@ -910,6 +928,86 @@ mod tests {
                 err.as_validation(),
                 Some(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. })
             )),
+            Err(err) => panic!("expected block gas validation error, got {err:?}"),
+            Ok(_) => panic!("expected block gas validation error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn admission_rejects_before_speculative_worker_failure_surfaces() {
+        // tx2 exceeds the remaining block gas AND touches accounts absent from the BAL,
+        // so its worker fails speculative execution. Block-level admission is the
+        // consensus verdict: the ordered commit loop must reject tx2 for block gas
+        // instead of surfacing the worker's BAL-state failure.
+        use alloy_consensus::TxLegacy;
+        use alloy_evm::block::BlockValidationError;
+        use alloy_primitives::TxKind;
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+
+        let evm_config = EthEvmConfig::mainnet();
+        let carol: alloy_primitives::Address = alloy_primitives::Address::from([0xCA; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+        let block_gas_limit = 1_000_000;
+        let tx_gas_limit = 990_000;
+
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+        let bob_kp = generate_key(&mut rng());
+        let bob = public_key_to_address(bob_kp.public_key());
+
+        let mut pre_block_db = system_contracts_db();
+        insert_funded(&mut pre_block_db, alice, sender_balance);
+        insert_funded(&mut pre_block_db, bob, sender_balance);
+
+        let chain_id = MAINNET.chain.id();
+        let make_tx = |kp, value| {
+            sign_tx_with_key_pair(
+                kp,
+                Transaction::Legacy(TxLegacy {
+                    chain_id: Some(chain_id),
+                    nonce: 0,
+                    gas_price: 1,
+                    gas_limit: tx_gas_limit,
+                    to: TxKind::Call(carol),
+                    value: U256::from(value),
+                    input: Default::default(),
+                }),
+            )
+        };
+        let tx1 = Recovered::new_unchecked(make_tx(alice_kp, 100u64), alice);
+        let tx2 = Recovered::new_unchecked(make_tx(bob_kp, 200u64), bob);
+
+        // Reference BAL covers only tx1, so tx2's worker fails on the missing accounts.
+        let reference_block = empty_amsterdam_block(B256::ZERO);
+        let reference_bal = reference_bal_for_block(
+            &evm_config,
+            pre_block_db.clone(),
+            &reference_block,
+            vec![tx1.clone()],
+        );
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
+        let low_gas_block = empty_amsterdam_block_with_gas_limit(bal_hash, block_gas_limit);
+
+        let result = run_execute_block(
+            &Runtime::test(),
+            evm_config,
+            db_factory(pre_block_db),
+            to_arc_decoded(reference_bal),
+            &low_gas_block,
+            vec![tx1, tx2],
+        );
+
+        match result {
+            Err(BalExecutionError::Execution(err)) => assert!(
+                matches!(
+                    err.as_validation(),
+                    Some(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. })
+                ),
+                "expected block gas validation error, got {err:?}"
+            ),
             Err(err) => panic!("expected block gas validation error, got {err:?}"),
             Ok(_) => panic!("expected block gas validation error, got Ok"),
         }

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -37,7 +37,7 @@ use revm::{
     database::{states::bundle_state::BundleRetention, State},
     state::bal::Bal as RevmBal,
 };
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::tree::payload_processor::receipt_root_task::IndexedReceipt;
 
@@ -59,7 +59,7 @@ pub fn execute_block<'a, Evm, Tx, Err, DB, MakeDb>(
 >
 where
     Evm: ConfigureEvm + 'static,
-    Tx: ExecutableTxFor<Evm> + Send + 'a,
+    Tx: ExecutableTxFor<Evm> + Clone + Send + 'a,
     Err: core::error::Error + Send + Sync + 'static,
     DB: Database + Send + 'a,
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'a,
@@ -102,7 +102,7 @@ fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
 >
 where
     Evm: ConfigureEvm + 'scope,
-    Tx: ExecutableTxFor<Evm> + Send + 'scope,
+    Tx: ExecutableTxFor<Evm> + Clone + Send + 'scope,
     Err: core::error::Error + Send + Sync + 'static,
     DB: Database + Send + 'scope,
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'scope,
@@ -120,6 +120,26 @@ where
         .with_bal_builder()
         .build();
 
+    // Tee the transaction stream so a speculative worker failure can be re-executed
+    // canonically: every transaction is stored before it is forwarded to a worker.
+    let tx_store: Arc<Mutex<Vec<Option<Tx>>>> =
+        Arc::new(Mutex::new((0..transaction_count).map(|_| None).collect()));
+    let (fwd_tx, fwd_rx) = crossbeam_channel::unbounded();
+    {
+        let tx_store = Arc::clone(&tx_store);
+        scope.spawn(move |_| {
+            for (index, tx) in txs.iter() {
+                if let Ok(tx) = &tx {
+                    tx_store.lock().expect("transaction store poisoned")[index] =
+                        Some(tx.clone());
+                }
+                if fwd_tx.send((index, tx)).is_err() {
+                    break;
+                }
+            }
+        });
+    }
+
     let (block_result, senders) = {
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
         let (abort_guard, abort_rx) = AbortGuard::new();
@@ -127,7 +147,7 @@ where
         for _ in 0..worker_count {
             worker::spawn_worker(
                 scope,
-                txs.clone(),
+                fwd_rx.clone(),
                 abort_rx.clone(),
                 result_tx.clone(),
                 evm_config,
@@ -138,6 +158,7 @@ where
             );
         }
         drop(result_tx);
+        drop(fwd_rx);
 
         let mut gas_tracker =
             BlockGasTracker::new(block_gas_limit, enable_amsterdam_eip8037, tx_gas_limit_cap);
@@ -148,29 +169,40 @@ where
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
-            let output = match output {
-                Ok(output) => output,
-                Err(err) => {
-                    // Block-level admission is the consensus verdict for a transaction
-                    // that cannot fit the remaining block gas; only a transaction that
-                    // passes admission surfaces its speculative execution failure.
-                    if let OrderedWorkerOutputError::Worker(worker::BalWorkerError::Execution {
-                        tx_gas_limit,
-                        ..
-                    }) = &err
-                    {
-                        gas_tracker.validate_tx_limit(*tx_gas_limit)?;
-                    }
-                    return Err(err.into());
+            match output {
+                Ok(output) => {
+                    gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
+                    gas_tracker.record_result(output.result.result());
+                    canonical_executor.evm_mut().db_mut().bump_bal_index();
+
+                    let _ = canonical_executor.commit_transaction(output.result);
+                    senders.push(output.signer);
                 }
-            };
+                Err(OrderedWorkerOutputError::Worker(worker::BalWorkerError::Execution {
+                    index,
+                    tx_gas_limit,
+                    ..
+                })) => {
+                    // Block-level admission is the consensus verdict for a transaction
+                    // that cannot fit the remaining block gas.
+                    gas_tracker.validate_tx_limit(tx_gas_limit)?;
 
-            gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
-            gas_tracker.record_result(output.result.result());
-            canonical_executor.evm_mut().db_mut().bump_bal_index();
+                    // The transaction passes admission, so its speculative failure is a
+                    // BAL/state divergence: re-execute it canonically and let canonical
+                    // execution (and post-execution validation) produce the verdict.
+                    let tx = tx_store.lock().expect("transaction store poisoned")[index]
+                        .take()
+                        .expect("transaction teed before worker execution");
+                    let signer = *tx.signer();
+                    canonical_executor.evm_mut().db_mut().bump_bal_index();
+                    let result = canonical_executor.execute_transaction_without_commit(tx)?;
+                    gas_tracker.record_result(result.result());
 
-            let _ = canonical_executor.commit_transaction(output.result);
-            senders.push(output.signer);
+                    let _ = canonical_executor.commit_transaction(result);
+                    senders.push(signer);
+                }
+                Err(err) => return Err(err.into()),
+            }
 
             let current_len = canonical_executor.receipts().len();
             if current_len > last_sent_len {
@@ -491,7 +523,7 @@ mod tests {
         txs: Vec<Tx>,
     ) -> Result<BlockExecutionOutput<Receipt>, BalExecutionError>
     where
-        Tx: ExecutableTxFor<EthEvmConfig> + Send,
+        Tx: ExecutableTxFor<EthEvmConfig> + Clone + Send,
         DB: Database + Send,
         MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
     {
@@ -508,7 +540,7 @@ mod tests {
         txs: Vec<Tx>,
     ) -> Result<(BlockExecutionOutput<Receipt>, BlockAccessList), BalExecutionError>
     where
-        Tx: ExecutableTxFor<EthEvmConfig> + Send,
+        Tx: ExecutableTxFor<EthEvmConfig> + Clone + Send,
         DB: Database + Send,
         MakeDb: Fn() -> Result<DB, BalExecutionError> + Sync,
     {
@@ -931,6 +963,78 @@ mod tests {
             Err(err) => panic!("expected block gas validation error, got {err:?}"),
             Ok(_) => panic!("expected block gas validation error, got Ok"),
         }
+    }
+
+    #[test]
+    fn reexecutes_canonically_when_bal_misses_admitted_transactions() {
+        // The BAL covers neither transaction, so both workers fail speculative
+        // execution. Both transactions pass admission, so each is re-executed
+        // canonically and the block completes with the canonical verdict.
+        use alloy_consensus::TxLegacy;
+        use alloy_primitives::TxKind;
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+
+        let evm_config = EthEvmConfig::mainnet();
+        let carol: alloy_primitives::Address = alloy_primitives::Address::from([0xCA; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+        let bob_kp = generate_key(&mut rng());
+        let bob = public_key_to_address(bob_kp.public_key());
+
+        let mut pre_block_db = system_contracts_db();
+        insert_funded(&mut pre_block_db, alice, sender_balance);
+        insert_funded(&mut pre_block_db, bob, sender_balance);
+
+        let chain_id = MAINNET.chain.id();
+        let make_tx = |kp, value| {
+            sign_tx_with_key_pair(
+                kp,
+                Transaction::Legacy(TxLegacy {
+                    chain_id: Some(chain_id),
+                    nonce: 0,
+                    gas_price: 1,
+                    gas_limit: 100_000,
+                    to: TxKind::Call(carol),
+                    value: U256::from(value),
+                    input: Default::default(),
+                }),
+            )
+        };
+        let tx1 = Recovered::new_unchecked(make_tx(alice_kp, 100u64), alice);
+        let tx2 = Recovered::new_unchecked(make_tx(bob_kp, 200u64), bob);
+
+        // Reference BAL covers no transactions at all.
+        let reference_block = empty_amsterdam_block(B256::ZERO);
+        let no_txs: Vec<Recovered<reth_ethereum_primitives::TransactionSigned>> = vec![];
+        let reference_bal = reference_bal_for_block(
+            &evm_config,
+            pre_block_db.clone(),
+            &reference_block,
+            no_txs,
+        );
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
+        let block = empty_amsterdam_block(bal_hash);
+
+        let (output, built_bal) = run_execute_block_full(
+            &Runtime::test(),
+            evm_config,
+            db_factory(pre_block_db),
+            to_arc_decoded(reference_bal),
+            &block,
+            vec![tx1, tx2],
+        )
+        .expect("canonical re-execution completes the block");
+
+        assert_eq!(output.result.receipts.len(), 2);
+        assert!(output.result.receipts.iter().all(|r| r.success));
+        // Canonical re-execution rebuilt the BAL the block actually produced.
+        assert!(built_bal.iter().any(|account| account.address == alice));
+        assert!(built_bal.iter().any(|account| account.address == bob));
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -32,15 +32,13 @@ impl From<OrderedWorkerOutputError> for BalExecutionError {
 /// state and performs no canonical commit work.
 ///
 /// Behavior:
-/// - each yielded `Ok` output has the next transaction index
-/// - indexed execution errors are deferred to their transaction slot, so every earlier
-///   transaction's output is yielded first and the consumer sees the failure in block order
-/// - non-indexed worker errors are forwarded immediately
-/// - closed channels before `total` outputs yield the deferred error if one is held, otherwise
-///   `Err`
+/// - each yielded item has the next transaction index, `Ok` and indexed execution errors
+///   alike: an execution error is a per-transaction result, deferred to its slot so the
+///   consumer observes it in block order and can recover and keep consuming
+/// - non-indexed worker errors are forwarded immediately and exhaust the iterator
+/// - closed channels before `total` outputs yield `Err` and exhaust the iterator
 /// - out-of-bounds and duplicate indices panic because they violate the internal worker/dispatcher
 ///   index invariant
-/// - after the first yielded error, the iterator is exhausted
 pub(super) fn ordered_worker_outputs<R>(
     result_rx: &Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
     total: usize,
@@ -50,8 +48,7 @@ pub(super) fn ordered_worker_outputs<R>(
 
 struct OrderedWorkerOutputs<'a, R> {
     result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
-    pending: Vec<Option<BalWorkerOutput<R>>>,
-    pending_error: Option<(usize, BalWorkerError)>,
+    pending: Vec<Option<Result<BalWorkerOutput<R>, BalWorkerError>>>,
     next: usize,
     total: usize,
     failed: bool,
@@ -65,7 +62,6 @@ impl<'a, R> OrderedWorkerOutputs<'a, R> {
         Self {
             result_rx,
             pending: (0..total).map(|_| None).collect(),
-            pending_error: None,
             next: 0,
             total,
             failed: false,
@@ -82,46 +78,28 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
         }
 
         loop {
-            if let Some((index, _)) = &self.pending_error {
-                if *index == self.next {
-                    self.failed = true;
-                    let (_, err) = self.pending_error.take().expect("pending error present");
-                    return Some(Err(err.into()));
-                }
-            }
-
-            if let Some(output) = self.pending[self.next].take() {
+            if let Some(slot) = self.pending[self.next].take() {
                 self.next += 1;
-                return Some(Ok(output));
+                return Some(slot.map_err(Into::into));
             }
 
-            let output = match self.result_rx.recv() {
-                Ok(Ok(output)) => output,
+            let (index, slot) = match self.result_rx.recv() {
+                Ok(Ok(output)) => (output.index, Ok(output)),
                 Ok(Err(err)) => {
-                    // Defer indexed execution errors until every earlier transaction has
-                    // been yielded, so the consumer observes the failure in block order.
-                    if let BalWorkerError::Execution { index, .. } = &err {
-                        if *index > self.next {
-                            match &self.pending_error {
-                                Some((held, _)) if *held <= *index => {}
-                                _ => self.pending_error = Some((*index, err)),
-                            }
-                            continue;
-                        }
-                    }
-                    self.failed = true;
-                    return Some(Err(err.into()));
+                    // An indexed execution error is a per-transaction result and takes
+                    // its transaction slot; anything else is fatal to the whole block.
+                    let BalWorkerError::Execution { index, .. } = &err else {
+                        self.failed = true;
+                        return Some(Err(err.into()));
+                    };
+                    (*index, Err(err))
                 }
                 Err(_) => {
                     self.failed = true;
-                    if let Some((_, err)) = self.pending_error.take() {
-                        return Some(Err(err.into()));
-                    }
                     return Some(Err(OrderedWorkerOutputError::ResultChannelClosed));
                 }
             };
 
-            let index = output.index;
             assert!(
                 index < self.total,
                 "BAL worker returned out-of-bounds transaction index {index}; total={}",
@@ -132,7 +110,7 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
                 "BAL worker returned duplicate transaction index {index}",
             );
 
-            self.pending[index] = Some(output);
+            self.pending[index] = Some(slot);
         }
     }
 }
@@ -207,19 +185,21 @@ mod tests {
     }
 
     #[test]
-    fn yields_deferred_error_when_channel_closes_early() {
+    fn continues_past_indexed_execution_errors() {
         let (tx, rx) = crossbeam_channel::unbounded();
         tx.send(Err(BalWorkerError::Execution {
-            index: 1,
+            index: 0,
             tx_gas_limit: 42,
             source: alloy_evm::block::BlockExecutionError::msg("bal miss"),
         }))
         .unwrap();
+        tx.send(Ok(output(1, 10))).unwrap();
         drop(tx);
 
-        let mut outputs = ordered_worker_outputs::<u64>(&rx, 2);
+        let mut outputs = ordered_worker_outputs(&rx, 2);
 
         expect_err_contains(outputs.next().expect("first item"), "bal miss");
+        assert_eq!(outputs.next().expect("second item").expect("second output").result, 10);
         assert!(outputs.next().is_none());
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -33,11 +33,14 @@ impl From<OrderedWorkerOutputError> for BalExecutionError {
 ///
 /// Behavior:
 /// - each yielded `Ok` output has the next transaction index
-/// - worker errors are forwarded unchanged
-/// - closed channels before `total` outputs yield `Err`
+/// - indexed execution errors are deferred to their transaction slot, so every earlier
+///   transaction's output is yielded first and the consumer sees the failure in block order
+/// - non-indexed worker errors are forwarded immediately
+/// - closed channels before `total` outputs yield the deferred error if one is held, otherwise
+///   `Err`
 /// - out-of-bounds and duplicate indices panic because they violate the internal worker/dispatcher
 ///   index invariant
-/// - after the first error, the iterator is exhausted
+/// - after the first yielded error, the iterator is exhausted
 pub(super) fn ordered_worker_outputs<R>(
     result_rx: &Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
     total: usize,
@@ -48,6 +51,7 @@ pub(super) fn ordered_worker_outputs<R>(
 struct OrderedWorkerOutputs<'a, R> {
     result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
     pending: Vec<Option<BalWorkerOutput<R>>>,
+    pending_error: Option<(usize, BalWorkerError)>,
     next: usize,
     total: usize,
     failed: bool,
@@ -61,6 +65,7 @@ impl<'a, R> OrderedWorkerOutputs<'a, R> {
         Self {
             result_rx,
             pending: (0..total).map(|_| None).collect(),
+            pending_error: None,
             next: 0,
             total,
             failed: false,
@@ -77,6 +82,14 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
         }
 
         loop {
+            if let Some((index, _)) = &self.pending_error {
+                if *index == self.next {
+                    self.failed = true;
+                    let (_, err) = self.pending_error.take().expect("pending error present");
+                    return Some(Err(err.into()));
+                }
+            }
+
             if let Some(output) = self.pending[self.next].take() {
                 self.next += 1;
                 return Some(Ok(output));
@@ -85,11 +98,25 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
             let output = match self.result_rx.recv() {
                 Ok(Ok(output)) => output,
                 Ok(Err(err)) => {
+                    // Defer indexed execution errors until every earlier transaction has
+                    // been yielded, so the consumer observes the failure in block order.
+                    if let BalWorkerError::Execution { index, .. } = &err {
+                        if *index > self.next {
+                            match &self.pending_error {
+                                Some((held, _)) if *held <= *index => {}
+                                _ => self.pending_error = Some((*index, err)),
+                            }
+                            continue;
+                        }
+                    }
                     self.failed = true;
                     return Some(Err(err.into()));
                 }
                 Err(_) => {
                     self.failed = true;
+                    if let Some((_, err)) = self.pending_error.take() {
+                        return Some(Err(err.into()));
+                    }
                     return Some(Err(OrderedWorkerOutputError::ResultChannelClosed));
                 }
             };
@@ -157,6 +184,42 @@ mod tests {
         let mut outputs = ordered_worker_outputs::<u64>(&rx, 1);
 
         expect_err_contains(outputs.next().expect("first item"), "worker failed");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn defers_indexed_execution_errors_to_their_slot() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Err(BalWorkerError::Execution {
+            index: 1,
+            tx_gas_limit: 42,
+            source: alloy_evm::block::BlockExecutionError::msg("bal miss"),
+        }))
+        .unwrap();
+        tx.send(Ok(output(0, 0))).unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs(&rx, 2);
+
+        assert_eq!(outputs.next().expect("first item").expect("first output").result, 0);
+        expect_err_contains(outputs.next().expect("second item"), "bal miss");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn yields_deferred_error_when_channel_closes_early() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Err(BalWorkerError::Execution {
+            index: 1,
+            tx_gas_limit: 42,
+            source: alloy_evm::block::BlockExecutionError::msg("bal miss"),
+        }))
+        .unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs::<u64>(&rx, 2);
+
+        expect_err_contains(outputs.next().expect("first item"), "bal miss");
         assert!(outputs.next().is_none());
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -99,14 +99,17 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let tx_gas_limit = tx.tx().gas_limit();
 
                 executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
-                let result = executor
-                    .execute_transaction_without_commit(tx)
-                    .map_err(|source| BalWorkerError::Execution { index, tx_gas_limit, source })?;
+                // A speculative failure is a per-transaction result: report it and keep
+                // serving the queue so the ordered commit loop can re-execute the
+                // transaction canonically while later transactions stay parallel.
+                let message = match executor.execute_transaction_without_commit(tx) {
+                    Ok(result) => Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }),
+                    Err(source) => {
+                        Err(BalWorkerError::Execution { index, tx_gas_limit, source })
+                    }
+                };
 
-                if result_tx
-                    .send(Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }))
-                    .is_err()
-                {
+                if result_tx.send(message).is_err() {
                     break;
                 }
             }

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -20,8 +20,16 @@ pub(super) enum BalWorkerError {
     #[error("BAL worker transaction conversion failed: {0}")]
     Transaction(Box<dyn core::error::Error + Send + Sync + 'static>),
     /// EVM transaction execution failed.
-    #[error("BAL worker EVM execution failed: {0}")]
-    Execution(BlockExecutionError),
+    #[error("BAL worker EVM execution failed: {source}")]
+    Execution {
+        /// Index of the transaction that failed.
+        index: usize,
+        /// Gas limit of the transaction that failed.
+        tx_gas_limit: u64,
+        /// The underlying execution error.
+        #[source]
+        source: BlockExecutionError,
+    },
 }
 
 impl From<BalWorkerError> for BalExecutionError {
@@ -29,7 +37,7 @@ impl From<BalWorkerError> for BalExecutionError {
         match err {
             BalWorkerError::Setup(err) => err,
             BalWorkerError::Transaction(err) => Self::Other(err),
-            BalWorkerError::Execution(err) => Self::Execution(err),
+            BalWorkerError::Execution { source, .. } => Self::Execution(source),
         }
     }
 }
@@ -93,7 +101,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
                 let result = executor
                     .execute_transaction_without_commit(tx)
-                    .map_err(BalWorkerError::Execution)?;
+                    .map_err(|source| BalWorkerError::Execution { index, tx_gas_limit, source })?;
 
                 if result_tx
                     .send(Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }))

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1134,7 +1134,7 @@ where
         InsertBlockErrorKind,
     >
     where
-        Tx: ExecutableTxFor<Evm> + Send,
+        Tx: ExecutableTxFor<Evm> + Clone + Send,
         Err: core::error::Error + Send + Sync + 'static,
         MakeStateProvider: Fn(bool) -> ProviderResult<StateProviderBox> + Sync,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
@@ -1370,7 +1370,7 @@ where
         parallel_bal_execution: bool,
     ) -> Result<
         PayloadHandle<
-            impl ExecutableTxFor<Evm> + use<N, P, Evm, V, T>,
+            impl ExecutableTxFor<Evm> + Clone + Send + use<N, P, Evm, V, T>,
             impl core::error::Error + Send + Sync + 'static + use<N, P, Evm, V, T>,
             N::Receipt,
         >,


### PR DESCRIPTION
Vibed with some eyes. Tagging for visibility and ping'd in STEEL discord.

On the parallel BAL path, a speculative worker failure aborted the whole payload with an internal `Bal error: Account … not found in BAL`, preempting the real consensus verdict. Failed transactions are now checked for block-gas admission first and otherwise re-executed canonically so the payload always reaches a real verdict.

Fixes the consume-engine fails of `tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py`, the `eip8037_state_creation_gas_cost_increase` gas suites, and `eip8282_builder_execution_requests/test_modified_builder_contract.py::test_system_contract_errors` on [hive glamsterdam-quick](https://hive.ethpandaops.io/#/test/glamsterdam-quick/1786545713-b58ee7108bac1061a0e86683cb053c10).
