### PR TITLE
fix(stages): validate block access list hash on import path (EIP-7928)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7844,6 +7844,7 @@ version = "2.5.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
@@ -10249,6 +10250,7 @@ name = "reth-stages"
 version = "2.5.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+checksum = "5074ab00e3f04a5b377bd7398d18ede2dd8110c178a10295abaaa52e2761b6ca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,7 +442,7 @@ alloy-sol-types = { version = "1.6.1", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-eip7928 = { version = "0.4.5", default-features = false, features = ["rlp"] }
+alloy-eip7928 = { version = "0.4.7", default-features = false, features = ["rlp"] }
 alloy-evm = { version = "0.38.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -123,6 +123,7 @@ arbitrary = [
     "reth-db/arbitrary",
     "reth-chainspec/arbitrary",
     "alloy-chains/arbitrary",
+    "alloy-eip7928/arbitrary",
     "alloy-eips/arbitrary",
     "alloy-primitives/arbitrary",
     "reth-codecs/test-utils",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -59,6 +59,7 @@ reth-discv4.workspace = true
 reth-discv5.workspace = true
 
 # ethereum
+alloy-eip7928.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -150,6 +150,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                 let evm_config = evm_config.with_jit_support();
                 let executor_lifetime = Duration::from_secs(600);
                 let provider = provider_factory.database_provider_ro()?.disable_long_read_transaction_safety();
+                // Reused across blocks for BAL hash encoding.
+                let mut bal_buf = Vec::new();
 
                 let db_at = {
                     |block_number: u64| {
@@ -200,8 +202,9 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
                         };
 
-                        let bal_hash =
-                            executor.take_bal().map(|bal| Bal::from(bal).compute_hash());
+                        let bal_hash = executor
+                            .take_bal()
+                            .map(|bal| Bal::from(bal).compute_hash_with_buf(&mut bal_buf));
 
                         if let Err(err) = consensus
                             .validate_block_post_execution(&block, &result, None, bal_hash)

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -5,7 +5,7 @@ use crate::common::{
     EnvironmentArgs,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
-use alloy_eip7928::compute_block_access_list_hash;
+use alloy_eip7928::bal::Bal;
 use alloy_primitives::{Address, B256, U256};
 use clap::Parser;
 use eyre::WrapErr;
@@ -200,10 +200,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
                         };
 
-                        let bal_hash = executor
-                            .take_bal()
-                            .as_ref()
-                            .map(|bal| compute_block_access_list_hash(bal.as_slice()));
+                        let bal_hash =
+                            executor.take_bal().map(|bal| Bal::from(bal).compute_hash());
 
                         if let Err(err) = consensus
                             .validate_block_post_execution(&block, &result, None, bal_hash)

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -264,6 +264,12 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                                 }
                             }
 
+                            if skip_invalid_blocks {
+                                executor =
+                                    evm_config.batch_executor(db_at(block.number()));
+                                let _ = info_tx.send((block, err));
+                                continue 'blocks;
+                            }
                             return Err(err);
                         }
                         let _ = stats_tx.send((block.number(), block.gas_used()));

--- a/crates/cli/commands/src/re_execute.rs
+++ b/crates/cli/commands/src/re_execute.rs
@@ -5,6 +5,7 @@ use crate::common::{
     EnvironmentArgs,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, TxReceipt};
+use alloy_eip7928::compute_block_access_list_hash;
 use alloy_primitives::{Address, B256, U256};
 use clap::Parser;
 use eyre::WrapErr;
@@ -199,8 +200,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                             }
                         };
 
+                        let bal_hash = executor
+                            .take_bal()
+                            .as_ref()
+                            .map(|bal| compute_block_access_list_hash(bal.as_slice()));
+
                         if let Err(err) = consensus
-                            .validate_block_post_execution(&block, &result, None,None)
+                            .validate_block_post_execution(&block, &result, None, bal_hash)
                             .wrap_err_with(|| {
                                 format!(
                                     "Failed to validate block {} {}",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -45,6 +45,7 @@ reth-trie-db = { workspace = true, features = ["metrics"] }
 
 reth-testing-utils = { workspace = true, optional = true }
 
+alloy-eip7928.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -363,13 +363,13 @@ where
             })?;
 
             let built_bal = executor.take_bal().map(Bal::from);
-            if let Some(bal) = &built_bal {
-                if let Err(err) = bal.validate_gas_limit(block.header().gas_limit()) {
-                    return Err(StageError::Block {
-                        block: Box::new(block.block_with_parent()),
-                        error: BlockErrorKind::Validation(err.into()),
-                    })
-                }
+            if let Some(bal) = &built_bal &&
+                let Err(err) = bal.validate_gas_limit(block.header().gas_limit())
+            {
+                return Err(StageError::Block {
+                    block: Box::new(block.block_with_parent()),
+                    error: BlockErrorKind::Validation(err.into()),
+                })
             }
             let bal_hash = built_bal.as_ref().map(|bal| bal.compute_hash_with_buf(&mut bal_buf));
 

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -1,9 +1,6 @@
 use crate::stages::MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD;
 use alloy_consensus::BlockHeader;
-use alloy_eip7928::{
-    compute_block_access_list_hash, constants::ITEM_COST, total_bal_items,
-    BlockAccessListGasError,
-};
+use alloy_eip7928::bal::Bal;
 use alloy_primitives::BlockNumber;
 use num_traits::Zero;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
@@ -363,21 +360,16 @@ where
                 })
             })?;
 
