### PR TITLE
fix(net): admit ETH responses before decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,8 +542,7 @@ dependencies = [
 [[package]]
 name = "alloy-rlp"
 version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
+source = "git+https://github.com/0xalpharush/rlp?rev=77ba5b0#77ba5b09a86d36c04a3fb685db3443490f010502"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -553,8 +552,7 @@ dependencies = [
 [[package]]
 name = "alloy-rlp-derive"
 version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
+source = "git+https://github.com/0xalpharush/rlp?rev=77ba5b0#77ba5b09a86d36c04a3fb685db3443490f010502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -695,3 +695,8 @@ vergen-git2 = "10.0.1"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+# Temporary integration of alloy-rlp's borrowed `RlpList` cursor, pending its release.
+alloy-rlp = { git = "https://github.com/0xalpharush/rlp", rev = "77ba5b0" }
+alloy-rlp-derive = { git = "https://github.com/0xalpharush/rlp", rev = "77ba5b0" }

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -111,7 +111,16 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         tx_memory_budget: usize,
     ) -> Result<Self, MessageError> {
         let message_type = EthMessageID::decode(buf)?;
+        Self::decode_payload_with_tx_memory_budget(version, message_type, buf, tx_memory_budget)
+    }
 
+    /// Decodes a message payload after its ETH message ID was read by the transport.
+    pub fn decode_payload_with_tx_memory_budget(
+        version: EthVersion,
+        message_type: EthMessageID,
+        buf: &mut &[u8],
+        tx_memory_budget: usize,
+    ) -> Result<Self, MessageError> {
         // For EIP-7642 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7642.md):
         // pre-merge (legacy) status messages include total difficulty, whereas eth/69 omits it.
         let message = match message_type {

--- a/crates/net/eth-wire/src/eth_snap.rs
+++ b/crates/net/eth-wire/src/eth_snap.rs
@@ -15,10 +15,9 @@ use crate::{
 };
 use alloy_primitives::bytes::{Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream, StreamExt};
-use reth_eth_wire_types::{
-    snap::{SnapProtocolMessage, SnapVersion},
-    RawCapabilityMessage,
-};
+#[cfg(test)]
+use reth_eth_wire_types::snap::SnapVersion;
+use reth_eth_wire_types::{snap::SnapProtocolMessage, RawCapabilityMessage};
 use reth_ethereum_forks::ForkFilter;
 use std::{
     io,
@@ -30,9 +29,8 @@ use std::{
 /// A dedicated stream that carries `eth` as the primary protocol and `snap/2` (EIP-8189) as a typed
 /// side-channel on the same `RLPx` connection.
 ///
-/// Both protocols are exposed through the [`Stream`]/[`Sink`] impls, which yield and accept
-/// [`EthSnapMessage`] (an `eth` message or a `snap/2` message). A single poll surfaces whichever
-/// protocol the next inbound frame belongs to, so the owner drives one stream rather than two.
+/// Inbound frames are exposed as [`RawCapabilityMessage`]s; the session that owns request state
+/// admits and decodes them. Outbound messages remain typed [`EthSnapMessage`]s.
 #[derive(Debug)]
 pub struct EthSnapStream<St, N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The raw `RLPx` stream carrying both `eth` and `snap/2` frames.
@@ -79,6 +77,12 @@ impl<St, N: NetworkPrimitives> EthSnapStream<St, N> {
     #[inline]
     pub const fn version(&self) -> EthVersion {
         self.eth.version()
+    }
+
+    /// Returns the maximum encoded ETH frame size accepted by this stream.
+    #[inline]
+    pub const fn max_message_size(&self) -> usize {
+        self.eth.max_message_size()
     }
 
     /// Sets whether to reject block announcement messages before RLP decoding.
@@ -139,7 +143,7 @@ where
     St: Stream<Item = io::Result<BytesMut>> + Sink<Bytes, Error = io::Error> + Unpin,
     N: NetworkPrimitives,
 {
-    type Item = Result<EthSnapMessage<N>, EthStreamError>;
+    type Item = Result<RawCapabilityMessage, EthStreamError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -153,18 +157,7 @@ where
             return Poll::Ready(Some(Err(P2PStreamError::EmptyProtocolMessage.into())))
         };
 
-        // `eth` occupies ids below the snap offset and is decoded by the shared codec. Ids at or
-        // above it are snap: rebased to snap-relative (`0x00..`) and validated by
-        // `decode_versioned`, which rejects ids that are out of range or invalid for `snap/2`.
-        let Some(snap_id) = id.checked_sub(this.snap_offset) else {
-            return Poll::Ready(Some(this.eth.decode_message(bytes).map(EthSnapMessage::Eth)))
-        };
-        bytes[0] = snap_id;
-        Poll::Ready(Some(
-            SnapProtocolMessage::decode_versioned(SnapVersion::V2, &bytes)
-                .map(EthSnapMessage::Snap)
-                .map_err(Into::into),
-        ))
+        Poll::Ready(Some(Ok(RawCapabilityMessage::new(id as usize, bytes.split_off(1).freeze()))))
     }
 }
 
@@ -353,7 +346,11 @@ mod tests {
             .unwrap();
 
             while let Some(Ok(msg)) = stream.next().await {
-                if let EthSnapMessage::Snap(SnapProtocolMessage::GetBlockAccessLists(req)) = msg {
+                let mut frame = vec![(msg.id - stream.snap_offset as usize) as u8];
+                frame.extend_from_slice(&msg.payload);
+                if let SnapProtocolMessage::GetBlockAccessLists(req) =
+                    SnapProtocolMessage::decode_versioned(SnapVersion::V2, &frame).unwrap()
+                {
                     let response = SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
                         request_id: req.request_id,
                         block_access_lists: reth_eth_wire_types::BlockAccessLists(vec![None]),
@@ -387,10 +384,13 @@ mod tests {
             .unwrap();
 
         let response = loop {
-            if let EthSnapMessage::Snap(SnapProtocolMessage::BlockAccessLists(resp)) =
-                stream.next().await.unwrap().unwrap()
+            let msg = stream.next().await.unwrap().unwrap();
+            let mut frame = vec![(msg.id - stream.snap_offset as usize) as u8];
+            frame.extend_from_slice(&msg.payload);
+            if let SnapProtocolMessage::BlockAccessLists(resp) =
+                SnapProtocolMessage::decode_versioned(SnapVersion::V2, &frame).unwrap()
             {
-                break resp;
+                break resp
             }
         };
         assert_eq!(response.request_id, 7);
@@ -398,10 +398,10 @@ mod tests {
         server.abort();
     }
 
-    /// End-to-end: message ids removed by snap/2 are rejected after capability negotiation rather
-    /// than being decoded as trie-node requests or responses.
+    /// End-to-end: the stream preserves unknown `snap/2` frames for the session, which owns
+    /// request correlation and protocol-message decoding.
     #[tokio::test(flavor = "multi_thread")]
-    async fn snap_two_rejects_removed_trie_node_messages_over_the_wire() {
+    async fn snap_two_preserves_removed_trie_node_message_ids_over_the_wire() {
         reth_tracing::init_test_tracing();
 
         for removed_snap_id in [0x06, 0x07] {
@@ -426,7 +426,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                stream.next().await.expect("peer should send a frame").unwrap_err()
+                stream.next().await.expect("peer should send a frame").unwrap()
             });
 
             let conn = connect_passthrough(local_addr, eth_snap_hello()).await;
@@ -449,11 +449,9 @@ mod tests {
                 .unwrap();
             stream.flush().await.unwrap();
 
-            let error = server.await.unwrap();
-            assert!(
-                error.to_string().contains("invalid for snap"),
-                "unexpected error for removed snap id {removed_snap_id:#x}: {error}"
-            );
+            let message = server.await.unwrap();
+            assert_eq!(message.id, combined_id);
+            assert_eq!(message.payload, Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]));
         }
     }
 }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -138,10 +138,35 @@ where
         self.version
     }
 
+    /// Returns the maximum encoded ETH frame size accepted by this stream.
+    #[inline]
+    pub const fn max_message_size(&self) -> usize {
+        self.max_message_size
+    }
+
     /// Sets whether to reject block announcement messages (`NewBlock`, `NewBlockHashes`) before
     /// RLP decoding.
     pub const fn set_reject_block_announcements(&mut self, reject: bool) {
         self.reject_block_announcements = reject;
+    }
+
+    /// Validates an inbound ETH frame without decoding its RLP payload.
+    pub fn decode_raw_message(
+        &self,
+        mut bytes: BytesMut,
+    ) -> Result<RawCapabilityMessage, EthStreamError> {
+        if bytes.len() > self.max_message_size {
+            return Err(EthStreamError::MessageTooBig(bytes.len()));
+        }
+        let Some(&id) = bytes.first() else {
+            return Err(EthStreamError::InvalidMessage(alloy_rlp::Error::InputTooShort.into()))
+        };
+        if self.reject_block_announcements &&
+            (id == EthMessageID::NewBlock.to_u8() || id == EthMessageID::NewBlockHashes.to_u8())
+        {
+            return Err(EthStreamError::UnsupportedMessage { message_id: id });
+        }
+        Ok(RawCapabilityMessage::new(id as usize, bytes.split_off(1).freeze()))
     }
 
     /// Decodes incoming bytes into an [`EthMessage`].
@@ -232,6 +257,12 @@ impl<S, N: NetworkPrimitives> EthStream<S, N> {
         self.eth.version()
     }
 
+    /// Returns the maximum encoded ETH frame size accepted by this stream.
+    #[inline]
+    pub const fn max_message_size(&self) -> usize {
+        self.eth.max_message_size()
+    }
+
     /// Sets whether to reject block announcement messages (`NewBlock`, `NewBlockHashes`) before
     /// RLP decoding.
     pub const fn set_reject_block_announcements(&mut self, reject: bool) {
@@ -285,14 +316,14 @@ where
     EthStreamError: From<E>,
     N: NetworkPrimitives,
 {
-    type Item = Result<EthMessage<N>, EthStreamError>;
+    type Item = Result<RawCapabilityMessage, EthStreamError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
         let res = ready!(this.inner.poll_next(cx));
 
         match res {
-            Some(Ok(bytes)) => Poll::Ready(Some(this.eth.decode_message(bytes))),
+            Some(Ok(bytes)) => Poll::Ready(Some(this.eth.decode_raw_message(bytes))),
             Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
             None => Poll::Ready(None),
         }
@@ -548,16 +579,17 @@ mod tests {
             .into(),
         );
 
-        let test_msg_clone = test_msg.clone();
+        let expected =
+            RawCapabilityMessage::eth(test_msg.message_id(), alloy_rlp::encode(&test_msg).into());
         let handle = tokio::spawn(async move {
             // roughly based off of the design of tokio::net::TcpListener
             let (incoming, _) = listener.accept().await.unwrap();
             let stream = PassthroughCodec::default().framed(incoming);
-            let mut stream = EthStream::new(EthVersion::Eth67, stream);
+            let mut stream = EthStream::<_, EthNetworkPrimitives>::new(EthVersion::Eth67, stream);
 
             // use the stream to get the next message
             let message = stream.next().await.unwrap().unwrap();
-            assert_eq!(message, test_msg_clone);
+            assert_eq!(message, expected);
         });
 
         let outgoing = TcpStream::connect(local_addr).await.unwrap();
@@ -583,16 +615,17 @@ mod tests {
             .into(),
         );
 
-        let test_msg_clone = test_msg.clone();
+        let expected =
+            RawCapabilityMessage::eth(test_msg.message_id(), alloy_rlp::encode(&test_msg).into());
         let handle = tokio::spawn(async move {
             // roughly based off of the design of tokio::net::TcpListener
             let (incoming, _) = listener.accept().await.unwrap();
             let stream = ECIESStream::incoming(incoming, server_key).await.unwrap();
-            let mut stream = EthStream::new(EthVersion::Eth67, stream);
+            let mut stream = EthStream::<_, EthNetworkPrimitives>::new(EthVersion::Eth67, stream);
 
             // use the stream to get the next message
             let message = stream.next().await.unwrap().unwrap();
-            assert_eq!(message, test_msg_clone);
+            assert_eq!(message, expected);
         });
 
         // create the server pubkey
@@ -641,7 +674,8 @@ mod tests {
 
         let status_copy = unified_status;
         let fork_filter_clone = fork_filter.clone();
-        let test_msg_clone = test_msg.clone();
+        let expected =
+            RawCapabilityMessage::eth(test_msg.message_id(), alloy_rlp::encode(&test_msg).into());
         let handle = tokio::spawn(async move {
             // roughly based off of the design of tokio::net::TcpListener
             let (incoming, _) = listener.accept().await.unwrap();
@@ -658,13 +692,13 @@ mod tests {
             let unauthed_stream = UnauthedP2PStream::new(stream);
             let (p2p_stream, _) = unauthed_stream.handshake(server_hello).await.unwrap();
             let (mut eth_stream, _) = UnauthedEthStream::new(p2p_stream)
-                .handshake(status_copy, fork_filter_clone)
+                .handshake::<EthNetworkPrimitives>(status_copy, fork_filter_clone)
                 .await
                 .unwrap();
 
             // use the stream to get the next message
             let message = eth_stream.next().await.unwrap().unwrap();
-            assert_eq!(message, test_msg_clone);
+            assert_eq!(message, expected);
         });
 
         // create the server pubkey

--- a/crates/net/network-api/src/events.rs
+++ b/crates/net/network-api/src/events.rs
@@ -2,8 +2,8 @@
 
 use reth_eth_wire_types::{
     message::RequestPair, snap::SnapProtocolMessage, BlockAccessLists, BlockBodies, BlockHeaders,
-    Capabilities, Cells, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion,
-    GetBlockAccessLists, GetBlockBodies, GetBlockHeaders, GetCells, GetNodeData,
+    Capabilities, Cells, DisconnectReason, EthMessage, EthMessageID, EthNetworkPrimitives,
+    EthVersion, GetBlockAccessLists, GetBlockBodies, GetBlockHeaders, GetCells, GetNodeData,
     GetPooledTransactions, GetReceipts, GetReceipts70, NetworkPrimitives, NodeData,
     PooledTransactions, Receipts, Receipts69, Receipts70, UnifiedStatus,
 };
@@ -298,6 +298,36 @@ pub enum RequestMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
 // === impl PeerRequest ===
 
 impl<N: NetworkPrimitives> PeerRequest<N> {
+    /// Returns the ETH response message ID and maximum number of top-level response items.
+    pub fn eth_response_bound(&self) -> Option<(EthMessageID, u64)> {
+        match self {
+            Self::GetBlockHeaders { request, .. } => {
+                Some((EthMessageID::BlockHeaders, request.limit))
+            }
+            Self::GetBlockBodies { request, .. } => {
+                Some((EthMessageID::BlockBodies, request.0.len() as u64))
+            }
+            Self::GetPooledTransactions { request, .. } => {
+                Some((EthMessageID::PooledTransactions, request.0.len() as u64))
+            }
+            Self::GetNodeData { request, .. } => {
+                Some((EthMessageID::NodeData, request.0.len() as u64))
+            }
+            Self::GetReceipts { request, .. } | Self::GetReceipts69 { request, .. } => {
+                Some((EthMessageID::Receipts, request.0.len() as u64))
+            }
+            Self::GetReceipts70 { request, .. } => {
+                Some((EthMessageID::Receipts, request.block_hashes.len() as u64))
+            }
+            Self::GetBlockAccessLists { request, .. } => {
+                Some((EthMessageID::BlockAccessLists, request.0.len() as u64))
+            }
+            Self::GetCells { request, .. } => {
+                Some((EthMessageID::Cells, request.hashes.len() as u64))
+            }
+            Self::GetSnap { .. } => None,
+        }
+    }
     /// Invoked if we received a response which does not match the request
     pub fn send_bad_response(self) {
         self.send_err_response(RequestError::BadResponse)

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -24,17 +24,19 @@ use crate::{
 };
 use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::Sealable;
+use alloy_rlp::RlpList;
 use futures::{stream::Fuse, SinkExt, StreamExt};
 use metrics::{Counter, Gauge};
 use reth_eth_wire::{
     errors::{EthHandshakeError, EthStreamError},
-    message::{EthBroadcastMessage, MessageError},
-    Capabilities, DisconnectP2P, DisconnectReason, EthMessage, EthSnapMessage, NetworkPrimitives,
-    NewBlockPayload,
+    message::{EthBroadcastMessage, MessageError, TX_MEMORY_BUDGET_MULTIPLIER},
+    Capabilities, DisconnectP2P, DisconnectReason, EthMessage, NetworkPrimitives, NewBlockPayload,
+    ProtocolMessage,
 };
 use reth_eth_wire_types::{
-    message::RequestPair, snap::SnapProtocolMessage, NewPooledTransactionHashes,
-    RawCapabilityMessage,
+    message::{EthMessageID, RequestPair},
+    snap::{SnapProtocolMessage, SnapVersion},
+    NewPooledTransactionHashes, RawCapabilityMessage,
 };
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_network_api::{PeerRequest, RequestMessage};
@@ -425,6 +427,124 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
             }
             EthMessage::Other(bytes) => self.try_emit_broadcast(PeerMessage::Other(bytes)).into(),
         }
+    }
+
+    /// Decodes an authenticated ETH capability frame after session-level admission can inspect it.
+    fn on_incoming_raw_message(
+        &mut self,
+        raw: RawCapabilityMessage,
+    ) -> OnIncomingMessageOutcome<N> {
+        let version = self.conn.version();
+        if raw.id < EthMessageID::message_count(version) as usize {
+            let Ok(message_id) = EthMessageID::try_from(raw.id) else {
+                return self.on_incoming_message(EthMessage::Other(raw))
+            };
+            if matches!(
+                message_id,
+                EthMessageID::BlockHeaders |
+                    EthMessageID::BlockBodies |
+                    EthMessageID::PooledTransactions |
+                    EthMessageID::NodeData |
+                    EthMessageID::Receipts |
+                    EthMessageID::BlockAccessLists |
+                    EthMessageID::Cells
+            ) {
+                match self.admit_eth_response(message_id, &raw.payload) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        self.on_bad_message();
+                        return OnIncomingMessageOutcome::Ok
+                    }
+                    Err(error) => {
+                        return OnIncomingMessageOutcome::BadMessage {
+                            error: EthStreamError::InvalidMessage(error),
+                            message: EthMessage::Other(raw),
+                        }
+                    }
+                }
+            }
+            let mut payload = raw.payload.as_ref();
+            let message = ProtocolMessage::decode_payload_with_tx_memory_budget(
+                version,
+                message_id,
+                &mut payload,
+                self.conn.max_message_size() * TX_MEMORY_BUDGET_MULTIPLIER,
+            )
+            .map(|message| message.message)
+            .map_err(EthStreamError::InvalidMessage);
+            return match message {
+                Ok(message) if !matches!(message, EthMessage::Status(_)) => {
+                    self.on_incoming_message(message)
+                }
+                Ok(_) => OnIncomingMessageOutcome::BadMessage {
+                    error: EthStreamError::EthHandshakeError(
+                        EthHandshakeError::StatusNotInHandshake,
+                    ),
+                    message: EthMessage::Other(raw),
+                },
+                Err(error) => {
+                    OnIncomingMessageOutcome::BadMessage { error, message: EthMessage::Other(raw) }
+                }
+            }
+        }
+
+        if !self.conn.supports_snap() {
+            return self.on_incoming_message(EthMessage::Other(raw))
+        }
+        let snap_id = raw.id - EthMessageID::message_count(version) as usize;
+        let Ok(snap_id) = u8::try_from(snap_id) else {
+            return OnIncomingMessageOutcome::BadMessage {
+                error: EthStreamError::UnsupportedMessage { message_id: u8::MAX },
+                message: EthMessage::Other(raw),
+            }
+        };
+        let mut frame = Vec::with_capacity(raw.payload.len() + 1);
+        frame.push(snap_id);
+        frame.extend_from_slice(&raw.payload);
+        match SnapProtocolMessage::decode_versioned(SnapVersion::V2, &frame) {
+            Ok(message) => self.on_incoming_snap_message(message),
+            Err(error) => OnIncomingMessageOutcome::BadMessage {
+                error: EthStreamError::InvalidMessage(MessageError::Other(error.to_string())),
+                message: EthMessage::Other(raw),
+            },
+        }
+    }
+
+    /// Checks a response against the request that is still in flight without decoding its entries.
+    fn admit_eth_response(
+        &self,
+        message_id: EthMessageID,
+        payload: &[u8],
+    ) -> Result<bool, MessageError> {
+        let mut encoded = payload;
+        let mut fields = RlpList::decode(&mut encoded)?;
+        if !encoded.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength.into())
+        }
+        let request_id: u64 = fields.next()?.ok_or(alloy_rlp::Error::UnexpectedLength)?;
+        let Some(inflight) = self.inflight_requests.get(&request_id) else { return Ok(false) };
+        let RequestState::Waiting(request) = &inflight.request else { return Ok(false) };
+        let Some((expected, limit)) = request.eth_response_bound() else { return Ok(false) };
+        if message_id != expected {
+            return Ok(false)
+        }
+
+        if message_id == EthMessageID::Receipts && self.conn.version() >= EthVersion::Eth70 {
+            fields.next::<bool>()?.ok_or(alloy_rlp::Error::UnexpectedLength)?;
+        }
+        if message_id == EthMessageID::Cells {
+            let mut hashes = RlpList::decode(
+                &mut fields.next_raw()?.ok_or(alloy_rlp::Error::UnexpectedLength)?,
+            )?;
+            let mut cells = RlpList::decode(
+                &mut fields.next_raw()?.ok_or(alloy_rlp::Error::UnexpectedLength)?,
+            )?;
+            fields.next_raw()?.ok_or(alloy_rlp::Error::UnexpectedLength)?;
+            return Ok(!hashes.has_more_than(limit)? && !cells.has_more_than(limit)?)
+        }
+        let mut result =
+            RlpList::decode(&mut fields.next_raw()?.ok_or(alloy_rlp::Error::UnexpectedLength)?)?;
+        Ok(!result.has_more_than(limit)?)
     }
 
     /// Handles an inbound `snap/2` message.
@@ -936,14 +1056,7 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     Poll::Ready(Some(res)) => {
                         match res {
                             Ok(msg) => {
-                                let outcome = match msg {
-                                    EthSnapMessage::Eth(msg) => {
-                                        trace!(target: "net::session", msg_id=?msg.message_id(), remote_peer_id=?this.remote_peer_id, "received eth message");
-                                        // decode and handle message
-                                        this.on_incoming_message(msg)
-                                    }
-                                    EthSnapMessage::Snap(msg) => this.on_incoming_snap_message(msg),
-                                };
+                                let outcome = this.on_incoming_raw_message(msg);
                                 match outcome {
                                     OnIncomingMessageOutcome::Ok => {
                                         // handled successfully
@@ -1321,7 +1434,8 @@ mod tests {
     use super::*;
     use crate::session::{handle::PendingSessionEvent, start_pending_incoming_session};
     use alloy_eips::eip2124::ForkFilter;
-    use alloy_primitives::B256;
+    use alloy_primitives::{Bytes, B256};
+    use alloy_rlp::{Encodable, Header};
     use futures::task::noop_waker;
     use reth_chainspec::MAINNET;
     use reth_ecies::stream::ECIESStream;
@@ -1558,6 +1672,19 @@ mod tests {
         );
         let id = *session.inflight_requests.keys().next().expect("eth request tracked");
         (id, rx)
+    }
+
+    fn raw_response(
+        message_id: EthMessageID,
+        request_id: u64,
+        result: &[u8],
+    ) -> RawCapabilityMessage {
+        let mut payload = Vec::with_capacity(request_id.length() + result.len() + 9);
+        Header { list: true, payload_length: request_id.length() + result.len() }
+            .encode(&mut payload);
+        request_id.encode(&mut payload);
+        payload.extend_from_slice(result);
+        RawCapabilityMessage::eth(message_id, Bytes::from(payload).into())
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1905,6 +2032,87 @@ mod tests {
         assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::BadResponse);
         assert!(matches!(
             futures::FutureExt::now_or_never(builder.active_session_rx.next()).flatten(),
+            Some(ActiveSessionMessage::BadMessage { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn raw_wrong_type_eth_response_is_rejected_before_payload_decode() {
+        let mut builder = SessionBuilder::default();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let fut = builder.with_client_stream(local_addr, async move |client_stream| {
+            let _client_stream = client_stream;
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        tokio::task::spawn(fut);
+        let (incoming, _) = listener.accept().await.unwrap();
+        let mut session = builder.connect_incoming(incoming).await;
+
+        let (id, _rx) = dispatch_block_bodies_request(&mut session);
+
+        // `0x80` is not the BlockHeaders result list. The response kind is wrong, so admission
+        // rejects it after only reading its outer request id and never reaches typed decoding.
+        let outcome =
+            session.on_incoming_raw_message(raw_response(EthMessageID::BlockHeaders, id, &[0x80]));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(session.inflight_requests.contains_key(&id));
+        assert!(matches!(
+            builder.active_session_rx.next().await,
+            Some(ActiveSessionMessage::BadMessage { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn raw_unknown_eth_response_is_rejected_before_payload_decode() {
+        let mut builder = SessionBuilder::default();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let fut = builder.with_client_stream(local_addr, async move |client_stream| {
+            let _client_stream = client_stream;
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        tokio::task::spawn(fut);
+        let (incoming, _) = listener.accept().await.unwrap();
+        let mut session = builder.connect_incoming(incoming).await;
+
+        // `0x80` would not type-decode as a BlockBodies result. No outgoing request owns this
+        // id, so the session rejects the frame after the request-id field alone.
+        let outcome =
+            session.on_incoming_raw_message(raw_response(EthMessageID::BlockBodies, 999, &[0x80]));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(session.inflight_requests.is_empty());
+        assert!(matches!(
+            builder.active_session_rx.next().await,
+            Some(ActiveSessionMessage::BadMessage { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn raw_eth_response_exceeding_requested_count_is_rejected() {
+        let mut builder = SessionBuilder::default();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let fut = builder.with_client_stream(local_addr, async move |client_stream| {
+            let _client_stream = client_stream;
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        tokio::task::spawn(fut);
+        let (incoming, _) = listener.accept().await.unwrap();
+        let mut session = builder.connect_incoming(incoming).await;
+
+        // The request contains no hashes, hence permits zero bodies. The result is an RLP list
+        // with one empty body; admission counts its raw entries without materializing a body.
+        let (id, _rx) = dispatch_block_bodies_request(&mut session);
+        let outcome = session.on_incoming_raw_message(raw_response(
+            EthMessageID::BlockBodies,
+            id,
+            &[0xc1, alloy_rlp::EMPTY_LIST_CODE],
+        ));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(session.inflight_requests.contains_key(&id));
+        assert!(matches!(
+            builder.active_session_rx.next().await,
             Some(ActiveSessionMessage::BadMessage { .. })
         ));
     }

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -62,6 +62,16 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         matches!(self, Self::EthSnap(_))
     }
 
+    /// Returns the maximum encoded ETH frame size accepted by this connection.
+    #[inline]
+    pub(crate) const fn max_message_size(&self) -> usize {
+        match self {
+            Self::EthOnly(conn) => conn.max_message_size(),
+            Self::EthSnap(conn) => conn.max_message_size(),
+            Self::Satellite(conn) => conn.primary().max_message_size(),
+        }
+    }
+
     /// Consumes this type and returns the wrapped [`P2PStream`].
     #[inline]
     pub(crate) fn into_inner(self) -> P2PStream<ECIESStream<TcpStream>> {
@@ -181,10 +191,10 @@ macro_rules! delegate_call {
 }
 
 impl<N: NetworkPrimitives> Stream for EthRlpxConnection<N> {
-    type Item = Result<EthSnapMessage<N>, EthStreamError>;
+    type Item = Result<RawCapabilityMessage, EthStreamError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        delegate_call!(self.poll_next_unpin(cx) => lift_eth)
+        delegate_call!(self.poll_next_unpin(cx))
     }
 }
 
@@ -212,14 +222,6 @@ impl<N: NetworkPrimitives> Sink<EthMessage<N>> for EthRlpxConnection<N> {
     }
 }
 
-/// Lifts a polled `eth` item into the shared [`EthSnapMessage`] item type.
-#[inline]
-fn lift_eth<N: NetworkPrimitives>(
-    poll: Poll<Option<Result<EthMessage<N>, EthStreamError>>>,
-) -> Poll<Option<Result<EthSnapMessage<N>, EthStreamError>>> {
-    poll.map(|opt| opt.map(|res| res.map(EthSnapMessage::Eth)))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,14 +229,14 @@ mod tests {
     const fn assert_eth_stream<N, St>()
     where
         N: NetworkPrimitives,
-        St: Stream<Item = Result<EthMessage<N>, EthStreamError>> + Sink<EthMessage<N>>,
+        St: Stream<Item = Result<RawCapabilityMessage, EthStreamError>> + Sink<EthMessage<N>>,
     {
     }
 
     const fn assert_eth_snap_stream<N, St>()
     where
         N: NetworkPrimitives,
-        St: Stream<Item = Result<EthSnapMessage<N>, EthStreamError>> + Sink<EthMessage<N>>,
+        St: Stream<Item = Result<RawCapabilityMessage, EthStreamError>> + Sink<EthMessage<N>>,
     {
     }
 


### PR DESCRIPTION
Keeps authenticated, decompressed capability frames raw until ActiveSession can correlate ETH responses with its existing in-flight request state. Known responses validate the request id, response kind, and requested item bound with Alloy RlpList before their payload is materialized.

This rejects unsolicited, mismatched, and oversized responses without decoding their entries. P2PStream still performs complete Snappy decompression; a stacked follow-up will move the same admission decision into that path.

Depends on https://github.com/alloy-rs/rlp/pull/73.

Checks: zepter; make lint-toml; cargo check -p reth-network -p reth-eth-wire; cargo test -p reth-eth-wire --lib; cargo test -p reth-network --lib.