### PR TITLE
chore: bump versions to 2.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7654,7 +7654,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7704,7 +7704,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bb"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7777,7 +7777,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7931,7 +7931,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7940,7 +7940,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8012,7 +8012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8026,7 +8026,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8040,7 +8040,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8100,7 +8100,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8159,7 +8159,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8201,7 +8201,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8226,7 +8226,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8348,7 +8348,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8374,7 +8374,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8396,7 +8396,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8493,7 +8493,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8522,7 +8522,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8547,7 +8547,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8606,7 +8606,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8644,7 +8644,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8672,7 +8672,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8712,7 +8712,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "clap",
  "eyre",
@@ -8735,7 +8735,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8751,7 +8751,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.8",
@@ -8780,7 +8780,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8840,7 +8840,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8866,7 +8866,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8891,7 +8891,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8909,7 +8909,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8942,7 +8942,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8987,7 +8987,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9018,7 +9018,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9035,7 +9035,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -9044,7 +9044,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9075,7 +9075,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bytes",
  "futures",
@@ -9097,7 +9097,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -9114,7 +9114,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -9122,7 +9122,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "futures",
  "libc",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9143,7 +9143,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9157,7 +9157,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9250,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9291,7 +9291,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9322,7 +9322,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9345,7 +9345,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9416,7 +9416,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9472,7 +9472,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9541,7 +9541,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9564,7 +9564,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9587,7 +9587,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bytes",
  "eyre",
@@ -9616,7 +9616,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9627,7 +9627,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9650,7 +9650,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9661,7 +9661,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9685,7 +9685,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9694,7 +9694,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9736,7 +9736,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9790,7 +9790,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9841,7 +9841,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9857,7 +9857,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9937,7 +9937,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9967,7 +9967,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10025,7 +10025,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10045,7 +10045,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10065,7 +10065,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10101,7 +10101,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10147,7 +10147,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10199,7 +10199,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-rpc-types-engine",
  "brotli",
@@ -10219,7 +10219,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10249,7 +10249,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10312,7 +10312,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10346,7 +10346,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10362,7 +10362,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10385,7 +10385,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10403,7 +10403,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10430,7 +10430,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10446,7 +10446,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10475,7 +10475,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10504,7 +10504,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10524,7 +10524,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10540,7 +10540,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10549,7 +10549,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "clap",
  "eyre",
@@ -10568,7 +10568,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10586,7 +10586,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10637,7 +10637,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10669,7 +10669,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10701,7 +10701,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10728,7 +10728,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10756,7 +10756,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.5.0"
+version = "2.5.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     { text: 'Rustdocs', link: '/docs' },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v2.5.0',
+      text: 'v2.5.1',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Bumps workspace crate versions and the docs version selector from 2.5.0 to 2.5.1, matching the 2.5.1 release.

Validated with `cargo +nightly fmt --all --check` and locked/offline Cargo metadata resolution.

Prompted by: @emmajam