### PR TITLE
fix(rpc): report highest known sync block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9918,6 +9918,7 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
+ "reth-stages-types",
  "reth-storage-api",
  "reth-tasks",
  "reth-testing-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10134,6 +10134,7 @@ dependencies = [
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
+ "reth-stages-types",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -29,6 +29,7 @@ reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-api.workspace = true
 reth-node-api.workspace = true
+reth-stages-types.workspace = true
 reth-trie-common = { workspace = true, features = ["eip1186"] }
 reth-prune-types.workspace = true
 

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -9,6 +9,7 @@ use reth_network_api::NetworkInfo;
 use reth_prune_types::{PruneMode, PruneSegment};
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_types::{EthCapabilities, EthCapabilitiesHead, EthCapabilitiesResource};
+use reth_stages_types::StageId;
 use reth_storage_api::{
     BlockNumReader, PruneCheckpointReader, StageCheckpointReader, TransactionsProvider,
 };
@@ -98,22 +99,25 @@ pub trait EthApiSpec: RpcNodeCore + EthApiTypes {
     /// Returns the [`SyncStatus`] of the network
     fn sync_status(&self) -> RethResult<SyncStatus> {
         let status = if self.is_syncing() {
-            let current_block = U256::from(
-                self.provider().chain_info().map(|info| info.best_number).unwrap_or_default(),
-            );
+            let current_block =
+                self.provider().chain_info().map(|info| info.best_number).unwrap_or_default();
 
-            let stages = self
+            let stages: Vec<Stage> = self
                 .provider()
                 .get_all_checkpoints()
                 .unwrap_or_default()
                 .into_iter()
                 .map(|(name, checkpoint)| Stage { name, block: checkpoint.block_number })
                 .collect();
+            let highest_block = estimate_highest_block(
+                current_block,
+                stages.iter().map(|stage| (stage.name.as_str(), stage.block)),
+            );
 
             SyncStatus::Info(Box::new(SyncInfo {
                 starting_block: self.starting_block(),
-                current_block,
-                highest_block: current_block,
+                current_block: U256::from(current_block),
+                highest_block: U256::from(highest_block),
                 warp_chunks_amount: None,
                 warp_chunks_processed: None,
                 stages: Some(stages),
@@ -123,6 +127,23 @@ pub trait EthApiSpec: RpcNodeCore + EthApiTypes {
         };
         Ok(status)
     }
+}
+
+/// Estimates the highest known block from the validated headers stage checkpoint.
+///
+/// The checkpoint can briefly lag the canonical head while a header gap is being committed, so the
+/// returned height never falls below `current_block`.
+pub fn estimate_highest_block<S>(
+    current_block: u64,
+    stages: impl IntoIterator<Item = (S, u64)>,
+) -> u64
+where
+    S: AsRef<str>,
+{
+    stages
+        .into_iter()
+        .find_map(|(name, block)| (name.as_ref() == StageId::Headers.as_str()).then_some(block))
+        .map_or(current_block, |block| block.max(current_block))
 }
 
 /// Derives the effective block availability for a capability resource from the prune checkpoints of
@@ -219,6 +240,27 @@ mod tests {
                 .map(|(segment, checkpoint)| (*segment, *checkpoint))
                 .collect())
         }
+    }
+
+    #[test]
+    fn highest_block_uses_headers_stage_checkpoint() {
+        let stages = [(StageId::Bodies.as_str(), 20), (StageId::Headers.as_str(), 30)];
+
+        assert_eq!(estimate_highest_block(10, stages), 30);
+    }
+
+    #[test]
+    fn highest_block_does_not_fall_behind_current_block() {
+        let stages = [(StageId::Headers.as_str(), 10)];
+
+        assert_eq!(estimate_highest_block(20, stages), 20);
+    }
+
+    #[test]
+    fn highest_block_falls_back_to_current_block_without_headers_checkpoint() {
+        let stages = [(StageId::Bodies.as_str(), 30)];
+
+        assert_eq!(estimate_highest_block(20, stages), 20);
     }
 
     #[test]

--- a/crates/rpc/rpc-eth-api/src/helpers/spec.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/spec.rs
@@ -102,17 +102,18 @@ pub trait EthApiSpec: RpcNodeCore + EthApiTypes {
             let current_block =
                 self.provider().chain_info().map(|info| info.best_number).unwrap_or_default();
 
-            let stages: Vec<Stage> = self
+            let highest_block = self
+                .provider()
+                .get_stage_checkpoint(StageId::Headers)?
+                .map_or(current_block, |checkpoint| checkpoint.block_number.max(current_block));
+
+            let stages = self
                 .provider()
                 .get_all_checkpoints()
                 .unwrap_or_default()
                 .into_iter()
                 .map(|(name, checkpoint)| Stage { name, block: checkpoint.block_number })
                 .collect();
-            let highest_block = estimate_highest_block(
-                current_block,
-                stages.iter().map(|stage| (stage.name.as_str(), stage.block)),
-            );
 
             SyncStatus::Info(Box::new(SyncInfo {
                 starting_block: self.starting_block(),
@@ -127,23 +128,6 @@ pub trait EthApiSpec: RpcNodeCore + EthApiTypes {
         };
         Ok(status)
     }
-}
-
-/// Estimates the highest known block from the validated headers stage checkpoint.
-///
-/// The checkpoint can briefly lag the canonical head while a header gap is being committed, so the
-/// returned height never falls below `current_block`.
-pub fn estimate_highest_block<S>(
-    current_block: u64,
-    stages: impl IntoIterator<Item = (S, u64)>,
-) -> u64
-where
-    S: AsRef<str>,
-{
-    stages
-        .into_iter()
-        .find_map(|(name, block)| (name.as_ref() == StageId::Headers.as_str()).then_some(block))
-        .map_or(current_block, |block| block.max(current_block))
 }
 
 /// Derives the effective block availability for a capability resource from the prune checkpoints of
@@ -240,27 +224,6 @@ mod tests {
                 .map(|(segment, checkpoint)| (*segment, *checkpoint))
                 .collect())
         }
-    }
-
-    #[test]
-    fn highest_block_uses_headers_stage_checkpoint() {
-        let stages = [(StageId::Bodies.as_str(), 20), (StageId::Headers.as_str(), 30)];
-
-        assert_eq!(estimate_highest_block(10, stages), 30);
-    }
-
-    #[test]
-    fn highest_block_does_not_fall_behind_current_block() {
-        let stages = [(StageId::Headers.as_str(), 10)];
-
-        assert_eq!(estimate_highest_block(20, stages), 20);
-    }
-
-    #[test]
-    fn highest_block_falls_back_to_current_block_without_headers_checkpoint() {
-        let stages = [(StageId::Bodies.as_str(), 30)];
-
-        assert_eq!(estimate_highest_block(20, stages), 20);
     }
 
     #[test]

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -21,6 +21,7 @@ reth-engine-primitives.workspace = true
 reth-errors.workspace = true
 reth-metrics.workspace = true
 reth-storage-api.workspace = true
+reth-stages-types.workspace = true
 reth-execution-types = { workspace = true, features = ["serde"] }
 reth-chain-state.workspace = true
 reth-transaction-pool.workspace = true

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -17,11 +17,11 @@ use reth_chain_state::CanonStateSubscriptions;
 use reth_network_api::NetworkInfo;
 use reth_rpc_convert::RpcHeader;
 use reth_rpc_eth_api::{
-    helpers::{spec::estimate_highest_block, EthSubscriptions},
-    pubsub::EthPubSubApiServer,
-    RpcConvert, RpcLog, RpcNodeCore, RpcTransaction,
+    helpers::EthSubscriptions, pubsub::EthPubSubApiServer, RpcConvert, RpcLog, RpcNodeCore,
+    RpcTransaction,
 };
 use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err};
+use reth_stages_types::StageId;
 use reth_storage_api::{BlockNumReader, StageCheckpointReader};
 use reth_tasks::Runtime;
 use reth_transaction_pool::{NewTransactionEvent, TransactionPool};
@@ -314,13 +314,12 @@ where
                 .chain_info()
                 .map(|info| info.best_number)
                 .unwrap_or_default();
-            let checkpoints = self.eth_api.provider().get_all_checkpoints().unwrap_or_default();
-            let highest_block = estimate_highest_block(
-                current_block,
-                checkpoints
-                    .iter()
-                    .map(|(name, checkpoint)| (name.as_str(), checkpoint.block_number)),
-            );
+            let highest_block = self
+                .eth_api
+                .provider()
+                .get_stage_checkpoint(StageId::Headers)
+                .unwrap_or_default()
+                .map_or(current_block, |checkpoint| checkpoint.block_number.max(current_block));
             PubSubSyncStatus::Detailed(SyncStatusMetadata {
                 syncing: true,
                 starting_block: 0,

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -17,11 +17,12 @@ use reth_chain_state::CanonStateSubscriptions;
 use reth_network_api::NetworkInfo;
 use reth_rpc_convert::RpcHeader;
 use reth_rpc_eth_api::{
-    helpers::EthSubscriptions, pubsub::EthPubSubApiServer, RpcConvert, RpcLog, RpcNodeCore,
-    RpcTransaction,
+    helpers::{spec::estimate_highest_block, EthSubscriptions},
+    pubsub::EthPubSubApiServer,
+    RpcConvert, RpcLog, RpcNodeCore, RpcTransaction,
 };
 use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err};
-use reth_storage_api::BlockNumReader;
+use reth_storage_api::{BlockNumReader, StageCheckpointReader};
 use reth_tasks::Runtime;
 use reth_transaction_pool::{NewTransactionEvent, TransactionPool};
 use serde::Serialize;
@@ -313,11 +314,18 @@ where
                 .chain_info()
                 .map(|info| info.best_number)
                 .unwrap_or_default();
+            let checkpoints = self.eth_api.provider().get_all_checkpoints().unwrap_or_default();
+            let highest_block = estimate_highest_block(
+                current_block,
+                checkpoints
+                    .iter()
+                    .map(|(name, checkpoint)| (name.as_str(), checkpoint.block_number)),
+            );
             PubSubSyncStatus::Detailed(SyncStatusMetadata {
                 syncing: true,
                 starting_block: 0,
                 current_block,
-                highest_block: Some(current_block),
+                highest_block: Some(highest_block),
             })
         } else {
             PubSubSyncStatus::Simple(false)


### PR DESCRIPTION
Closes #26675

Reports `eth_syncing.highestBlock` from the validated Headers-stage checkpoint instead of mirroring the local canonical head. Uses the local head as a fallback when the checkpoint is unavailable or behind, and applies the same estimate to syncing subscriptions.
