### PR TITLE
fix(engine): keep messages responsive during pending handoff

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -710,17 +710,24 @@ where
 
     /// Blocks until the next event that can safely be processed is ready.
     ///
-    /// A pending persisted handoff only accepts the notification that all active payload builds
-    /// have finished. This keeps queued engine messages from starting replacement payload jobs
-    /// before the handoff can reclaim the in-memory overlay. Otherwise, uses biased selection to
-    /// prioritize persistence completion to update in-memory state and unblock further writes.
+    /// A pending persisted handoff keeps processing engine messages while prioritizing the
+    /// notification that all active payload builds have finished. This keeps the engine responsive
+    /// without reclaiming the in-memory overlay while a payload job may still access it. Otherwise,
+    /// uses biased selection to prioritize persistence completion to update in-memory state and
+    /// unblock further writes.
     fn wait_for_event(&mut self) -> LoopEvent<T, N> {
         if self.pending_persisted_handoff.is_some() {
             self.metrics.engine.backpressure_active.set(0.0);
-            return match self.payload_build_finished.recv() {
-                Ok(()) => LoopEvent::PayloadBuildFinished,
-                Err(_) => LoopEvent::Disconnected,
-            };
+            return crossbeam_channel::select_biased! {
+                recv(self.payload_build_finished) -> result => match result {
+                    Ok(()) => LoopEvent::PayloadBuildFinished,
+                    Err(_) => LoopEvent::Disconnected,
+                },
+                recv(self.incoming) -> msg => match msg {
+                    Ok(m) => LoopEvent::EngineMessage(m),
+                    Err(_) => LoopEvent::Disconnected,
+                },
+            }
         }
 
         // Take ownership of persistence rx if present

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -709,7 +709,7 @@ fn persistence_handoff_waits_for_active_payload_jobs() {
 }
 
 #[test]
-fn pending_persisted_handoff_blocks_engine_messages_until_payload_build_finishes() {
+fn pending_persisted_handoff_keeps_engine_messages_responsive() {
     let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
     let mut test_harness = TestHarness::with_config(
         MAINNET.clone(),
@@ -732,34 +732,23 @@ fn pending_persisted_handoff_blocks_engine_messages_until_payload_build_finishes
         .unwrap();
     assert!(test_harness.tree.pending_persisted_handoff.is_some());
 
-    // Forkchoice updates received while the handoff is pending could start replacement payload
-    // builds and keep the final completion notification from reaching the tree. Queue a generic
-    // engine message to prove the gate leaves every message upstream until then.
+    // Engine messages remain processable while the handoff waits for the active payload build.
     test_harness.to_tree_tx.send(FromEngine::Event(FromOrchestrator::BackfillSyncStarted)).unwrap();
+    assert_matches!(
+        test_harness.tree.wait_for_event(),
+        super::LoopEvent::EngineMessage(FromEngine::Event(FromOrchestrator::BackfillSyncStarted))
+    );
+    assert!(test_harness.tree.pending_persisted_handoff.is_some());
+    assert!(test_harness.tree.state.tree_state.contains_hash(&persisted.hash));
 
-    let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
-    let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
-    std::thread::scope(|scope| {
-        let tree = &mut test_harness.tree;
-        scope.spawn(move || {
-            started_tx.send(()).unwrap();
-            event_tx
-                .send(matches!(tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished))
-                .unwrap();
-        });
-
-        started_rx.recv().unwrap();
-        assert!(
-            event_rx.recv_timeout(Duration::from_millis(100)).is_err(),
-            "a pending handoff must prevent queued engine messages from being processed"
-        );
-
-        drop(payload_build);
-        assert_eq!(event_rx.recv_timeout(Duration::from_secs(1)), Ok(true));
-    });
-
+    // Once the final lease drops, its completion is prioritized over queued engine messages so the
+    // handoff gets the first opportunity to reclaim the overlay.
+    test_harness.to_tree_tx.send(FromEngine::Event(FromOrchestrator::BackfillSyncStarted)).unwrap();
+    drop(payload_build);
+    assert_matches!(test_harness.tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished);
     test_harness.tree.on_payload_build_finished().unwrap();
     assert!(test_harness.tree.pending_persisted_handoff.is_none());
+    assert!(!test_harness.tree.state.tree_state.contains_hash(&persisted.hash));
     assert_matches!(
         test_harness.tree.wait_for_event(),
         super::LoopEvent::EngineMessage(FromEngine::Event(FromOrchestrator::BackfillSyncStarted))


### PR DESCRIPTION
Closes #26704

Follow-up to #26559. Unblocks tempoxyz/tempo#7142.

#26559 correctly defers the destructive persisted-state handoff until every payload-build overlay lease has been released. However, once that handoff is pending, the tree currently waits exclusively for `payload_build_finished`. A slow or stuck payload build therefore also stops the tree from reading incoming Engine messages, leaving `forkchoiceUpdated`, `getPayload`, and other requests queued for the lifetime of the job. The changeset-cache miss reported in #26704 turns that coupling into an 8–18 second Engine API outage.

Use a biased select while the handoff is pending: process the payload-build completion first when it is ready, but otherwise continue processing Engine messages. The handoff remains stored and the in-memory overlay is not reclaimed until the final lease drops, so the safety property introduced by #26559 is preserved.

This intentionally separates Engine API liveness from persistence progress. It does not cancel or forcibly release payload jobs: a job that never releases its lease can still delay the handoff, and continuously replacing leases may require a separate cancellation/poisoning design. Blocking all Engine input is not a safe fallback for that condition because it makes the execution client unable to follow consensus.

Tempo exposed the issue after its Reth bump in tempoxyz/tempo#7142. Tempo can begin the next consensus proposal while its executor actor independently sends `newPayload`/`forkchoiceUpdated` for the parent. With a pending handoff, those Engine calls stopped being serviced until the active build ended, causing its consensus and snapshot E2E tests to stop progressing. Tempo temporarily gated executor heartbeats on the payload-job count; this change is intended to make that workaround unnecessary.

The pending-parent validator lookup in tempoxyz/tempo#7142 is a separate pre-existing ordering race: a locally executed parent may still be pending when DKG reads it. This PR addresses only Engine-loop responsiveness and should not be interpreted as making that pending-aware lookup unnecessary.
