### PR TITLE
feat(rpc): implement debug_accountRange, debug_dumpBlock and debug_storageRangeAt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9962,6 +9962,7 @@ dependencies = [
  "reth-trie-common",
  "serde",
  "serde_json",
+ "serde_with",
  "tokio",
 ]
 

--- a/crates/ethereum/node/tests/e2e/main.rs
+++ b/crates/ethereum/node/tests/e2e/main.rs
@@ -11,6 +11,7 @@ mod prestate;
 mod rpc;
 mod selfdestruct;
 mod simulate;
+mod state_dump;
 mod utils;
 
 const fn main() {}

--- a/crates/ethereum/node/tests/e2e/state_dump.rs
+++ b/crates/ethereum/node/tests/e2e/state_dump.rs
@@ -1,0 +1,245 @@
+use alloy_consensus::constants::EMPTY_ROOT_HASH;
+use alloy_eips::BlockId;
+use alloy_genesis::{Genesis, GenesisAccount};
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_provider::Provider;
+use eyre::{eyre, Result};
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_node_ethereum::EthereumNode;
+use reth_rpc_api::HashedStateDump;
+use reth_rpc_server_types::RpcModuleSelection;
+use reth_tasks::Runtime;
+use std::{collections::BTreeMap, sync::Arc};
+
+/// Storage slots of the account that still fits into a single dump.
+const SMALL_STORAGE_SLOTS: u64 = 128;
+
+/// Storage slots of the account that exceeds the dump's storage budget of 16384 slots.
+const HUGE_STORAGE_SLOTS: u64 = 20_000;
+
+/// Number of plain (storage-less) accounts allocated in genesis.
+const PLAIN_ACCOUNTS: u64 = 5;
+
+/// Accounts per page requested while paging through the entire state.
+const PAGE_SIZE: u64 = 3;
+
+/// Exercises `debug_accountRange` and `debug_dumpBlock` against a genesis that allocates an
+/// account with more storage than a single dump is allowed to read.
+#[tokio::test]
+async fn debug_account_range_dumps_genesis_state() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let plain_accounts = (0..PLAIN_ACCOUNTS)
+        .map(|i| {
+            (
+                account_address(i),
+                GenesisAccount::default()
+                    .with_balance(U256::from(i + 1))
+                    .with_nonce(Some(i))
+                    .with_code(Some(account_code(i))),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let small_storage_address = account_address(PLAIN_ACCOUNTS);
+    let small_storage_account = GenesisAccount::default()
+        .with_balance(U256::from(1_000))
+        .with_code(Some(account_code(PLAIN_ACCOUNTS)))
+        .with_storage(Some(storage(SMALL_STORAGE_SLOTS)));
+
+    // Dumping this account's storage must exceed the budget, so its hash is picked to sort last
+    // and the dump ends before it rather than on it.
+    let huge_storage_address = last_sorting_address();
+    let huge_storage_account = GenesisAccount::default()
+        .with_balance(U256::from(2_000))
+        .with_storage(Some(storage(HUGE_STORAGE_SLOTS)));
+
+    let mut genesis = Genesis::default();
+    genesis.alloc.extend(plain_accounts.iter().cloned());
+    genesis.alloc.insert(small_storage_address, small_storage_account.clone());
+    genesis.alloc.insert(huge_storage_address, huge_storage_account.clone());
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(genesis)
+            .cancun_activated()
+            .build(),
+    );
+
+    let node_config = NodeConfig::test().with_chain(chain_spec).with_rpc(
+        RpcServerArgs::default()
+            .with_unused_ports()
+            .with_http()
+            .with_http_api(RpcModuleSelection::all_modules().into()),
+    );
+
+    let NodeHandle { node, node_exit_future: _ } = NodeBuilder::new(node_config)
+        .testing_node(Runtime::test())
+        .node(EthereumNode::default())
+        .launch()
+        .await?;
+
+    let provider = node.rpc_server_handle().eth_http_provider().unwrap();
+    let genesis_root = provider
+        .get_block(BlockId::latest())
+        .await?
+        .ok_or_else(|| eyre!("missing genesis block"))?
+        .header
+        .state_root;
+
+    // Page through the whole state, without storage, to learn the full account set.
+    let mut all_accounts = Vec::new();
+    let mut start = Bytes::new();
+    loop {
+        let dump: HashedStateDump = provider
+            .client()
+            .request("debug_accountRange", (BlockId::latest(), start, PAGE_SIZE, true, true, false))
+            .await?;
+
+        assert_eq!(dump.root, genesis_root);
+        assert!(dump.accounts.len() as u64 <= PAGE_SIZE, "page exceeds maxResults");
+        all_accounts.extend(dump.accounts);
+
+        let Some(next) = dump.next else { break };
+        assert_eq!(next.len(), 32, "next must be a hashed address");
+        start = next;
+    }
+
+    let hashes = all_accounts.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+    assert!(hashes.windows(2).all(|pair| pair[0] < pair[1]), "accounts must be strictly ascending");
+
+    let huge_storage_hash = keccak256(huge_storage_address);
+    assert_eq!(
+        hashes.last(),
+        Some(&huge_storage_hash),
+        "the account with huge storage must sort last"
+    );
+
+    // Accounts are keyed by their hashed address, and carry no address preimage.
+    for (address, account) in &plain_accounts {
+        let hashed_address = keccak256(address);
+        let dumped = all_accounts
+            .iter()
+            .find_map(|(hash, dumped)| (*hash == hashed_address).then_some(dumped))
+            .ok_or_else(|| eyre!("account {address} missing from dump"))?;
+
+        assert_eq!(dumped.balance, account.balance);
+        assert_eq!(Some(dumped.nonce), account.nonce);
+        assert_eq!(Some(dumped.code_hash), account.code_hash());
+        assert_eq!(dumped.root, EMPTY_ROOT_HASH);
+        assert_eq!(dumped.address, None);
+        assert_eq!(dumped.address_hash, Some(hashed_address));
+        assert_eq!(dumped.code, None, "nocode was requested");
+        assert_eq!(dumped.storage, None, "nostorage was requested");
+    }
+
+    // A single account, with its storage and code.
+    let dump: HashedStateDump = provider
+        .client()
+        .request(
+            "debug_accountRange",
+            (
+                BlockId::latest(),
+                Bytes::from(keccak256(small_storage_address).0),
+                1,
+                false,
+                false,
+                false,
+            ),
+        )
+        .await?;
+
+    let (hashed_address, dumped) =
+        dump.accounts.first_key_value().ok_or_else(|| eyre!("account range is empty"))?;
+    assert_eq!(*hashed_address, keccak256(small_storage_address));
+    assert_eq!(dumped.code, small_storage_account.code);
+    assert_eq!(
+        dumped.storage.as_ref().map(|storage| storage.len()),
+        Some(SMALL_STORAGE_SLOTS as usize),
+    );
+
+    // Storage slots are keyed by hashed slot, for the same reason accounts are.
+    let expected_storage = storage(SMALL_STORAGE_SLOTS)
+        .into_iter()
+        .map(|(slot, value)| (keccak256(slot), U256::from_be_bytes(value.0)))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(dumped.storage.as_ref(), Some(&expected_storage));
+
+    let proof = provider.get_proof(small_storage_address, Vec::new()).await?;
+    assert_eq!(dumped.root, proof.storage_hash);
+
+    // Reading the huge account's storage would blow the budget, so it is refused outright rather
+    // than dumped partially.
+    let err = provider
+        .client()
+        .request::<_, HashedStateDump>(
+            "debug_accountRange",
+            (BlockId::latest(), Bytes::from(huge_storage_hash.0), 1, false, false, false),
+        )
+        .await
+        .expect_err("dumping an account over the storage budget must fail");
+    assert!(err.to_string().contains("nostorage"), "unexpected error: {err}");
+
+    // Without storage it dumps fine, storage root included.
+    let dump: HashedStateDump = provider
+        .client()
+        .request(
+            "debug_accountRange",
+            (BlockId::latest(), Bytes::from(huge_storage_hash.0), 1, false, true, false),
+        )
+        .await?;
+    let dumped = dump.accounts.get(&huge_storage_hash).ok_or_else(|| eyre!("account missing"))?;
+    assert_eq!(dumped.storage, None);
+    assert_eq!(dumped.balance, huge_storage_account.balance);
+
+    let proof = provider.get_proof(huge_storage_address, Vec::new()).await?;
+    assert_eq!(dumped.root, proof.storage_hash);
+    assert_ne!(dumped.root, EMPTY_ROOT_HASH);
+
+    // `debug_dumpBlock` dumps a single page with storage, so it stops before the huge account and
+    // points at it.
+    let dump: HashedStateDump =
+        provider.client().request("debug_dumpBlock", (BlockId::latest(),)).await?;
+
+    assert_eq!(dump.root, genesis_root);
+    assert_eq!(dump.next, Some(Bytes::from(huge_storage_hash.0)));
+    assert_eq!(
+        dump.accounts.keys().copied().collect::<Vec<_>>(),
+        hashes[..hashes.len() - 1].to_vec(),
+        "every account but the huge one must be dumped"
+    );
+    assert_eq!(
+        dump.accounts[&keccak256(small_storage_address)].storage.as_ref(),
+        Some(&expected_storage)
+    );
+
+    Ok(())
+}
+
+/// Returns a deterministic address for the given index.
+fn account_address(index: u64) -> Address {
+    Address::from_slice(&keccak256(index.to_be_bytes())[..20])
+}
+
+/// Returns deterministic, non-empty code for the given index.
+fn account_code(index: u64) -> Bytes {
+    Bytes::from(vec![0x60, 0x00, 0x60, index as u8, 0x55])
+}
+
+/// Returns an address whose hash sorts after every other genesis account's.
+fn last_sorting_address() -> Address {
+    (0u64..)
+        .map(account_address)
+        .find(|address| keccak256(address)[0] == 0xff)
+        .expect("address with a 0xff-prefixed hash")
+}
+
+/// Returns `slots` deterministic, non-zero storage entries.
+fn storage(slots: u64) -> BTreeMap<B256, B256> {
+    (0..slots)
+        .map(|slot| (B256::from(U256::from(slot)), B256::from(U256::from(slot + 1))))
+        .collect()
+}

--- a/crates/ethereum/node/tests/e2e/state_dump.rs
+++ b/crates/ethereum/node/tests/e2e/state_dump.rs
@@ -1,14 +1,17 @@
+use crate::utils::eth_payload_attributes;
 use alloy_consensus::constants::EMPTY_ROOT_HASH;
-use alloy_eips::BlockId;
+use alloy_eips::{eip2718::Encodable2718, BlockId};
 use alloy_genesis::{Genesis, GenesisAccount};
-use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_primitives::{keccak256, Address, Bytes, TxKind, B256, U256};
 use alloy_provider::Provider;
+use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
 use eyre::{eyre, Result};
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_e2e_test_utils::{setup, transaction::TransactionTestContext};
 use reth_node_builder::{NodeBuilder, NodeHandle};
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
 use reth_node_ethereum::EthereumNode;
-use reth_rpc_api::HashedStateDump;
+use reth_rpc_api::{HashedStateDump, HashedStorageRangeResult};
 use reth_rpc_server_types::RpcModuleSelection;
 use reth_tasks::Runtime;
 use std::{collections::BTreeMap, sync::Arc};
@@ -242,4 +245,135 @@ fn storage(slots: u64) -> BTreeMap<B256, B256> {
     (0..slots)
         .map(|slot| (B256::from(U256::from(slot)), B256::from(U256::from(slot + 1))))
         .collect()
+}
+
+/// Storage slots the storage-writing contract is allocated with in genesis.
+const SEEDED_SLOTS: u64 = 4;
+
+/// Writes `sstore(calldataload(0), calldataload(0x20))`.
+const STORAGE_WRITER_CODE: &[u8] = &[0x60, 0x20, 0x35, 0x60, 0x00, 0x35, 0x55, 0x00];
+
+/// Exercises `debug_storageRangeAt` across the transactions of a block that writes storage.
+#[tokio::test]
+async fn debug_storage_range_at_replays_block_transactions() -> Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let contract = account_address(u64::MAX);
+    let mut genesis: Genesis =
+        serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
+    genesis.alloc.insert(
+        contract,
+        GenesisAccount::default()
+            .with_code(Some(Bytes::from_static(STORAGE_WRITER_CODE)))
+            .with_storage(Some(storage(SEEDED_SLOTS))),
+    );
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(genesis)
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) =
+        setup::<EthereumNode>(1, chain_spec.clone(), false, eth_payload_attributes).await?;
+    let mut node = nodes.pop().unwrap();
+    let signer = wallet.wallet_gen().swap_remove(0);
+    let chain_id = chain_spec.chain.id();
+
+    // Two transactions in one block, each writing a distinct slot.
+    let written = [
+        (B256::from(U256::from(0xaa)), B256::from(U256::from(0x11))),
+        (B256::from(U256::from(0xbb)), B256::from(U256::from(0x22))),
+    ];
+    for (nonce, (slot, value)) in written.iter().enumerate() {
+        let mut calldata = slot.to_vec();
+        calldata.extend_from_slice(value.as_slice());
+        let tx = TransactionRequest {
+            nonce: Some(nonce as u64),
+            value: Some(U256::ZERO),
+            to: Some(TxKind::Call(contract)),
+            gas: Some(100_000),
+            max_fee_per_gas: Some(1000e9 as u128),
+            max_priority_fee_per_gas: Some(20e9 as u128),
+            chain_id: Some(chain_id),
+            input: TransactionInput { input: None, data: Some(calldata.into()) },
+            ..Default::default()
+        };
+        let signed = TransactionTestContext::sign_tx(signer.clone(), tx).await;
+        node.rpc.inject_tx(signed.encoded_2718().into()).await.map_err(|err| eyre!("{err:?}"))?;
+    }
+
+    let payload = node.advance_block().await?;
+    let block = payload.block().hash();
+    assert_eq!(payload.block().body().transactions.len(), written.len());
+
+    let provider = node.inner.rpc_server_handle().eth_http_provider().unwrap();
+    let seeded = storage(SEEDED_SLOTS)
+        .into_iter()
+        .map(|(slot, value)| (keccak256(slot), value))
+        .collect::<BTreeMap<_, _>>();
+
+    // Before the first transaction only the genesis storage is visible, and without preimages.
+    let range = storage_range(&provider, block, 0, contract, Bytes::new(), 100).await?;
+    assert_eq!(range.next_key, None);
+    assert_eq!(range.storage.len(), seeded.len());
+    for (hashed_slot, entry) in &range.storage {
+        assert_eq!(entry.key, None, "reth has no storage key preimages");
+        assert_eq!(Some(&entry.value), seeded.get(hashed_slot));
+    }
+
+    // Replaying up to a transaction reveals the slots it wrote, with their preimages, since those
+    // are known from the replay itself.
+    for (index, (slot, value)) in written.iter().enumerate() {
+        let range = storage_range(&provider, block, index + 1, contract, Bytes::new(), 100).await?;
+
+        assert_eq!(range.storage.len(), seeded.len() + index + 1);
+        let entry = range
+            .storage
+            .get(&keccak256(slot))
+            .ok_or_else(|| eyre!("slot {slot} written by transaction {index} is missing"))?;
+        assert_eq!(entry.key, Some(*slot));
+        assert_eq!(entry.value, *value);
+
+        // The later transaction's slot isn't visible yet.
+        for (slot, _) in &written[index + 1..] {
+            assert!(!range.storage.contains_key(&keccak256(slot)));
+        }
+    }
+
+    // Paging walks the same entries one at a time.
+    let full = storage_range(&provider, block, written.len(), contract, Bytes::new(), 100).await?;
+    let mut paged = BTreeMap::new();
+    let mut start = Bytes::new();
+    loop {
+        let page = storage_range(&provider, block, written.len(), contract, start, 1).await?;
+        assert!(page.storage.len() <= 1);
+        paged.extend(page.storage);
+
+        let Some(next_key) = page.next_key else { break };
+        start = Bytes::from(next_key.0);
+    }
+    assert_eq!(paged, full.storage);
+
+    Ok(())
+}
+
+/// Calls `debug_storageRangeAt` on the given block and transaction index.
+async fn storage_range<P: Provider>(
+    provider: &P,
+    block: B256,
+    tx_index: usize,
+    address: Address,
+    key_start: Bytes,
+    max_result: u64,
+) -> Result<HashedStorageRangeResult> {
+    Ok(provider
+        .client()
+        .request(
+            "debug_storageRangeAt",
+            (BlockId::from(block), tx_index, address, key_start, max_result),
+        )
+        .await?)
 }

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -28,8 +28,8 @@ use reth_network_peers::PeerId;
 use reth_primitives_traits::Block;
 use reth_storage_api::{
     errors::provider::ProviderResult, BalProvider, BlockReader, BytecodeReader,
-    GetBlockAccessListLimit, HeaderProvider, RangeEnd, RangeResponse, StateProviderFactory,
-    StateRangeProviderFactory,
+    GetBlockAccessListLimit, HeaderProvider, RangeEnd, RangeLimits, RangeResponse,
+    StateProviderFactory, StateRangeProviderFactory,
 };
 use reth_transaction_pool::{blobstore::NoopBlobStore, BlobStore};
 use std::{
@@ -536,8 +536,11 @@ where
         let Some(state) = self.client.state_range_provider(req.root_hash)? else {
             return Ok(empty)
         };
-        let RangeResponse { items: accounts, end } =
-            state.account_range(req.starting_hash, req.limit_hash, response_bytes)?;
+        let RangeResponse { items: accounts, end } = state.account_range(
+            req.starting_hash,
+            req.limit_hash,
+            RangeLimits::bytes(response_bytes),
+        )?;
 
         let proof = if req.starting_hash == B256::ZERO && end == RangeEnd::Exhausted {
             Vec::new()
@@ -596,8 +599,12 @@ where
             } else {
                 (B256::ZERO, B256::repeat_byte(0xff))
             };
-            let Some(RangeResponse { items: account_slots, end }) =
-                state.storage_range(hashed_address, origin, limit, remaining_bytes)?
+            let Some(RangeResponse { items: account_slots, end }) = state.storage_range(
+                hashed_address,
+                origin,
+                limit,
+                RangeLimits::bytes(remaining_bytes),
+            )?
             else {
                 return Ok(empty)
             };

--- a/crates/rpc/rpc-api/Cargo.toml
+++ b/crates/rpc/rpc-api/Cargo.toml
@@ -40,6 +40,7 @@ alloy-genesis.workspace = true
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serde_with = { workspace = true, features = ["base64"] }
 
 [features]
 client = [

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -2,7 +2,7 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_genesis::ChainConfig;
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::{Address, Bytes, B256, U64};
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{AccountState, ExecutionWitness};
 use alloy_rpc_types_eth::{Account, AccountInfo, Bundle, Index, StateContext};
 use alloy_rpc_types_trace::geth::{
     ChainBlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
@@ -10,6 +10,9 @@ use alloy_rpc_types_trace::geth::{
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
+use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, serde_as};
+use std::collections::BTreeMap;
 
 /// Debug rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "debug"))]
@@ -200,18 +203,20 @@ pub trait DebugApi<TxReq: RpcObject> {
     /// Enumerates all accounts at a given block with paging capability. `maxResults` are returned
     /// in the page and the items have keys that come after the `start` key (hashed address).
     ///
-    /// If incompletes is false, then accounts for which the key preimage (i.e: the address) doesn't
-    /// exist in db are skipped. NB: geth by default does not store preimages.
+    /// Reth stores no address preimages, so every returned account is what geth calls
+    /// "incomplete": keyed by hashed address, with the `address` field unset. The `incompletes`
+    /// argument is therefore accepted but ignored, since honoring `incompletes = false` would
+    /// filter out every account.
     #[method(name = "accountRange")]
     async fn debug_account_range(
         &self,
-        block_number: BlockNumberOrTag,
+        block_id: BlockId,
         start: Bytes,
         max_results: u64,
         nocode: bool,
         nostorage: bool,
         incompletes: bool,
-    ) -> RpcResult<()>;
+    ) -> RpcResult<HashedStateDump>;
 
     /// Flattens the entire key-value database into a single level, removing all unused slots and
     /// merging all keys.
@@ -251,8 +256,11 @@ pub trait DebugApi<TxReq: RpcObject> {
 
     /// Retrieves the state that corresponds to the block number and returns a list of accounts
     /// (including storage and code).
+    ///
+    /// Like geth, this is capped at a single page of accounts; use
+    /// [`debug_accountRange`](Self::debug_account_range) to page through the entire state.
     #[method(name = "dumpBlock")]
-    async fn debug_dump_block(&self, number: BlockId) -> RpcResult<()>;
+    async fn debug_dump_block(&self, number: BlockId) -> RpcResult<HashedStateDump>;
 
     /// Forces garbage collection.
     #[method(name = "freeOSMemory")]
@@ -381,4 +389,28 @@ pub trait DebugApi<TxReq: RpcObject> {
         block_hash: B256,
         opts: Option<GethDebugTracingCallOptions>,
     ) -> RpcResult<Vec<TraceResult>>;
+}
+
+/// Result of `debug_accountRange` and `debug_dumpBlock`: a partial dump of the state trie.
+///
+/// This mirrors geth's `state.Dump`, except that accounts are keyed by their hashed address:
+/// reth stores no address preimages, so the plain address of a dumped account is unknown. This is
+/// the same output geth produces for accounts whose preimage it is missing, which is the default
+/// for a geth node that runs without `--cache.preimages`.
+#[serde_as]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HashedStateDump {
+    /// The state root of the dumped state.
+    pub root: B256,
+    /// The dumped accounts, keyed by `keccak256(address)`.
+    ///
+    /// Storage slots of an account are keyed by `keccak256(slot)` for the same reason.
+    pub accounts: BTreeMap<B256, AccountState>,
+    /// The hashed address to resume the dump from, if this dump is only partial.
+    ///
+    /// Base64-encoded, matching geth's encoding of the same field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<Base64>")]
+    pub next: Option<Bytes>,
 }

--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -370,15 +370,19 @@ pub trait DebugApi<TxReq: RpcObject> {
     /// Returns the storage at the given block height and transaction index. The result can be
     /// paged by providing a `maxResult` to cap the number of storage slots returned as well as
     /// specifying the offset via `keyStart` (hash of storage key).
+    ///
+    /// The state is the one after executing the first `txIdx` transactions of the block, i.e. the
+    /// state the transaction at `txIdx` runs on, matching geth. Passing the block's transaction
+    /// count addresses the state after the entire block.
     #[method(name = "storageRangeAt")]
     async fn debug_storage_range_at(
         &self,
-        block_hash: B256,
+        block_id: BlockId,
         tx_idx: usize,
         contract_address: Address,
-        key_start: B256,
+        key_start: Bytes,
         max_result: u64,
-    ) -> RpcResult<()>;
+    ) -> RpcResult<HashedStorageRangeResult>;
 
     /// Returns the structured logs created during the execution of EVM against a block pulled
     /// from the pool of bad ones and returns them as a JSON object. For the second parameter see
@@ -413,4 +417,28 @@ pub struct HashedStateDump {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<Base64>")]
     pub next: Option<Bytes>,
+}
+
+/// Result of `debug_storageRangeAt`: a page of one account's storage.
+///
+/// This mirrors geth's `StorageRangeResult`, which is already keyed by hashed storage key. The
+/// plain key is only known for slots the replayed transactions touched, and is `None` otherwise,
+/// just like geth reports slots whose preimage it is missing.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HashedStorageRangeResult {
+    /// The storage slots, keyed by `keccak256(slot)`.
+    pub storage: BTreeMap<B256, HashedStorageEntry>,
+    /// The hashed storage key to resume from, if this page is only partial.
+    pub next_key: Option<B256>,
+}
+
+/// A single entry of a [`HashedStorageRangeResult`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HashedStorageEntry {
+    /// The plain storage key, if known.
+    pub key: Option<B256>,
+    /// The value stored at the slot.
+    pub value: B256,
 }

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -32,7 +32,7 @@ mod txpool;
 mod validation;
 mod web3;
 
