### PR TITLE
feat(txpool): add consensus encoding helper

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -6,7 +6,6 @@ use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
     eip4895::Withdrawals,
     eip7685::RequestsOrHash,
-    Encodable2718,
 };
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, Sealable, B128, B256, U64};
 use alloy_rpc_types_engine::{
@@ -31,7 +30,7 @@ use reth_primitives_traits::{Block, BlockBody};
 use reth_rpc_api::{EngineApiServer, IntoEngineApiRpcModule};
 use reth_storage_api::{BalProvider, BlockReader, HeaderProvider, StateProviderFactory};
 use reth_tasks::Runtime;
-use reth_transaction_pool::{BestTransactions, PoolTransaction, TransactionPool};
+use reth_transaction_pool::{BestTransactions, TransactionPool};
 use std::{
     sync::Arc,
     time::{Instant, SystemTime},
@@ -485,7 +484,7 @@ where
         let mut inclusion_list = Vec::new();
 
         for pool_tx in self.inner.tx_pool.best_transactions().without_blobs().without_updates() {
-            let encoded: Bytes = pool_tx.transaction.consensus_ref().encoded_2718().into();
+            let encoded = pool_tx.encoded_2718_consensus();
             let new_size = total_size + alloy_rlp::Encodable::length(&encoded);
             if new_size + alloy_rlp::length_of_length(new_size) >
                 MAX_BYTES_PER_INCLUSION_LIST as usize
@@ -1765,7 +1764,7 @@ struct EngineApiInner<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSp
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_eips::{eip7685::Requests, NumHash};
+    use alloy_eips::{eip7685::Requests, Encodable2718, NumHash};
     use alloy_primitives::{Address, Bytes, B256};
     use alloy_rpc_types_engine::{
         ClientCode, ClientVersionV1, ExecutionPayloadV2, PayloadAttributes, PayloadStatusEnum,
@@ -1902,7 +1901,7 @@ mod tests {
         let third = pooled_transaction(
             TransactionBuilder::default().max_fee_per_gas(1_000_000_000u128).into_legacy(),
         );
-        let expected: Bytes = first.consensus_ref().encoded_2718().into();
+        let expected = first.encoded_2718_consensus();
 
         pool.add_transaction(TransactionOrigin::External, first).await.unwrap();
         pool.add_transaction(TransactionOrigin::External, second).await.unwrap();
@@ -1931,7 +1930,7 @@ mod tests {
                 .max_priority_fee_per_gas(1_000_000_000u128)
                 .into_eip1559(),
         );
-        let expected: Bytes = non_blob.consensus_ref().encoded_2718().into();
+        let expected = non_blob.encoded_2718_consensus();
 
         pool.add_transaction(TransactionOrigin::External, blob).await.unwrap();
         pool.add_transaction(TransactionOrigin::External, non_blob).await.unwrap();

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -9,7 +9,7 @@ use crate::{
     TransactionOrigin,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Typed2718};
-use alloy_eips::{BlockNumberOrTag, Decodable2718, Encodable2718};
+use alloy_eips::{BlockNumberOrTag, Decodable2718};
 use alloy_primitives::{
     map::{AddressSet, HashSet},
     Address, BlockHash, BlockNumber, Bytes,
@@ -770,12 +770,7 @@ where
 
     let local_transactions = local_transactions
         .into_iter()
-        .map(|tx| {
-            let consensus_tx = tx.to_consensus().into_inner();
-            let rlp_data = consensus_tx.encoded_2718();
-
-            TxBackup { rlp: rlp_data.into(), origin: tx.origin }
-        })
+        .map(|tx| TxBackup { rlp: tx.encoded_2718_consensus(), origin: tx.origin })
         .collect::<Vec<_>>();
 
     let json_data = match serde_json::to_string(&local_transactions) {

--- a/crates/transaction-pool/src/test_utils/mock.rs
+++ b/crates/transaction-pool/src/test_utils/mock.rs
@@ -17,6 +17,7 @@ use alloy_consensus::{
 };
 use alloy_eips::{
     eip1559::MIN_PROTOCOL_BASE_FEE,
+    eip2718::Encodable2718,
     eip2930::AccessList,
     eip4844::{BlobTransactionSidecar, BlobTransactionValidationError, DATA_GAS_PER_BLOB},
     eip7594::BlobTransactionSidecarVariant,
@@ -711,6 +712,10 @@ impl PoolTransaction for MockTransaction {
     type Consensus = TransactionSigned;
 
     type Pooled = PooledTransactionVariant;
+
+    fn encoded_2718_consensus(&self) -> Bytes {
+        self.clone_into_consensus().encoded_2718().into()
+    }
 
     fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
         unimplemented!("mock transaction does not wrap a consensus transaction")

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1364,9 +1364,9 @@ pub trait PoolTransaction:
 
     /// Returns the EIP-2718 encoded consensus transaction.
     ///
-    /// Implementations that wrap the consensus transaction can override this to avoid cloning it.
+    /// Implementations that synthesize the consensus representation should override this method.
     fn encoded_2718_consensus(&self) -> Bytes {
-        self.clone_into_consensus().encoded_2718().into()
+        self.consensus_ref().encoded_2718().into()
     }
 
     /// Returns a reference to the consensus transaction with the recovered sender.
@@ -1614,10 +1614,6 @@ impl PoolTransaction for EthPooledTransaction {
 
     fn clone_into_consensus(&self) -> Recovered<Self::Consensus> {
         self.transaction().clone()
-    }
-
-    fn encoded_2718_consensus(&self) -> Bytes {
-        self.transaction.encoded_2718().into()
     }
 
     fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
@@ -1988,7 +1984,7 @@ mod tests {
     use alloy_primitives::Signature;
 
     #[test]
-    fn test_default_consensus_encoding() {
+    fn test_mock_consensus_encoding() {
         let transaction = MockTransaction::legacy();
 
         assert_eq!(

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1362,6 +1362,13 @@ pub trait PoolTransaction:
         self.clone().into_consensus()
     }
 
+    /// Returns the EIP-2718 encoded consensus transaction.
+    ///
+    /// Implementations that wrap the consensus transaction can override this to avoid cloning it.
+    fn encoded_2718_consensus(&self) -> Bytes {
+        self.clone_into_consensus().encoded_2718().into()
+    }
+
     /// Returns a reference to the consensus transaction with the recovered sender.
     fn consensus_ref(&self) -> Recovered<&Self::Consensus>;
 
@@ -1607,6 +1614,10 @@ impl PoolTransaction for EthPooledTransaction {
 
     fn clone_into_consensus(&self) -> Recovered<Self::Consensus> {
         self.transaction().clone()
+    }
+
+    fn encoded_2718_consensus(&self) -> Bytes {
+        self.transaction.encoded_2718().into()
     }
 
     fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
@@ -1968,13 +1979,23 @@ impl<Tx: PoolTransaction> Stream for NewSubpoolTransactionStream<Tx> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blobstore::BlobCellAvailability;
+    use crate::{blobstore::BlobCellAvailability, test_utils::MockTransaction};
     use alloy_consensus::{
         EthereumTxEnvelope, SignableTransaction, TxEip1559, TxEip2930, TxEip4844, TxEip7702,
         TxEnvelope, TxLegacy,
     };
     use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7594::BlobCellMask};
     use alloy_primitives::Signature;
+
+    #[test]
+    fn test_default_consensus_encoding() {
+        let transaction = MockTransaction::legacy();
+
+        assert_eq!(
+            transaction.encoded_2718_consensus(),
+            transaction.into_consensus().encoded_2718()
+        );
+    }
 
     #[test]
     fn test_pool_size_invariants() {
@@ -2016,7 +2037,7 @@ mod tests {
     #[test]
     fn test_eth_pooled_transaction_new_legacy() {
         // Create a legacy transaction with specific parameters
-        let tx = TxEnvelope::Legacy(
+        let tx = EthereumTxEnvelope::<TxEip4844>::Legacy(
             TxLegacy {
                 gas_price: 10,
                 gas_limit: 1000,
@@ -2035,6 +2056,7 @@ mod tests {
         assert!(pooled_tx.blob_cell_availability.is_none());
         assert_eq!(pooled_tx.blob_cell_availability().map(BlobCellAvailability::get), None);
         assert_eq!(pooled_tx.cost, U256::from(100) + U256::from(10 * 1000));
+        assert_eq!(pooled_tx.encoded_2718_consensus(), transaction.encoded_2718());
     }
 
     #[test]

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     PriceBumpConfig,
 };
 use alloy_eips::eip7702::SignedAuthorization;
-use alloy_primitives::{Address, TxHash, B256, U256};
+use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
 use futures_util::future::Either;
 use reth_primitives_traits::{Block, Recovered, SealedBlock};
 use std::{fmt, fmt::Debug, future::Future, time::Instant};
@@ -453,6 +453,11 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
     /// Note: this takes `&self` since indented usage is via `Arc<Self>`.
     pub fn to_consensus(&self) -> Recovered<T::Consensus> {
         self.transaction.clone_into_consensus()
+    }
+
+    /// Returns the EIP-2718 encoded consensus transaction.
+    pub fn encoded_2718_consensus(&self) -> Bytes {
+        self.transaction.encoded_2718_consensus()
     }
 
     /// Determines whether a candidate transaction (`maybe_replacement`) is underpriced compared to


### PR DESCRIPTION
Adds a `PoolTransaction::encoded_2718_consensus` helper that encodes the borrowed consensus transaction by default and forwards it through `ValidPoolTransaction`. Synthetic pool transactions can override the helper, and the local transaction backup path now uses it instead of cloning through the consensus conversion.
