### PR TITLE
fix(engine): validate forkchoice state before committing new head

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1438,9 +1438,20 @@ where
         // Ensure we can apply a new chain update for the head block
         if let Some(chain_update) = self.on_new_head(state.head_block_hash)? {
             let tip = chain_update.tip().clone_sealed_header();
+
+            // Validate the safe and finalized hashes against the new chain *before* committing it.
+            // Committing the head first and validating afterwards would return -38002 while
+            // leaving the rejected head as the canonical head, corrupting the chain (e.g.
+            // `eth_getBlockByNumber("latest")` would report the rejected head).
+            if let Err(outcome) = self.validate_forkchoice_state_for_new_chain(state, &chain_update)
+            {
+                // safe or finalized hashes are invalid
+                return Ok(Some(TreeOutcome::new(outcome)));
+            }
+
             self.on_canonical_chain_update(chain_update);
 
-            // Update the safe and finalized blocks and ensure their values are valid
+            // Record the validated safe and finalized blocks now that the head is canonical.
             if let Err(outcome) = self.ensure_consistent_forkchoice_state(state) {
                 // safe or finalized hashes are invalid
                 return Ok(Some(TreeOutcome::new(outcome)));
@@ -3468,6 +3479,59 @@ where
         // This ensures that the safe block is consistent with the head block, i.e. the safe
         // block is an ancestor of the head block.
         self.update_safe_block(state.safe_block_hash)
+    }
+
+    /// Validates that the `safe` and `finalized` hashes of the given forkchoice `state` belong to
+    /// the new canonical chain described by `chain_update`, without mutating any tracked state.
+    ///
+    /// This must be called *before* [`Self::on_canonical_chain_update`] commits the new head.
+    /// [`Self::ensure_consistent_forkchoice_state`] only reflects the new chain once the head has
+    /// been made canonical, so relying on it alone updates the canonical head first and rejects the
+    /// update afterwards, leaving the rejected head applied (and its canonical notifications
+    /// emitted).
+    ///
+    /// The blocks in `chain_update` are not yet part of the canonical in-memory state, so they are
+    /// consulted directly: any non-zero hash must be one of the newly added blocks (this includes
+    /// the new head itself) or a canonical ancestor at or below the fork point. Anything else, an
+    /// unknown block or a reorged-out sibling above the fork, makes the forkchoice state invalid.
+    fn validate_forkchoice_state_for_new_chain(
+        &self,
+        state: ForkchoiceState,
+        chain_update: &NewCanonicalChain<N>,
+    ) -> Result<(), OnForkChoiceUpdated> {
+        let new_blocks = match chain_update {
+            NewCanonicalChain::Commit { new } | NewCanonicalChain::Reorg { new, .. } => new,
+        };
+
+        // The highest block still shared with the current canonical chain. Ancestors at or below
+        // this number are validated against the existing canonical chain; anything above must be
+        // part of the newly added blocks to be an ancestor of the new head.
+        let fork_number = chain_update.tip().number().saturating_sub(new_blocks.len() as u64);
+
+        for hash in [state.finalized_block_hash, state.safe_block_hash] {
+            if hash.is_zero() {
+                continue
+            }
+
+            // part of the newly added chain segment
+            if new_blocks.iter().any(|block| block.recovered_block().hash() == hash) {
+                continue
+            }
+
+            match self.find_canonical_header(hash) {
+                // a known canonical ancestor at or below the fork point
+                Ok(Some(header)) if header.number() <= fork_number => {}
+                // known but not an ancestor of the new head, or entirely unknown
+                Ok(_) => return Err(OnForkChoiceUpdated::invalid_state()),
+                // mirror the lenient behavior of `update_{safe,finalized}_block`: a transient
+                // lookup failure must not reject an otherwise valid forkchoice update
+                Err(err) => {
+                    error!(target: "engine::tree", %err, "Failed to fetch forkchoice block header");
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Validates the payload attributes with respect to the header and fork choice state.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1827,6 +1827,68 @@ async fn test_fcu_with_unknown_safe_hash_does_not_change_canonical_head() {
     );
 }
 
+#[tokio::test]
+async fn test_fcu_reorg_with_reorged_out_safe_hash_does_not_change_canonical_head() {
+    // Regression test for the reorg variant: an FCU that would reorg the canonical chain to a new
+    // head, but whose safe (or finalized) hash points at a block the reorg removes (a known block
+    // above the fork point, so not an ancestor of the new head), must be rejected with -38002
+    // without committing the reorg. This exercises the fork-point height check in
+    // `validate_forkchoice_state_for_new_chain`; the reorged-out block is still persisted, so a
+    // naive existence check would wrongly accept it.
+    reth_tracing::init_test_tracing();
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+
+    // canonical chain of five blocks, head is block 5
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..6).collect();
+    let canonical_head = blocks.last().unwrap().recovered_block().clone();
+    // block 4 is canonical now but is reorged out by the competing fork below
+    let reorged_out = blocks[3].recovered_block().clone();
+    // the competing fork branches off block 2
+    let fork_base = blocks[1].recovered_block().hash();
+    test_harness = test_harness.with_blocks(blocks);
+
+    // a fork off block 2 that is one block longer, so an FCU to its tip reorgs the canonical chain
+    let fork_3 = test_block_builder.get_executed_block_with_number(3, fork_base);
+    let fork_4 =
+        test_block_builder.get_executed_block_with_number(4, fork_3.recovered_block().hash());
+    let fork_5 =
+        test_block_builder.get_executed_block_with_number(5, fork_4.recovered_block().hash());
+    let fork_6 =
+        test_block_builder.get_executed_block_with_number(6, fork_5.recovered_block().hash());
+    let fork_head = fork_6.recovered_block().hash();
+    for block in [fork_3, fork_4, fork_5, fork_6] {
+        test_harness.tree.state.tree_state.insert_executed(block);
+    }
+
+    // FCU to the fork tip with a safe hash that the reorg removes (block 4 of the old chain)
+    let err = test_harness
+        .tree
+        .on_forkchoice_updated(
+            ForkchoiceState {
+                head_block_hash: fork_head,
+                safe_block_hash: reorged_out.hash(),
+                finalized_block_hash: B256::ZERO,
+            },
+            None,
+        )
+        .unwrap()
+        .outcome
+        .await
+        .unwrap_err();
+
+    // the forkchoice state is rejected as invalid (-38002)
+    assert_matches!(err, ForkchoiceUpdateError::InvalidState);
+
+    // the reorg is not applied: the canonical head is unchanged
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), canonical_head.hash());
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
+        canonical_head.hash()
+    );
+}
+
 /// Test that verifies the happy path where a new payload extends the canonical chain
 #[test]
 fn test_on_new_payload_canonical_insertion() {

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1779,6 +1779,54 @@ async fn test_fcu_with_canonical_ancestor_above_finalized_starts_payload_build()
     );
 }
 