-pub use debug::HashedStateDump;
+pub use debug::{HashedStateDump, HashedStorageEntry, HashedStorageRangeResult};
 pub use reth::RethJitAction;
 pub use testing::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1, TESTING_COMMIT_BLOCK_V1};
 

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -32,6 +32,7 @@ mod txpool;
 mod validation;
 mod web3;
 
+pub use debug::HashedStateDump;
 pub use reth::RethJitAction;
 pub use testing::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1, TESTING_COMMIT_BLOCK_V1};
 

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -9,7 +9,7 @@ use reth_primitives_traits::{BlockTy, HeaderTy, ReceiptTy, TxTy};
 use reth_rpc_eth_types::EthStateCache;
 use reth_storage_api::{
     BalProvider, BlockReader, BlockReaderIdExt, PruneCheckpointReader, StageCheckpointReader,
-    StateProviderFactory,
+    StateProviderFactory, StateRangeProviderFactory,
 };
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
@@ -40,6 +40,7 @@ pub trait RpcNodeCore: Clone + Send + Sync + Unpin + 'static {
         + StageCheckpointReader
         + PruneCheckpointReader
         + BalProvider
+        + StateRangeProviderFactory
         + Send
         + Sync
         + Clone
@@ -135,6 +136,7 @@ where
         + StageCheckpointReader
         + PruneCheckpointReader
         + BalProvider
