### PR TITLE
fix(trie): include created empty and selfdestructed accounts in sparse-trie post-state (#26499)

### DIFF
--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -501,7 +501,7 @@ pub fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
             trace!(target: "trie::parallel::sparse", ?address, ?hashed_address, "Adding account to state update");
 
             let destroyed = account.is_selfdestructed();
-            if account.info != account.original_info() {
+            if account.is_created() || destroyed || account.info != account.original_info() {
                 let info = if destroyed { None } else { Some(account.info.into()) };
                 hashed_state.accounts.insert(hashed_address, info);
             }
@@ -553,6 +553,34 @@ mod tests {
 
         assert_eq!(hashed_state.accounts.get(&hashed_address), Some(&None));
         assert!(!hashed_state.storages.contains_key(&hashed_address));
+    }
+
+    #[test]
+    fn created_empty_account_is_included() {
+        let address = Address::repeat_byte(0x03);
+        let mut account = Account::default();
+        account.mark_touch();
+        assert!(account.mark_created_locally());
+
+        let hashed_state =
+            evm_state_to_hashed_post_state(EvmState::from_iter([(address, account)]));
+        let hashed_address = keccak256(address);
+
+        assert!(matches!(hashed_state.accounts.get(&hashed_address), Some(Some(_))));
+    }
+
+    #[test]
+    fn unmodified_selfdestruct_account_is_included_as_none() {
+        let address = Address::repeat_byte(0x04);
+        let mut account = Account::default();
+        account.mark_touch();
+        assert!(account.mark_selfdestructed_locally());
+
+        let hashed_state =
+            evm_state_to_hashed_post_state(EvmState::from_iter([(address, account)]));
+        let hashed_address = keccak256(address);
+
+        assert_eq!(hashed_state.accounts.get(&hashed_address), Some(&None));
     }
 
     #[test]


### PR DESCRIPTION
Closes #26499

`evm_state_to_hashed_post_state` in the parallel sparse-trie state-root pipeline previously only emitted account updates when `account.info != account.original_info()`.

This omitted:
1. Newly created empty accounts (where `account.is_created()` is true but `info` equals default `original_info()`), and
2. Existing self-destructed accounts whose metadata did not otherwise change (`account.is_selfdestructed() == true`),

causing the precomputed sparse-trie state root to diverge from the canonical Merkle state root.

### Changes
- Updated `evm_state_to_hashed_post_state` to emit account updates whenever `account.is_created() || destroyed || account.info != account.original_info()`.
- Added unit tests `created_empty_account_is_included` and `unmodified_selfdestruct_account_is_included_as_none` in `state_root_task.rs` to verify created empty and self-destructed accounts are properly included in `HashedPostState`.
