### PR TITLE
fix(engine): derive precise validation errors for BAL path failures

### DIFF
--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -127,4 +127,13 @@ pub enum InsertPayloadError<B: Block> {
     /// Payload validation error
     #[error(transparent)]
     Payload(#[from] NewPayloadError),
+    /// A failure that is not attributable to the block itself and must be returned as an actual
+    /// error instead of a `PayloadStatus`, e.g. malformed request params.
+    ///
+    /// Unlike [`Self::Block`], this variant does not require a converted block: it is used for
+    /// failures detected before payload conversion succeeds, such as undecodable block access
+    /// list bytes, which must be rejected with an invalid params error even if the payload also
+    /// fails conversion or block hash validation.
+    #[error(transparent)]
+    Fatal(#[from] InsertBlockFatalError),
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -951,6 +951,9 @@ where
                     InsertPayloadError::Payload(error) => {
                         self.on_new_payload_error(error, num_hash, parent_hash)?
                     }
+                    // Failures that are not attributable to the block, e.g. malformed request
+                    // params, are returned as actual errors instead of a `PayloadStatus`.
+                    InsertPayloadError::Fatal(error) => return Err(error),
                 };
 
                 Ok(TryInsertPayloadResult { status, already_seen: false })

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -106,7 +106,10 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash_with_buf, BlockAccessList};
+use alloy_eip7928::{
+    bal::DecodedBal, compute_block_access_list_hash, compute_block_access_list_hash_with_buf,
+    BlockAccessList,
+};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{
@@ -132,8 +135,9 @@ use reth_engine_primitives::{
 };
 use reth_errors::{BlockExecutionError, ProviderResult};
 use reth_evm::{
-    block::BlockExecutor, execute::ExecutableTxFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
-    OnStateHook, SpecFor,
+    block::BlockExecutor,
+    execute::{BasicBlockExecutor, ExecutableTxFor, Executor as _},
+    ConfigureEvm, EvmEnvFor, ExecutionCtxFor, OnStateHook, SpecFor,
 };
 use reth_execution_cache::{CacheFillMode, CacheStats};
 use reth_payload_builder::{PayloadBuilderLease, PayloadBuilderResources};
@@ -566,11 +570,19 @@ where
             .map_err(NewPayloadError::other)?;
 
         // Extract the decoded BAL, if present. Undecodable block access list bytes are malformed
-        // request params, not an invalid block.
-        let decoded_bal = ensure_ok!(input
-            .try_decoded_access_list()
-            .map_err(ConsensusError::BlockAccessListDecode))
-        .map(Arc::new);
+        // request params, not an invalid block, and take precedence over any conversion or
+        // validation failure of the block itself (notably the block hash mismatch that malformed
+        // BAL bytes also cause, because the header's BAL hash is derived from them), so this must
+        // not join the concurrent block conversion for its error path.
+        let decoded_bal = match input.try_decoded_access_list() {
+            Ok(decoded_bal) => decoded_bal.map(Arc::new),
+            Err(err) => {
+                return Err(crate::tree::error::InsertBlockFatalError::InvalidParams(Box::new(
+                    ConsensusError::BlockAccessListDecode(err),
+                ))
+                .into())
+            }
+        };
 
         if let Some(decoded_bal) = decoded_bal.as_deref() {
             // Reject oversized BAL sidecars before executing the block.
@@ -732,7 +744,19 @@ where
         if let (Some(metrics), Some(stats)) = (&state_provider_metrics, &state_provider_stats) {
             metrics.record_totals(stats);
         }
-        let (output, senders, receipt_root_rx, built_bal) = ensure_ok!(execution_result);
+        let (output, senders, receipt_root_rx, built_bal) = match execution_result {
+            Ok(val) => val,
+            Err(e) => {
+                let block = validated_block.try_into_inner().expect("sole handle")?;
+                let e = if parallel_bal_execution && matches!(e, InsertBlockErrorKind::Execution(_))
+                {
+                    self.refine_bal_execution_error(&block, &provider_builder, e)
+                } else {
+                    e
+                };
+                return Err(InsertBlockError::new(block, e).into())
+            }
+        };
 
         // After executing the block we can stop prewarming transactions
         handle.stop_prewarming_execution();
@@ -789,17 +813,23 @@ where
                 .ok()
         };
 
-        ensure_ok_post_block!(
-            self.validate_post_execution(
-                &block,
-                &parent_block,
-                &output,
-                &mut ctx,
-                receipt_root_bloom,
-                built_bal
-            ),
-            block
-        );
+        if let Err(e) = self.validate_post_execution(
+            &block,
+            &parent_block,
+            &output,
+            &mut ctx,
+            receipt_root_bloom,
+            built_bal,
+        ) {
+            // On the BAL path a consensus failure can be a consequence of executing against a
+            // corrupt BAL (e.g. wrong gas used), so re-derive the precise error serially.
+            let e = if parallel_bal_execution && matches!(e, InsertBlockErrorKind::Consensus(_)) {
+                self.refine_bal_execution_error(block.sealed_block(), &provider_builder, e)
+            } else {
+                e
+            };
+            return Err(InsertBlockError::new(block.into_sealed_block(), e).into())
+        }
 
         let mut hashed_state_validate_result = debug_span!(
             target: "engine::tree::payload_validator",
@@ -1182,6 +1212,63 @@ where
         );
 
         Ok((output, senders, result_rx, Some(built_bal)))
+    }
+
+    /// Re-executes a block serially to refine the error reported by a failed BAL-path execution.
+    ///
+    /// BAL-path workers resolve state through the received BAL, so an invalid block often
+    /// surfaces as an internal BAL lookup error (e.g. "account not found in BAL") instead of the
+    /// consensus error that caused it. Serial execution against the parent state re-derives the
+    /// precise validation error: a block-level gas admission failure, a failed system contract
+    /// call, or — when serial execution succeeds — a block access list mismatch found by
+    /// post-execution validation. Only runs for blocks that are already known to be invalid, so
+    /// the extra execution is bounded by the block gas limit and never on the happy path.
+    fn refine_bal_execution_error(
+        &self,
+        block: &SealedBlock<N::Block>,
+        provider_builder: &StateProviderBuilder<N, P>,
+        original_error: InsertBlockErrorKind,
+    ) -> InsertBlockErrorKind {
+        // Build an uncached parent-state provider: the shared execution cache and txpool
+        // snapshot may already reflect this block's own execution by the time post-execution
+        // validation fails, which would poison the serial re-execution.
+        let Ok(state_provider) = provider_builder.build() else { return original_error };
+        let Ok(block) = block.clone().try_recover() else { return original_error };
+
+        let mut executor = BasicBlockExecutor::new(
+            self.evm_config.clone(),
+            StateProviderDatabase::new(state_provider),
+        );
+        let refined = match executor.execute_one(&block) {
+            Err(err) => err.into(),
+            Ok(result) => {
+                let bal_hash =
+                    executor.take_bal().map(|bal| compute_block_access_list_hash(bal.as_slice()));
+                match self.consensus.validate_block_post_execution(&block, &result, None, bal_hash)
+                {
+                    Err(err) => err.into(),
+                    Ok(()) => {
+                        // Serial execution fully validated the block even though the BAL path
+                        // rejected it; keep the original error but make the divergence visible.
+                        debug!(
+                            target: "engine::tree::payload_validator",
+                            block = ?block.num_hash(),
+                            %original_error,
+                            "Serial re-execution validated block rejected by BAL-path execution",
+                        );
+                        return original_error
+                    }
+                }
+            }
+        };
+        debug!(
+            target: "engine::tree::payload_validator",
+            block = ?block.num_hash(),
+            %original_error,
+            %refined,
+            "Refined BAL-path execution error via serial re-execution",
+        );
+        refined
     }
 
     fn spawn_receipt_root_task(

--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -69,7 +69,7 @@ pub trait EngineApi<Engine: EngineTypes> {
     #[method(name = "newPayloadV4")]
     async fn new_payload_v4(
         &self,
-        payload: ExecutionPayloadV3,
+        payload: ExecutionPayloadInputV4,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
         execution_requests: RequestsOrHash,
@@ -478,4 +478,31 @@ pub trait EngineEthApi<TxReq: RpcObject, B: RpcObject, R: RpcObject, L: RpcObjec
     /// Returns the EIP-7928 block access list bytes for a block by number.
     #[method(name = "getBlockAccessListRaw")]
     async fn block_access_list_raw(&self, block: BlockId) -> RpcResult<Option<Bytes>>;
+}
+
+/// Input structure for `engine_newPayloadV4`.
+///
+/// A [`ExecutionPayloadV3`] that also captures the post-Amsterdam `blockAccessList` and
+/// `slotNumber` fields if a caller includes them. The engine API requires the provided set of
+/// parameters to strictly match the expected structure of the method's version, so a V4 payload
+/// carrying either field must be rejected with `-32602: Invalid params` instead of silently
+/// dropping the unknown fields during deserialization.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionPayloadInputV4 {
+    /// The V3 payload structure expected by `engine_newPayloadV4`.
+    #[serde(flatten)]
+    pub payload: ExecutionPayloadV3,
+    /// Post-Amsterdam (EIP-7928) field, invalid in V4 payloads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_access_list: Option<Bytes>,
+    /// Post-Amsterdam (EIP-7843) field, invalid in V4 payloads.
+    #[serde(default, with = "alloy_serde::quantity::opt", skip_serializing_if = "Option::is_none")]
+    pub slot_number: Option<u64>,
+}
+
+impl From<ExecutionPayloadV3> for ExecutionPayloadInputV4 {
+    fn from(payload: ExecutionPayloadV3) -> Self {
+        Self { payload, block_access_list: None, slot_number: None }
+    }
 }

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -44,7 +44,9 @@ pub mod servers {
         admin::AdminApiServer,
         anvil::AnvilApiServer,
         debug::DebugApiServer,
-        engine::{EngineApiServer, EngineEthApiServer, IntoEngineApiRpcModule},
+        engine::{
+            EngineApiServer, EngineEthApiServer, ExecutionPayloadInputV4, IntoEngineApiRpcModule,
+        },
         hardhat::HardhatApiServer,
         mev::{MevFullApiServer, MevSimApiServer},
         miner::MinerApiServer,

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -22,11 +22,11 @@ use reth_engine_primitives::{ConsensusEngineHandle, EngineApiValidator, EngineTy
 use reth_network_api::{CellCustody, NetworkInfo};
 use reth_payload_builder::PayloadStore;
 use reth_payload_primitives::{
-    validate_payload_timestamp, EngineApiMessageVersion, MessageValidationKind,
-    PayloadOrAttributes, PayloadTypes,
+    validate_payload_timestamp, EngineApiMessageVersion, EngineObjectValidationError,
+    MessageValidationKind, PayloadOrAttributes, PayloadTypes, VersionSpecificValidationError,
 };
 use reth_primitives_traits::{Block, BlockBody};
-use reth_rpc_api::{EngineApiServer, IntoEngineApiRpcModule};
+use reth_rpc_api::{EngineApiServer, ExecutionPayloadInputV4, IntoEngineApiRpcModule};
 use reth_storage_api::{BalProvider, BlockReader, HeaderProvider, StateProviderFactory};
 use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
@@ -1292,12 +1292,29 @@ where
     /// See also <https://github.com/ethereum/execution-apis/blob/03911ffc053b8b806123f1fc237184b0092a485a/src/engine/prague.md#engine_newpayloadv4>
     async fn new_payload_v4(
         &self,
-        payload: ExecutionPayloadV3,
+        payload: ExecutionPayloadInputV4,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
         requests: RequestsOrHash,
     ) -> RpcResult<PayloadStatus> {
         trace!(target: "rpc::engine", "Serving engine_newPayloadV4");
+
+        // The V4 params must not carry post-Amsterdam payload fields. An empty byte string is
+        // treated as not provided, like a `null` value: fixtures serialize an absent block
+        // access list as `0x` for blocks whose header carries only the hash field.
+        if payload.block_access_list.as_ref().is_some_and(|bal| !bal.is_empty()) {
+            return Err(EngineApiError::from(EngineObjectValidationError::Payload(
+                VersionSpecificValidationError::BlockAccessListNotSupported,
+            ))
+            .into());
+        }
+        if payload.slot_number.is_some() {
+            return Err(EngineApiError::from(EngineObjectValidationError::Payload(
+                VersionSpecificValidationError::SlotNumberNotSupported,
+            ))
+            .into());
+        }
+        let payload = payload.payload;
 
         // Accept requests as a hash only if it is explicitly allowed
         if requests.is_hash() && !self.inner.accept_execution_requests_hash {


### PR DESCRIPTION
Fixes the remaining reth-attributable failures in the glamsterdam-devnet-8 hive eels/consume-engine suite (strict exception matching).

BAL-path workers resolve state through the received BAL, so an invalid block surfaced internal lookup errors ("database error: Bal error: Account ... not found in BAL") instead of the consensus error that caused it, and a corrupt BAL that completed execution surfaced consequences like a gas used mismatch instead of the BAL mismatch itself. On BAL-path failure we now re-execute the block serially against the uncached parent state to re-derive the precise error (block gas admission, system contract call failure, or the post-execution block access list hash mismatch), mirroring the sync import path. This only runs for blocks that are already invalid, so there is no happy-path cost.

Two engine API param fixes ride along, also required by the suite:

- Undecodable block access list bytes were still answered with an INVALID status despite #26694: the header's BAL hash is derived from the raw bytes, so malformed bytes always fail block hash validation first and that error preempted the decode error. Decode failures now short-circuit as `-32602` via a new `InsertPayloadError::Fatal` variant before the conversion result is consumed.
- `newPayloadV4` deserialized its params into `ExecutionPayloadV3`, silently dropping `blockAccessList`/`slotNumber` from pre-fork payloads that must be rejected with `-32602`. The params are now captured with `ExecutionPayloadInputV4`, which rejects the fields for V4 (an empty `0x` block access list counts as not provided, matching fixture serialization).

Verified against the eels/consume-engine suite locally: 52 failures down to 0 of 547 together with alloy-rs/evm#401 and ethereum/execution-specs#3380.