### PR TITLE
feat(rpc): expose raw block transactions on auth server

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -16,7 +16,7 @@ use alloy_rpc_types_engine::{
     ForkchoiceUpdatedResponseV2, PayloadId, PayloadStatus, PayloadStatusV2,
 };
 use alloy_rpc_types_eth::{
-    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, SyncStatus,
+    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, Index, SyncStatus,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
@@ -429,6 +429,22 @@ pub trait EngineEthApi<TxReq: RpcObject, B: RpcObject, R: RpcObject, L: RpcObjec
     /// Returns all transaction receipts for a given block.
     #[method(name = "getBlockReceipts")]
     async fn block_receipts(&self, block_id: BlockId) -> RpcResult<Option<Vec<R>>>;
+
+    /// Returns the EIP-2718 encoded transaction by block hash and transaction index position.
+    #[method(name = "getRawTransactionByBlockHashAndIndex")]
+    async fn raw_transaction_by_block_hash_and_index(
+        &self,
+        hash: B256,
+        index: Index,
+    ) -> RpcResult<Option<Bytes>>;
+
+    /// Returns the EIP-2718 encoded transaction by block number and transaction index position.
+    #[method(name = "getRawTransactionByBlockNumberAndIndex")]
+    async fn raw_transaction_by_block_number_and_index(
+        &self,
+        number: BlockNumberOrTag,
+        index: Index,
+    ) -> RpcResult<Option<Bytes>>;
 
     /// Sends signed transaction, returning its hash.
     #[method(name = "sendRawTransaction")]

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -1,7 +1,7 @@
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
 use alloy_rpc_types_eth::{
-    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, SyncStatus,
+    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, Index, SyncStatus,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::core::RpcResult as Result;
@@ -120,6 +120,30 @@ where
         block_id: BlockId,
     ) -> Result<Option<Vec<RpcReceipt<Eth::NetworkTypes>>>> {
         self.eth.block_receipts(block_id).instrument(engine_span!()).await
+    }
+
+    /// Handler for: `eth_getRawTransactionByBlockHashAndIndex`
+    async fn raw_transaction_by_block_hash_and_index(
+        &self,
+        hash: B256,
+        index: Index,
+    ) -> Result<Option<Bytes>> {
+        self.eth
+            .raw_transaction_by_block_hash_and_index(hash, index)
+            .instrument(engine_span!())
+            .await
+    }
+
+    /// Handler for: `eth_getRawTransactionByBlockNumberAndIndex`
+    async fn raw_transaction_by_block_number_and_index(
+        &self,
+        number: BlockNumberOrTag,
+        index: Index,
+    ) -> Result<Option<Bytes>> {
+        self.eth
+            .raw_transaction_by_block_number_and_index(number, index)
+            .instrument(engine_span!())
+            .await
     }
 
     /// Handler for: `eth_sendRawTransaction`


### PR DESCRIPTION
Adds `eth_getRawTransactionByBlockHashAndIndex` and `eth_getRawTransactionByBlockNumberAndIndex` to `EngineEthApi`.

Authenticated engine clients can now retrieve EIP-2718 encoded transactions from blocks without enabling the public `eth` RPC server.
