### PR TITLE
feat(payload): finalize pending build on resolve

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -288,9 +288,15 @@ where
             continue
         }
 
-        // check if the job was cancelled, if so we can exit early
-        if cancel.is_cancelled() {
-            return Ok(BuildOutcome::Cancelled)
+        // Check the common interrupt flag first so the hot path only performs one atomic load.
+        if cancel.is_interrupted() {
+            if cancel.is_cancelled() {
+                return Ok(BuildOutcome::Cancelled)
+            }
+
+            // A payload was requested before this build completed. Stop adding transactions and
+            // seal the work accumulated so far.
+            break
         }
 
         // convert tx to a signed transaction

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -288,15 +288,9 @@ where
             continue
         }
 
-        // Check the common interrupt flag first so the hot path only performs one atomic load.
-        if cancel.is_interrupted() {
-            if cancel.is_cancelled() {
-                return Ok(BuildOutcome::Cancelled)
-            }
-
-            // A payload was requested before this build completed. Stop adding transactions and
-            // seal the work accumulated so far.
-            break
+        // check if the job was cancelled, if so we can exit early
+        if cancel.is_cancelled() {
+            return Ok(BuildOutcome::Cancelled)
         }
 
         // convert tx to a signed transaction

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -416,7 +416,7 @@ where
         trace!(target: "payload_builder", id = %self.config.payload_id(), "spawn new payload build task");
         let (tx, rx) = oneshot::channel();
         let cancel = CancelOnDrop::default();
-        let _cancel = cancel.clone();
+        let pending_cancel = cancel.clone();
         let guard = self.payload_task_guard.clone();
         let payload_config = self.config.clone();
         let best_payload = self.best_payload.payload().cloned();
@@ -446,7 +446,7 @@ where
             });
         });
 
-        self.pending_block = Some(PendingPayload { _cancel, payload: rx });
+        self.pending_block = Some(PendingPayload { cancel: pending_cancel, payload: rx });
     }
 }
 
