### PR TITLE
refactor(chain-state): add trie data reference collectors

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -876,12 +876,19 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         self.trie_data().sorted.hashed_state
     }
 
+    /// Returns a reference to the hashed state result of the execution outcome.
+    ///
+    /// May wait for trie data if the deferred task hasn't completed.
+    #[inline]
+    pub fn hashed_state_ref(&self) -> &HashedPostStateSorted {
+        &self.trie_data.get().sorted.hashed_state
+    }
+
     /// Returns references to the hashed state results of the executed blocks.
     ///
     /// May wait for trie data if any deferred task hasn't completed.
-    #[inline]
     pub fn hashed_state_refs(blocks: &[Self]) -> Vec<&HashedPostStateSorted> {
-        blocks.iter().map(|block| block.trie_data.get().sorted.hashed_state.as_ref()).collect()
+        blocks.iter().map(Self::hashed_state_ref).collect()
     }
 
     /// Returns the trie updates resulting from the execution outcome.
@@ -892,12 +899,19 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         self.trie_data().sorted.trie_updates
     }
 
+    /// Returns a reference to the trie updates resulting from the execution outcome.
+    ///
+    /// May wait for trie data if the deferred task hasn't completed.
+    #[inline]
+    pub fn trie_updates_ref(&self) -> &TrieUpdatesSorted {
+        &self.trie_data.get().sorted.trie_updates
+    }
+
     /// Returns references to the trie updates of the executed blocks.
     ///
     /// May wait for trie data if any deferred task hasn't completed.
-    #[inline]
     pub fn trie_updates_refs(blocks: &[Self]) -> Vec<&TrieUpdatesSorted> {
-        blocks.iter().map(|block| block.trie_data.get().sorted.trie_updates.as_ref()).collect()
+        blocks.iter().map(Self::trie_updates_ref).collect()
     }
 
     /// Returns a [`BlockNumber`] of the block.

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -876,12 +876,28 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         self.trie_data().sorted.hashed_state
     }
 
+    /// Returns references to the hashed state results of the executed blocks.
+    ///
+    /// May wait for trie data if any deferred task hasn't completed.
+    #[inline]
+    pub fn hashed_state_refs(blocks: &[Self]) -> Vec<&HashedPostStateSorted> {
+        blocks.iter().map(|block| block.trie_data.get().sorted.hashed_state.as_ref()).collect()
+    }
+
     /// Returns the trie updates resulting from the execution outcome.
     ///
     /// May wait for trie data if the deferred task hasn't completed.
     #[inline]
     pub fn trie_updates(&self) -> Arc<TrieUpdatesSorted> {
         self.trie_data().sorted.trie_updates
+    }
+
+    /// Returns references to the trie updates of the executed blocks.
+    ///
+    /// May wait for trie data if any deferred task hasn't completed.
+    #[inline]
+    pub fn trie_updates_refs(blocks: &[Self]) -> Vec<&TrieUpdatesSorted> {
+        blocks.iter().map(|block| block.trie_data.get().sorted.trie_updates.as_ref()).collect()
     }
 
     /// Returns a [`BlockNumber`] of the block.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -774,14 +774,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             // This reduces cursor open/close overhead from N calls to 1.
             if save_mode.with_state() && !state_trie_blocks.is_empty() {
                 let start = Instant::now();
-                let batch = state_trie_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-                    .collect::<Vec<_>>();
-                let mask = state_trie_masking_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.hashed_state.as_ref())
-                    .collect::<Vec<_>>();
+                let batch = ExecutedBlock::hashed_state_refs(state_trie_blocks);
+                let mask = ExecutedBlock::hashed_state_refs(state_trie_masking_blocks);
                 let merged_hashed_state =
                     HashedPostStateSorted::disjointed_merge_batch(&batch, &mask);
                 if !merged_hashed_state.is_empty() {
@@ -790,14 +784,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 timings.write_hashed_state += start.elapsed();
 
                 let start = Instant::now();
-                let batch = state_trie_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-                    .collect::<Vec<_>>();
-                let mask = state_trie_masking_blocks
-                    .iter()
-                    .map(|block| block.trie_data.get().sorted.trie_updates.as_ref())
-                    .collect::<Vec<_>>();
+                let batch = ExecutedBlock::trie_updates_refs(state_trie_blocks);
+                let mask = ExecutedBlock::trie_updates_refs(state_trie_masking_blocks);
                 let merged_trie = TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask);
                 if !merged_trie.is_empty() {
                     self.write_trie_updates_sorted(&merged_trie)?;


### PR DESCRIPTION
Adds `ExecutedBlock` utilities that collect borrowed hashed states and trie updates for block slices. Replaces the repeated `iter`/`map`/`collect` sequences in database persistence for both batch and mask inputs.

Prompted by: @mattsse