### PR TITLE
fix(engine): adjudicate speculative BAL worker failures in transaction order

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -10,11 +10,18 @@
 //! worker results in transaction order, tracks block gas admission, and builds the BAL that this
 //! execution actually produced.
 //!
+//! Speculative execution failures are deferred to their transaction slot and adjudicated in
+//! block order: block-gas admission at an earlier slot takes precedence, otherwise the first
+//! failure decides the block's verdict.
+//!
 //! The rebuilt BAL is returned to the outer payload validator for consensus post-execution
 //! validation. This module only logs the first divergence between the received BAL and the BAL
 //! rebuilt from canonical execution.
 
-use super::{ordered_outputs::ordered_worker_outputs, worker, BalExecutionError};
+use super::{
+    ordered_outputs::{ordered_worker_outputs, OrderedWorkerOutputError},
+    worker, BalExecutionError,
+};
 use alloy_eip7928::{
     bal::{Bal as AlloyBal, DecodedBal},
     compute_block_access_list_hash, BlockAccessList,
@@ -145,7 +152,29 @@ where
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
-            let output = output?;
+            let output = match output {
+                Ok(output) => output,
+                Err(OrderedWorkerOutputError::Worker(worker::BalWorkerError::Execution {
+                    index,
+                    tx_gas_limit,
+                    source,
+                })) => {
+                    // Block-gas admission is adjudicated in transaction order and takes
+                    // precedence over the failure at this slot.
+                    gas_tracker.validate_tx_limit(tx_gas_limit)?;
+
+                    // The transaction is admitted, so its execution failure is the block's
+                    // verdict: a BAL miss proves the received BAL diverges from this execution.
+                    tracing::debug!(
+                        target: "engine::tree::payload_processor::bal",
+                        index,
+                        err = %source,
+                        "Speculative BAL execution failed; rejecting block in transaction order"
+                    );
+                    return Err(BalExecutionError::Execution(source));
+                }
+                Err(err) => return Err(err.into()),
+            };
 
             gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
             gas_tracker.record_result(output.result.result());
@@ -910,6 +939,121 @@ mod tests {
                 err.as_validation(),
                 Some(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. })
             )),
