### PR TITLE
fix(engine): enforce state-gas admission on the BAL execution path

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -266,6 +266,22 @@ impl BlockGasTracker {
         }
     }
 
+    /// Verifies that the transaction's gas limit fits the block's remaining gas budget(s): the
+    /// admission check `EthBlockExecutor::execute_transaction_without_commit` performs before
+    /// executing a transaction.
+    ///
+    /// The commit loop never calls that entry point — workers execute speculatively and their
+    /// results are committed directly via `commit_transaction` — so the check must be replayed
+    /// here for BAL and serial execution to reach the same block validity verdict.
+    ///
+    /// Pre-Amsterdam there is one budget: the tx gas limit, capped by `tx_gas_limit_cap`
+    /// (EIP-7825), must fit `block_gas_limit - cumulative_tx_gas_used`.
+    ///
+    /// Amsterdam (EIP-8037) splits gas into two lanes, each budgeted at `block_gas_limit`:
+    /// - regular: the capped tx gas limit must fit the remaining regular budget
+    /// - state: the full, uncapped tx gas limit must fit the remaining state budget, since state
+    ///   gas is drawn from the reservoir above `tx_gas_limit_cap` (execution-specs
+    ///   `check_block_gas_capacity`)
     fn validate_tx_limit(&self, tx_gas_limit: u64) -> Result<(), BlockExecutionError> {
         let block_gas_used = if self.enable_amsterdam_eip8037 {
             self.block_regular_gas_used
@@ -284,9 +300,6 @@ impl BlockGasTracker {
             .into());
         }
 
-        // Amsterdam+: the state-gas dimension has its own budget of `block_gas_limit`. The
-        // transaction's full gas limit counts against it — state gas is drawn from the reservoir
-        // above `tx_gas_limit_cap`, so the cap does not bound it.
         if self.enable_amsterdam_eip8037 {
             let state_gas_available =
                 self.block_gas_limit.saturating_sub(self.block_state_gas_used);

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -239,7 +239,7 @@ impl AbortGuard {
     }
 }
 
-/// Mirrors `EthBlockExecutor`'s cumulative gas admission check in the ordered BAL commit loop.
+/// Mirrors `EthBlockExecutor`'s gas admission checks in the ordered BAL commit loop.
 #[derive(Debug)]
 struct BlockGasTracker {
     block_gas_limit: u64,
@@ -247,6 +247,7 @@ struct BlockGasTracker {
     tx_gas_limit_cap: Option<u64>,
     cumulative_tx_gas_used: u64,
     block_regular_gas_used: u64,
+    block_state_gas_used: u64,
 }
 
 impl BlockGasTracker {
@@ -261,6 +262,7 @@ impl BlockGasTracker {
             tx_gas_limit_cap,
             cumulative_tx_gas_used: 0,
             block_regular_gas_used: 0,
+            block_state_gas_used: 0,
         }
     }
 
@@ -282,6 +284,21 @@ impl BlockGasTracker {
             .into());
         }
 
+        // Amsterdam+: the state-gas dimension has its own budget of `block_gas_limit`. The
+        // transaction's full gas limit counts against it — state gas is drawn from the reservoir
+        // above `tx_gas_limit_cap`, so the cap does not bound it.
+        if self.enable_amsterdam_eip8037 {
+            let state_gas_available =
+                self.block_gas_limit.saturating_sub(self.block_state_gas_used);
+            if tx_gas_limit > state_gas_available {
+                return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                    transaction_gas_limit: tx_gas_limit,
+                    block_available_gas: state_gas_available,
+                }
+                .into());
+            }
+        }
+
         Ok(())
     }
 
@@ -290,6 +307,8 @@ impl BlockGasTracker {
         self.cumulative_tx_gas_used = self.cumulative_tx_gas_used.saturating_add(gas.tx_gas_used());
         self.block_regular_gas_used =
             self.block_regular_gas_used.saturating_add(gas.block_regular_gas_used());
+        self.block_state_gas_used =
+            self.block_state_gas_used.saturating_add(gas.block_state_gas_used());
     }
 }
 
