### PR TITLE
ci: fail the release build if a macOS asset is not self-contained

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,24 @@ jobs:
           cp -R LICENSES ./artifacts/LICENSES
           cp README.md ./artifacts/README.md
 
+      # A released binary has to run on a clean machine. The macOS runners have
+      # Homebrew present, so a dependency that resolves against a Homebrew dylib
+      # links fine here and then fails at launch for everyone else. Catch that
+      # before the asset is packaged rather than after it is published.
+      - name: Verify macOS binary is self-contained
+        if: runner.os == 'macOS'
+        run: |
+          bin="./artifacts/${{ matrix.build.binary }}"
+          otool -L "$bin"
+          foreign="$(otool -L "$bin" | tail -n +2 | awk '{print $1}' \
+            | grep -Ev '^(/usr/lib/|/System/Library/)' || true)"
+          if [ -n "$foreign" ]; then
+            echo "::error::release binary links libraries that are not part of macOS:"
+            echo "$foreign"
+            exit 1
+          fi
+        shell: bash
+
       - name: Configure GPG and create artifacts
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}


### PR DESCRIPTION
Closes #26747.

The v2.5.0 `aarch64-apple-darwin` asset links `/opt/homebrew/opt/z3/lib/libz3.4.16.dylib`, so it aborts at launch on any Mac that does not have that exact Homebrew z3. The runners have Homebrew, so the link resolves during the build and the breakage only shows up for users.

This adds a check on the packaged binary before it is signed and uploaded. Anything resolving outside `/usr/lib` or `/System/Library` fails the job.

I traced the reference in the issue thread: `jit` is in the reth binary's default features, the release builds with `FEATURES` empty so defaults apply, and `jit` pulls `revmc` with `llvm-prefer-static`, which links against whatever `LLVM_SYS_221_PREFIX` points at. `install_llvm_brew.sh` points it at Homebrew's `llvm@22`.

I deliberately have not changed that here. Whether to drop `jit` from the macOS release or to build against an LLVM without Z3 is your call, and this check is useful either way. It fails today, which is the correct signal.
