### PR TITLE
fix(rpc): preserve gas limit in eth_sendTransaction

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -509,11 +509,12 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             let chain_id = self.chain_id();
             request.as_mut().set_chain_id(chain_id.to());
 
-            let estimated_gas = self
-                .estimate_gas_at(request.clone(), BlockId::pending(), EvmOverrides::default())
-                .await?;
-            let gas_limit = estimated_gas;
-            request.as_mut().set_gas_limit(gas_limit.to());
+            if request.as_ref().gas_limit().is_none() {
+                let estimated_gas = self
+                    .estimate_gas_at(request.clone(), BlockId::pending(), EvmOverrides::default())
+                    .await?;
+                request.as_mut().set_gas_limit(estimated_gas.to());
+            }
 
             let transaction = self.sign_request(&from, request).await?.with_signer(from);
 

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -132,7 +132,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eth::helpers::types::EthRpcConverter;
+    use crate::eth::helpers::{signer::DevSigner, types::EthRpcConverter};
     use alloy_consensus::{
         BlobTransactionSidecar, Block, Header, SidecarBuilder, SimpleCoder, Transaction,
     };
@@ -287,6 +287,35 @@ mod tests {
                 if duration == Duration::from_millis(1)
         ));
         assert_eq!(eth_api.pool().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_transaction_preserves_provided_gas_limit() {
+        let signers = DevSigner::random_signers(1);
+        let address = signers[0].accounts()[0];
+        let accounts = AddressMap::from_iter([(
+            address,
+            ExtendedAccount::new(0, U256::from(10_000_000_000_000_000_000u64)),
+        )]);
+        let eth_api = mock_eth_api(accounts);
+        eth_api.signers().write().extend(signers);
+
+        let provided_gas_limit = 90_000;
+        let tx_req = TransactionRequest {
+            from: Some(address),
+            to: Some(address.into()),
+            gas: Some(provided_gas_limit),
+            gas_price: Some(1_000_000_000),
+            ..Default::default()
+        };
+
+        let hash = eth_api
+            .send_transaction_request(tx_req)
+            .await
+            .expect("send_transaction should succeed");
+        let pooled = eth_api.pool().get(&hash).expect("transaction should be in the pool");
+
+        assert_eq!(pooled.transaction.gas_limit(), provided_gas_limit);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #26742

Preserves an explicitly supplied gas limit in `eth_sendTransaction` and estimates gas only when the field is omitted. Adds a regression test that verifies the signed pooled transaction retains the caller-provided limit.

Prompted by: @mattsse