### PR TITLE
fix(rpc): reject oversized raw transactions before decoding

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,4 +1,5 @@
 use crate::utils::{eth_payload_attributes, eth_payload_attributes_amsterdam};
+use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
 use alloy_eips::{eip2718::Encodable2718, eip7910::EthConfig, BlockNumberOrTag};
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, Bytes, B256, U256};
@@ -16,7 +17,10 @@ use alloy_rpc_types_engine::{
 };
 use alloy_rpc_types_eth::{error::EthRpcErrorCode, TransactionRequest};
 use alloy_rpc_types_trace::geth::{ChainBlockTraceResult, GethDebugTracingOptions};
-use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
+use jsonrpsee::{
+    core::client::{ClientT, Subscription, SubscriptionClientT},
+    types::error::ErrorCode,
+};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
 use reth_e2e_test_utils::{setup_engine, E2ETestSetupBuilder};
@@ -32,7 +36,7 @@ use reth_primitives_traits::Block as _;
 use reth_rpc_api::servers::AdminApiServer;
 use reth_rpc_server_types::RpcModuleSelection;
 use reth_tasks::Runtime;
-use reth_transaction_pool::error::InvalidPoolTransactionError;
+use reth_transaction_pool::error::{InvalidPoolTransactionError, RawPoolTransactionError};
 use std::{
     net::{IpAddr, Ipv4Addr},
     sync::Arc,
@@ -600,6 +604,21 @@ async fn test_send_raw_transaction_rejects_oversized_bytes() -> eyre::Result<()>
         InvalidPoolTransactionError::OversizedData { size: raw_tx.len(), limit: MAX_BYTES };
     assert_eq!(err.code(), EthRpcErrorCode::InvalidInput.code());
     assert_eq!(err.message(), expected.to_string());
+
+    let mut raw_blob_tx = vec![0; MAX_BYTES + 1];
+    raw_blob_tx[0] = EIP4844_TX_TYPE_ID;
+    let err = client
+        .request::<B256, _>(
+            "eth_sendRawTransaction",
+            jsonrpsee::rpc_params![Bytes::from(raw_blob_tx)],
+        )
+        .await
+        .unwrap_err();
+    let jsonrpsee::core::client::Error::Call(err) = err else {
+        panic!("expected an invalid params error object, got {err:?}")
+    };
+    assert_eq!(err.code(), ErrorCode::InvalidParams.code());
+    assert_eq!(err.message(), RawPoolTransactionError::FailedToDecodeSignedTransaction.to_string());
 
     Ok(())
 }

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -14,9 +14,9 @@ use alloy_rpc_types_engine::{
     BlobsBundleV1, CancunPayloadFields, ExecutionPayload, ExecutionPayloadSidecar,
     ExecutionPayloadV3, PraguePayloadFields,
 };
-use alloy_rpc_types_eth::TransactionRequest;
+use alloy_rpc_types_eth::{error::EthRpcErrorCode, TransactionRequest};
 use alloy_rpc_types_trace::geth::{ChainBlockTraceResult, GethDebugTracingOptions};
-use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
+use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
 use reth_e2e_test_utils::{setup_engine, E2ETestSetupBuilder};
@@ -32,6 +32,7 @@ use reth_primitives_traits::Block as _;
 use reth_rpc_api::servers::AdminApiServer;
 use reth_rpc_server_types::RpcModuleSelection;
 use reth_tasks::Runtime;