+        + StateRangeProviderFactory
         + Send
         + Sync
         + Unpin

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
 use alloy_evm::{env::BlockEnvironment, Evm};
 use alloy_genesis::ChainConfig;
-use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U256, U64};
+use alloy_primitives::{hex::decode, keccak256, uint, Address, Bytes, B256, U256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
 use alloy_rpc_types_debug::{AccountState, ExecutionWitness};
@@ -29,7 +29,7 @@ use reth_primitives_traits::{
     Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom, RecoveredBlock,
 };
 use reth_revm::{db::State, witness::ExecutionWitnessRecord};
-use reth_rpc_api::{DebugApiServer, HashedStateDump};
+use reth_rpc_api::{DebugApiServer, HashedStateDump, HashedStorageEntry, HashedStorageRangeResult};
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
@@ -995,16 +995,171 @@ where
             .await
     }
 
+    /// Returns a page of `address`'s storage, as of the state the transaction at `tx_index` of
+    /// the given block runs on.
+    ///
+    /// The number of slots read is bounded by [`STORAGE_RANGE_MAX_RESULTS`], plus the slots the
+    /// replayed transactions touched.
+    pub async fn debug_storage_range_at(
+        &self,
+        block_id: BlockId,
+        tx_index: usize,
+        address: Address,
+        key_start: Bytes,
+        max_result: u64,
+    ) -> Result<HashedStorageRangeResult, Eth::Error> {
+        if key_start.len() > 32 {
+            return Err(EthApiError::InvalidParams(format!(
+                "key start must be at most 32 bytes, got {}",
+                key_start.len()
+            ))
+            .into())
+        }
+
+        let mut start_key = B256::ZERO;
+        start_key[..key_start.len()].copy_from_slice(&key_start);
+        let max_result = (max_result as usize).min(STORAGE_RANGE_MAX_RESULTS);
+
+        // This replays part of a block, so it is rate limited like the tracing calls.
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(RethError::other)
+            .map_err(EthApiError::Internal)?;
+
+        let block = self
+            .eth_api()
+            .recovered_block(block_id)
+            .await?
+            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+
+        let transaction_count = block.transaction_count();
+        if tx_index > transaction_count {
+            return Err(EthApiError::InvalidParams(format!(
+                "tx_index {tx_index} out of bounds for block with {transaction_count} transactions"
+            ))
+            .into())
+        }
+
+        let parent_hash = block.parent_hash();
+        let parent_state_root = self
+            .provider()
+            .header(parent_hash)
+            .map_err(Eth::Error::from_eth_err)?
+            .ok_or(EthApiError::HeaderNotFound(parent_hash.into()))?
+            .state_root();
+        let hashed_address = keccak256(address);
+
+        self.eth_api()
+            .spawn_with_state_at_block(parent_hash, move |eth_api, mut db| {
+                let mut executor = eth_api
+                    .evm_config()
+                    .executor_for_block(&mut db, block.sealed_block())
+                    .map_err(RethError::other)
+                    .map_err(Eth::Error::from_eth_err)?;
+                executor.apply_pre_execution_changes().map_err(Eth::Error::from_eth_err)?;
+
+                for tx in block.transactions_recovered().take(tx_index) {
+                    executor.execute_transaction(tx).map_err(Eth::Error::from_eth_err)?;
+                }
+                drop(executor);
+
+                // Slots the replay touched, with their preimages. Values shadow the persisted
+                // state, and are the account's entire storage if it was destroyed.
+                let (touched, wiped) = db
+                    .cache
+                    .accounts
+                    .get(&address)
+                    .and_then(|account| {
+                        account.account.as_ref().map(|plain_account| {
+                            let touched = plain_account
+                                .storage
+                                .iter()
+                                .map(|(slot, value)| {
+                                    let slot = B256::from(*slot);
+                                    (keccak256(slot), (slot, *value))
+                                })
+                                .collect::<BTreeMap<_, _>>();
+                            (touched, account.status.was_destroyed())
+                        })
+                    })
+                    .unwrap_or_default();
+
+                // Reading one entry past the page, plus room for the touched slots, is enough for
+                // the merge below to fill the page and find the key to resume from: each touched
+                // slot displaces at most one persisted entry.
+                let persisted = if wiped {
+                    Vec::new()
+                } else {
+                    let range = eth_api
+                        .provider()
+                        .state_range_provider(parent_state_root)
+                        .map_err(Eth::Error::from_eth_err)?
+                        .ok_or_else(|| {
+                            EthApiError::InvalidParams(format!(
+                                "state at block {} is no longer available",
+                                block.number().saturating_sub(1)
+                            ))
+                        })?;
+                    Self::storage_page_from(
+                        &range,
+                        hashed_address,
+                        start_key,
+                        max_result.saturating_add(1).saturating_add(touched.len()),
+                    )?
+                };
+
+                let mut slots = persisted
+                    .into_iter()
+                    .map(|(hashed_slot, value)| (hashed_slot, (None, value)))
+                    .collect::<BTreeMap<_, _>>();
+                for (hashed_slot, (slot, value)) in touched {
+                    if hashed_slot < start_key {
+                        continue
+                    }
+                    if value.is_zero() {
+                        slots.remove(&hashed_slot);
+                    } else {
+                        slots.insert(hashed_slot, (Some(slot), value));
+                    }
+                }
+
+                let mut result = HashedStorageRangeResult::default();
+                for (hashed_slot, (slot, value)) in slots {
+                    if result.storage.len() == max_result {
+                        result.next_key = Some(hashed_slot);
+                        break
+                    }
+                    result
+                        .storage
+                        .insert(hashed_slot, HashedStorageEntry { key: slot, value: value.into() });
+                }
+
+                Ok(result)
+            })
+            .await
+    }
+
     /// Reads at most `max_slots` storage slots of the given account, in hashed key order.
     fn storage_page(
         range: &StateRangeView,
         hashed_address: B256,
         max_slots: usize,
     ) -> Result<Vec<(B256, U256)>, Eth::Error> {
+        Self::storage_page_from(range, hashed_address, B256::ZERO, max_slots)
+    }
+
+    /// Same as [`Self::storage_page`], but starting at the given hashed storage key.
+    fn storage_page_from(
+        range: &StateRangeView,
+        hashed_address: B256,
+        start: B256,
+        max_slots: usize,
+    ) -> Result<Vec<(B256, U256)>, Eth::Error> {
         Ok(range
             .storage_range(
                 hashed_address,
-                B256::ZERO,
+                start,
                 B256::repeat_byte(0xff),
                 RangeLimits::items(max_slots),
             )
@@ -1018,6 +1173,11 @@ where
 ///
 /// Matches geth's `AccountRangeMaxResults`.
 const ACCOUNT_RANGE_MAX_RESULTS: usize = 256;
+
+/// Maximum number of storage slots a single `debug_storageRangeAt` call returns.
+///
+/// A capped page still reports where to resume via `nextKey`.
+const STORAGE_RANGE_MAX_RESULTS: usize = 4096;
 
 /// Maximum number of storage slots read across a single state dump.
 ///
@@ -1582,15 +1742,25 @@ where
         Self::debug_state_root_with_updates(self, hashed_state, block_id).await.map_err(Into::into)
     }
 
+    /// Handler for `debug_storageRangeAt`
     async fn debug_storage_range_at(
         &self,
-        _block_hash: B256,
-        _tx_idx: usize,
-        _contract_address: Address,
-        _key_start: B256,
-        _max_result: u64,
-    ) -> RpcResult<()> {
-        Ok(())
+        block_id: BlockId,
+        tx_idx: usize,
+        contract_address: Address,
+        key_start: Bytes,
+        max_result: u64,
+    ) -> RpcResult<HashedStorageRangeResult> {
+        Self::debug_storage_range_at(
+            self,
+            block_id,
+            tx_idx,
+            contract_address,
+            key_start,
+            max_result,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn debug_trace_bad_block(

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,11 +1,15 @@
-use alloy_consensus::{constants::KECCAK_EMPTY, transaction::TxHashRef, BlockHeader};
+use alloy_consensus::{
+    constants::{EMPTY_ROOT_HASH, KECCAK_EMPTY},
+    transaction::TxHashRef,
+    BlockHeader,
+};
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
 use alloy_evm::{env::BlockEnvironment, Evm};
 use alloy_genesis::ChainConfig;
 use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
-use alloy_rpc_types_debug::ExecutionWitness;
+use alloy_rpc_types_debug::{AccountState, ExecutionWitness};
 use alloy_rpc_types_eth::{
     state::EvmOverrides, Account, AccountInfo, BlockError, Bundle, Index, StateContext,
 };
@@ -25,7 +29,7 @@ use reth_primitives_traits::{
     Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom, RecoveredBlock,
 };
 use reth_revm::{db::State, witness::ExecutionWitnessRecord};
-use reth_rpc_api::DebugApiServer;
+use reth_rpc_api::{DebugApiServer, HashedStateDump};
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
@@ -34,8 +38,9 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
-    BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
-    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, StorageRootProvider,
+    BlockIdReader, BlockReaderIdExt, BytecodeReader, HashedPostStateProvider, HeaderProvider,
+    ProviderBlock, RangeLimits, RangeResponse, ReceiptProviderIdExt, StateProviderFactory,
+    StateRangeProviderFactory, StateRangeView, StateRootProvider, StorageRootProvider,
     TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
@@ -47,7 +52,10 @@ use reth_trie_common::{
 use revm::{database::states::bundle_state::BundleRetention, Database, DatabaseCommit};
 use revm_inspectors::tracing::{DebugInspector, TransactionContext};
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 
@@ -831,6 +839,192 @@ where
     }
 }
 
+impl<Eth> DebugApi<Eth>
+where
+    Eth: TraceExt,
+{
+    /// Dumps a single page of the state at the given block, starting at the hashed address
+    /// `start`.
+    ///
+    /// This backs both `debug_accountRange` and `debug_dumpBlock`. The amount of state read per
+    /// call is bounded by [`ACCOUNT_RANGE_MAX_RESULTS`] accounts and
+    /// [`ACCOUNT_RANGE_MAX_STORAGE_SLOTS`] storage slots.
+    pub async fn debug_state_dump(
+        &self,
+        block_id: BlockId,
+        start: Bytes,
+        max_results: u64,
+        nocode: bool,
+        nostorage: bool,
+    ) -> Result<HashedStateDump, Eth::Error> {
+        if start.len() > 32 {
+            return Err(EthApiError::InvalidParams(format!(
+                "start key must be at most 32 bytes, got {}",
+                start.len()
+            ))
+            .into())
+        }
+
+        // geth takes a trie path prefix here, which addresses the hashed address it is a prefix of.
+        let mut start_key = B256::ZERO;
+        start_key[..start.len()].copy_from_slice(&start);
+
+        let max_results = match max_results as usize {
+            0 => ACCOUNT_RANGE_MAX_RESULTS,
+            n => n.min(ACCOUNT_RANGE_MAX_RESULTS),
+        };
+
+        // Dumping walks the state and recomputes storage roots, so it is rate limited alongside
+        // tracing and proof requests.
+        let _permit = self
+            .acquire_trace_permit()
+            .await
+            .map_err(RethError::other)
+            .map_err(EthApiError::Internal)?;
+
+        let header = self
+            .provider()
+            .sealed_header_by_id(block_id)
+            .map_err(Eth::Error::from_eth_err)?
+            .ok_or(EthApiError::HeaderNotFound(block_id))?;
+
+        self.eth_api()
+            .spawn_blocking_io(move |this| {
+                let state_root = header.state_root();
+                let range = this
+                    .provider()
+                    .state_range_provider(state_root)
+                    .map_err(Eth::Error::from_eth_err)?
+                    .ok_or_else(|| {
+                        EthApiError::InvalidParams(format!(
+                            "state at block {} is not available for dumping",
+                            header.number()
+                        ))
+                    })?;
+                let state = this
+                    .provider()
+                    .state_by_block_hash(header.hash())
+                    .map_err(Eth::Error::from_eth_err)?;
+
+                // Read one account past the page to learn where a follow-up call should resume.
+                let RangeResponse { items: mut accounts, .. } = range
+                    .account_range(
+                        start_key,
+                        B256::repeat_byte(0xff),
+                        RangeLimits::items(max_results.saturating_add(1)),
+                    )
+                    .map_err(Eth::Error::from_eth_err)?;
+                let mut next =
+                    (accounts.len() > max_results).then(|| accounts.pop().expect("checked len").0);
+
+                let mut dump =
+                    HashedStateDump { root: state_root, accounts: BTreeMap::new(), next: None };
+                let mut slot_budget = ACCOUNT_RANGE_MAX_STORAGE_SLOTS;
+
+                for (hashed_address, account) in accounts {
+                    let mut storage = None;
+                    let has_storage = if nostorage {
+                        !Self::storage_page(&range, hashed_address, 1)?.is_empty()
+                    } else {
+                        // One slot over budget is enough to tell that this account doesn't fit.
+                        let slots = Self::storage_page(
+                            &range,
+                            hashed_address,
+                            slot_budget.saturating_add(1),
+                        )?;
+
+                        if slots.len() > slot_budget {
+                            if dump.accounts.is_empty() {
+                                return Err(EthApiError::InvalidParams(format!(
+                                    "account {hashed_address} has more than \
+                                     {ACCOUNT_RANGE_MAX_STORAGE_SLOTS} storage slots, retry with \
+                                     nostorage"
+                                ))
+                                .into())
+                            }
+                            // Accounts are dumped whole: end the page before this one instead of
+                            // returning a partial account.
+                            next = Some(hashed_address);
+                            break
+                        }
+
+                        slot_budget -= slots.len();
+                        let has_storage = !slots.is_empty();
+                        storage = Some(slots.into_iter().collect::<BTreeMap<_, _>>());
+                        has_storage
+                    };
+
+                    // Computing a storage root walks the account's entire storage trie, so it is
+                    // only done for accounts that actually have storage.
+                    let storage_root = if has_storage {
+                        range
+                            .storage_root_by_hash(hashed_address)
+                            .map_err(Eth::Error::from_eth_err)?
+                    } else {
+                        EMPTY_ROOT_HASH
+                    };
+
+                    let code = match account.bytecode_hash {
+                        Some(code_hash) if !nocode => state
+                            .bytecode_by_hash(&code_hash)
+                            .map_err(Eth::Error::from_eth_err)?
+                            .map(|code| code.original_bytes()),
+                        _ => None,
+                    };
+
+                    dump.accounts.insert(
+                        hashed_address,
+                        AccountState {
+                            balance: account.balance,
+                            nonce: account.nonce,
+                            root: storage_root,
+                            code_hash: account.get_bytecode_hash(),
+                            code,
+                            storage,
+                            // Reth stores no address preimages.
+                            address: None,
+                            address_hash: Some(hashed_address),
+                        },
+                    );
+                }
+
+                dump.next = next.map(|hashed_address| Bytes::from(hashed_address.0));
+
+                Ok(dump)
+            })
+            .await
+    }
+
+    /// Reads at most `max_slots` storage slots of the given account, in hashed key order.
+    fn storage_page(
+        range: &StateRangeView,
+        hashed_address: B256,
+        max_slots: usize,
+    ) -> Result<Vec<(B256, U256)>, Eth::Error> {
+        Ok(range
+            .storage_range(
+                hashed_address,
+                B256::ZERO,
+                B256::repeat_byte(0xff),
+                RangeLimits::items(max_slots),
+            )
+            .map_err(Eth::Error::from_eth_err)?
+            .map(|response| response.items)
+            .unwrap_or_default())
+    }
+}
+
+/// Maximum number of accounts a single state dump returns.
+///
+/// Matches geth's `AccountRangeMaxResults`.
+const ACCOUNT_RANGE_MAX_RESULTS: usize = 256;
+
+/// Maximum number of storage slots read across a single state dump.
+///
+/// Accounts are dumped whole, so a dump ends before the first account that doesn't fit in the
+/// remaining budget and points at it via `next`.
+const ACCOUNT_RANGE_MAX_STORAGE_SLOTS: usize = 16_384;
+
 #[async_trait]
 impl<Eth> DebugApiServer<RpcTxReq<Eth::NetworkTypes>> for DebugApi<Eth>
 where
@@ -1199,16 +1393,22 @@ where
         Self::debug_account_info_at(self, block_id, tx_index, address).await.map_err(Into::into)
     }
 
+    /// Handler for `debug_accountRange`
+    ///
+    /// `incompletes` is ignored: reth has no address preimages, so every dumped account is keyed
+    /// by its hashed address.
     async fn debug_account_range(
         &self,
-        _block_number: BlockNumberOrTag,
-        _start: Bytes,
-        _max_results: u64,
-        _nocode: bool,
-        _nostorage: bool,
+        block_id: BlockId,
+        start: Bytes,
+        max_results: u64,
+        nocode: bool,
+        nostorage: bool,
         _incompletes: bool,
-    ) -> RpcResult<()> {
-        Ok(())
+    ) -> RpcResult<HashedStateDump> {
+        Self::debug_state_dump(self, block_id, start, max_results, nocode, nostorage)
+            .await
+            .map_err(Into::into)
     }
 
     async fn debug_chaindb_compact(&self) -> RpcResult<()> {
@@ -1273,8 +1473,20 @@ where
         self.debug_code_by_hash(code_hash, None).await.map_err(Into::into)
     }
 
-    async fn debug_dump_block(&self, _number: BlockId) -> RpcResult<()> {
-        Ok(())
+    /// Handler for `debug_dumpBlock`
+    ///
+    /// Like geth, this returns at most a single page of accounts.
+    async fn debug_dump_block(&self, number: BlockId) -> RpcResult<HashedStateDump> {
+        Self::debug_state_dump(
+            self,
+            number,
+            Bytes::new(),
+            ACCOUNT_RANGE_MAX_RESULTS as u64,
+            false,
+            false,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn debug_free_os_memory(&self) -> RpcResult<()> {

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -847,8 +847,8 @@ where
     /// `start`.
     ///
     /// This backs both `debug_accountRange` and `debug_dumpBlock`. The amount of state read per
-    /// call is bounded by [`ACCOUNT_RANGE_MAX_RESULTS`] accounts and
-    /// [`ACCOUNT_RANGE_MAX_STORAGE_SLOTS`] storage slots.
+    /// call is bounded by `ACCOUNT_RANGE_MAX_RESULTS` accounts and
+    /// `ACCOUNT_RANGE_MAX_STORAGE_SLOTS` storage slots.
     pub async fn debug_state_dump(
         &self,
         block_id: BlockId,
@@ -998,7 +998,7 @@ where
     /// Returns a page of `address`'s storage, as of the state the transaction at `tx_index` of
     /// the given block runs on.
     ///
-    /// The number of slots read is bounded by [`STORAGE_RANGE_MAX_RESULTS`], plus the slots the
+    /// The number of slots read is bounded by `STORAGE_RANGE_MAX_RESULTS`, plus the slots the
     /// replayed transactions touched.
     pub async fn debug_storage_range_at(
         &self,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -589,7 +589,9 @@ mod tests {
         PruneCheckpointReader, StageCheckpointReader,
     };
     use reth_rpc_eth_api::{node::RpcNodeCoreAdapter, EthApiServer};
-    use reth_storage_api::{BalProvider, BlockReader, BlockReaderIdExt, StateProviderFactory};
+    use reth_storage_api::{
+        BalProvider, BlockReader, BlockReaderIdExt, StateProviderFactory, StateRangeProviderFactory,
+    };
     use reth_testing_utils::generators;
     use reth_transaction_pool::test_utils::{testing_pool, TestPool};
 
@@ -611,6 +613,7 @@ mod tests {
             + StageCheckpointReader
             + PruneCheckpointReader
             + BalProvider
+            + StateRangeProviderFactory
             + Unpin
             + Clone
             + 'static,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -31,9 +31,9 @@ use reth_prune_types::{PruneCheckpoint, PruneSegment};
 use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
-    BlockBodyIndicesProvider, NodePrimitivesProvider, RangeEnd, RangeResponse, RangeResult,
-    StateRangeProvider, StateRangeProviderFactory, StateRangeView, StorageChangeSetReader,
-    StorageRangeResult, TryIntoHistoricalStateProvider,
+    BlockBodyIndicesProvider, NodePrimitivesProvider, RangeEnd, RangeLimits, RangeResponse,
+    RangeResult, StateRangeProvider, StateRangeProviderFactory, StateRangeView,
+    StorageChangeSetReader, StorageRangeResult, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_storage_overlay::{
@@ -270,8 +270,12 @@ impl<N: ProviderNodeTypes> StateRangeProvider for HistoricalStateRangeView<N> {
         &self,
         start: B256,
         limit: B256,
-        response_bytes: usize,
+        limits: RangeLimits,
     ) -> RangeResult<(B256, Account)> {
+        if limits.max_items == 0 {
+            return Ok(RangeResponse { items: Vec::new(), end: RangeEnd::ItemLimit })
+        }
+
         let mut cursor = self.provider.hashed_account_cursor().map_err(ProviderError::Database)?;
 
         let mut accounts = Vec::new();
@@ -288,7 +292,11 @@ impl<N: ProviderNodeTypes> StateRangeProvider for HistoricalStateRangeView<N> {
                 end = RangeEnd::HashLimit;
                 break
             }
-            if total_bytes > response_bytes {
+            if accounts.len() >= limits.max_items {
+                end = RangeEnd::ItemLimit;
+                break
+            }
+            if total_bytes > limits.response_bytes {
                 end = RangeEnd::ByteLimit;
                 break
             }
@@ -316,7 +324,7 @@ impl<N: ProviderNodeTypes> StateRangeProvider for HistoricalStateRangeView<N> {
         hashed_address: B256,
         start: B256,
         limit: B256,
-        response_bytes: usize,
+        limits: RangeLimits,
     ) -> StorageRangeResult {
         // Distinguish an absent account from one with no storage, so callers don't silently
         // omit it and shift later accounts' positions.
@@ -325,6 +333,10 @@ impl<N: ProviderNodeTypes> StateRangeProvider for HistoricalStateRangeView<N> {
         let found = account_cursor.seek(hashed_address).map_err(ProviderError::Database)?;
         if found.map(|(hash, _)| hash) != Some(hashed_address) {
             return Ok(None)
+        }
+
+        if limits.max_items == 0 {
+            return Ok(Some(RangeResponse { items: Vec::new(), end: RangeEnd::ItemLimit }))
         }
 
         let mut cursor =
@@ -344,7 +356,11 @@ impl<N: ProviderNodeTypes> StateRangeProvider for HistoricalStateRangeView<N> {
                 end = RangeEnd::HashLimit;
                 break
             }
-            if total_bytes > response_bytes {
+            if slots.len() >= limits.max_items {
+                end = RangeEnd::ItemLimit;
+                break
+            }
+            if total_bytes > limits.response_bytes {
                 end = RangeEnd::ByteLimit;
                 break
             }
@@ -1040,10 +1056,10 @@ mod tests {
     use reth_storage_api::{
         BlockBodyIndicesProvider, BlockHashReader, BlockIdReader, BlockNumReader, BlockReader,
         BlockReaderIdExt, BlockSource, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-        HashingWriter, HeaderProvider, RangeEnd, ReceiptProvider, ReceiptProviderIdExt,
-        StageCheckpointWriter, StateProviderFactory, StateRangeProvider, StateRangeProviderFactory,
-        StateRootProvider, StateWriteConfig, StateWriter, StorageRootProvider, TransactionVariant,
-        TransactionsProvider,
+        HashingWriter, HeaderProvider, RangeEnd, RangeLimits, ReceiptProvider,
+        ReceiptProviderIdExt, StageCheckpointWriter, StateProviderFactory, StateRangeProvider,
+        StateRangeProviderFactory, StateRootProvider, StateWriteConfig, StateWriter,
+        StorageRootProvider, TransactionVariant, TransactionsProvider,
     };
     use reth_testing_utils::generators::{
         self, random_block, random_block_range, random_changeset_range, random_eoa_accounts,
@@ -2880,13 +2896,14 @@ mod tests {
         expected.sort_by_key(|(hash, _)| *hash);
         let state = provider.state_range_provider(EMPTY_ROOT_HASH)?.unwrap();
 
-        let all = state.account_range(B256::ZERO, B256::repeat_byte(0xff), 10_000)?;
+        let all =
+            state.account_range(B256::ZERO, B256::repeat_byte(0xff), RangeLimits::bytes(10_000))?;
         assert_eq!(all.end, RangeEnd::Exhausted);
         assert_eq!(all.items, expected);
 
         // The limit exactly matches the second account's hash, so the range ends there rather
         // than by exhausting the trie.
-        let bounded = state.account_range(B256::ZERO, expected[1].0, 10_000)?;
+        let bounded = state.account_range(B256::ZERO, expected[1].0, RangeLimits::bytes(10_000))?;
         assert_eq!(bounded.end, RangeEnd::HashLimit);
         assert_eq!(bounded.items, expected[..2]);
 
@@ -2908,9 +2925,60 @@ mod tests {
         let state = provider.state_range_provider(EMPTY_ROOT_HASH)?.unwrap();
 
         // Budget only fits a single account.
-        let partial = state.account_range(B256::ZERO, B256::repeat_byte(0xff), 150)?;
+        let partial =
+            state.account_range(B256::ZERO, B256::repeat_byte(0xff), RangeLimits::bytes(150))?;
         assert_eq!(partial.end, RangeEnd::ByteLimit);
         assert_eq!(partial.items.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn state_range_provider_ranges_respect_max_items() -> eyre::Result<()> {
+        let factory = test_provider_factory_with_genesis()?;
+        let provider_rw = factory.provider_rw()?;
+
+        let accounts: Vec<_> = (0..5u64).map(random_account).collect();
+        provider_rw.insert_account_for_hashing(
+            accounts.iter().map(|(address, account)| (*address, Some(*account))),
+        )?;
+        let (address, _) = accounts[0];
+        let hashed_address = keccak256(address);
+        provider_rw.insert_storage_for_hashing([(
+            address,
+            (0..4u64)
+                .map(|slot| StorageEntry {
+                    key: B256::from(U256::from(slot)),
+                    value: U256::from(slot + 1),
+                })
+                .collect::<Vec<_>>(),
+        )])?;
+        provider_rw.commit()?;
+
+        let provider = BlockchainProvider::new(factory)?;
+        let state = provider.state_range_provider(EMPTY_ROOT_HASH)?.unwrap();
+
+        let capped =
+            state.account_range(B256::ZERO, B256::repeat_byte(0xff), RangeLimits::items(2))?;
+        assert_eq!(capped.end, RangeEnd::ItemLimit);
+        assert_eq!(capped.items.len(), 2);
+
+        let slots = state
+            .storage_range(
+                hashed_address,
+                B256::ZERO,
+                B256::repeat_byte(0xff),
+                RangeLimits::items(3),
+            )?
+            .unwrap();
+        assert_eq!(slots.end, RangeEnd::ItemLimit);
+        assert_eq!(slots.items.len(), 3);
+
+        // A zero cap reads nothing, rather than the one entry ranges otherwise always return.
+        let none =
+            state.account_range(B256::ZERO, B256::repeat_byte(0xff), RangeLimits::items(0))?;
+        assert_eq!(none.end, RangeEnd::ItemLimit);
+        assert!(none.items.is_empty());
 
         Ok(())
     }
@@ -2937,7 +3005,12 @@ mod tests {
         assert_eq!(state.storage_root_by_hash(hashed_address)?, expected_root);
 
         let returned = state
-            .storage_range(hashed_address, B256::ZERO, B256::repeat_byte(0xff), 10_000)?
+            .storage_range(
+                hashed_address,
+                B256::ZERO,
+                B256::repeat_byte(0xff),
+                RangeLimits::bytes(10_000),
+            )?
             .unwrap();
         assert_eq!(returned.end, RangeEnd::Exhausted);
         let mut expected: Vec<_> =
@@ -2946,14 +3019,20 @@ mod tests {
         assert_eq!(returned.items, expected);
 
         // `start == limit == ZERO` means the first real slot's hash already reaches the limit.
-        let empty_window =
-            state.storage_range(hashed_address, B256::ZERO, B256::ZERO, 10_000)?.unwrap();
+        let empty_window = state
+            .storage_range(hashed_address, B256::ZERO, B256::ZERO, RangeLimits::bytes(10_000))?
+            .unwrap();
         assert_eq!(empty_window.end, RangeEnd::HashLimit);
         assert_eq!(empty_window.items, expected[..1]);
 
         // An account absent from the trie is distinguished from one with no storage.
         assert!(state
-            .storage_range(B256::repeat_byte(0xee), B256::ZERO, B256::repeat_byte(0xff), 10_000)?
+            .storage_range(
+                B256::repeat_byte(0xee),
+                B256::ZERO,
+                B256::repeat_byte(0xff),
+                RangeLimits::bytes(10_000)
+            )?
             .is_none());
 
         Ok(())
@@ -3097,7 +3176,8 @@ mod tests {
 
         let state =
             provider.state_range_provider(unique_root)?.expect("in-memory root must resolve");
-        let range = state.account_range(B256::ZERO, B256::repeat_byte(0xff), 10_000)?;
+        let range =
+            state.account_range(B256::ZERO, B256::repeat_byte(0xff), RangeLimits::bytes(10_000))?;
         assert_eq!(range.items, vec![(hashed_address, account)]);
 
         Ok(())
@@ -3178,7 +3258,8 @@ mod tests {
         // so the noise account must not leak into the result.
         let state =
             provider.state_range_provider(unique_root)?.expect("in-memory root must resolve");
-        let range = state.account_range(B256::ZERO, B256::repeat_byte(0xff), 10_000)?;
+        let range =
+            state.account_range(B256::ZERO, B256::repeat_byte(0xff), RangeLimits::bytes(10_000))?;
         assert_eq!(range.items, vec![(target_hashed, target_account)]);
 
         Ok(())
@@ -3268,11 +3349,17 @@ mod tests {
         let provider = BlockchainProvider::new(factory)?;
         let state =
             provider.state_range_provider(anchor_root)?.expect("retained root must resolve");
-        let range = state.account_range(B256::ZERO, B256::repeat_byte(0xff), 10_000)?;
+        let range =
+            state.account_range(B256::ZERO, B256::repeat_byte(0xff), RangeLimits::bytes(10_000))?;
         assert_eq!(range.items, vec![(hashed_address, account_a)]);
 
         let storage_range = state
-            .storage_range(hashed_address, B256::ZERO, B256::repeat_byte(0xff), 10_000)?
+            .storage_range(
+                hashed_address,
+                B256::ZERO,
+                B256::repeat_byte(0xff),
+                RangeLimits::bytes(10_000),
+            )?
             .expect("account must have storage");
         assert_eq!(storage_range.items, vec![(hashed_slot, value_a)]);
 

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -2,7 +2,7 @@ use crate::{
     traits::{BlockSource, ReceiptProvider},
     AccountReader, BalProvider, BalStoreHandle, BlockHashReader, BlockIdReader, BlockNumReader,
     BlockReader, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader, HeaderProvider,
-    PruneCheckpointReader, RangeEnd, RangeResponse, RangeResult, ReceiptProviderIdExt,
+    PruneCheckpointReader, RangeEnd, RangeLimits, RangeResponse, RangeResult, ReceiptProviderIdExt,
     StateProvider, StateProviderBox, StateProviderFactory, StateRangeProvider,
     StateRangeProviderFactory, StateRangeView, StateReader, StateRootProvider, StorageRangeResult,
     TransactionVariant, TransactionsProvider,
@@ -396,7 +396,7 @@ impl<T: NodePrimitives, ChainSpec> StateRangeProvider for MockEthProvider<T, Cha
         &self,
         _start: B256,
         _limit: B256,
-        _response_bytes: usize,
+        _limits: RangeLimits,
     ) -> RangeResult<(B256, Account)> {
         self.ensure_snap_state_reads_succeed()?;
         let (items, end) =
@@ -418,14 +418,14 @@ impl<T: NodePrimitives, ChainSpec> StateRangeProvider for MockEthProvider<T, Cha
         hashed_address: B256,
         start: B256,
         limit: B256,
-        response_bytes: usize,
+        limits: RangeLimits,
     ) -> StorageRangeResult {
         self.ensure_snap_state_reads_succeed()?;
         self.snap_storage_range_requests.lock().push((
             hashed_address,
             start,
             limit,
-            response_bytes,
+            limits.response_bytes,
         ));
         let outcome =
             self.snap_storage_ranges.lock().pop_front().ok_or(ProviderError::BestBlockNotFound)?;

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -71,12 +71,12 @@ pub trait StorageRootProvider {
 /// requests. Hash-native throughout, unlike [`StorageRootProvider`].
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateRangeProvider {
-    /// Returns accounts (hash, account) in `[start, limit]`, bounded by `response_bytes`.
+    /// Returns accounts (hash, account) in `[start, limit]`, bounded by `limits`.
     fn account_range(
         &self,
         start: B256,
         limit: B256,
-        response_bytes: usize,
+        limits: RangeLimits,
     ) -> RangeResult<(B256, Account)>;
 
     /// Returns the storage root for `hashed_address` without needing its address preimage.
@@ -91,7 +91,7 @@ pub trait StateRangeProvider {
         hashed_address: B256,
         start: B256,
         limit: B256,
-        response_bytes: usize,
+        limits: RangeLimits,
     ) -> StorageRangeResult;
 
     /// Returns an account-trie boundary proof for the already-hashed `keys`.
@@ -121,6 +121,30 @@ pub struct RangeResponse<T> {
     pub end: RangeEnd,
 }
 
+/// Caps on how much a [`StateRangeProvider`] range query reads.
+///
+/// Both caps are enforced, whichever is hit first: `max_items` bounds the number of entries the
+/// cursor walks, `response_bytes` bounds their cumulative encoded size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RangeLimits {
+    /// Maximum number of items to return.
+    pub max_items: usize,
+    /// Maximum cumulative size of the returned items, in bytes.
+    pub response_bytes: usize,
+}
+
+impl RangeLimits {
+    /// Returns limits that only bound the response size.
+    pub const fn bytes(response_bytes: usize) -> Self {
+        Self { max_items: usize::MAX, response_bytes }
+    }
+
+    /// Returns limits that only bound the number of returned items.
+    pub const fn items(max_items: usize) -> Self {
+        Self { max_items, response_bytes: usize::MAX }
+    }
+}
+
 /// Why a range query stopped before the caller-requested `limit`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RangeEnd {
@@ -128,8 +152,10 @@ pub enum RangeEnd {
     Exhausted,
     /// The last returned item's key reached or passed the requested `limit`.
     HashLimit,
-    /// `response_bytes` was exceeded before `limit` was reached.
+    /// [`RangeLimits::response_bytes`] was exceeded before `limit` was reached.
     ByteLimit,
+    /// [`RangeLimits::max_items`] was reached before `limit` was.
+    ItemLimit,
 }
 
 /// Result of a [`StateRangeProvider`] range query.


### PR DESCRIPTION
Closes #17848

`debug_accountRange`, `debug_dumpBlock` and `debug_storageRangeAt` were registered stubs returning null. They now dump state, backed by the `StateRangeProvider` that already serves snap `GetAccountRange`/`GetStorageRanges`, so they work for the canonical tip, still in-memory blocks, and the last 128 persisted blocks.

Reth stores no address preimages, and under the v2 storage layout the plain state tables aren't populated at all, so there is no way to recover an account's address from the state. Dumped accounts are therefore keyed by hashed address with the `address` field unset, and storage slots by hashed slot. That is exactly what geth returns for accounts whose preimage it is missing, which is its default without `--cache.preimages`. As a consequence `incompletes` is accepted but ignored: honoring `incompletes = false` would filter out every account.

Reads are bounded per call: 256 accounts, matching geth's `AccountRangeMaxResults`, and 16384 storage slots. Accounts are dumped whole, so a page ends before the first account that doesn't fit into the remaining slot budget and points at it via `next`; an account that can't fit on its own is refused with an error suggesting `nostorage`. Storage roots are only computed for accounts that actually have storage.

`debug_storageRangeAt` replays the block up to, but not including, the transaction at `txIdx`, matching geth's state selection. The parent block's persisted storage range is merged with the slots the replay touched, which is also where the response's key preimages come from. Pages are capped at 4096 slots and report `nextKey`.

All three handlers take the tracing permit and do their work on the blocking pool, like the proof endpoints.

`StateRangeProvider`'s range methods now take a `RangeLimits { max_items, response_bytes }` instead of a bare byte budget, and `StateRangeProviderFactory` was added to `RpcNodeCore::Provider`'s bounds alongside `BalProvider`.