-            let built_bal = executor.take_bal();
+            let built_bal = executor.take_bal().map(Bal::from);
             if let Some(bal) = &built_bal {
-                let gas_limit = block.header().gas_limit();
-                let items = total_bal_items(bal);
-                if items > gas_limit / ITEM_COST as u64 {
+                if let Err(err) = bal.validate_gas_limit(block.header().gas_limit()) {
                     return Err(StageError::Block {
                         block: Box::new(block.block_with_parent()),
-                        error: BlockErrorKind::Validation(
-                            BlockAccessListGasError::new(items, gas_limit).into(),
-                        ),
+                        error: BlockErrorKind::Validation(err.into()),
                     })
                 }
             }
-            let bal_hash =
-                built_bal.as_ref().map(|bal| compute_block_access_list_hash(bal.as_slice()));
+            let bal_hash = built_bal.as_ref().map(|bal| bal.compute_hash());
 
             if let Err(err) =
                 self.consensus.validate_block_post_execution(&block, &result, None, bal_hash)

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -1,5 +1,9 @@
 use crate::stages::MERKLE_STAGE_DEFAULT_INCREMENTAL_THRESHOLD;
 use alloy_consensus::BlockHeader;
+use alloy_eip7928::{
+    compute_block_access_list_hash, constants::ITEM_COST, total_bal_items,
+    BlockAccessListGasError,
+};
 use alloy_primitives::BlockNumber;
 use num_traits::Zero;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
@@ -359,8 +363,24 @@ where
                 })
             })?;
 
+            let built_bal = executor.take_bal();
+            if let Some(bal) = &built_bal {
+                let gas_limit = block.header().gas_limit();
+                let items = total_bal_items(bal);
+                if items > gas_limit / ITEM_COST as u64 {
+                    return Err(StageError::Block {
+                        block: Box::new(block.block_with_parent()),
+                        error: BlockErrorKind::Validation(
+                            BlockAccessListGasError::new(items, gas_limit).into(),
+                        ),
+                    })
+                }
+            }
+            let bal_hash =
+                built_bal.as_ref().map(|bal| compute_block_access_list_hash(bal.as_slice()));
+
             if let Err(err) =
-                self.consensus.validate_block_post_execution(&block, &result, None, None)
+                self.consensus.validate_block_post_execution(&block, &result, None, bal_hash)
             {
                 return Err(StageError::Block {
                     block: Box::new(block.block_with_parent()),

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -334,6 +334,8 @@ where
 
         let mut blocks = Vec::new();
         let mut results = Vec::new();
+        // Reused across blocks for BAL hash encoding.
+        let mut bal_buf = Vec::new();
         for block_number in start_block..=max_block {
             // Fetch the block
             let fetch_block_start = Instant::now();
@@ -369,7 +371,7 @@ where
                     })
                 }
             }
-            let bal_hash = built_bal.as_ref().map(|bal| bal.compute_hash());
+            let bal_hash = built_bal.as_ref().map(|bal| bal.compute_hash_with_buf(&mut bal_buf));
 
             if let Err(err) =
                 self.consensus.validate_block_post_execution(&block, &result, None, bal_hash)


### PR DESCRIPTION
Takes over #26692 from @spencer-tb, retargeted at `main`.

The RLP-import path (`reth import` / pipeline sync) accepts blocks whose block access list is invalid: `ExecutionStage` calls `validate_block_post_execution(&block, &result, None, None)`, and with `None` for the computed BAL hash the EIP-7928 comparison silently skips; the item-cost-vs-gas-limit constraint is not checked on this path at all. The executor already builds the BAL during import (`execute_one` enables the builder whenever the header carries a BAL hash), it was just never harvested for validation. The engine path validates both, which is why hive only catches this on consume-rlp: on glamsterdam-quick this accounts for ~70 of reth's 125 fails (every `test_bal_invalid_*` consume-rlp case plus the `test_bal_gas_limit_boundary` / `test_fork_transition_bal_size_constraint` consume-rlp cases).

This harvests the built BAL via the existing `Executor::take_bal()` in `ExecutionStage`, validates the item cost against the gas limit, and passes the computed hash to `validate_block_post_execution`, mirroring the engine path (also wired in `reth re-execute`). Pre-Amsterdam blocks build no BAL, so `take_bal()` returns `None` and behavior is unchanged.

On top of the original PR this uses the `alloy_eip7928::bal::Bal` helpers (`validate_gas_limit`, `compute_hash`) instead of open-coding the item-count math, the same helper the engine path runs on the decoded payload BAL.

See #26692 for the hive run and fixture-level verification.

Closes #26692
