### PR TITLE
chore(deps): bump h2 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Updates `h2` from 0.4.14 to 0.4.16 to pick up the fix for RUSTSEC-2026-0258. The advisory caused `cargo deny` to fail across otherwise unrelated PRs, including #26751.
