### PR TITLE
feat(storage): configure historical state root warning threshold

### DIFF
--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -95,6 +95,9 @@ impl EngineNodeLauncher {
         // Create the overlay manager that will be shared across the provider and engine.
         let overlay_manager = OverlayManager::<N::Primitives>::new(
             ctx.task_executor.state_trie_overlay_worker_pool(),
+        )
+        .with_historical_state_root_warning_threshold(
+            config.storage.historical_state_root_warning_threshold,
         );
         let disabled_stages = N::disabled_stages();
 

--- a/crates/node/core/src/args/storage.rs
+++ b/crates/node/core/src/args/storage.rs
@@ -1,5 +1,6 @@
 //! clap [Args](clap::Args) for storage configuration
 
+use alloy_eips::merge::EPOCH_SLOTS;
 use clap::Args;
 use std::sync::OnceLock;
 
@@ -12,6 +13,7 @@ static STORAGE_DEFAULTS: OnceLock<DefaultStorageValues> = OnceLock::new();
 #[derive(Debug, Clone)]
 pub struct DefaultStorageValues {
     v2: bool,
+    historical_state_root_warning_threshold: u64,
 }
 
 impl DefaultStorageValues {
@@ -30,11 +32,17 @@ impl DefaultStorageValues {
         self.v2 = v;
         self
     }
+
+    /// Set the historical state root warning threshold.
+    pub const fn with_historical_state_root_warning_threshold(mut self, threshold: u64) -> Self {
+        self.historical_state_root_warning_threshold = threshold;
+        self
+    }
 }
 
 impl Default for DefaultStorageValues {
     fn default() -> Self {
-        Self { v2: true }
+        Self { v2: true, historical_state_root_warning_threshold: EPOCH_SLOTS }
     }
 }
 
@@ -59,12 +67,25 @@ pub struct StorageArgs {
         default_missing_value = "true",
     )]
     pub v2: bool,
+
+    /// Number of blocks into the past after which historical state root calculation emits an OOM
+    /// warning.
+    #[arg(
+        long = "storage.historical-state-root-warning-threshold",
+        value_name = "BLOCKS",
+        default_value_t = DefaultStorageValues::get_global().historical_state_root_warning_threshold,
+    )]
+    pub historical_state_root_warning_threshold: u64,
 }
 
 impl Default for StorageArgs {
     fn default() -> Self {
         let defaults = DefaultStorageValues::get_global();
-        Self { v2: defaults.v2 }
+        Self {
+            v2: defaults.v2,
+            historical_state_root_warning_threshold: defaults
+                .historical_state_root_warning_threshold,
+        }
     }
 }
 
