### PR TITLE
perf(txpool): Accelerate best transaction iteration

### DIFF
--- a/crates/transaction-pool/Cargo.toml
+++ b/crates/transaction-pool/Cargo.toml
@@ -133,3 +133,8 @@ arbitrary = [
 name = "saturated_pool"
 harness = false
 required-features = ["test-utils"]
+
+[[bench]]
+name = "best_transactions"
+harness = false
+required-features = ["test-utils"]

--- a/crates/transaction-pool/benches/best_transactions.rs
+++ b/crates/transaction-pool/benches/best_transactions.rs
@@ -1,0 +1,98 @@
+#![allow(missing_docs)]
+
+//! Benchmarks for creating and consuming best transaction snapshots.
+
+use std::{hint::black_box, sync::Arc};
+
+use alloy_primitives::{Address, B256, U256};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use reth_transaction_pool::{
+    pool::PendingPool,
+    test_utils::{MockOrdering, MockTransaction, MockTransactionFactory},
+    BestTransactions,
+};
+
+const TRANSACTION_COUNTS: &[usize] = &[1_000, 10_000, 100_000];
+
+fn pool(transaction_count: usize, sender_count: usize) -> PendingPool<MockOrdering> {
+    let mut pool = PendingPool::new(MockOrdering::default());
+    let mut factory = MockTransactionFactory::default();
+    for index in 0..transaction_count {
+        let sender = index % sender_count;
+        let transaction = MockTransaction::eip1559()
+            .with_sender(Address::from_word(U256::from(sender + 1).into()))
+            .with_nonce((index / sender_count) as u64)
+            .with_hash(B256::from(U256::from(index + 1)));
+        pool.add_transaction(Arc::new(factory.validated(transaction)), 0);
+    }
+    pool
+}
+
+fn best_transactions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("best_transactions");
+    group.sample_size(10);
+
+    for &transaction_count in TRANSACTION_COUNTS {
+        let pool = pool(transaction_count, transaction_count);
+        group.throughput(Throughput::Elements(transaction_count as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("end_to_end", transaction_count),
+            &transaction_count,
+            |b, _| {
+                b.iter(|| {
+                    let mut best = pool.best();
+                    best.no_updates();
+                    assert_eq!(best.by_ref().map(black_box).count(), transaction_count);
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("snapshot", transaction_count),
+            &transaction_count,
+            |b, _| {
+                b.iter(|| {
+                    let mut best = pool.best();
+                    best.no_updates();
+                    black_box(best);
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("iterate", transaction_count),
+            &transaction_count,
+            |b, _| {
+                b.iter_batched(
+                    || {
+                        let mut best = pool.best();
+                        best.no_updates();
+                        best
+                    },
+                    |mut best| {
+                        assert_eq!(best.by_ref().map(black_box).count(), transaction_count);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+
+    for sender_count in [1, 1_000] {
+        let pool = pool(100_000, sender_count);
+        let mut group = c.benchmark_group(format!("best_transactions/{sender_count}_senders"));
+        group.sample_size(10);
+        group.throughput(Throughput::Elements(100_000));
+        group.bench_function("end_to_end/100000", |b| {
+            b.iter(|| {
+                let mut best = pool.best();
+                best.no_updates();
+                assert_eq!(best.by_ref().map(black_box).count(), 100_000);
+            });
+        });
+        group.finish();
+    }
+}
+
+criterion_group!(benches, best_transactions);
+criterion_main!(benches);

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -9,9 +9,9 @@ use alloy_primitives::map::AddressSet;
 use core::fmt;
 use imbl::OrdMap;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
-    collections::{BTreeSet, VecDeque},
+    collections::{BinaryHeap, VecDeque},
     sync::Arc,
 };
 use tokio::sync::broadcast::{error::TryRecvError, Receiver};
@@ -98,9 +98,21 @@ pub struct BestTransactions<T: TransactionOrdering> {
     pub(crate) all: OrdMap<TransactionId, PendingTransaction<T>>,
     /// Transactions that can be executed right away: these have the expected nonce.
     ///
-    /// Once an `independent` transaction with the nonce `N` is returned, it unlocks `N+1`, which
-    /// then can be moved from the `all` set to the `independent` set.
-    pub(crate) independent: BTreeSet<PendingTransaction<T>>,
+    /// This is sorted when the iterator is created so removing the best transaction is constant
+    /// time.
+    pub(crate) independent: Vec<PendingTransaction<T>>,
+    /// Transactions unlocked or received after this iterator was created.
+    pub(crate) unlocked: BinaryHeap<PendingTransaction<T>>,
+    /// Dependent transactions in sender and nonce order.
+    pub(crate) dependents: Vec<PendingTransaction<T>>,
+    /// Index of each sender's next transaction in `dependents`.
+    pub(crate) next_dependent: FxHashMap<SenderId, usize>,
+    /// Whether transactions have been added after the static snapshot was created.
+    pub(crate) has_updates: bool,
+    /// Transactions that have already been yielded from this snapshot.
+    pub(crate) yielded: FxHashSet<TransactionId>,
+    /// Number of transactions yielded from this snapshot.
+    pub(crate) yielded_count: usize,
     /// There might be the case where a yielded transactions is invalid, this will track it.
     pub(crate) invalid: FxHashSet<SenderId>,
     /// Used to receive any new pending transactions that have been added to the pool after this
@@ -134,7 +146,8 @@ impl<T: TransactionOrdering> BestTransactions<T> {
     /// Note: for a transaction with nonce higher than the current on chain nonce this will always
     /// return an ancestor since all transactions in this pool are gapless.
     pub(crate) fn ancestor(&self, id: &TransactionId) -> Option<&PendingTransaction<T>> {
-        self.all.get(&id.unchecked_ancestor()?)
+        let ancestor = id.unchecked_ancestor()?;
+        (!self.yielded.contains(&ancestor)).then(|| self.all.get(&ancestor)).flatten()
     }
 
     /// Non-blocking read on the new pending transactions subscription channel
@@ -169,12 +182,40 @@ impl<T: TransactionOrdering> BestTransactions<T> {
         }
     }
 
-    /// Removes the currently best independent transaction from the independent set and the total
-    /// set.
+    /// Removes the best transaction from the initial transactions or transactions unlocked later.
     fn pop_best(&mut self) -> Option<PendingTransaction<T>> {
-        self.independent.pop_last().inspect(|best| {
-            self.all.remove(best.transaction.id());
+        let best = match (self.independent.last(), self.unlocked.peek()) {
+            (Some(independent), Some(unlocked)) if unlocked > independent => self.unlocked.pop(),
+            (Some(_), _) => self.independent.pop(),
+            (None, _) => self.unlocked.pop(),
+        };
+        best.inspect(|best| {
+            self.yielded_count += 1;
+            if self.new_transaction_receiver.is_some() {
+                self.yielded.insert(*best.transaction.id());
+            }
         })
+    }
+
+    /// Returns the next transaction of a sender from the static snapshot.
+    fn next_dependent(&mut self, expected: &TransactionId) -> Option<PendingTransaction<T>> {
+        let sender = expected.sender;
+        let index = *self.next_dependent.get(&sender)?;
+        let dependent = self.dependents.get(index)?.clone();
+        if self.has_updates && dependent.transaction.id() != expected {
+            return None
+        }
+        let next_index = index + 1;
+        if self
+            .dependents
+            .get(next_index)
+            .is_some_and(|transaction| transaction.transaction.sender_id() == sender)
+        {
+            self.next_dependent.insert(sender, next_index);
+        } else {
+            self.next_dependent.remove(&sender);
+        }
+        Some(dependent)
     }
 
     /// Checks for new transactions that have come into the `PendingPool` after this iterator was
@@ -186,13 +227,15 @@ impl<T: TransactionOrdering> BestTransactions<T> {
 
                 match pending_tx {
                     IncomingTransaction::Process(tx) => {
+                        self.has_updates = true;
                         let tx_id = *tx.transaction.id();
                         if self.ancestor(&tx_id).is_none() {
-                            self.independent.insert(tx.clone());
+                            self.unlocked.push(tx.clone());
                         }
                         self.all.insert(tx_id, tx);
                     }
                     IncomingTransaction::Stash(tx) => {
+                        self.has_updates = true;
                         let tx_id = *tx.transaction.id();
                         self.all.insert(tx_id, tx);
                     }
@@ -225,8 +268,12 @@ impl<T: TransactionOrdering> BestTransactions<T> {
             }
 
             // Insert transactions that just got unlocked.
-            if let Some(unlocked) = self.all.get(&best.unlocks()) {
-                self.independent.insert(unlocked.clone());
+            let unlocks = best.unlocks();
+            let snapshot_unlocked = self.next_dependent(&unlocks);
+            let unlocked =
+                if self.has_updates { self.all.get(&unlocks).cloned() } else { snapshot_unlocked };
+            if let Some(unlocked) = unlocked {
+                self.unlocked.push(unlocked);
             }
 
             if self.skip_blobs && best.transaction.is_eip4844() {
@@ -306,7 +353,12 @@ impl<T: TransactionOrdering> Iterator for BestTransactions<T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, self.new_transaction_receiver.is_none().then_some(self.all.len()))
+        (
+            0,
+            self.new_transaction_receiver
+                .is_none()
+                .then_some(self.all.len().saturating_sub(self.yielded_count)),
+        )
     }
 }
 
@@ -510,7 +562,7 @@ mod tests {
 
         // check tx are returned in order
         for nonce in 0..num_tx {
-            assert_eq!(best.independent.len(), 1);
+            assert_eq!(best.independent.len() + best.unlocked.len(), 1);
             let tx = best.next().unwrap();
             assert_eq!(tx.nonce(), nonce);
         }
@@ -855,8 +907,8 @@ mod tests {
         assert!(best.all.contains_key(valid_new_tx.id()));
 
         // Verify that the new transaction has been added to the 'independent' set
-        assert_eq!(best.independent.len(), 2);
-        assert!(best.independent.contains(&pending_tx));
+        assert_eq!(best.independent.len() + best.unlocked.len(), 2);
+        assert!(best.unlocked.iter().any(|transaction| transaction == &pending_tx));
     }
 
     #[test]
@@ -902,8 +954,8 @@ mod tests {
         assert!(best.all.contains_key(valid_new_tx1.id()));
 
         // Verify that the new transaction has been added to the 'independent' set
-        assert_eq!(best.independent.len(), 2);
-        assert!(best.independent.contains(&pending_tx1));
+        assert_eq!(best.independent.len() + best.unlocked.len(), 2);
+        assert!(best.unlocked.iter().any(|transaction| transaction == &pending_tx1));
 
         // Attempt to add a new transaction with a different nonce (not a duplicate)
         let base_tx2 = base_tx1.with_nonce(6);
@@ -925,8 +977,8 @@ mod tests {
         assert!(best.all.contains_key(valid_new_tx2.id()));
 
         // Verify that the new transaction has not been added to the 'independent' set
-        assert_eq!(best.independent.len(), 2);
-        assert!(!best.independent.contains(&pending_tx2));
+        assert_eq!(best.independent.len() + best.unlocked.len(), 2);
+        assert!(!best.unlocked.iter().any(|transaction| transaction == &pending_tx2));
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -102,9 +102,33 @@ impl<T: TransactionOrdering> PendingPool<T> {
     /// which case the transaction's subgraph is also automatically marked invalid, See (1.).
     /// Invalid transactions are skipped.
     pub fn best(&self) -> BestTransactions<T> {
+        let mut independent: Vec<_> = self.independent_transactions.values().cloned().collect();
+        independent.sort_unstable();
+        let dependent_count = self.by_id.len() - independent.len();
+        let mut dependents = Vec::with_capacity(dependent_count);
+        let mut next_dependent = FxHashMap::default();
+        if dependent_count > 0 {
+            for (id, transaction) in &self.by_id {
+                if self
+                    .independent_transactions
+                    .get(&id.sender)
+                    .is_some_and(|independent| independent.transaction.id() == id)
+                {
+                    continue
+                }
+                next_dependent.entry(id.sender).or_insert(dependents.len());
+                dependents.push(transaction.clone());
+            }
+        }
         BestTransactions {
             all: self.by_id.clone(),
-            independent: self.independent_transactions.values().cloned().collect(),
+            independent,
+            unlocked: Default::default(),
+            dependents,
+            next_dependent,
+            has_updates: false,
+            yielded: Default::default(),
+            yielded_count: 0,
             invalid: Default::default(),
             new_transaction_receiver: Some(self.new_transaction_notifier.subscribe()),
             last_priority: None,
@@ -140,12 +164,13 @@ impl<T: TransactionOrdering> PendingPool<T> {
     ) -> BestTransactionsWithFees<T> {
         let mut best = self.best();
         for (submission_id, tx) in (self.submission_id + 1..).zip(unlocked) {
+            best.has_updates = true;
             debug_assert!(!best.all.contains_key(tx.id()), "transaction already included");
             let priority = self.ordering.priority(&tx.transaction, base_fee);
             let tx_id = *tx.id();
             let transaction = PendingTransaction { submission_id, transaction: tx, priority };
             if best.ancestor(&tx_id).is_none() {
-                best.independent.insert(transaction.clone());
+                best.unlocked.push(transaction.clone());
             }
             best.all.insert(tx_id, transaction);
         }


### PR DESCRIPTION
### Summary
Improves `BestTransactions` iteration performance by moving ordering work into snapshot creation and avoiding per-transaction persistent tree mutations.

Ready transactions are sorted once and popped from a vector, while nonce-dependent transactions use compact sender cursors and a heap only when unlocked.

### Results

| Workload | Topology | Before | After | Speedup |
|----------|-----------|---|-------|-------|
| Saturated pool | 10k txs, 2,500 senders, 4 txs/sender | 1.74ms | 0.53ms | 3.3x |
| Independent | 100k txs, 100k senders | 27.32ms | 5.78ms | 4.7x |
| Single sender | 100k sequential txs | 24.40ms | 4.09ms | 6.0x |
| Multi-sender chains | 100k txs, 1,000 senders | 29.49ms | 8.57ms | 3.4x |
| Snapshot only | 100k independent txs | 6.50ms | 4.49ms | 1.4x |
| Iteration only | 100k independent txs | 20.48ms | 1.56ms | 13.1x |

The largest improvement is during iteration because the old implementation mutated persistent ordered trees for every selected transaction. The new implementation performs ordering during snapshot creation, then uses constant-time vector operations for the common static path.