### PR TITLE
feat(node): testing node with persistent datadir

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -283,6 +283,33 @@ impl<DB, ChainSpec: EthChainSpec> NodeBuilder<DB, ChainSpec> {
 
         WithLaunchContext { builder: self.with_database(db), task_executor }
     }
+
+    /// Creates a preconfigured test node whose datadir is preserved when the node is dropped.
+    ///
+    /// The caller owns cleanup of `datadir`. This is useful for tests that stop a node and launch
+    /// a new instance against the same database and static files.
+    #[cfg(feature = "test-utils")]
+    pub fn testing_node_with_persistent_datadir(
+        mut self,
+        task_executor: TaskExecutor,
+        datadir: impl Into<std::path::PathBuf>,
+    ) -> WithLaunchContext<NodeBuilder<Arc<reth_db::DatabaseEnv>, ChainSpec>> {
+        let path = reth_node_core::dirs::MaybePlatformPath::<DataDirPath>::from(datadir.into());
+        self.config = self.config.with_datadir_args(reth_node_core::args::DatadirArgs {
+            datadir: path.clone(),
+            ..Default::default()
+        });
+
+        let data_dir =
+            path.unwrap_or_chain_default(self.config.chain.chain(), self.config.datadir.clone());
+        let db_path = data_dir.data_dir().join("db");
+        let db = reth_db::init_db(&db_path, reth_db::mdbx::DatabaseArguments::test())
+            .unwrap_or_else(|error| {
+                panic!("could not create test database at {db_path:?}: {error}")
+            });
+
+        WithLaunchContext { builder: self.with_database(Arc::new(db)), task_executor }
+    }
 }
 
 impl<DB, ChainSpec> NodeBuilder<DB, ChainSpec>
@@ -1040,5 +1067,31 @@ impl<Node: FullNodeTypes> std::fmt::Debug for BuilderContext<Node> {
             .field("executor", &self.executor)
             .field("config", &self.config())
             .finish()
+    }
+}
+
+#[cfg(all(test, feature = "test-utils"))]
+mod tests {
+    use super::*;
+    use reth_chainspec::ChainSpec;
+    use reth_tasks::Runtime;
+
+    #[test]
+    fn persistent_test_datadir_can_be_reopened() {
+        let root = tempfile::tempdir().unwrap();
+        let datadir = root.path().join("node");
+        let runtime = Runtime::test();
+
+        let config = || NodeConfig::new(Arc::new(ChainSpec::<alloy_consensus::Header>::default()));
+        let first = NodeBuilder::new(config())
+            .testing_node_with_persistent_datadir(runtime.clone(), datadir.clone());
+        assert!(datadir.join("db").exists());
+        drop(first);
+        assert!(datadir.join("db").exists());
+
+        let reopened = NodeBuilder::new(config())
+            .testing_node_with_persistent_datadir(runtime, datadir.clone());
+        drop(reopened);
+        assert!(datadir.join("db").exists());
     }
 }


### PR DESCRIPTION
This is useful for tests that stop a node and launch a new instance against the same database and static files.