@@ -84,6 +105,7 @@ mod tests {
     fn test_default_storage_args() {
         let args = CommandParser::<StorageArgs>::parse_from(["reth"]).args;
         assert!(args.v2);
+        assert_eq!(args.historical_state_root_warning_threshold, EPOCH_SLOTS);
     }
 
     #[test]
@@ -102,5 +124,16 @@ mod tests {
     fn test_storage_v2_explicit_false() {
         let args = CommandParser::<StorageArgs>::parse_from(["reth", "--storage.v2=false"]).args;
         assert!(!args.v2);
+    }
+
+    #[test]
+    fn test_historical_state_root_warning_threshold() {
+        let args = CommandParser::<StorageArgs>::parse_from([
+            "reth",
+            "--storage.historical-state-root-warning-threshold",
+            "128",
+        ])
+        .args;
+        assert_eq!(args.historical_state_root_warning_threshold, 128);
     }
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -2,7 +2,6 @@ use crate::{
     AccountReader, BlockHashReader, ChangeSetReader, EitherReader, HashedPostStateProvider,
     ProviderError, RocksDBProviderFactory, StateProvider, StateRootProvider,
 };
-use alloy_eips::merge::EPOCH_SLOTS;
 use alloy_primitives::{Address, BlockNumber, Bytes, StorageKey, StorageValue, B256};
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
@@ -281,7 +280,9 @@ where
         Provider:
             BlockHashReader + PruneCheckpointReader + StageCheckpointReader + StorageSettingsCache,
     {
-        if self.check_distance_against_limit(EPOCH_SLOTS)? {
+        if self.check_distance_against_limit(
+            self.overlay_manager.historical_state_root_warning_threshold(),
+        )? {
             tracing::warn!(
                 target: "providers::historical_sp",
                 target = self.block_number,

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -8,7 +8,7 @@ use crate::{
     changeset_cache::compute_block_trie_updates, database_state_frontiers, ChangesetCache,
     OverlayBuilder,
 };
-use alloy_eips::BlockNumHash;
+use alloy_eips::{merge::EPOCH_SLOTS, BlockNumHash};
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
@@ -49,6 +49,7 @@ pub struct OverlayManager<N: NodePrimitives = EthPrimitives> {
     preserved_sparse_trie: Arc<Mutex<Option<PreservedSparseTrie>>>,
     #[cfg(feature = "rayon")]
     worker_pool: Option<Arc<WorkerPool>>,
+    historical_state_root_warning_threshold: u64,
     metrics: StateTrieOverlayMetrics,
 }
 
@@ -73,6 +74,7 @@ impl<N: NodePrimitives> Default for OverlayManager<N> {
             preserved_sparse_trie: Default::default(),
             #[cfg(feature = "rayon")]
             worker_pool: None,
+            historical_state_root_warning_threshold: EPOCH_SLOTS,
             metrics: Default::default(),
         }
     }
@@ -97,8 +99,22 @@ impl<N: NodePrimitives> OverlayManager<N> {
             changeset_cache: Default::default(),
             preserved_sparse_trie: Default::default(),
             worker_pool: Some(worker_pool),
+            historical_state_root_warning_threshold: EPOCH_SLOTS,
             metrics: Default::default(),
         }
+    }
+
+    /// Sets the distance from the tip after which historical state root calculation emits an OOM
+    /// warning.
+    pub const fn with_historical_state_root_warning_threshold(mut self, threshold: u64) -> Self {
+        self.historical_state_root_warning_threshold = threshold;
+        self
+    }
+
+    /// Returns the distance from the tip after which historical state root calculation emits an
+    /// OOM warning.
+    pub const fn historical_state_root_warning_threshold(&self) -> u64 {
+        self.historical_state_root_warning_threshold
     }
 
     /// Creates an overlay builder for `parent_hash`.

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -152,6 +152,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
   -u, --url <URL>
           Specify a snapshot URL or let the command propose a default one.
 

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
       --file-type <FILE_TYPE>
           The ERA file format to export: `era1` writes `.era1` files, `ere` writes `.ere` files.
 

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
       --path <IMPORT_ERA_PATH>
           The path to a directory for import.
 

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
       --no-state
           Disables stages that require state.
 

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
       --without-evm
           Specifies whether to initialize the state without relying on EVM historical data.
 

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1183,6 +1183,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
 JIT:
       --jit
           Enable JIT compilation of EVM bytecode

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
 Metrics:
       --metrics <PROMETHEUS>
           Enable Prometheus metrics.

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
       --from <FROM>
           The height to start at
 

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
   <STAGE>
           Possible values:
           - headers:         The headers stage within the pipeline

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -138,6 +138,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
 Logging:
       --log.stdout.format <FORMAT>
           The format to use for logs written to stdout

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -131,6 +131,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
       --metrics <SOCKET>
           Enable Prometheus metrics.
 

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -136,6 +136,11 @@ Storage:
           [default: true]
           [possible values: true, false]
 
+      --storage.historical-state-root-warning-threshold <BLOCKS>
+          Number of blocks into the past after which historical state root calculation emits an OOM warning
+
+          [default: 32]
+
       --offline
           If this is enabled, then all stages except headers, bodies, and sender recovery will be unwound
 


### PR DESCRIPTION
## Summary

Adds `--storage.historical-state-root-warning-threshold` to configure when historical state root calculation emits an OOM warning. The default remains one epoch (32 blocks), and the generated CLI reference is updated.