### PR TITLE
fix(rpc): stop cancelled blocking IO tasks

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -164,6 +164,9 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
         self.io_task_spawner().spawn_blocking_task(async move {
+            if tx.is_closed() {
+                return
+            }
             let res = f(this);
             let _ = tx.send(res);
         });
@@ -184,11 +187,18 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         F: FnOnce(Self) -> Fut + Send + 'static,
         R: Send + 'static,
     {
-        let (tx, rx) = oneshot::channel();
+        let (mut tx, rx) = oneshot::channel();
         let this = self.clone();
         self.io_task_spawner().spawn_blocking_task(async move {
-            let res = f(this).await;
-            let _ = tx.send(res);
+            let fut = f(this);
+            tokio::pin!(fut);
+            let res = tokio::select! {
+                res = &mut fut => Some(res),
+                _ = tx.closed() => None,
+            };
+            if let Some(res) = res {
+                let _ = tx.send(res);
+            }
         });
 
         async move { rx.await.map_err(|_| EthApiError::InternalEthError)? }

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -193,8 +193,10 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
             let fut = f(this);
             tokio::pin!(fut);
             let res = tokio::select! {
-                res = &mut fut => Some(res),
+                // Futures executed here may perform blocking work before their first yield.
+                biased;
                 _ = tx.closed() => None,
+                res = &mut fut => Some(res),
             };
             if let Some(res) = res {
                 let _ = tx.send(res);

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -658,12 +658,18 @@ where
             return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter))
         }
 
-        let (tx, rx) = oneshot::channel();
+        let (mut tx, rx) = oneshot::channel();
         let this = self.clone();
         self.task_spawner.spawn_blocking_task(async move {
-            let res =
-                this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits).await;
-            let _ = tx.send(res);
+            let fut = this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits);
+            tokio::pin!(fut);
+            let res = tokio::select! {
+                res = &mut fut => Some(res),
+                _ = tx.closed() => None,
+            };
+            if let Some(res) = res {
+                let _ = tx.send(res);
+            }
         });
 
         rx.await.map_err(|_| EthFilterError::InternalError)?

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -664,8 +664,10 @@ where
             let fut = this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits);
             tokio::pin!(fut);
             let res = tokio::select! {
-                res = &mut fut => Some(res),
+                // Range scans perform blocking reads before their first yield.
+                biased;
                 _ = tx.closed() => None,
+                res = &mut fut => Some(res),
             };
             if let Some(res) = res {
                 let _ = tx.send(res);


### PR DESCRIPTION
Related to #26531. Same approach as #26546, applied to the eth-API blocking IO path.

Stops eth-API blocking IO tasks once their response receiver has closed. These run as `TaskKind::Blocking`, so each holds a blocking-executor thread for the entire lifetime of the future; previously a task whose caller had already gone away kept that thread until the work finished, including while parked awaiting the state cache. `spawn_blocking_io` takes a synchronous closure with no await point, so it only checks `is_closed()` before starting.