+            Err(err) => panic!("expected block gas validation error, got {err:?}"),
+            Ok(_) => panic!("expected block gas validation error, got Ok"),
+        }
+    }
+
+    /// Two funded senders each transferring to a fresh recipient, plus the reference BAL of a
+    /// block containing only the covered subset of those transfers.
+    fn two_transfers_with_reference_bal(
+        tx_gas_limit: u64,
+        bal_covers_first: bool,
+    ) -> (
+        CacheDB<EmptyDB>,
+        BlockAccessList,
+        Recovered<reth_ethereum_primitives::TransactionSigned>,
+        Recovered<reth_ethereum_primitives::TransactionSigned>,
+    ) {
+        use alloy_consensus::TxLegacy;
+        use alloy_primitives::TxKind;
+        use reth_chainspec::MAINNET;
+        use reth_ethereum_primitives::Transaction;
+        use reth_primitives_traits::crypto::secp256k1::public_key_to_address;
+        use reth_testing_utils::generators::{generate_key, rng, sign_tx_with_key_pair};
+
+        let evm_config = EthEvmConfig::mainnet();
+        let recipient = alloy_primitives::Address::from([0xCA; 20]);
+        let sender_balance = U256::from(alloy_consensus::constants::ETH_TO_WEI);
+
+        let alice_kp = generate_key(&mut rng());
+        let alice = public_key_to_address(alice_kp.public_key());
+        let bob_kp = generate_key(&mut rng());
+        let bob = public_key_to_address(bob_kp.public_key());
+
+        let mut pre_block_db = system_contracts_db();
+        insert_funded(&mut pre_block_db, alice, sender_balance);
+        insert_funded(&mut pre_block_db, bob, sender_balance);
+
+        let chain_id = MAINNET.chain.id();
+        let make_tx = |kp, value| {
+            sign_tx_with_key_pair(
+                kp,
+                Transaction::Legacy(TxLegacy {
+                    chain_id: Some(chain_id),
+                    nonce: 0,
+                    gas_price: 1,
+                    gas_limit: tx_gas_limit,
+                    to: TxKind::Call(recipient),
+                    value: U256::from(value),
+                    input: Default::default(),
+                }),
+            )
+        };
+        let tx1 = Recovered::new_unchecked(make_tx(alice_kp, 100u64), alice);
+        let tx2 = Recovered::new_unchecked(make_tx(bob_kp, 200u64), bob);
+
+        let reference_block = empty_amsterdam_block(B256::ZERO);
+        let covered = if bal_covers_first { vec![tx1.clone()] } else { vec![] };
+        let reference_bal =
+            reference_bal_for_block(&evm_config, pre_block_db.clone(), &reference_block, covered);
+        (pre_block_db, reference_bal, tx1, tx2)
+    }
+
+    #[test]
+    fn propagates_bal_miss_of_admitted_transaction_as_block_verdict() {
+        // The BAL covers neither transaction: the first slot's speculative failure is
+        // adjudicated in block order and becomes the block's verdict.
+        let (pre_block_db, reference_bal, tx1, tx2) =
+            two_transfers_with_reference_bal(100_000, false);
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
+        let block = empty_amsterdam_block(bal_hash);
+
+        let result = run_execute_block(
+            &Runtime::test(),
+            EthEvmConfig::mainnet(),
+            db_factory(pre_block_db),
+            to_arc_decoded(reference_bal),
+            &block,
+            vec![tx1, tx2],
+        );
+
+        match result {
+            Err(BalExecutionError::Execution(err)) => {
+                let msg = err.to_string();
+                assert!(msg.contains("not found in BAL"), "expected BAL miss error, got {msg}");
+            }
+            Err(err) => panic!("expected BAL execution error, got {err:?}"),
+            Ok(_) => panic!("expected BAL execution error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn admission_rejects_before_speculative_worker_failure_surfaces() {
+        // tx2 exceeds the remaining block gas AND misses the BAL; block-gas admission is
+        // adjudicated first, so the verdict is the gas error, not tx2's BAL failure.
+        let (pre_block_db, reference_bal, tx1, tx2) =
+            two_transfers_with_reference_bal(990_000, true);
+        let bal_hash = alloy_eip7928::compute_block_access_list_hash(&reference_bal);
+        let low_gas_block = empty_amsterdam_block_with_gas_limit(bal_hash, 1_000_000);
+
+        let result = run_execute_block(
+            &Runtime::test(),
+            EthEvmConfig::mainnet(),
+            db_factory(pre_block_db),
+            to_arc_decoded(reference_bal),
+            &low_gas_block,
+            vec![tx1, tx2],
+        );
+
+        match result {
+            Err(BalExecutionError::Execution(err)) => assert!(
+                matches!(
+                    err.as_validation(),
+                    Some(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas { .. })
+                ),
+                "expected block gas validation error, got {err:?}"
+            ),
             Err(err) => panic!("expected block gas validation error, got {err:?}"),
             Ok(_) => panic!("expected block gas validation error, got Ok"),
         }

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -155,7 +155,7 @@ where
             let output = match output {
                 Ok(output) => output,
                 Err(OrderedWorkerOutputError::Worker(worker::BalWorkerError::Execution {
-                    index,
+                    tx_index,
                     tx_gas_limit,
                     source,
                 })) => {
@@ -167,7 +167,7 @@ where
                     // verdict: a BAL miss proves the received BAL diverges from this execution.
                     tracing::debug!(
                         target: "engine::tree::payload_processor::bal",
-                        index,
+                        tx_index,
                         err = %source,
                         "Speculative BAL execution failed; rejecting block in transaction order"
                     );

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -95,11 +95,11 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
                     // consumer observes them in block order: verdict precedence must follow
                     // block position, not worker completion order. Errors without an index
                     // cannot be attributed to a transaction and end the iteration.
-                    let BalWorkerError::Execution { index, .. } = &err else {
+                    let BalWorkerError::Execution { tx_index, .. } = &err else {
                         self.failed = true;
                         return Some(Err(err.into()));
                     };
-                    (*index, Err(err))
+                    (*tx_index, Err(err))
                 }
                 Err(_) => {
                     self.failed = true;
@@ -176,7 +176,7 @@ mod tests {
     fn defers_indexed_execution_errors_to_their_slot() {
         let (tx, rx) = crossbeam_channel::unbounded();
         tx.send(Err(BalWorkerError::Execution {
-            index: 1,
+            tx_index: 1,
             tx_gas_limit: 42,
             source: alloy_evm::block::BlockExecutionError::msg("bal miss"),
         }))
@@ -187,7 +187,7 @@ mod tests {
         let mut outputs = ordered_worker_outputs(&rx, 2);
 
         assert_eq!(outputs.next().expect("first item").expect("first output").result, 0);
-        expect_err_contains(outputs.next().expect("second item"), "bal miss");
+        expect_err_contains(outputs.next().expect("second item"), "transaction 1: bal miss");
         assert!(outputs.next().is_none());
     }
 
@@ -195,7 +195,7 @@ mod tests {
     fn continues_past_indexed_execution_errors() {
         let (tx, rx) = crossbeam_channel::unbounded();
         tx.send(Err(BalWorkerError::Execution {
-            index: 0,
+            tx_index: 0,
             tx_gas_limit: 42,
             source: alloy_evm::block::BlockExecutionError::msg("bal miss"),
         }))
@@ -205,7 +205,7 @@ mod tests {
 
         let mut outputs = ordered_worker_outputs(&rx, 2);
 
-        expect_err_contains(outputs.next().expect("first item"), "bal miss");
+        expect_err_contains(outputs.next().expect("first item"), "transaction 0: bal miss");
         assert_eq!(outputs.next().expect("second item").expect("second output").result, 10);
         assert!(outputs.next().is_none());
     }

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -32,12 +32,13 @@ impl From<OrderedWorkerOutputError> for BalExecutionError {
 /// state and performs no canonical commit work.
 ///
 /// Behavior:
-/// - each yielded `Ok` output has the next transaction index
-/// - worker errors are forwarded unchanged
-/// - closed channels before `total` outputs yield `Err`
+/// - each yielded item has the next transaction index, `Ok` and indexed execution errors alike: an
+///   execution error is a per-transaction result, deferred to its slot so the consumer observes it
+///   in block order
+/// - non-indexed worker errors are forwarded immediately and exhaust the iterator
+/// - closed channels before `total` outputs yield `Err` and exhaust the iterator
 /// - out-of-bounds and duplicate indices panic because they violate the internal worker/dispatcher
 ///   index invariant
-/// - after the first error, the iterator is exhausted
 pub(super) fn ordered_worker_outputs<R>(
     result_rx: &Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
     total: usize,
@@ -47,9 +48,14 @@ pub(super) fn ordered_worker_outputs<R>(
 
 struct OrderedWorkerOutputs<'a, R> {
     result_rx: &'a Receiver<Result<BalWorkerOutput<R>, BalWorkerError>>,
-    pending: Vec<Option<BalWorkerOutput<R>>>,
+    /// Slot per transaction: an out-of-order output (or its indexed execution error) is parked
+    /// here until every earlier transaction has been yielded.
+    pending: Vec<Option<Result<BalWorkerOutput<R>, BalWorkerError>>>,
+    /// Next transaction index to yield.
     next: usize,
+    /// Total number of transactions in the block.
     total: usize,
+    /// Set on a fatal error; the iterator is exhausted afterwards.
     failed: bool,
 }
 
@@ -77,16 +83,23 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
         }
 
         loop {
-            if let Some(output) = self.pending[self.next].take() {
+            if let Some(slot) = self.pending[self.next].take() {
                 self.next += 1;
-                return Some(Ok(output));
+                return Some(slot.map_err(Into::into));
             }
 
-            let output = match self.result_rx.recv() {
-                Ok(Ok(output)) => output,
+            let (index, slot) = match self.result_rx.recv() {
+                Ok(Ok(output)) => (output.index, Ok(output)),
                 Ok(Err(err)) => {
-                    self.failed = true;
-                    return Some(Err(err.into()));
+                    // Execution failures are deferred to their transaction's slot so the
+                    // consumer observes them in block order: verdict precedence must follow
+                    // block position, not worker completion order. Errors without an index
+                    // cannot be attributed to a transaction and end the iteration.
+                    let BalWorkerError::Execution { index, .. } = &err else {
+                        self.failed = true;
+                        return Some(Err(err.into()));
+                    };
+                    (*index, Err(err))
                 }
                 Err(_) => {
                     self.failed = true;
@@ -94,7 +107,6 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
                 }
             };
 
-            let index = output.index;
             assert!(
                 index < self.total,
                 "BAL worker returned out-of-bounds transaction index {index}; total={}",
@@ -105,7 +117,7 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
                 "BAL worker returned duplicate transaction index {index}",
             );
 
-            self.pending[index] = Some(output);
+            self.pending[index] = Some(slot);
         }
     }
 }
@@ -157,6 +169,44 @@ mod tests {
         let mut outputs = ordered_worker_outputs::<u64>(&rx, 1);
 
         expect_err_contains(outputs.next().expect("first item"), "worker failed");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn defers_indexed_execution_errors_to_their_slot() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Err(BalWorkerError::Execution {
+            index: 1,
+            tx_gas_limit: 42,
+            source: alloy_evm::block::BlockExecutionError::msg("bal miss"),
+        }))
+        .unwrap();
+        tx.send(Ok(output(0, 0))).unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs(&rx, 2);
+
+        assert_eq!(outputs.next().expect("first item").expect("first output").result, 0);
+        expect_err_contains(outputs.next().expect("second item"), "bal miss");
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn continues_past_indexed_execution_errors() {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(Err(BalWorkerError::Execution {
+            index: 0,
+            tx_gas_limit: 42,
+            source: alloy_evm::block::BlockExecutionError::msg("bal miss"),
+        }))
+        .unwrap();
+        tx.send(Ok(output(1, 10))).unwrap();
+        drop(tx);
+
+        let mut outputs = ordered_worker_outputs(&rx, 2);
+
+        expect_err_contains(outputs.next().expect("first item"), "bal miss");
+        assert_eq!(outputs.next().expect("second item").expect("second output").result, 10);
         assert!(outputs.next().is_none());
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -20,10 +20,10 @@ pub(super) enum BalWorkerError {
     #[error("BAL worker transaction conversion failed: {0}")]
     Transaction(Box<dyn core::error::Error + Send + Sync + 'static>),
     /// EVM transaction execution failed.
-    #[error("BAL worker EVM execution failed: {source}")]
+    #[error("BAL worker EVM execution failed for transaction {tx_index}: {source}")]
     Execution {
         /// Index of the transaction that failed.
-        index: usize,
+        tx_index: usize,
         /// Gas limit of the transaction that failed.
         tx_gas_limit: u64,
         /// The underlying execution error.
@@ -87,7 +87,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
             let mut executor = evm_config.create_executor_with_state(evm, ctx.clone());
 
             loop {
-                let (index, tx) = crossbeam_channel::select_biased! {
+                let (tx_index, tx) = crossbeam_channel::select_biased! {
                     recv(abort_rx) -> _ => break,
                     recv(tx_rx) -> msg => match msg {
                         Ok(ix_tx) => ix_tx,
@@ -98,13 +98,20 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let signer = *tx.signer();
                 let tx_gas_limit = tx.tx().gas_limit();
 
-                executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
+                executor
+                    .evm_mut()
+                    .db_mut()
+                    .set_bal_index(BlockAccessIndex::new(tx_index as u64 + 1));
                 // An execution failure is a per-transaction result: report it with its
                 // index and keep serving the queue so the commit loop can adjudicate it
                 // in block order.
                 let message = match executor.execute_transaction_without_commit(tx) {
-                    Ok(result) => Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }),
-                    Err(source) => Err(BalWorkerError::Execution { index, tx_gas_limit, source }),
+                    Ok(result) => {
+                        Ok(BalWorkerOutput { index: tx_index, signer, tx_gas_limit, result })
+                    }
+                    Err(source) => {
+                        Err(BalWorkerError::Execution { tx_index, tx_gas_limit, source })
+                    }
                 };
 
                 if result_tx.send(message).is_err() {

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -20,8 +20,16 @@ pub(super) enum BalWorkerError {
     #[error("BAL worker transaction conversion failed: {0}")]
     Transaction(Box<dyn core::error::Error + Send + Sync + 'static>),
     /// EVM transaction execution failed.
-    #[error("BAL worker EVM execution failed: {0}")]
-    Execution(BlockExecutionError),
+    #[error("BAL worker EVM execution failed: {source}")]
+    Execution {
+        /// Index of the transaction that failed.
+        index: usize,
+        /// Gas limit of the transaction that failed.
+        tx_gas_limit: u64,
+        /// The underlying execution error.
+        #[source]
+        source: BlockExecutionError,
+    },
 }
 
 impl From<BalWorkerError> for BalExecutionError {
@@ -29,7 +37,7 @@ impl From<BalWorkerError> for BalExecutionError {
         match err {
             BalWorkerError::Setup(err) => err,
             BalWorkerError::Transaction(err) => Self::Other(err),
-            BalWorkerError::Execution(err) => Self::Execution(err),
+            BalWorkerError::Execution { source, .. } => Self::Execution(source),
         }
     }
 }
@@ -91,14 +99,15 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let tx_gas_limit = tx.tx().gas_limit();
 
                 executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
-                let result = executor
-                    .execute_transaction_without_commit(tx)
-                    .map_err(BalWorkerError::Execution)?;
+                // An execution failure is a per-transaction result: report it with its
+                // index and keep serving the queue so the commit loop can adjudicate it
+                // in block order.
+                let message = match executor.execute_transaction_without_commit(tx) {
+                    Ok(result) => Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }),
+                    Err(source) => Err(BalWorkerError::Execution { index, tx_gas_limit, source }),
+                };
 
-                if result_tx
-                    .send(Ok(BalWorkerOutput { index, signer, tx_gas_limit, result }))
-                    .is_err()
-                {
+                if result_tx.send(message).is_err() {
                     break;
                 }
             }


### PR DESCRIPTION
Defer speculative BAL execution and recovery failures to their transaction slots so an earlier gas-admission error wins over a later BAL miss. Keep parallel recovery running until the ordered consumer stops, and rebuild failed executors before serving more work.

BAL misses short-circuit at their slot without replay, so serial execution can report a different validation reason.