+use reth_transaction_pool::error::InvalidPoolTransactionError;
 use std::{
     net::{IpAddr, Ipv4Addr},
     sync::Arc,
@@ -560,6 +561,45 @@ async fn test_eth_config() -> eyre::Result<()> {
     assert_eq!(config.last.unwrap().activation_time, osaka_timestamp);
     assert_eq!(config.current.activation_time, prague_timestamp);
     assert_eq!(config.next.unwrap().activation_time, osaka_timestamp);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_send_raw_transaction_rejects_oversized_bytes() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    const MAX_BYTES: usize = 4;
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+    let (mut nodes, _) =
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, eth_payload_attributes)
+            .with_node_config_modifier(|mut config| {
+                config.txpool.max_tx_input_bytes = MAX_BYTES;
+                config
+            })
+            .build()
+            .await?;
+    let node = nodes.pop().unwrap();
+    let client = node.rpc_client().unwrap();
+
+    let raw_tx = Bytes::from(vec![0; MAX_BYTES + 1]);
+    let err = client
+        .request::<B256, _>("eth_sendRawTransaction", jsonrpsee::rpc_params![raw_tx.clone()])
+        .await
+        .unwrap_err();
+    let jsonrpsee::core::client::Error::Call(err) = err else {
+        panic!("expected an invalid input error object, got {err:?}")
+    };
+    let expected =
+        InvalidPoolTransactionError::OversizedData { size: raw_tx.len(), limit: MAX_BYTES };
+    assert_eq!(err.code(), EthRpcErrorCode::InvalidInput.code());
+    assert_eq!(err.message(), expected.to_string());
 
     Ok(())
 }

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -34,7 +34,7 @@ use reth_node_core::{
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
 use reth_rpc::{
     eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
-    AdminApi,
+    AdminApi, EthTransactionsConfig,
 };
 use reth_rpc_api::{eth::helpers::EthTransactions, IntoEngineApiRpcModule};
 use reth_rpc_builder::{
@@ -1119,6 +1119,7 @@ where
         let ctx = EthApiCtx {
             components: &node,
             config: eth_config,
+            transactions_config: EthTransactionsConfig::new(config.txpool.max_tx_input_bytes),
             cache,
             engine_handle: beacon_engine_handle.clone(),
         };
@@ -1289,6 +1290,8 @@ pub struct EthApiCtx<'a, N: FullNodeTypes> {
     pub components: &'a N,
     /// Eth API configuration
     pub config: EthConfig,
+    /// Transaction-related RPC configuration.
+    pub transactions_config: EthTransactionsConfig,
     /// Cache for eth state
     pub cache: EthStateCache<PrimitivesTy<N::Types>>,
     /// Handle to the beacon consensus engine
@@ -1314,6 +1317,7 @@ impl<'a, N: FullNodeComponents<Types: NodeTypes<ChainSpec: Hardforks + EthereumH
             .max_blocking_io_requests(self.config.max_blocking_io_requests)
             .pending_block_kind(self.config.pending_block_kind)
             .raw_tx_forwarder(self.config.raw_tx_forwarder)
+            .transactions_config(self.transactions_config)
             .evm_memory_limit(self.config.rpc_evm_memory_limit)
             .force_blob_sidecar_upcasting(self.config.force_blob_sidecar_upcasting)
     }

--- a/crates/rpc/rpc-eth-api/src/helpers/mod.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/mod.rs
@@ -42,7 +42,7 @@ pub use spec::EthApiSpec;
 pub use state::{EthState, LoadState};
 pub use subscriptions::EthSubscriptions;
 pub use trace::Trace;
-pub use transaction::{EthTransactions, LoadTransaction};
+pub use transaction::{EthTransactions, EthTransactionsConfig, LoadTransaction};
 
 use crate::FullEthApiTypes;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -8,6 +8,7 @@ use crate::{
     RpcTransaction,
 };
 use alloy_consensus::{
+    constants::EIP4844_TX_TYPE_ID,
     transaction::{SignerRecoverable, TransactionMeta, TxHashRef},
     BlockHeader, Transaction,
 };
@@ -87,7 +88,10 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
         async move {
             let max_bytes = self.transactions_config().max_bytes;
-            if tx.len() > max_bytes {
+            // Blob transaction network encodings include the sidecar. The pool validator applies
+            // this limit to the executable transaction data after decoding instead.
+            let is_eip4844 = tx.first().copied() == Some(EIP4844_TX_TYPE_ID);
+            if tx.len() > max_bytes && !is_eip4844 {
                 let err =
                     InvalidPoolTransactionError::OversizedData { size: tx.len(), limit: max_bytes };
                 return Err(Self::Error::from_eth_err(EthApiError::PoolError(err.into())));

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -33,6 +33,7 @@ use reth_storage_api::{
     TransactionsProvider,
 };
 use reth_transaction_pool::{
+    error::InvalidPoolTransactionError, validate::DEFAULT_MAX_TX_INPUT_BYTES,
     AddedTransactionOutcome, PoolPooledTx, PoolTransaction, PoolTx, TransactionOrigin,
     TransactionPool,
 };
@@ -61,6 +62,9 @@ use std::{sync::Arc, time::Duration};
 ///
 /// This implementation follows the behaviour of Geth and disables the basefee check for tracing.
 pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
+    /// Returns the transaction-related RPC configuration.
+    fn transactions_config(&self) -> &EthTransactionsConfig;
+
     /// Returns a handle for signing data.
     ///
     /// Signer access in default (L1) trait method implementations.
@@ -82,6 +86,13 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         tx: Bytes,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
         async move {
+            let max_bytes = self.transactions_config().max_bytes;
+            if tx.len() > max_bytes {
+                let err =
+                    InvalidPoolTransactionError::OversizedData { size: tx.len(), limit: max_bytes };
+                return Err(Self::Error::from_eth_err(EthApiError::PoolError(err.into())));
+            }
+
             let pool_transaction =
                 <PoolTx<Self::Pool> as PoolTransaction>::recover_raw_transaction(&tx)
                     .map_err(Self::Error::from_eth_err)?;
@@ -682,6 +693,26 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             .find(|signer| signer.is_signer_for(account))
             .map(|signer| dyn_clone::clone_box(&**signer))
             .ok_or_else(|| SignError::NoAccount.into_eth_err())
+    }
+}
+
+/// Configuration for transaction-related RPC methods.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct EthTransactionsConfig {
+    /// Maximum encoded transaction size accepted by raw transaction RPC methods before decoding.
+    pub max_bytes: usize,
+}
+
+impl EthTransactionsConfig {
+    /// Creates a new transaction RPC configuration.
+    pub const fn new(max_bytes: usize) -> Self {
+        Self { max_bytes }
+    }
+}
+
+impl Default for EthTransactionsConfig {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_TX_INPUT_BYTES)
     }
 }
 

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -7,7 +7,9 @@ use reth_chainspec::ChainSpecProvider;
 use reth_primitives_traits::HeaderTy;
 use reth_rpc_convert::{RpcConvert, RpcConverter};
 use reth_rpc_eth_api::{
-    helpers::pending_block::PendingEnvBuilder, node::RpcNodeCoreAdapter, RpcNodeCore,
+    helpers::{pending_block::PendingEnvBuilder, EthTransactionsConfig},
+    node::RpcNodeCoreAdapter,
+    RpcNodeCore,
 };
 use reth_rpc_eth_types::{
     builder::config::PendingBlockKind, fee_history::fee_history_cache_new_blocks_task,
@@ -46,6 +48,7 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     max_blocking_io_requests: usize,
     pending_block_kind: PendingBlockKind,
     raw_tx_forwarder: ForwardConfig,
+    transactions_config: EthTransactionsConfig,
     send_raw_transaction_sync_timeout: Duration,
     evm_memory_limit: u64,
     force_blob_sidecar_upcasting: bool,
@@ -100,6 +103,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
@@ -124,6 +128,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
@@ -159,6 +164,7 @@ where
             max_blocking_io_requests: DEFAULT_MAX_BLOCKING_IO_REQUEST,
             pending_block_kind: PendingBlockKind::Full,
             raw_tx_forwarder: ForwardConfig::default(),
+            transactions_config: EthTransactionsConfig::default(),
             send_raw_transaction_sync_timeout: Duration::from_secs(30),
             evm_memory_limit: (1 << 32) - 1,
             force_blob_sidecar_upcasting: false,
@@ -201,6 +207,7 @@ where
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
@@ -225,6 +232,7 @@ where
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
@@ -256,6 +264,7 @@ where
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
@@ -280,6 +289,7 @@ where
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
@@ -384,6 +394,12 @@ where
         self
     }
 
