### PR TITLE
chore(deps): bump alloy-eip7928 to 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5074ab00e3f04a5b377bd7398d18ede2dd8110c178a10295abaaa52e2761b6ca"
+checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,7 +442,7 @@ alloy-sol-types = { version = "1.6.1", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-eip7928 = { version = "0.4.7", default-features = false, features = ["rlp"] }
+alloy-eip7928 = { version = "0.4.8", default-features = false, features = ["rlp"] }
 alloy-evm = { version = "0.38.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }


### PR DESCRIPTION
Follow-up to #26696: pulls in the BAL quantity serde fix from alloy-rs/eips#118.