### PR TITLE
fix(rpc): refactor rpc blocking task model to avoid rpc stuck

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -152,11 +152,10 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         guard.clone().acquire_many_owned(permits_to_acquire)
     }
 
-    /// Executes `f` on the blocking pool.
+    /// Executes the future on a new blocking task.
     ///
-    /// `f` must be self-contained and must not depend on other queued work.
-    ///
-    /// For CPU-bound work use [`spawn_tracing`](Self::spawn_tracing).
+    /// Note: This is expected for futures that are dominated by blocking IO operations, for tracing
+    /// or CPU bound operations in general use [`spawn_tracing`](Self::spawn_tracing).
     fn spawn_blocking_io<F, R>(&self, f: F) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
         F: FnOnce(Self) -> Result<R, Self::Error> + Send + 'static,
@@ -165,7 +164,6 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
         self.io_task_spawner().spawn_blocking_task(async move {
-            // the caller is already gone, so the result has nowhere to go
             if tx.is_closed() {
                 return
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -152,10 +152,11 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         guard.clone().acquire_many_owned(permits_to_acquire)
     }
 
-    /// Executes the future on a new blocking task.
+    /// Executes `f` on the blocking pool.
     ///
-    /// Note: This is expected for futures that are dominated by blocking IO operations, for tracing
-    /// or CPU bound operations in general use [`spawn_tracing`](Self::spawn_tracing).
+    /// `f` must be self-contained and must not depend on other queued work.
+    ///
+    /// For CPU-bound work use [`spawn_tracing`](Self::spawn_tracing).
     fn spawn_blocking_io<F, R>(&self, f: F) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
         F: FnOnce(Self) -> Result<R, Self::Error> + Send + 'static,
@@ -164,30 +165,11 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
         self.io_task_spawner().spawn_blocking_task(async move {
+            // the caller is already gone, so the result has nowhere to go
+            if tx.is_closed() {
+                return
+            }
             let res = f(this);
-            let _ = tx.send(res);
-        });
-
-        async move { rx.await.map_err(|_| EthApiError::InternalEthError)? }
-    }
-
-    /// Executes the future on a new blocking task.
-    ///
-    /// Note: This is expected for futures that are dominated by blocking IO operations, for tracing
-    /// or CPU bound operations in general use [`spawn_tracing`](Self::spawn_tracing).
-    fn spawn_blocking_io_fut<F, R, Fut>(
-        &self,
-        f: F,
-    ) -> impl Future<Output = Result<R, Self::Error>> + Send
-    where
-        Fut: Future<Output = Result<R, Self::Error>> + Send + 'static,
-        F: FnOnce(Self) -> Fut + Send + 'static,
-        R: Send + 'static,
-    {
-        let (tx, rx) = oneshot::channel();
-        let this = self.clone();
-        self.io_task_spawner().spawn_blocking_task(async move {
-            let res = f(this).await;
             let _ = tx.send(res);
         });
 

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -439,10 +439,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let block_id = block_number.unwrap_or_default();
             let (evm_env, at) = self.evm_env_at(block_id).await?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                this.create_access_list_with(evm_env, at, request, state_override).await
-            })
-            .await
+            self.create_access_list_with(evm_env, at, request, state_override).await
         }
     }
 
