### PR TITLE
fix(engine): enforce Bogota fork timeframe in engine method validation

### DIFF
--- a/crates/payload/primitives/src/lib.rs
+++ b/crates/payload/primitives/src/lib.rs
@@ -62,8 +62,10 @@ pub trait PayloadTypes: Send + Sync + Unpin + core::fmt::Debug + Clone + 'static
 /// * If V2, this ensures that the payload timestamp is pre-Cancun.
 /// * If V3, this ensures that the payload timestamp is within the Cancun timestamp.
 /// * If V4, this ensures that the payload timestamp is within the Prague timestamp.
-/// * If V5, this ensures that the payload timestamp is within the Osaka timestamp.
-/// * If V6, this ensures that the payload timestamp is within the Amsterdam timestamp.
+/// * If V5, this ensures that the payload timestamp is within the Osaka timestamp, and within the
+///   Bogota timestamp for `engine_forkchoiceUpdatedV5` payload attributes.
+/// * If V6, this ensures that the payload timestamp is within the Amsterdam timestamp, and within
+///   the Bogota timestamp for `engine_newPayloadV6` payloads.
 ///
 /// Additionally, it ensures that `engine_getPayloadV4` is not used for an Osaka payload and that
 /// staggered endpoint upgrades reject the next fork once a newer method version is required.
@@ -183,6 +185,51 @@ pub fn validate_payload_timestamp(
         // 1. Client software MUST return -38005: Unsupported fork error if the timestamp of the
         //    built payload does not fall within the time frame of the Amsterdam fork.
 
+        return Err(EngineObjectValidationError::UnsupportedFork)
+    }
+
+    let is_bogota = chain_spec.is_bogota_active_at_timestamp(timestamp);
+
+    // Staggered endpoint upgrades must reject Bogota payloads until the Bogota-specific method
+    // version is used.
+    //
+    // From the Engine API spec:
+    // <https://github.com/ethereum/execution-apis/blob/main/src/engine/bogota.md#update-the-methods-of-previous-forks>
+    //
+    // For `engine_newPayloadV5` and `engine_forkchoiceUpdatedV4`:
+    //
+    // 1. Client software MUST return -38005: Unsupported fork error if the timestamp of payload is
+    //    greater than or equal to the Bogota activation timestamp.
+    if is_bogota &&
+        matches!(
+            (version, kind),
+            (EngineApiMessageVersion::V4, MessageValidationKind::PayloadAttributes) |
+                (EngineApiMessageVersion::V5, MessageValidationKind::Payload)
+        )
+    {
+        return Err(EngineObjectValidationError::UnsupportedFork)
+    }
+
+    if !is_bogota &&
+        matches!(
+            (version, kind),
+            (EngineApiMessageVersion::V5, MessageValidationKind::PayloadAttributes) |
+                (EngineApiMessageVersion::V6, MessageValidationKind::Payload)
+        )
+    {
+        // From the Engine API spec:
+        // <https://github.com/ethereum/execution-apis/blob/main/src/engine/bogota.md>
+        //
+        // For `engine_newPayloadV6`:
+        //
+        // 1. Client software MUST return -38005: Unsupported fork error if the timestamp of the
+        //    payload does not fall within the time frame of the Bogota fork.
+        //
+        // For `engine_forkchoiceUpdatedV5`:
+        //
+        // 2. Client software MUST return -38005: Unsupported fork error if the payloadAttributes is
+        //    set and the payloadAttributes.timestamp does not fall within the time frame of the
+        //    Bogota fork.
         return Err(EngineObjectValidationError::UnsupportedFork)
     }
 
@@ -741,6 +788,94 @@ mod tests {
         );
         assert_matches!(res, Err(EngineObjectValidationError::UnsupportedFork));
 
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V6,
+            0,
+            MessageValidationKind::GetPayload,
+        );
+        assert_matches!(res, Ok(()));
+    }
+
+    #[test]
+    fn validate_bogota_fork_timeframe() {
+        // Amsterdam active, Bogota not scheduled: the Bogota-specific methods must reject
+        let chain_spec = ChainSpecBuilder::mainnet().amsterdam_activated().build();
+
+        // `engine_newPayloadV6` requires a Bogota timestamp
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V6,
+            0,
+            MessageValidationKind::Payload,
+        );
+        assert_matches!(res, Err(EngineObjectValidationError::UnsupportedFork));
+
+        // `engine_forkchoiceUpdatedV5` requires Bogota payload attributes
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V5,
+            0,
+            MessageValidationKind::PayloadAttributes,
+        );
+        assert_matches!(res, Err(EngineObjectValidationError::UnsupportedFork));
+
+        // the Amsterdam methods remain valid pre-Bogota
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V5,
+            0,
+            MessageValidationKind::Payload,
+        );
+        assert_matches!(res, Ok(()));
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V4,
+            0,
+            MessageValidationKind::PayloadAttributes,
+        );
+        assert_matches!(res, Ok(()));
+    }
+
+    #[test]
+    fn validate_bogota_staggered_version_restrictions() {
+        let chain_spec = ChainSpecBuilder::mainnet().bogota_activated().build();
+
+        // `engine_newPayloadV5` must reject Bogota payloads
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V5,
+            0,
+            MessageValidationKind::Payload,
+        );
+        assert_matches!(res, Err(EngineObjectValidationError::UnsupportedFork));
+
+        // `engine_forkchoiceUpdatedV4` must reject Bogota payload attributes
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V4,
+            0,
+            MessageValidationKind::PayloadAttributes,
+        );
+        assert_matches!(res, Err(EngineObjectValidationError::UnsupportedFork));
+
+        // the Bogota-specific methods are accepted
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V6,
+            0,
+            MessageValidationKind::Payload,
+        );
+        assert_matches!(res, Ok(()));
+        let res = validate_payload_timestamp(
+            &chain_spec,
+            EngineApiMessageVersion::V5,
+            0,
+            MessageValidationKind::PayloadAttributes,
+        );
+        assert_matches!(res, Ok(()));
+
+        // Bogota defines no new getPayload version, `engine_getPayloadV6` remains valid
         let res = validate_payload_timestamp(
             &chain_spec,
             EngineApiMessageVersion::V6,


### PR DESCRIPTION
Closes #26709

Follow-up to #26706. Per [bogota.md](https://github.com/ethereum/execution-apis/blob/main/src/engine/bogota.md), `engine_newPayloadV6` payloads and `engine_forkchoiceUpdatedV5` payload attributes must be rejected with `-38005: Unsupported fork` outside the Bogota timeframe, and the previous-fork methods (`engine_newPayloadV5`, `engine_forkchoiceUpdatedV4`) must reject Bogota-era timestamps. `engine_getPayloadV6` stays Amsterdam-gated since Bogota defines no new getPayload version.

The checks are keyed on `(version, MessageValidationKind)` because `EngineApiMessageVersion` values now alias methods from different forks (V5 = Amsterdam newPayload and Bogota fcu, V6 = Amsterdam getPayload and Bogota newPayload).