@@ -1144,7 +1163,8 @@ mod tests {
 
     #[test]
     fn gas_tracker_non_amsterdam_uses_cumulative_gas() {
-        // All-state-gas results keep block_regular_gas_used at 0, so a second tx that fits
+        // A half-state-gas result keeps both Amsterdam budgets (regular and state) at
+        // 300_000 used while cumulative_tx_gas_used is 600_000, so a second tx that fits
         // within the block limit but not the remaining cumulative budget proves that
         // non-Amsterdam reads cumulative_tx_gas_used while Amsterdam does not.
         use revm::{
@@ -1158,7 +1178,7 @@ mod tests {
         let first_tx_gas = 600_000u64;
         let second_tx_gas_limit = 500_000u64; // fits in total limit but not after cumulative deduction
 
-        let gas = ResultGas::new_with_state_gas(first_tx_gas, 0, 0, first_tx_gas);
+        let gas = ResultGas::new_with_state_gas(first_tx_gas, 0, 0, first_tx_gas / 2);
         let fake_result: ResultAndState<revm::context::result::HaltReason> =
             ExecResultAndState::new(
                 ExecutionResult::Success {
@@ -1178,12 +1198,63 @@ mod tests {
             "non-Amsterdam tracker must reject tx that exceeds remaining cumulative gas",
         );
 
-        // Amsterdam: block_available_gas = 1_000_000 - 0 = 1_000_000 → accept 500_000.
+        // Amsterdam: both regular and state budgets have 700_000 left → accept 500_000.
         let mut amsterdam = BlockGasTracker::new(block_gas_limit, true, None);
         amsterdam.record_result(&fake_result);
         assert!(
             amsterdam.validate_tx_limit(second_tx_gas_limit).is_ok(),
-            "Amsterdam tracker must accept the same tx since block_regular_gas_used stays 0",
+            "Amsterdam tracker must accept the same tx since per-dimension budgets still fit",
+        );
+    }
+
+    #[test]
+    fn gas_tracker_amsterdam_enforces_state_gas_budget() {
+        // An all-state-gas result leaves the regular budget untouched, so only the
+        // state-gas admission check can reject the second transaction. The tx's full gas
+        // limit counts against the state budget — tx_gas_limit_cap does not bound it.
+        use revm::{
+            context::result::{
+                ExecResultAndState, ExecutionResult, Output, ResultGas, SuccessReason,
+            },
+            state::EvmState,
+        };
+
+        let block_gas_limit = 1_000_000u64;
+        let first_tx_state_gas = 600_000u64;
+        let second_tx_gas_limit = 500_000u64; // exceeds the remaining 400_000 state budget
+
+        let gas = ResultGas::new_with_state_gas(first_tx_state_gas, 0, 0, first_tx_state_gas);
+        let fake_result: ResultAndState<revm::context::result::HaltReason> =
+            ExecResultAndState::new(
+                ExecutionResult::Success {
+                    reason: SuccessReason::Return,
+                    gas,
+                    logs: vec![],
+                    output: Output::Call(Default::default()),
+                },
+                EvmState::default(),
+            );
+
+        // Regular budget is full (block_regular_gas_used = 0) but the state budget has
+        // only 400_000 left → reject 500_000.
+        let mut amsterdam = BlockGasTracker::new(block_gas_limit, true, None);
+        amsterdam.record_result(&fake_result);
+        assert!(
+            amsterdam.validate_tx_limit(second_tx_gas_limit).is_err(),
+            "Amsterdam tracker must reject tx whose gas limit exceeds the remaining state budget",
+        );
+        assert!(
+            amsterdam.validate_tx_limit(400_000).is_ok(),
+            "Amsterdam tracker must accept tx whose gas limit exactly fits the state budget",
+        );
+
+        // With a cap of 400_000 the capped regular check passes, but the full 500_000
+        // limit still counts against the state budget → reject.
+        let mut capped = BlockGasTracker::new(block_gas_limit, true, Some(400_000));
+        capped.record_result(&fake_result);
+        assert!(
+            capped.validate_tx_limit(second_tx_gas_limit).is_err(),
+            "tx_gas_limit_cap must not bound the state-gas admission check",
         );
     }
 


### PR DESCRIPTION
Under Amsterdam (EIP-8037) the serial executor enforces a second admission rule in `execute_transaction_without_commit`: the transaction's full gas limit must fit the remaining state-gas budget (`block_gas_limit - block_state_gas_used`), uncapped by `tx_gas_limit_cap` (execution-specs `check_block_gas_capacity`, added in alloy-rs/evm@8293b9a). glamsterdam-devnet-8 pins that rev; main's alloy-evm 0.38.0 from crates.io does not include it yet, so on main the serial-side check arrives once a future alloy-evm bump ships it. The BAL commit loop commits speculative worker results directly and only mirrored the regular-gas check in `BlockGasTracker`, so a block whose tx gas limit exceeds the remaining state-gas budget (while its actual usage fits) is accepted by BAL execution but rejected by serial execution.

Adds the state-gas dimension to `BlockGasTracker` so both paths reach the same verdict. Composes with #26693 in either merge order, since that PR keeps routing admission through `validate_tx_limit`.

Supersedes #26718 (same change, was based on glamsterdam-devnet-8); devnet-8 picks this up with the next main merge.