### PR TITLE
feat(cli): return snapshot manifest after download

### DIFF
--- a/crates/cli/commands/src/download/config_gen.rs
+++ b/crates/cli/commands/src/download/config_gen.rs
@@ -294,6 +294,7 @@ mod tests {
             base_url: None,
             reth_version: None,
             components: BTreeMap::new(),
+            extensions: BTreeMap::new(),
         }
     }
 

--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -52,6 +52,9 @@ pub struct SnapshotManifest {
     pub reth_version: Option<String>,
     /// Available snapshot components.
     pub components: BTreeMap<String, ComponentManifest>,
+    /// Additional top-level fields supplied by downstream snapshot formats.
+    #[serde(flatten)]
+    pub extensions: BTreeMap<String, serde_json::Value>,
 }
 
 /// Manifest entry for a single snapshot component.
@@ -728,6 +731,7 @@ pub fn generate_manifest(
         base_url: base_url.map(str::to_owned),
         reth_version: Some(reth_node_core::version::version_metadata().short_version.to_string()),
         components,
+        extensions: BTreeMap::new(),
     })
 }
 
@@ -1015,7 +1019,25 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn preserves_manifest_extensions() {
+        let value = serde_json::json!({
+            "block": 1,
+            "chain_id": 1,
+            "storage_version": 2,
+            "timestamp": 0,
+            "components": {},
+            "consensus": { "archive": "consensus.tar.zst" }
+        });
+
+        let manifest: SnapshotManifest = serde_json::from_value(value.clone()).unwrap();
+
+        assert_eq!(manifest.extensions.get("consensus"), value.get("consensus"));
+        assert_eq!(serde_json::to_value(manifest).unwrap(), value);
     }
 
     #[test]
@@ -1067,6 +1089,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
 
         let urls = m.archive_urls_for_distance(SnapshotComponentType::RocksdbIndices, Some(10));
@@ -1126,6 +1149,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         }
     }
 
@@ -1218,6 +1242,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
         let urls = m.archive_urls(SnapshotComponentType::StorageChangesets);
         assert_eq!(urls.len(), 49);
@@ -1299,6 +1324,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
 
         assert_eq!(manifest.output_size_for_distance(SnapshotComponentType::State, None), 1_000);
@@ -1360,6 +1386,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
 
         let state = m.snapshot_archives_for_distance(SnapshotComponentType::State, None);
@@ -1477,6 +1504,7 @@ mod tests {
             base_url: Some("https://example.com/mainnet".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
 
         let urls = m.archive_urls(SnapshotComponentType::Headers);
@@ -1560,6 +1588,7 @@ mod tests {
             base_url: Some("https://example.com/mainnet".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
 
         let ComponentManifest::Chunked(chunked) =

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -456,7 +456,10 @@ pub struct DownloadCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCommand<C> {
     /// Runs the download command in single-archive or manifest mode.
-    pub async fn execute<N>(self) -> Result<()> {
+    ///
+    /// Returns the loaded manifest after a successful modular download, or [`None`] when running
+    /// in snapshot-listing or legacy single-archive mode.
+    pub async fn execute<N>(self) -> Result<Option<SnapshotManifest>> {
         let chain = self.env.chain.chain();
         let chain_id = chain.id();
 
@@ -464,7 +467,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         if self.list {
             let entries = fetch_snapshot_api_entries(chain_id).await?;
             print_snapshot_listing(&entries, chain_id);
-            return Ok(());
+            return Ok(None);
         }
 
         let data_dir = self.env.datadir.clone().resolve_datadir(chain);
@@ -498,14 +501,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             .await?;
             info!(target: "reth::cli", "Snapshot downloaded and extracted successfully");
 
-            return Ok(());
+            return Ok(None);
         }
 
         let ResolvedDownload { manifest, selections, preset, planned } =
             self.resolve_download(chain_id).await?;
         if self.print_plan_json {
             DownloadPlan::from_planned(&manifest, &planned).write_json(std::io::stdout().lock())?;
-            return Ok(())
+            return Ok(Some(manifest))
         }
 
         let target_dir = data_dir.data_dir();
@@ -537,7 +540,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
 
         self.finalize_modular_download(&selections, &manifest, preset, target_dir, &data_dir.db())?;
 
-        Ok(())
+        Ok(Some(manifest))
     }
 
     /// Resolves the exact modular archive plan without downloading or modifying the data dir.
@@ -1089,6 +1092,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         }
     }
 

--- a/crates/cli/commands/src/download/planning.rs
+++ b/crates/cli/commands/src/download/planning.rs
@@ -418,6 +418,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
 
         let selections = BTreeMap::from([
@@ -494,6 +495,7 @@ mod tests {
             base_url: Some("https://example.com/mainnet".to_string()),
             reth_version: None,
             components,
+            extensions: BTreeMap::new(),
         };
         let selections =
             BTreeMap::from([(SnapshotComponentType::Transactions, ComponentSelection::All)]);

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -201,7 +201,8 @@ where
         Commands::Db(command) => {
             runner.run_blocking_command_until_exit(|ctx| command.execute::<N>(ctx))
         }
-        Commands::Download(command) => runner.run_blocking_until_ctrl_c(command.execute::<N>()),
+        Commands::Download(command) => runner
+            .run_blocking_until_ctrl_c(async move { command.execute::<N>().await.map(|_| ()) }),
         Commands::SnapshotManifest(command) => command.execute(),
         Commands::Stage(command) => {
             runner.run_command_until_exit(|ctx| command.execute::<N, _>(ctx, components))


### PR DESCRIPTION
Returns the parsed `SnapshotManifest` from successful modular download execution; snapshot listing and legacy single-archive modes return `None`. Unknown top-level fields are preserved so downstream commands can reuse manifest extensions without fetching the manifest again.

Prompted by: @SuperFluffy
