### PR TITLE
feat(download): expose prepared snapshot context

### DIFF
--- a/crates/cli/commands/src/download/config_gen.rs
+++ b/crates/cli/commands/src/download/config_gen.rs
@@ -294,6 +294,7 @@ mod tests {
             base_url: None,
             reth_version: None,
             components: BTreeMap::new(),
+            extensions: Default::default(),
         }
     }
 

--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -52,6 +52,12 @@ pub struct SnapshotManifest {
     pub reth_version: Option<String>,
     /// Available snapshot components.
     pub components: BTreeMap<String, ComponentManifest>,
+    /// Chain-specific manifest fields not interpreted by Reth.
+    ///
+    /// Extensions are retained so downstream commands can consume snapshot metadata without
+    /// refetching or reparsing the manifest selected by Reth.
+    #[serde(default, flatten)]
+    pub extensions: BTreeMap<String, serde_json::Value>,
 }
 
 /// Manifest entry for a single snapshot component.
@@ -728,6 +734,7 @@ pub fn generate_manifest(
         base_url: base_url.map(str::to_owned),
         reth_version: Some(reth_node_core::version::version_metadata().short_version.to_string()),
         components,
+        extensions: Default::default(),
     })
 }
 
@@ -1015,7 +1022,28 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         }
+    }
+
+    #[test]
+    fn manifest_preserves_extensions() {
+        let manifest: SnapshotManifest = serde_json::from_str(
+            r#"{
+                "block": 1,
+                "chain_id": 1,
+                "storage_version": 2,
+                "timestamp": 0,
+                "components": {},
+                "consensus": { "archive": "consensus.tar.zst" }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            manifest.extensions.get("consensus"),
+            Some(&serde_json::json!({ "archive": "consensus.tar.zst" }))
+        );
     }
 
     #[test]
@@ -1067,6 +1095,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
 
         let urls = m.archive_urls_for_distance(SnapshotComponentType::RocksdbIndices, Some(10));
@@ -1126,6 +1155,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         }
     }
 
@@ -1218,6 +1248,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
         let urls = m.archive_urls(SnapshotComponentType::StorageChangesets);
         assert_eq!(urls.len(), 49);
@@ -1299,6 +1330,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
 
         assert_eq!(manifest.output_size_for_distance(SnapshotComponentType::State, None), 1_000);
@@ -1360,6 +1392,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
 
         let state = m.snapshot_archives_for_distance(SnapshotComponentType::State, None);
