### PR TITLE
ci(hive): install ripgrep for failure logs

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -217,6 +217,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Download hive assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -399,6 +402,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Download hive assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION

Hive failure diagnostics use `ripgrep` to extract panic and error context
from Reth logs. Installing it in CI prevents `rg: command not found` and
keeps failure logs actionable.