### PR TITLE
fix(provider): handle storage wipes in batched persistence

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -798,9 +798,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                     .iter()
                     .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
                     .collect::<Vec<_>>();
-                // A whole-trie deletion cannot be filtered node-by-node. Fall back to the
-                // ordinary merge in that case; persisting the overwritten nodes is redundant but
-                // correct because the masking suffix is still applied by the in-memory overlay.
+                // Sparse-trie streaming produces node updates, but serial state-root computation,
+                // including the fallback, can emit a whole-storage-trie wipe for a destroyed
+                // account. Disjoint merging cannot represent that marker, so use the ordered
+                // merge; writes hidden by the masking suffix are redundant but remain correct
+                // under the in-memory overlay.
                 let contains_storage_wipe = batch.iter().chain(&mask).any(|updates| {
                     updates.storage_tries_ref().values().any(|storage| storage.is_deleted)
                 });
@@ -4934,6 +4936,57 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(storage_entries.is_empty());
+    }
+
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn test_save_blocks_batches_transient_storage_wipe() {
+        use alloy_primitives::map::B256Set;
+        use reth_trie::{updates::TrieUpdates, HashBuilder, HashedPostStateSorted};
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let mut test_block_builder = TestBlockBuilder::eth().with_state();
+        let genesis = test_block_builder.get_executed_blocks(0..1).next().unwrap();
+        let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..4).collect();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        save_genesis(&provider_rw, &genesis).unwrap();
+        provider_rw.commit().unwrap();
+
+        // A contract created and self-destructed in the same transaction leaves an empty whole-
+        // storage wipe in the trie updates, even though the account never reaches persisted state.
+        let ephemeral_account = B256::with_last_byte(0x57);
+        let hashed_state = HashedPostStateSorted::default();
+        let mut trie_updates = TrieUpdates::default();
+        trie_updates.finalize(
+            HashBuilder::default(),
+            Default::default(),
+            B256Set::from_iter([ephemeral_account]),
+        );
+        let trie_updates = trie_updates.into_sorted();
+        assert!(trie_updates.storage_tries_ref()[&ephemeral_account].is_deleted);
+        let selfdestruct_block = ExecutedBlock::new(
+            Arc::clone(&blocks[2].recovered_block),
+            Arc::clone(&blocks[2].execution_output),
+            ComputedTrieData::new(Arc::new(hashed_state), Arc::new(trie_updates)),
+        );
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(
+            vec![blocks[0].clone(), blocks[1].clone(), selfdestruct_block],
+            0,
+            0,
+            3,
+            3,
+        );
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let checkpoint =
+            factory.provider().unwrap().get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(checkpoint.block_number, 3);
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -803,6 +803,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 // account. Disjoint merging cannot represent that marker, so use the ordered
                 // merge; writes hidden by the masking suffix are redundant but remain correct
                 // under the in-memory overlay.
+                //
+                // A revm release with bluealloy/revm#3863 will keep post-Cancun selfdestructs from
+                // reaching trie construction as wipes. Wipes remain valid `save_blocks` input,
+                // including when processing pre-Cancun historical data, so persistence cannot
+                // rely on that revm behavior.
                 let contains_storage_wipe = batch.iter().chain(&mask).any(|updates| {
                     updates.storage_tries_ref().values().any(|storage| storage.is_deleted)
                 });

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -792,9 +792,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 // masking suffix is redundant but safe: the in-memory overlay still takes
                 // precedence.
                 //
-                // A revm release with bluealloy/revm#3863 clears post-Cancun selfdestructs in
-                // place. Wipes remain valid `save_blocks` input when processing
-                // pre-Cancun historical data.
+                // With a revm release containing bluealloy/revm#3863, post-Cancun selfdestructs
+                // will no longer result in `storage.is_deleted` in serial trie updates. The flag
+                // remains valid `save_blocks` input when processing pre-Cancun historical data.
                 let contains_storage_wipe = batch.iter().chain(&mask).any(|updates| {
                     updates.storage_tries_ref().values().any(|storage| storage.is_deleted)
                 });

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -798,7 +798,19 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                     .iter()
                     .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
                     .collect::<Vec<_>>();
-                let merged_trie = TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask);
+                // A whole-trie deletion cannot be filtered node-by-node. Fall back to the
+                // ordinary merge in that case; persisting the overwritten nodes is redundant but
+                // correct because the masking suffix is still applied by the in-memory overlay.
+                let contains_storage_wipe = batch.iter().chain(&mask).any(|updates| {
+                    updates.storage_tries_ref().values().any(|storage| storage.is_deleted)
+                });
+                let merged_trie = if contains_storage_wipe {
+                    TrieUpdatesSorted::merge_batch(
+                        state_trie_blocks.iter().rev().map(|block| block.trie_updates()),
+                    )
+                } else {
+                    Arc::new(TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask))
+                };
                 if !merged_trie.is_empty() {
                     self.write_trie_updates_sorted(&merged_trie)?;
                 }
@@ -4856,6 +4868,72 @@ mod tests {
             .unwrap();
         assert_eq!(masked_entries.len(), 1);
         assert_eq!(masked_entries[0].1.nibbles.0, masked_storage_node);
+    }
+
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn test_save_blocks_merges_storage_wipe_in_multi_block_batch() {
+        use reth_trie::{
+            updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
+            BranchNodeCompact, HashedPostStateSorted,
+        };
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let mut test_block_builder = TestBlockBuilder::eth().with_state();
+        let genesis = test_block_builder.get_executed_blocks(0..1).next().unwrap();
+        let mut blocks: Vec<_> = test_block_builder.get_executed_blocks(1..4).collect();
+        let address = B256::with_last_byte(1);
+        let storage_path = Nibbles::from_nibbles([0x1, 0x2]);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        save_genesis(&provider_rw, &genesis).unwrap();
+        provider_rw
+            .write_trie_updates_sorted(&TrieUpdatesSorted::new(
+                vec![],
+                B256Map::from_iter([(
+                    address,
+                    StorageTrieUpdatesSorted {
+                        is_deleted: false,
+                        storage_nodes: vec![(storage_path, Some(BranchNodeCompact::default()))],
+                    },
+                )]),
+            ))
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        let wipe = TrieUpdatesSorted::new(
+            vec![],
+            B256Map::from_iter([(
+                address,
+                StorageTrieUpdatesSorted { is_deleted: true, storage_nodes: vec![] },
+            )]),
+        );
+        let wipe_block = &blocks[2];
+        blocks[2] = ExecutedBlock::new(
+            Arc::clone(&wipe_block.recovered_block),
+            Arc::clone(&wipe_block.execution_output),
+            ComputedTrieData::new(Arc::new(HashedPostStateSorted::default()), Arc::new(wipe)),
+        );
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(blocks, 0, 0, 3, 3);
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(checkpoint.block_number, 3);
+        let storage_entries = provider
+            .tx_ref()
+            .cursor_dup_read::<tables::StoragesTrie>()
+            .unwrap()
+            .walk_dup(Some(address), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(storage_entries.is_empty());
     }
 
     #[cfg(feature = "partial-persistence")]


### PR DESCRIPTION
## Summary
- detect whole-storage-trie deletions before using the node-level disjoint merge
- fall back to the existing wipe-aware batch merge for those rare persistence batches
- cover the reported three-block storage-v2 persistence failure and verify the trie is cleared

## Tests
- cargo test -p reth-provider --features partial-persistence providers::database::provider::tests::test_save_blocks_
- cargo +nightly clippy -p reth-provider --all-targets --features partial-persistence -- -D warnings
- cargo +nightly fmt --all -- --check

Prompted by: @mattsse