@@ -1477,6 +1510,7 @@ mod tests {
             base_url: Some("https://example.com/mainnet".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
 
         let urls = m.archive_urls(SnapshotComponentType::Headers);
@@ -1560,6 +1594,7 @@ mod tests {
             base_url: Some("https://example.com/mainnet".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
 
         let ComponentManifest::Chunked(chunked) =

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -456,24 +456,21 @@ pub struct DownloadCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCommand<C> {
     /// Runs the download command in single-archive or manifest mode.
-    pub async fn execute<N>(self) -> Result<()> {
+    pub async fn execute<N>(self) -> Result<Option<PreparedSnapshotDownload>> {
         let chain = self.env.chain.chain();
-        let chain_id = chain.id();
 
         // --list: print available snapshots and exit
         if self.list {
-            let entries = fetch_snapshot_api_entries(chain_id).await?;
-            print_snapshot_listing(&entries, chain_id);
-            return Ok(());
+            let entries = fetch_snapshot_api_entries(chain.id()).await?;
+            print_snapshot_listing(&entries, chain.id());
+            return Ok(None);
         }
-
-        let data_dir = self.env.datadir.clone().resolve_datadir(chain);
-
-        let cancel_token = CancellationToken::new();
-        let _cancel_guard = cancel_token.drop_guard();
 
         // Legacy single-URL mode: download one archive and extract it
         if let Some(ref url) = self.url {
+            let cancel_token = CancellationToken::new();
+            let _cancel_guard = cancel_token.drop_guard();
+            let data_dir = self.env.datadir.clone().resolve_datadir(chain);
             let target_dir = data_dir.data_dir();
             if self.force {
                 clear_existing_datadir(target_dir)?;
@@ -498,17 +495,22 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             .await?;
             info!(target: "reth::cli", "Snapshot downloaded and extracted successfully");
 
-            return Ok(());
+            return Ok(None);
         }
 
         let ResolvedDownload { manifest, selections, preset, planned } =
-            self.resolve_download(chain_id).await?;
+            self.resolve_download(chain.id()).await?;
+        let data_dir = self.env.datadir.clone().resolve_datadir(chain).data_dir().to_path_buf();
+        let prepared = PreparedSnapshotDownload { manifest, data_dir };
         if self.print_plan_json {
-            DownloadPlan::from_planned(&manifest, &planned).write_json(std::io::stdout().lock())?;
-            return Ok(())
+            DownloadPlan::from_planned(&prepared.manifest, &planned)
+                .write_json(std::io::stdout().lock())?;
+            return Ok(Some(prepared))
         }
 
-        let target_dir = data_dir.data_dir();
+        let target_dir = prepared.data_dir.as_path();
+        let cancel_token = CancellationToken::new();
+        let _cancel_guard = cancel_token.drop_guard();
         if self.force {
             clear_existing_datadir(target_dir)?;
         }
@@ -535,16 +537,28 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         )
         .await?;
 
-        self.finalize_modular_download(&selections, &manifest, preset, target_dir, &data_dir.db())?;
+        self.finalize_modular_download(
+            &selections,
+            &prepared.manifest,
+            preset,
+            target_dir,
+            &target_dir.join("db"),
+        )?;
 
-        Ok(())
+        Ok(Some(prepared))
     }
 
-    /// Resolves the exact modular archive plan without downloading or modifying the data dir.
-    pub async fn plan(&self) -> Result<DownloadPlan> {
-        let chain_id = self.env.chain.chain().id();
-        let resolved = self.resolve_download(chain_id).await?;
-        Ok(DownloadPlan::from_planned(&resolved.manifest, &resolved.planned))
+    /// Resolves the exact modular archive plan and manifest context without downloading or
+    /// modifying the data dir.
+    pub async fn plan(&self) -> Result<(DownloadPlan, PreparedSnapshotDownload)> {
+        let chain = self.env.chain.chain();
+        let resolved = self.resolve_download(chain.id()).await?;
+        let plan = DownloadPlan::from_planned(&resolved.manifest, &resolved.planned);
+        let prepared = PreparedSnapshotDownload {
+            manifest: resolved.manifest,
+            data_dir: self.env.datadir.clone().resolve_datadir(chain).data_dir().to_path_buf(),
+        };
+        Ok((plan, prepared))
     }
 
     async fn resolve_download(&self, chain_id: u64) -> Result<ResolvedDownload> {
@@ -1034,6 +1048,15 @@ impl<C: ChainSpecParser> DownloadCommand<C> {
     }
 }
 
+/// A modular snapshot download after manifest and data-directory resolution.
+#[derive(Debug)]
+pub struct PreparedSnapshotDownload {
+    /// Manifest selected by the command, with a normalized `base_url`.
+    pub manifest: SnapshotManifest,
+    /// Chain-resolved directory where Reth installs the snapshot.
+    pub data_dir: PathBuf,
+}
+
 struct ResolvedDownload {
     manifest: SnapshotManifest,
     selections: BTreeMap<SnapshotComponentType, ComponentSelection>,
@@ -1089,6 +1112,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         }
     }
 

--- a/crates/cli/commands/src/download/planning.rs
+++ b/crates/cli/commands/src/download/planning.rs
@@ -418,6 +418,7 @@ mod tests {
             base_url: Some("https://example.com".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
 
         let selections = BTreeMap::from([
@@ -494,6 +495,7 @@ mod tests {
             base_url: Some("https://example.com/mainnet".to_string()),
             reth_version: None,
             components,
+            extensions: Default::default(),
         };
         let selections =
             BTreeMap::from([(SnapshotComponentType::Transactions, ComponentSelection::All)]);

--- a/crates/ethereum/cli/src/app.rs
+++ b/crates/ethereum/cli/src/app.rs
@@ -201,7 +201,8 @@ where
         Commands::Db(command) => {
             runner.run_blocking_command_until_exit(|ctx| command.execute::<N>(ctx))
         }
-        Commands::Download(command) => runner.run_blocking_until_ctrl_c(command.execute::<N>()),
+        Commands::Download(command) => runner
+            .run_blocking_until_ctrl_c(async move { command.execute::<N>().await.map(|_| ()) }),
         Commands::SnapshotManifest(command) => command.execute(),
         Commands::Stage(command) => {
             runner.run_command_until_exit(|ctx| command.execute::<N, _>(ctx, components))


### PR DESCRIPTION
Preserves chain-specific manifest extensions and returns the resolved manifest plus chain-specific data directory from modular snapshot downloads. This lets downstream node commands consume extension archives without duplicating manifest resolution.