+    /// Sets the transaction-related RPC configuration.
+    pub const fn transactions_config(mut self, config: EthTransactionsConfig) -> Self {
+        self.transactions_config = config;
+        self
+    }
+
     /// Returns the gas cap.
     pub const fn get_gas_cap(&self) -> &GasCap {
         &self.gas_cap
@@ -437,6 +453,11 @@ where
     /// Returns a reference to the raw tx forwarder config.
     pub const fn get_raw_tx_forwarder(&self) -> &ForwardConfig {
         &self.raw_tx_forwarder
+    }
+
+    /// Returns the transaction-related RPC configuration.
+    pub const fn get_transactions_config(&self) -> &EthTransactionsConfig {
+        &self.transactions_config
     }
 
     /// Returns a mutable reference to the fee history cache config.
@@ -528,6 +549,7 @@ where
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder,
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
@@ -581,6 +603,7 @@ where
             max_blocking_io_requests,
             pending_block_kind,
             raw_tx_forwarder.forwarder_client(),
+            transactions_config,
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -16,7 +16,9 @@ use reth_network_api::noop::NoopNetwork;
 use reth_node_api::{FullNodeComponents, FullNodeTypes};
 use reth_rpc_convert::{RpcConvert, RpcConverter};
 use reth_rpc_eth_api::{
-    helpers::{pending_block::PendingEnvBuilder, spec::SignersForRpc, SpawnBlocking},
+    helpers::{
+        pending_block::PendingEnvBuilder, spec::SignersForRpc, EthTransactionsConfig, SpawnBlocking,
+    },
     node::{RpcNodeCoreAdapter, RpcNodeCoreExt},
     EthApiTypes, RpcNodeCore,
 };
@@ -263,6 +265,9 @@ pub struct EthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Raw transaction forwarder
     raw_tx_forwarder: Option<RpcClient>,
 
+    /// Configuration for transaction-related RPC methods.
+    transactions_config: EthTransactionsConfig,
+
     /// Converter for RPC types.
     converter: Rpc,
 
@@ -314,6 +319,7 @@ where
         max_blocking_io_requests: usize,
         pending_block_kind: PendingBlockKind,
         raw_tx_forwarder: Option<RpcClient>,
+        transactions_config: EthTransactionsConfig,
         send_raw_transaction_sync_timeout: Duration,
         evm_memory_limit: u64,
         force_blob_sidecar_upcasting: bool,
@@ -355,6 +361,7 @@ where
             blocking_io_request_semaphore: Arc::new(Semaphore::new(max_blocking_io_requests)),
             raw_tx_sender,
             raw_tx_forwarder,
+            transactions_config,
             converter,
             next_env_builder: Box::new(next_env),
             tx_batch_sender,
@@ -536,6 +543,12 @@ where
     #[inline]
     pub const fn raw_tx_forwarder(&self) -> Option<&RpcClient> {
         self.raw_tx_forwarder.as_ref()
+    }
+
+    /// Returns the transaction-related RPC configuration.
+    #[inline]
+    pub const fn transactions_config(&self) -> &EthTransactionsConfig {
+        &self.transactions_config
     }
 
     /// Returns the timeout duration for `send_raw_transaction_sync` RPC method.

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -10,7 +10,7 @@ use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_primitives_traits::{AlloyBlockHeader, WithEncoded};
 use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::{
-    helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction},
+    helpers::{spec::SignersForRpc, EthTransactions, EthTransactionsConfig, LoadTransaction},
     FromEvmError, RpcNodeCore,
 };
 use reth_rpc_eth_types::{error::RpcPoolError, EthApiError};
@@ -26,6 +26,11 @@ where
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
+    #[inline]
+    fn transactions_config(&self) -> &EthTransactionsConfig {
+        self.inner.transactions_config()
+    }
+
     #[inline]
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.signers()

--- a/crates/rpc/rpc/src/lib.rs
+++ b/crates/rpc/rpc/src/lib.rs
@@ -51,6 +51,7 @@ pub use net::NetApi;
 pub use otterscan::OtterscanApi;
 pub use reth::RethApi;
 pub use reth_rpc_convert::RpcTypes;
+pub use reth_rpc_eth_api::helpers::EthTransactionsConfig;
 pub use rpc::RPCApi;
 pub use testing::TestingApi;
 pub use trace::TraceApi;


### PR DESCRIPTION
Rejects non-blob eth_sendRawTransaction payloads that exceed --txpool.max-tx-input-bytes before transaction decoding, returning the existing oversized-pool error. EIP-4844 envelopes bypass this pre-decode cap and remain subject to the pool validator limit on executable input and access-list data. Adds an EthTransactionsConfig container so future transaction RPC settings can use the same trait hook.