### PR TITLE
fix(dev): canonicalize mined blocks immediately

### DIFF
--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -283,6 +283,8 @@ where
             self.last_block_hashes.pop_front();
         }
 
+        self.update_forkchoice_state().await?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Send a forkchoice update immediately after inserting a locally mined payload so the block becomes canonical without waiting for the next mining tick.