@@ -609,9 +606,7 @@ pub trait Call:
         F: FnOnce(Self, StateCacheDb) -> Result<R, Self::Error> + Send + 'static,
         R: Send + 'static,
     {
-        let at = at.into();
-        self.spawn_blocking_io_fut(async move |this| {
-            let state = this.state_at_block_id(at).await?;
+        self.spawn_with_state(Some(at.into()), move |this, state| {
             let db = State::builder()
                 .with_database(StateProviderDatabase::new(StateProviderTraitObjWrapper(state)))
                 .build();

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -606,7 +606,7 @@ pub trait Call:
         F: FnOnce(Self, StateCacheDb) -> Result<R, Self::Error> + Send + 'static,
         R: Send + 'static,
     {
-        self.spawn_with_state(Some(at.into()), move |this, state| {
+        self.spawn_blocking_with_state(Some(at.into()), move |this, state| {
             let db = State::builder()
                 .with_database(StateProviderDatabase::new(StateProviderTraitObjWrapper(state)))
                 .build();

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -316,8 +316,7 @@ pub trait EstimateCall: Call {
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id(at).await?;
+            self.spawn_with_state(Some(at), move |this, state| {
                 EstimateCall::estimate_gas_with(&this, evm_env, request, state, overrides)
             })
             .await

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -316,7 +316,7 @@ pub trait EstimateCall: Call {
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
 
-            self.spawn_with_state(Some(at), move |this, state| {
+            self.spawn_blocking_with_state(Some(at), move |this, state| {
                 EstimateCall::estimate_gas_with(&this, evm_env, request, state, overrides)
             })
             .await

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -77,10 +77,8 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(async move |this| {
-            Ok(this
-                .state_at_block_id_or_latest(block_id)
-                .await?
+        self.spawn_with_state(block_id, move |_, state| {
+            Ok(state
                 .account_balance(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default())
@@ -94,10 +92,9 @@ pub trait EthState: LoadState + SpawnBlocking {
         index: JsonStorageKey,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(async move |this| {
+        self.spawn_with_state(block_id, move |_, state| {
             Ok(B256::new(
-                this.state_at_block_id_or_latest(block_id)
-                    .await?
+                state
                     .storage(address, index.as_b256())
                     .map_err(Self::Error::from_eth_err)?
                     .unwrap_or_default()
@@ -130,9 +127,7 @@ pub trait EthState: LoadState + SpawnBlocking {
                 )));
             }
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id_or_latest(block_id).await?;
-
+            self.spawn_with_state(block_id, move |_, state| {
                 let mut result = HashMap::with_capacity(requests.len());
                 for (address, slots) in requests {
                     let mut values = Vec::with_capacity(slots.len());
@@ -175,8 +170,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id(block_id).await?;
+            self.spawn_with_state(Some(block_id), move |_, state| {
                 let storage_keys = keys.iter().map(|key| key.as_b256()).collect::<Vec<_>>();
                 let proof = state
                     .proof(Default::default(), address, &storage_keys)
@@ -209,8 +203,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id(block_id).await?;
+            self.spawn_with_state(Some(block_id), move |_, state| {
                 let mut proof_targets = MultiProofTargets::with_capacity(targets.len());
                 for (address, slots) in &targets {
                     proof_targets
@@ -252,8 +245,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         async move {
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id(block_id).await?;
+            self.spawn_with_state(Some(block_id), move |_, state| {
                 let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
                 let Some(account) = account else { return Ok(None) };
 
@@ -279,8 +271,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: BlockId,
     ) -> impl Future<Output = Result<AccountInfo, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(async move |this| {
-            let state = this.state_at_block_id(block_id).await?;
+        self.spawn_with_state(Some(block_id), move |_, state| {
             let account = state
                 .basic_account(&address)
                 .map_err(Self::Error::from_eth_err)?
@@ -361,6 +352,43 @@ pub trait LoadState:
             } else {
                 Ok(self.latest_state()?)
             }
+        }
+    }
+
+    /// Resolves the state for `block_id` (`None` meaning latest) and runs `f` with it on a
+    /// blocking task.
+    ///
+    /// Only the `pending` tag resolves on the calling async task, because that is the one branch
+    /// that awaits, and a task holding a blocking thread while it awaits can exhaust the blocking
+    /// pool. Every other tag is a synchronous provider read and is resolved inside `f`'s task,
+    /// which keeps it off the reactor and keeps the read transaction from outliving the read.
+    fn spawn_with_state<F, R>(
+        &self,
+        block_id: Option<BlockId>,
+        f: F,
+    ) -> impl Future<Output = Result<R, Self::Error>> + Send
+    where
+        Self: SpawnBlocking,
+        F: FnOnce(Self, StateProviderBox) -> Result<R, Self::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        async move {
+            let pending = match block_id {
+                Some(at) if at.is_pending() => self.local_pending_state().await.ok().flatten(),
+                _ => None,
+            };
+
+            self.spawn_blocking_io(move |this| {
+                let state = match (pending, block_id) {
+                    (Some(state), _) => state,
+                    (None, Some(at)) => {
+                        this.provider().state_by_block_id(at).map_err(Self::Error::from_eth_err)?
+                    }
+                    (None, None) => this.latest_state()?,
+                };
+                f(this, state)
+            })
+            .await
         }
     }
 
@@ -502,11 +530,9 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_blocking_io_fut(async move |this| {
+        self.spawn_with_state(block_id, move |this, state| {
             // first fetch the on chain nonce of the account
-            let on_chain_account_nonce = this
-                .state_at_block_id_or_latest(block_id)
-                .await?
+            let on_chain_account_nonce = state
                 .account_nonce(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default();
@@ -548,10 +574,8 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_blocking_io_fut(async move |this| {
-            Ok(this
-                .state_at_block_id_or_latest(block_id)
-                .await?
+        self.spawn_with_state(block_id, move |_, state| {
+            Ok(state
                 .account_code(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default()

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -77,7 +77,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
-        self.spawn_with_state(block_id, move |_, state| {
+        self.spawn_blocking_with_state(block_id, move |_, state| {
             Ok(state
                 .account_balance(&address)
                 .map_err(Self::Error::from_eth_err)?
@@ -92,7 +92,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         index: JsonStorageKey,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
-        self.spawn_with_state(block_id, move |_, state| {
+        self.spawn_blocking_with_state(block_id, move |_, state| {
             Ok(B256::new(
                 state
                     .storage(address, index.as_b256())
@@ -127,7 +127,7 @@ pub trait EthState: LoadState + SpawnBlocking {
                 )));
             }
 
-            self.spawn_with_state(block_id, move |_, state| {
+            self.spawn_blocking_with_state(block_id, move |_, state| {
                 let mut result = HashMap::with_capacity(requests.len());
                 for (address, slots) in requests {
                     let mut values = Vec::with_capacity(slots.len());
@@ -170,7 +170,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_with_state(Some(block_id), move |_, state| {
+            self.spawn_blocking_with_state(Some(block_id), move |_, state| {
                 let storage_keys = keys.iter().map(|key| key.as_b256()).collect::<Vec<_>>();
                 let proof = state
                     .proof(Default::default(), address, &storage_keys)
@@ -203,7 +203,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_with_state(Some(block_id), move |_, state| {
+            self.spawn_blocking_with_state(Some(block_id), move |_, state| {
                 let mut proof_targets = MultiProofTargets::with_capacity(targets.len());
                 for (address, slots) in &targets {
                     proof_targets
@@ -245,7 +245,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         async move {
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_with_state(Some(block_id), move |_, state| {
+            self.spawn_blocking_with_state(Some(block_id), move |_, state| {
                 let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
                 let Some(account) = account else { return Ok(None) };
 
@@ -271,7 +271,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: BlockId,
     ) -> impl Future<Output = Result<AccountInfo, Self::Error>> + Send {
-        self.spawn_with_state(Some(block_id), move |_, state| {
+        self.spawn_blocking_with_state(Some(block_id), move |_, state| {
             let account = state
                 .basic_account(&address)
                 .map_err(Self::Error::from_eth_err)?
@@ -362,7 +362,7 @@ pub trait LoadState:
     /// that awaits, and a task holding a blocking thread while it awaits can exhaust the blocking
     /// pool. Every other tag is a synchronous provider read and is resolved inside `f`'s task,
     /// which keeps it off the reactor and keeps the read transaction from outliving the read.
-    fn spawn_with_state<F, R>(
+    fn spawn_blocking_with_state<F, R>(
         &self,
         block_id: Option<BlockId>,
         f: F,
@@ -530,7 +530,7 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_with_state(block_id, move |this, state| {
+        self.spawn_blocking_with_state(block_id, move |this, state| {
             // first fetch the on chain nonce of the account
             let on_chain_account_nonce = state
                 .account_nonce(&address)
@@ -574,7 +574,7 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_with_state(block_id, move |_, state| {
+        self.spawn_blocking_with_state(block_id, move |_, state| {
             Ok(state
                 .account_code(&address)
                 .map_err(Self::Error::from_eth_err)?

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -371,6 +371,22 @@ impl<Provider> EthStateCacheService<Provider, Runtime>
 where
     Provider: BlockReader + BalProvider + Clone + Unpin + 'static,
 {
+    /// Waits for a rate-limit permit on the async runtime, then runs the read on the blocking
+    /// pool.
+    ///
+    /// This avoids holding a blocking thread while queued on the limiter.
+    fn spawn_rate_limited(&self, f: impl FnOnce() + Send + 'static) {
+        let executor = self.action_task_spawner.clone();
+        let rate_limiter = self.rate_limiter.clone();
+        self.action_task_spawner.spawn_task(async move {
+            let permit = rate_limiter.acquire_owned().await;
+            executor.spawn_blocking(move || {
+                let _permit = permit;
+                f();
+            });
+        });
+    }
+
     /// Indexes all transactions in a block by transaction hash.
     fn index_block_transactions(&mut self, block: &RecoveredBlock<Provider::Block>) {
         let block_hash = block.hash();
@@ -535,12 +551,9 @@ where
                             if this.full_block_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
-                                let rate_limiter = this.rate_limiter.clone();
                                 let mut action_sender =
                                     ActionSender::new(CacheKind::Block, block_hash, action_tx);
-                                this.action_task_spawner.spawn_blocking_task(async move {
-                                    // Acquire permit
-                                    let _permit = rate_limiter.acquire().await;
+                                this.spawn_rate_limited(move || {
                                     // Only look in the database to prevent situations where we
                                     // looking up the tree is blocking
                                     let block_sender = provider
@@ -564,12 +577,9 @@ where
                             if this.receipts_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
-                                let rate_limiter = this.rate_limiter.clone();
                                 let mut action_sender =
                                     ActionSender::new(CacheKind::Receipt, block_hash, action_tx);
-                                this.action_task_spawner.spawn_blocking_task(async move {
-                                    // Acquire permit
-                                    let _permit = rate_limiter.acquire().await;
+                                this.spawn_rate_limited(move || {
                                     let res = provider
                                         .receipts_by_block(block_hash.into())
                                         .map(|maybe_receipts| maybe_receipts.map(Arc::new));
@@ -596,12 +606,9 @@ where
                             if this.headers_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
-                                let rate_limiter = this.rate_limiter.clone();
                                 let mut action_sender =
                                     ActionSender::new(CacheKind::Header, block_hash, action_tx);
-                                this.action_task_spawner.spawn_blocking_task(async move {
-                                    // Acquire permit
-                                    let _permit = rate_limiter.acquire().await;
+                                this.spawn_rate_limited(move || {
                                     let header = provider.header(block_hash).and_then(|header| {
                                         header.ok_or_else(|| {
                                             ProviderError::HeaderNotFound(block_hash.into())
@@ -620,11 +627,9 @@ where
                             if this.bal_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
-                                let rate_limiter = this.rate_limiter.clone();
                                 let mut action_sender =
                                     ActionSender::new(CacheKind::Bal, block_hash, action_tx);
-                                this.action_task_spawner.spawn_blocking_task(async move {
-                                    let _permit = rate_limiter.acquire().await;
+                                this.spawn_rate_limited(move || {
                                     let res = provider.get_bal_by_hash(block_hash).and_then(
                                         |maybe_bal| {
                                             maybe_bal.map(CachedRevmBal::try_from_raw).transpose()

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -42,10 +42,10 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    sync::{mpsc::Receiver, oneshot, Mutex},
+    sync::{mpsc::Receiver, Mutex},
     time::MissedTickBehavior,
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 impl<Eth> EngineEthFilter<RpcLog<Eth::NetworkTypes>> for EthFilter<Eth>
 where
@@ -658,39 +658,95 @@ where
             return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter))
         }
 
-        let (tx, rx) = oneshot::channel();
-        let this = self.clone();
-        self.task_spawner.spawn_blocking_task(async move {
-            let res =
-                this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits).await;
-            let _ = tx.send(res);
-        });
+        let filter = Arc::new(filter);
+        let mut all_logs = Vec::new();
 
-        rx.await.map_err(|_| EthFilterError::InternalError)?
+        let chain_tip = self.provider().best_block_number()?;
+
+        // the bloom scan is synchronous, so it is offloaded
+        let matching_headers = {
+            let this = self.clone();
+            let filter = filter.clone();
+            offload(&self.task_spawner, move || {
+                this.scan_matching_headers(&filter, from_block, to_block)
+            })
+            .await?
+        };
+
+        // initialize the appropriate range mode based on collected headers
+        let mut range_mode = RangeMode::new(
+            self.clone(),
+            matching_headers,
+            from_block,
+            to_block,
+            self.max_headers_range,
+            chain_tip,
+        );
+
+        // iterate through the range mode to get receipts and blocks
+        while let Some(ReceiptBlockResult { receipts, recovered_block, header }) =
+            range_mode.next().await?
+        {
+            let num_hash = header.num_hash();
+            // Repeated once per matching block, and resolving tx hashes reads the db when the
+            // block is not in hand, so this is offloaded rather than run on the reactor.
+            let this = self.clone();
+            let filter = filter.clone();
+            all_logs = offload(&self.task_spawner, move || {
+                append_matching_block_logs(
+                    &mut all_logs,
+                    this.eth_api.converter(),
+                    recovered_block
+                        .map(ProviderOrBlock::Block)
+                        .unwrap_or_else(|| ProviderOrBlock::Provider(this.provider())),
+                    &filter,
+                    &header,
+                    &receipts,
+                    false,
+                )?;
+                Ok(all_logs)
+            })
+            .await?;
+
+            // size check but only if range is multiple blocks, so we always return all
+            // logs of a single block
+            let is_multi_block_range = from_block != to_block;
+            if let Some(max_logs_per_response) = limits.max_logs_per_response &&
+                is_multi_block_range &&
+                all_logs.len() > max_logs_per_response
+            {
+                let retry_to_block =
+                    if num_hash.number == from_block { from_block } else { num_hash.number - 1 };
+
+                debug!(
+                    target: "rpc::eth::filter",
+                    logs_found = all_logs.len(),
+                    max_logs_per_response,
+                    from_block,
+                    to_block = retry_to_block,
+                    "Query exceeded max logs per response limit"
+                );
+                return Err(EthFilterError::QueryExceedsMaxResults {
+                    max_logs: max_logs_per_response,
+                    from_block,
+                    to_block: retry_to_block,
+                });
+            }
+        }
+
+        Ok(all_logs)
     }
 
-    /// Returns all logs in the given _inclusive_ range that match the filter
+    /// Returns every header in the given _inclusive_ range whose bloom matches the filter.
     ///
-    /// Note: This function uses a mix of blocking db operations for fetching indices and header
-    /// ranges and utilizes the rpc cache for optimistically fetching receipts and blocks.
-    /// This function is considered blocking and should thus be spawned on a blocking task.
-    ///
-    /// Returns an error if:
-    ///  - underlying database error
-    async fn get_logs_in_block_range_inner(
-        self: Arc<Self>,
+    /// Fully synchronous; intended to be offloaded to the blocking pool.
+    fn scan_matching_headers(
+        &self,
         filter: &Filter,
         from_block: u64,
         to_block: u64,
-        limits: QueryLimits,
-    ) -> Result<Vec<RpcLog<Eth::NetworkTypes>>, EthFilterError> {
-        let mut all_logs = Vec::new();
+    ) -> Result<Vec<SealedHeader<<Eth::Provider as HeaderProvider>::Header>>, EthFilterError> {
         let mut matching_headers = Vec::new();
-
-        // get current chain tip to determine processing mode
-        let chain_tip = self.provider().best_block_number()?;
-
-        // first collect all headers that match the bloom filter for cached mode decision
         for (from, to) in
             BlockRangeInclusiveIter::new(from_block..=to_block, self.max_headers_range)
         {
@@ -720,60 +776,7 @@ where
             }
         }
 
-        // initialize the appropriate range mode based on collected headers
-        let mut range_mode = RangeMode::new(
-            self.clone(),
-            matching_headers,
-            from_block,
-            to_block,
-            self.max_headers_range,
-            chain_tip,
-        );
-
-        // iterate through the range mode to get receipts and blocks
-        while let Some(ReceiptBlockResult { receipts, recovered_block, header }) =
-            range_mode.next().await?
-        {
-            let num_hash = header.num_hash();
-            append_matching_block_logs(
-                &mut all_logs,
-                self.eth_api.converter(),
-                recovered_block
-                    .map(ProviderOrBlock::Block)
-                    .unwrap_or_else(|| ProviderOrBlock::Provider(self.provider())),
-                filter,
-                &header,
-                &receipts,
-                false,
-            )?;
-
-            // size check but only if range is multiple blocks, so we always return all
-            // logs of a single block
-            let is_multi_block_range = from_block != to_block;
-            if let Some(max_logs_per_response) = limits.max_logs_per_response &&
-                is_multi_block_range &&
-                all_logs.len() > max_logs_per_response
-            {
-                let retry_to_block =
-                    if num_hash.number == from_block { from_block } else { num_hash.number - 1 };
-
-                debug!(
-                    target: "rpc::eth::filter",
-                    logs_found = all_logs.len(),
-                    max_logs_per_response,
-                    from_block,
-                    to_block = retry_to_block,
-                    "Query exceeded max logs per response limit"
-                );
-                return Err(EthFilterError::QueryExceedsMaxResults {
-                    max_logs: max_logs_per_response,
-                    from_block,
-                    to_block: retry_to_block,
-                });
-            }
-        }
-
-        Ok(all_logs)
+        Ok(matching_headers)
     }
 }
 
@@ -1172,6 +1175,34 @@ impl<
     }
 }
 
+/// Runs `f` on the blocking pool.
+///
+/// `f` must be self-contained: a task that holds a blocking thread must never wait for another
+/// task, or the pool can deadlock with every thread parked on work that needs a thread.
+fn offload<F, R>(
+    spawner: &Runtime,
+    f: F,
+) -> impl Future<Output = Result<R, EthFilterError>> + Send + 'static
+where
+    F: FnOnce() -> Result<R, EthFilterError> + Send + 'static,
+    R: Send + 'static,
+{
+    // `Runtime::spawn_blocking` does not propagate the span the way `spawn_blocking_task` does.
+    let span = tracing::Span::current();
+    let handle = spawner.spawn_blocking(move || {
+        let _entered = span.enter();
+        f()
+    });
+
+    async move {
+        handle.await.map_err(|error| {
+            // a panic in the closure, or runtime shutdown while it was queued
+            warn!(target: "rpc::eth::filter", ?error, "Offloaded task did not complete");
+            EthFilterError::InternalError
+        })?
+    }
+}
+
 /// Type alias for parallel receipt fetching task futures used in `RangeBlockMode`
 type ReceiptFetchFuture<P> =
     Pin<Box<dyn Future<Output = Result<Vec<ReceiptBlockResult<P>>, EthFilterError>> + Send>>;
@@ -1278,8 +1309,14 @@ impl<
             let receipts = match maybe_receipts {
                 Some(receipts) => receipts,
                 None => {
-                    // Not cached - fetch directly from provider
-                    match self.filter_inner.provider().receipts_by_block(header.hash().into())? {
+                    // not cached - the provider read is synchronous, so it is offloaded
+                    let this = self.filter_inner.clone();
+                    let hash = header.hash();
+                    match offload(&self.filter_inner.task_spawner, move || {
+                        Ok(this.provider().receipts_by_block(hash.into())?)
+                    })
+                    .await?
+                    {
                         Some(receipts) => Arc::new(receipts),
                         None => continue, // No receipts found
                     }
@@ -1318,8 +1355,9 @@ impl<
         // Spawn each chunk as a separate task directly into the FuturesOrdered stream
         for chunk_headers in header_chunks {
             let filter_inner = self.filter_inner.clone();
-            let chunk_task = Box::pin(async move {
-                let chunk_task = tokio::task::spawn_blocking(move || {
+            self.pending_tasks.push_back(Box::pin(offload(
+                &self.filter_inner.task_spawner,
+                move || {
                     let mut chunk_results = Vec::with_capacity(chunk_headers.len());
 
                     for header in chunk_headers {
@@ -1343,20 +1381,8 @@ impl<
                     }
 
                     Ok(chunk_results)
-                });
-
-                // Await the blocking task and handle the result
-                match chunk_task.await {
-                    Ok(Ok(chunk_results)) => Ok(chunk_results),
-                    Ok(Err(e)) => Err(e),
-                    Err(join_err) => {
-                        trace!(target: "rpc::eth::filter", error = ?join_err, "Task join error");
-                        Err(EthFilterError::InternalError)
-                    }
-                }
-            });
-
-            self.pending_tasks.push_back(chunk_task);
+                },
+            )));
         }
     }
 }

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockId;
@@ -61,26 +61,29 @@ where
     Provider: BlockReaderIdExt + ChangeSetReader + StateProviderFactory + 'static,
     EvmConfig: Send + Sync + 'static,
 {
-    /// Executes the future on a new blocking task.
-    async fn on_blocking_task<C, F, R>(&self, c: C) -> EthResult<R>
+    /// Executes the closure on a new blocking task.
+    ///
+    /// `c` must be self-contained and must not depend on other queued work.
+    async fn on_blocking_task<C, R>(&self, c: C) -> EthResult<R>
     where
-        C: FnOnce(Self) -> F,
-        F: Future<Output = EthResult<R>> + Send + 'static,
+        C: FnOnce(Self) -> EthResult<R> + Send + 'static,
         R: Send + 'static,
     {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
-        let f = c(this);
         self.inner.task_spawner.spawn_blocking_task(async move {
-            let res = f.await;
-            let _ = tx.send(res);
+            // the caller is already gone, so the result has nowhere to go
+            if tx.is_closed() {
+                return
+            }
+            let _ = tx.send(c(this));
         });
         rx.await.map_err(|_| EthApiError::InternalEthError)?
     }
 
     /// Returns a map of addresses to changed account balanced for a particular block.
     pub async fn balance_changes_in_block(&self, block_id: BlockId) -> EthResult<AddressMap<U256>> {
-        self.on_blocking_task(async move |this| this.try_balance_changes_in_block(block_id)).await
+        self.on_blocking_task(move |this| this.try_balance_changes_in_block(block_id)).await
     }
 
     fn try_balance_changes_in_block(&self, block_id: BlockId) -> EthResult<AddressMap<U256>> {
@@ -138,7 +141,7 @@ where
             .acquire_owned()
             .await
             .map_err(|_| EthApiError::InternalEthError)?;
-        self.on_blocking_task(async move |this| {
+        self.on_blocking_task(move |this| {
             let _permit = permit;
             this.try_block_execution_outcome(block_id, block_count)
         })


### PR DESCRIPTION
Closes #26531

Tasks spawned as `TaskKind::Blocking` own a blocking thread for their whole lifetime, including across `.await`. Several state-serving RPC paths used that to await work which itself needs a blocking thread, so enough concurrent requests park every thread on work that can never be scheduled.

## The two chains

**1. `pending` state.** `spawn_blocking_io_fut` callers resolved state through `state_at_block_id`, which awaits in exactly one branch — `pending` (`state.rs:324`):

```
state_at_block_id(pending)
  -> local_pending_state()               pending_block.rs:111
  -> pool_pending_block()                pending_block.rs:134
  -> build_pool_pending_block()          pending_block.rs:158
       .pending_block().lock().await           # serialises all pending callers
       .spawn_blocking_io(build_block).await   # needs *another* blocking thread
```

N concurrent `pending` requests hold N blocking threads, all parked on an inner `spawn_blocking_io` that can never get one.

**2. `eth_getLogs`.** `get_logs_in_block_range` wrapped the whole range scan in `spawn_blocking_task` and then awaited `EthStateCache`. The cache service serves each miss with its own `spawn_blocking_task` that *first* awaits a rate-limiter permit, so the readers also sit on blocking threads while queued on the semaphore.

Local repro, `max_blocking_threads=4`, concurrent `eth_getLogs`:

| concurrency | before | after |
|---|---|---|
| 2 | 2/2 | 2/2 |
| 8 | **0/8** | 8/8 |
| 32 | **0/32** | 32/32 |

**`debug_trace*` is not affected.** Those go through `spawn_with_state_at_block(...)` with a concrete block hash (`debug.rs:124` etc.), never `pending`, so `state_at_block_id` never awaits there. They are converted along with everything else because they share the helper, and they inherit the cancellation behaviour.

## Changes

- new `LoadState::spawn_blocking_with_state`: resolves `pending` on the async task, every other tag inside the blocking task (synchronous provider read)
- `EthStateCacheService::spawn_rate_limited`: await the permit on the reactor, then take a blocking thread
- `eth_getLogs` becomes an async driver; only the bloom scan, receipt reads and log matching are offloaded
- `RethApi::on_blocking_task` narrowed to a synchronous closure

`spawn_blocking_io_fut` is kept as-is per review.

