### PR TITLE
fix(provider): handle storage wipes in block persistence

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -774,6 +774,10 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // This reduces cursor open/close overhead from N calls to 1.
             if save_mode.with_state() && !state_trie_blocks.is_empty() {
                 let start = Instant::now();
+                // `disjointed_merge_batch` cannot represent a storage wipe, so a batch containing
+                // one falls back to the wipe-aware merge and forgoes mask filtering. Skipping the
+                // filter only costs redundant writes: the masking suffix stays in memory and is
+                // persisted by a later call, which overwrites whatever is written here.
                 let can_filter_hashed_state =
                     state_trie_blocks.iter().chain(state_trie_masking_blocks).all(|block| {
                         block
@@ -4762,7 +4766,10 @@ mod tests {
         let checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
         assert_eq!(checkpoint.block_number, 3);
 
-        let mut storage_trie = provider.tx_ref().cursor_dup_read::<tables::StoragesTrie>().unwrap();
+        // Storage v2 shares the `StoragesTrie` table but encodes subkeys packed, so the entries
+        // have to be read back through the packed view.
+        let mut storage_trie =
+            provider.tx_ref().cursor_dup_read::<reth_trie_db::PackedStoragesTrie>().unwrap();
         let entries = storage_trie
             .walk_dup(Some(trie_address), None)
             .unwrap()
@@ -4778,6 +4785,101 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(entries.is_empty());
+    }
+
+    /// A trie wipe without a matching hashed-state wipe is the shape the serial state root
+    /// produces, because `TrieUpdates::finalize` marks every destroyed account deleted while
+    /// `HashedPostState::from_bundle_state` never sets `wiped`.
+    #[cfg(feature = "partial-persistence")]
+    #[test]
+    fn test_save_blocks_applies_trie_wipe_with_masking_suffix() {
+        use reth_trie::{
+            updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
+            BranchNodeCompact, ComputedTrieData, HashedPostStateSorted,
+        };
+
+        fn branch(mask: u16) -> BranchNodeCompact {
+            BranchNodeCompact::new(mask, 0, 0, vec![], None)
+        }
+
+        fn trie_data(
+            trie_updates: TrieUpdatesSorted,
+        ) -> (Arc<HashedPostStateSorted>, Arc<TrieUpdatesSorted>) {
+            (Arc::new(HashedPostStateSorted::default()), Arc::new(trie_updates))
+        }
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let mut test_block_builder = TestBlockBuilder::eth().with_state();
+        let genesis_base = test_block_builder.get_executed_blocks(0..1).next().unwrap();
+        let block_bases = test_block_builder.get_executed_blocks(1..3).collect::<Vec<_>>();
+
+        let wiped_account = B256::with_last_byte(1);
+        let stale_node = Nibbles::from_nibbles([0x1]);
+        let fresh_node = Nibbles::from_nibbles([0x2]);
+
+        let storage_trie = |is_deleted, node, value| {
+            TrieUpdatesSorted::new(
+                vec![],
+                B256Map::from_iter([(
+                    wiped_account,
+                    StorageTrieUpdatesSorted {
+                        is_deleted,
+                        storage_nodes: vec![(node, Some(branch(value)))],
+                    },
+                )]),
+            )
+        };
+
+        let (hashed_state, trie_updates) = trie_data(storage_trie(false, stale_node, 0b1111));
+        let genesis = ExecutedBlock::new(
+            Arc::clone(&genesis_base.recovered_block),
+            Arc::clone(&genesis_base.execution_output),
+            ComputedTrieData::new(hashed_state, trie_updates),
+        );
+
+        let provider_rw = factory.provider_rw().unwrap();
+        save_genesis(&provider_rw, &genesis).unwrap();
+        provider_rw.commit().unwrap();
+
+        // Block 1 is persisted and wipes the storage trie. Block 2 is the masking suffix and
+        // rewrites the same node, which is exactly what the mask filter would drop.
+        let (hashed_state, trie_updates) = trie_data(storage_trie(true, fresh_node, 0b1010));
+        let batch_block = ExecutedBlock::new(
+            Arc::clone(&block_bases[0].recovered_block),
+            Arc::clone(&block_bases[0].execution_output),
+            ComputedTrieData::new(hashed_state, trie_updates),
+        );
+        let (hashed_state, trie_updates) = trie_data(storage_trie(false, fresh_node, 0b0101));
+        let masking_block = ExecutedBlock::new(
+            Arc::clone(&block_bases[1].recovered_block),
+            Arc::clone(&block_bases[1].execution_output),
+            ComputedTrieData::new(hashed_state, trie_updates),
+        );
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(vec![batch_block, masking_block], 0, 0, 2, 1);
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(checkpoint.block_number, 2);
+        assert_eq!(checkpoint.finish_stage_checkpoint().unwrap().partial_state_trie, Some(1));
+
+        let mut storage_trie_cursor =
+            provider.tx_ref().cursor_dup_read::<reth_trie_db::PackedStoragesTrie>().unwrap();
+        let entries = storage_trie_cursor
+            .walk_dup(Some(wiped_account), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        // The wipe removed the genesis node, and the wiping block's own node survived the mask.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1.nibbles.0, fresh_node);
+        assert_eq!(entries[0].1.node, branch(0b1010));
     }
 
     #[cfg(feature = "partial-persistence")]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -774,31 +774,67 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // This reduces cursor open/close overhead from N calls to 1.
             if save_mode.with_state() && !state_trie_blocks.is_empty() {
                 let start = Instant::now();
-                let batch = state_trie_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-                    .collect::<Vec<_>>();
-                let mask = state_trie_masking_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-                    .collect::<Vec<_>>();
-                let merged_hashed_state =
-                    HashedPostStateSorted::disjointed_merge_batch(&batch, &mask);
+                let can_filter_hashed_state =
+                    state_trie_blocks.iter().chain(state_trie_masking_blocks).all(|block| {
+                        block
+                            .trie_data
+                            .get()
+                            .sorted
+                            .hashed_state
+                            .storages
+                            .values()
+                            .all(|storage| !storage.wiped)
+                    });
+                let merged_hashed_state = if can_filter_hashed_state {
+                    let batch = state_trie_blocks
+                        .iter()
+                        .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
+                        .collect::<Vec<_>>();
+                    let mask = state_trie_masking_blocks
+                        .iter()
+                        .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
+                        .collect::<Vec<_>>();
+                    Arc::new(HashedPostStateSorted::disjointed_merge_batch(&batch, &mask))
+                } else {
+                    HashedPostStateSorted::merge_batch(
+                        state_trie_blocks
+                            .iter()
+                            .rev()
+                            .map(|block| block.trie_data().sorted.hashed_state),
+                    )
+                };
                 if !merged_hashed_state.is_empty() {
                     self.write_hashed_state(&merged_hashed_state)?;
                 }
                 timings.write_hashed_state += start.elapsed();
 
                 let start = Instant::now();
-                let batch = state_trie_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-                    .collect::<Vec<_>>();
-                let mask = state_trie_masking_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-                    .collect::<Vec<_>>();
-                let merged_trie = TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask);
+                let can_filter_trie_updates =
+                    state_trie_blocks.iter().chain(state_trie_masking_blocks).all(|block| {
+                        block
+                            .trie_data
+                            .get()
+                            .sorted
+                            .trie_updates
+                            .storage_tries_ref()
+                            .values()
+                            .all(|storage_trie| !storage_trie.is_deleted)
+                    });
+                let merged_trie = if can_filter_trie_updates {
+                    let batch = state_trie_blocks
+                        .iter()
+                        .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
+                        .collect::<Vec<_>>();
+                    let mask = state_trie_masking_blocks
+                        .iter()
+                        .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
+                        .collect::<Vec<_>>();
+                    Arc::new(TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask))
+                } else {
+                    TrieUpdatesSorted::merge_batch(
+                        state_trie_blocks.iter().rev().map(|block| block.trie_updates()),
+                    )
+                };
                 if !merged_trie.is_empty() {
                     self.write_trie_updates_sorted(&merged_trie)?;
                 }
@@ -4083,9 +4119,7 @@ mod tests {
         map::{AddressMap, B256Map},
         U256,
     };
-    #[cfg(feature = "partial-persistence")]
-    use reth_chain_state::test_utils::TestBlockBuilder;
-    use reth_chain_state::ExecutedBlock;
+    use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_db_api::models::StorageSettings;
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::{AccountRevertInit, BlockExecutionOutput, BlockExecutionResult};
@@ -4634,6 +4668,116 @@ mod tests {
         assert_eq!(storage_entries2.len(), 0, "Storage address2 should be empty after wipe");
 
         provider_rw.commit().unwrap();
+    }
+
+    #[test]
+    fn test_save_blocks_falls_back_for_storage_wipe() {
+        use reth_trie::{
+            updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
+            BranchNodeCompact, ComputedTrieData, HashedPostStateSorted, HashedStorageSorted,
+        };
+
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let mut test_block_builder = TestBlockBuilder::eth().with_state();
+        let genesis_base = test_block_builder.get_executed_blocks(0..1).next().unwrap();
+        let block_bases = test_block_builder.get_executed_blocks(1..4).collect::<Vec<_>>();
+        let trie_address = B256::with_last_byte(1);
+        let path = Nibbles::from_nibbles([0x1]);
+        let hashed_state_address = B256::with_last_byte(2);
+        let hashed_slot = B256::with_last_byte(3);
+
+        let genesis = ExecutedBlock::new(
+            Arc::clone(&genesis_base.recovered_block),
+            Arc::clone(&genesis_base.execution_output),
+            ComputedTrieData::new(
+                Arc::new(HashedPostStateSorted::new(
+                    vec![],
+                    B256Map::from_iter([(
+                        hashed_state_address,
+                        HashedStorageSorted {
+                            wiped: false,
+                            storage_slots: vec![(hashed_slot, U256::from(1))],
+                        },
+                    )]),
+                )),
+                Arc::new(TrieUpdatesSorted::new(
+                    vec![],
+                    B256Map::from_iter([(
+                        trie_address,
+                        StorageTrieUpdatesSorted {
+                            is_deleted: false,
+                            storage_nodes: vec![(path, Some(BranchNodeCompact::default()))],
+                        },
+                    )]),
+                )),
+            ),
+        );
+
+        let provider_rw = factory.provider_rw().unwrap();
+        save_genesis(&provider_rw, &genesis).unwrap();
+        provider_rw.commit().unwrap();
+
+        let blocks = block_bases
+            .into_iter()
+            .enumerate()
+            .map(|(index, block)| {
+                let hashed_state = if index == 0 {
+                    HashedPostStateSorted::new(
+                        vec![],
+                        B256Map::from_iter([(
+                            hashed_state_address,
+                            HashedStorageSorted { wiped: true, storage_slots: vec![] },
+                        )]),
+                    )
+                } else {
+                    HashedPostStateSorted::default()
+                };
+                let trie_updates = if index == 0 {
+                    TrieUpdatesSorted::new(
+                        vec![],
+                        B256Map::from_iter([(
+                            trie_address,
+                            StorageTrieUpdatesSorted { is_deleted: true, storage_nodes: vec![] },
+                        )]),
+                    )
+                } else {
+                    TrieUpdatesSorted::default()
+                };
+                ExecutedBlock::new(
+                    Arc::clone(&block.recovered_block),
+                    Arc::clone(&block.execution_output),
+                    ComputedTrieData::new(Arc::new(hashed_state), Arc::new(trie_updates)),
+                )
+            })
+            .collect();
+
+        let provider_rw = factory.provider_rw().unwrap();
+        let input = SaveBlocksInput::new(blocks, 0, 0, 3, 3);
+        provider_rw.save_blocks(&input).unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
+        assert_eq!(checkpoint.block_number, 3);
+
+        let mut storage_trie = provider.tx_ref().cursor_dup_read::<tables::StoragesTrie>().unwrap();
+        let entries = storage_trie
+            .walk_dup(Some(trie_address), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(entries.is_empty());
+
+        let mut hashed_storage =
+            provider.tx_ref().cursor_dup_read::<tables::HashedStorages>().unwrap();
+        let entries = hashed_storage
+            .walk_dup(Some(hashed_state_address), None)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(entries.is_empty());
     }
 
     #[cfg(feature = "partial-persistence")]


### PR DESCRIPTION
Falls back to the ordered state/trie batch merge when persisted or masking blocks contain storage wipes. The disjoint merge rejects wipes and caused the persistence service to panic before committing affected batches.

Wipes reach persistence through the serial state root: `TrieUpdates::finalize` marks every destroyed account deleted, while the sparse state root task never sets the flag and `HashedPostState::from_bundle_state` never sets `wiped`. A block that deletes an account therefore panics in `TrieUpdatesSorted::disjointed_merge_batch` whenever the serial path computed its trie updates, which is why the crash is reported against `crates/trie/common/src/updates.rs` and not the hashed-state merge that runs first. Regressed in #26521; 2.4.1 used the wipe-aware `merge_batch`. Note the default `num_state_masking_blocks` of 0 does not avoid this, since the disjoint merge also replaced the plain merge on the unmasked path.

Adds Storage v2 coverage for a three-block batch that wipes both hashed storage and storage trie data, plus a trie-only wipe with a non-empty masking suffix. The latter is the shape the serial state root actually produces and the only configuration where the mask filter would drop the wiping block's own nodes.