+#[tokio::test]
+async fn test_fcu_with_unknown_safe_hash_does_not_change_canonical_head() {
+    // Regression test: an FCU whose head is a valid new block but whose safe (or finalized) hash
+    // is unknown must be rejected with -38002 *without* making the new head canonical. Previously
+    // the new head was committed before the safe and finalized hashes were validated, so a rejected
+    // FCU left the chain on the invalid head (`eth_getBlockByNumber("latest")` would report it).
+    reth_tracing::init_test_tracing();
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec.clone());
+    let mut test_block_builder = TestBlockBuilder::eth().with_chain_spec((*chain_spec).clone());
+
+    // canonical chain of five blocks, head is block 5
+    let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..6).collect();
+    let head = blocks.last().unwrap().recovered_block().clone();
+    test_harness = test_harness.with_blocks(blocks);
+
+    // a valid child of the current head that is not part of the canonical chain yet
+    let child = test_block_builder.get_executed_block_with_number(6, head.hash());
+    let child_hash = child.recovered_block().hash();
+    test_harness.tree.state.tree_state.insert_executed(child);
+
+    // FCU to the new head with an unknown safe hash
+    let err = test_harness
+        .tree
+        .on_forkchoice_updated(
+            ForkchoiceState {
+                head_block_hash: child_hash,
+                safe_block_hash: B256::random(),
+                finalized_block_hash: B256::ZERO,
+            },
+            None,
+        )
+        .unwrap()
+        .outcome
+        .await
+        .unwrap_err();
+
+    // the forkchoice state is rejected as invalid (-38002)
+    assert_matches!(err, ForkchoiceUpdateError::InvalidState);
+
+    // the canonical head is untouched: the rejected head must not be applied
+    assert_eq!(test_harness.tree.state.tree_state.canonical_block_hash(), head.hash());
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_canonical_head().hash(),
+        head.hash()
+    );
+}
+
 /// Test that verifies the happy path where a new payload extends the canonical chain
 #[test]
 fn test_on_new_payload_canonical_insertion() {


### PR DESCRIPTION
An FCU whose head is a valid new block but whose safe or finalized hash does
not belong to the new chain was made canonical *before* the safe and finalized
hashes were validated. The update then returned `-38002`, but the rejected head
was left as the canonical head and its canonical notifications were already
emitted, so `eth_getBlockByNumber("latest")` reported the rejected head.

The safe and finalized hashes are now validated against the new chain before
`on_canonical_chain_update` commits it. The pending blocks are consulted
directly since they are not yet part of the canonical in-memory state.