@@ -567,6 +567,10 @@ where
         let mut empty_payload = None;
 
         if best_payload.is_none() {
+            if let Some(pending) = maybe_better.as_ref() {
+                pending.cancel.request_finalization();
+            }
+
             debug!(target: "payload_builder", id=%self.config.payload_id(), "no best payload yet to resolve, building empty payload");
 
             let args = BuildArguments {
@@ -734,8 +738,8 @@ where
 /// A future that resolves to the result of the block building job.
 #[derive(Debug)]
 pub struct PendingPayload<P> {
-    /// The marker to cancel the job on drop
-    _cancel: CancelOnDrop,
+    /// Cancels the job on drop and carries cooperative control signals.
+    cancel: CancelOnDrop,
     /// The channel to send the result to.
     payload: oneshot::Receiver<Result<BuildOutcome<P>, PayloadBuilderError>>,
 }
@@ -746,7 +750,7 @@ impl<P> PendingPayload<P> {
         cancel: CancelOnDrop,
         payload: oneshot::Receiver<Result<BuildOutcome<P>, PayloadBuilderError>>,
     ) -> Self {
-        Self { _cancel: cancel, payload }
+        Self { cancel, payload }
     }
 }
 

--- a/crates/revm/src/cancelled.rs
+++ b/crates/revm/src/cancelled.rs
@@ -1,26 +1,42 @@
 use alloc::sync::Arc;
-use core::sync::atomic::AtomicBool;
+use core::sync::atomic::{AtomicBool, Ordering};
 
-/// A marker that can be used to cancel execution.
+/// Cancels execution on drop and supports cooperative finalization.
 ///
 /// If dropped, it will set the `cancelled` flag to true.
 ///
 /// This is most useful when a payload job needs to be cancelled.
 #[derive(Default, Clone, Debug)]
-pub struct CancelOnDrop(Arc<AtomicBool>);
+pub struct CancelOnDrop(Arc<ControlState>);
+
+#[derive(Default, Debug)]
+struct ControlState {
+    cancelled: AtomicBool,
+    finalization_requested: AtomicBool,
+}
 
 // === impl CancelOnDrop ===
 
 impl CancelOnDrop {
     /// Returns true if the job was cancelled.
     pub fn is_cancelled(&self) -> bool {
-        self.0.load(core::sync::atomic::Ordering::Relaxed)
+        self.0.cancelled.load(Ordering::Relaxed)
+    }
+
+    /// Requests that the current work be finalized without cancelling it.
+    pub fn request_finalization(&self) {
+        self.0.finalization_requested.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns true if finalization was requested.
+    pub fn is_finalization_requested(&self) -> bool {
+        self.0.finalization_requested.load(Ordering::Relaxed)
     }
 }
 
 impl Drop for CancelOnDrop {
     fn drop(&mut self) {
-        self.0.store(true, core::sync::atomic::Ordering::Relaxed);
+        self.0.cancelled.store(true, Ordering::Relaxed);
     }
 }
 
@@ -143,5 +159,20 @@ mod tests {
         assert!(cancel.is_cancelled());
         assert!(clone2.is_cancelled());
         assert!(clone3.is_cancelled());
+    }
+
+    #[test]
+    fn test_cancel_on_drop_finalization_request() {
+        let cancel = CancelOnDrop::default();
+        let clone = cancel.clone();
+
+        cancel.request_finalization();
+
+        assert!(clone.is_finalization_requested());
+        assert!(!clone.is_cancelled());
+
+        drop(cancel);
+
+        assert!(clone.is_cancelled());
     }
 }

--- a/crates/revm/src/cancelled.rs
+++ b/crates/revm/src/cancelled.rs
@@ -1,8 +1,11 @@
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
+/// Payload building is still in progress.
 const RUNNING: u8 = 0;
+/// Payload building should stop accepting transactions and seal the accumulated work.
 const FINALIZATION_REQUESTED: u8 = 1;
+/// Payload building should stop and discard the accumulated work.
 const CANCELLED: u8 = 2;
 
 /// Cancels execution on drop and supports cooperative finalization.

--- a/crates/revm/src/cancelled.rs
+++ b/crates/revm/src/cancelled.rs
@@ -1,5 +1,9 @@
 use alloc::sync::Arc;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+const RUNNING: u8 = 0;
+const FINALIZATION_REQUESTED: u8 = 1;
+const CANCELLED: u8 = 2;
 
 /// Cancels execution on drop and supports cooperative finalization.
 ///
@@ -7,36 +11,40 @@ use core::sync::atomic::{AtomicBool, Ordering};
 ///
 /// This is most useful when a payload job needs to be cancelled.
 #[derive(Default, Clone, Debug)]
-pub struct CancelOnDrop(Arc<ControlState>);
-
-#[derive(Default, Debug)]
-struct ControlState {
-    cancelled: AtomicBool,
-    finalization_requested: AtomicBool,
-}
+pub struct CancelOnDrop(Arc<AtomicU8>);
 
 // === impl CancelOnDrop ===
 
 impl CancelOnDrop {
+    /// Returns true if the current work should be interrupted.
+    pub fn is_interrupted(&self) -> bool {
+        self.0.load(Ordering::Relaxed) != RUNNING
+    }
+
     /// Returns true if the job was cancelled.
     pub fn is_cancelled(&self) -> bool {
-        self.0.cancelled.load(Ordering::Relaxed)
+        self.0.load(Ordering::Relaxed) == CANCELLED
     }
 
     /// Requests that the current work be finalized without cancelling it.
     pub fn request_finalization(&self) {
-        self.0.finalization_requested.store(true, Ordering::Relaxed);
+        let _ = self.0.compare_exchange(
+            RUNNING,
+            FINALIZATION_REQUESTED,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
     }
 
     /// Returns true if finalization was requested.
     pub fn is_finalization_requested(&self) -> bool {
-        self.0.finalization_requested.load(Ordering::Relaxed)
+        self.0.load(Ordering::Relaxed) == FINALIZATION_REQUESTED
     }
 }
 
 impl Drop for CancelOnDrop {
     fn drop(&mut self) {
-        self.0.cancelled.store(true, Ordering::Relaxed);
+        self.0.store(CANCELLED, Ordering::Relaxed);
     }
 }
 
@@ -71,6 +79,7 @@ mod tests {
     #[test]
     fn test_default_cancelled() {
         let c = CancelOnDrop::default();
+        assert!(!c.is_interrupted());
         assert!(!c.is_cancelled());
     }
 
@@ -138,6 +147,7 @@ mod tests {
         drop(cancel);
 
         // The cloned instance should now see the cancelled flag as true
+        assert!(cloned_cancel.is_interrupted());
         assert!(cloned_cancel.is_cancelled());
     }
 
@@ -156,6 +166,7 @@ mod tests {
         // Drop one clone - this should cancel all instances
         drop(clone1);
 
+        assert!(cancel.is_interrupted());
         assert!(cancel.is_cancelled());
         assert!(clone2.is_cancelled());
         assert!(clone3.is_cancelled());
@@ -168,11 +179,18 @@ mod tests {
 
         cancel.request_finalization();
 
+        assert!(clone.is_interrupted());
         assert!(clone.is_finalization_requested());
         assert!(!clone.is_cancelled());
 
         drop(cancel);
 
         assert!(clone.is_cancelled());
+        assert!(!clone.is_finalization_requested());
+
+        clone.request_finalization();
+
+        assert!(clone.is_cancelled());
+        assert!(!clone.is_finalization_requested());
     }
 }


### PR DESCRIPTION
- Request cooperative finalization when a payload is resolved before its first build completes, allowing builders to seal accumulated work instead of discarding it.
- Preserve cancellation-on-drop semantics and existing builder behavior unless a builder observes the new signal.