### PR TITLE
fix(engine): honor cancellation in BAL prewarm and sparse trie task

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -5,7 +5,7 @@ use reth_provider::{
 };
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     thread::JoinHandle,
@@ -31,6 +31,7 @@ enum PrewarmMsg {
         build: Arc<BuildProviderFn>,
         caches: ExecutionCache,
         txpool_snapshot: Option<TxPoolPrewarmCacheSnapshot>,
+        cancelled: Arc<AtomicBool>,
     },
     /// Warm one target into the held provider's cache. Ignored if no provider is held.
     Warm(PrewarmTarget),
@@ -75,23 +76,29 @@ impl BalPrewarmPool {
         build: Arc<BuildProviderFn>,
         caches: ExecutionCache,
         txpool_snapshot: Option<TxPoolPrewarmCacheSnapshot>,
-    ) {
+        cancelled: Arc<AtomicBool>,
+    ) -> BalPrewarmBlock<'_> {
+        let mut started = true;
         for worker in &self.workers {
-            let _ = worker.send(PrewarmMsg::BeginBlock {
-                build: build.clone(),
-                caches: caches.clone(),
-                txpool_snapshot: txpool_snapshot.clone(),
-            });
+            started &= worker
+                .send(PrewarmMsg::BeginBlock {
+                    build: build.clone(),
+                    caches: caches.clone(),
+                    txpool_snapshot: txpool_snapshot.clone(),
+                    cancelled: cancelled.clone(),
+                })
+                .is_ok();
         }
+        BalPrewarmBlock { pool: self, cancelled, started, finished: false }
     }
 
     /// Fire-and-forget: warm an account (basic account + bytecode) on some worker.
-    pub(crate) fn warm_account(&self, addr: Address) {
+    fn warm_account(&self, addr: Address) {
         self.send_warm(PrewarmTarget::Account(addr));
     }
 
     /// Fire-and-forget: warm one storage slot on some worker.
-    pub(crate) fn warm_storage(&self, addr: Address, slot: StorageKey) {
+    fn warm_storage(&self, addr: Address, slot: StorageKey) {
         self.send_warm(PrewarmTarget::Storage(addr, slot));
     }
 
@@ -99,21 +106,61 @@ impl BalPrewarmPool {
     /// requests queued ahead of this message.
     ///
     /// Blocks until all workers processed the end block message.
-    pub(crate) fn end_block(&self) {
+    fn end_block(&self) -> bool {
         let (tx, rx) = oneshot::channel();
         let tx = Arc::new(SendOnDrop { sender: Some(tx) });
 
+        let mut sent = true;
         for worker in &self.workers {
-            let _ = worker.send(PrewarmMsg::EndBlock(tx.clone()));
+            sent &= worker.send(PrewarmMsg::EndBlock(tx.clone())).is_ok();
         }
 
         drop(tx);
-        rx.blocking_recv().expect("BAL prewarm pool dropped without signaling completion");
+        sent && rx.blocking_recv().is_ok()
     }
 
     fn send_warm(&self, target: PrewarmTarget) {
         let i = self.next.fetch_add(1, Ordering::Relaxed) % self.workers.len();
         let _ = self.workers[i].send(PrewarmMsg::Warm(target));
+    }
+}
+
+/// A BAL prewarm generation that closes every worker's provider when dropped.
+///
+/// Keeping the end marker in a guard prevents panics or early returns in the dispatcher from
+/// leaving read transactions pinned or mixing a later block with the current generation.
+pub(crate) struct BalPrewarmBlock<'a> {
+    pool: &'a BalPrewarmPool,
+    cancelled: Arc<AtomicBool>,
+    started: bool,
+    finished: bool,
+}
+
+impl BalPrewarmBlock<'_> {
+    /// Queues an account read in this generation.
+    pub(crate) fn warm_account(&self, addr: Address) {
+        self.pool.warm_account(addr);
+    }
+
+    /// Queues a storage read in this generation.
+    pub(crate) fn warm_storage(&self, addr: Address, slot: StorageKey) {
+        self.pool.warm_storage(addr, slot);
+    }
+
+    /// Ends this generation and returns whether every worker processed its end marker.
+    pub(crate) fn finish(mut self) -> bool {
+        self.finished = true;
+        let ended = self.pool.end_block();
+        self.started && ended
+    }
+}
+
+impl Drop for BalPrewarmBlock<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.cancelled.store(true, Ordering::Relaxed);
+            let _ = self.pool.end_block();
+        }
     }
 }
 
@@ -143,23 +190,37 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and
     // `EndBlock`. `None` while idle, so no read txn is pinned across the inter-block gap.
     let mut provider: Option<CachedStateProvider<StateProviderBox>> = None;
+    let mut cancelled: Option<Arc<AtomicBool>> = None;
 
     // Blocks when idle; the channel disconnects (and the loop ends) when the pool is dropped.
     while let Ok(msg) = rx.recv() {
         match msg {
-            PrewarmMsg::BeginBlock { build, caches, txpool_snapshot } => {
-                provider = match (build)() {
-                    Ok(inner) => Some(
-                        CachedStateProvider::new_prewarm(inner, caches)
-                            .with_txpool_snapshot(txpool_snapshot),
-                    ),
-                    Err(err) => {
-                        trace!(target: "engine::tree::bal_prewarm_pool", %err, "failed to build provider");
-                        None
+            PrewarmMsg::BeginBlock {
+                build,
+                caches,
+                txpool_snapshot,
+                cancelled: block_cancelled,
+            } => {
+                provider = if block_cancelled.load(Ordering::Relaxed) {
+                    None
+                } else {
+                    match (build)() {
+                        Ok(inner) => Some(
+                            CachedStateProvider::new_prewarm(inner, caches)
+                                .with_txpool_snapshot(txpool_snapshot),
+                        ),
+                        Err(err) => {
+                            trace!(target: "engine::tree::bal_prewarm_pool", %err, "failed to build provider");
+                            None
+                        }
                     }
                 };
+                cancelled = Some(block_cancelled);
             }
             PrewarmMsg::Warm(target) => {
+                if cancelled.as_ref().is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                    continue
+                }
                 let Some(provider) = provider.as_ref() else { continue };
                 match target {
                     PrewarmTarget::Account(addr) => {
@@ -177,6 +238,7 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
             }
             PrewarmMsg::EndBlock(end_tx) => {
                 provider = None;
+                cancelled = None;
                 drop(end_tx);
             }
         }
@@ -192,5 +254,42 @@ impl Drop for SendOnDrop {
         if let Some(sender) = self.sender.take() {
             let _ = sender.send(());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Address;
+    use reth_execution_cache::CachedStatus;
+    use reth_provider::test_utils::MockEthProvider;
+    use std::{convert::Infallible, time::Duration};
+
+    #[test]
+    fn cancellation_discards_queued_warm_reads() {
+        let pool = BalPrewarmPool::new(1);
+        let caches = ExecutionCache::new(1_000);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let address = Address::repeat_byte(0x11);
+        let (build_started_tx, build_started_rx) = crossbeam_channel::bounded(1);
+        let (release_build_tx, release_build_rx) = crossbeam_channel::bounded(0);
+        let provider = MockEthProvider::default();
+        provider.enable_database_provider();
+        let build = Arc::new(move || {
+            let _ = build_started_tx.send(());
+            let _ = release_build_rx.recv();
+            Ok(Box::new(provider.clone()) as StateProviderBox)
+        });
+
+        let block = pool.begin_block(build, caches.clone(), None, Arc::clone(&cancelled));
+        build_started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        block.warm_account(address);
+        cancelled.store(true, Ordering::Relaxed);
+        release_build_tx.send(()).unwrap();
+
+        assert!(block.finish());
+        let status =
+            caches.get_or_try_insert_account_with(address, || Ok::<_, Infallible>(None)).unwrap();
+        assert_eq!(status, CachedStatus::NotCached(None));
     }
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -370,6 +370,7 @@ where
         let saved_cache = self.disable_state_cache.not().then(|| self.cache_for(env.parent_hash));
 
         let executed_tx_index = Arc::new(AtomicUsize::new(0));
+        let cancelled = Arc::new(AtomicBool::new(false));
         // configure prewarming
         let prewarm_ctx = PrewarmContext {
             env,
@@ -381,7 +382,7 @@ where
             cache_metrics: self.cache_metrics.clone(),
             cache_state_metrics: self.cache_state_metrics.clone(),
             terminate_execution: Arc::new(AtomicBool::new(false)),
-            cancelled: Arc::new(AtomicBool::new(false)),
+            cancelled: Arc::clone(&cancelled),
             executed_tx_index: Arc::clone(&executed_tx_index),
             precompile_cache_disabled: self.precompile_cache_disabled,
             precompile_cache_map: self.precompile_cache_map.clone(),
@@ -402,6 +403,7 @@ where
             saved_cache,
             to_prewarm_task: Some(to_prewarm_task),
             executed_tx_index,
+            cancelled,
             cache_metrics: self.cache_metrics.clone(),
         }
     }
@@ -548,11 +550,12 @@ impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
     /// bundle state. Using `Arc<ExecutionOutcome>` allows sharing with the main execution
     /// path without cloning the expensive `BundleState`.
     ///
-    /// Returns a sender for the channel that should be notified on block validation success.
+    /// Returns a guard that should be notified on block validation success. Dropping it cancels
+    /// remaining BAL work for an abandoned block.
     pub fn terminate_caching(
         &mut self,
         execution_outcome: Option<Arc<BlockExecutionOutput<R>>>,
-    ) -> Option<mpsc::Sender<()>> {
+    ) -> Option<CacheValidationGuard> {
         self.prewarm_handle.terminate_caching(execution_outcome)
     }
 
@@ -580,6 +583,8 @@ pub struct CacheTaskHandle<R> {
     /// Shared counter tracking the next transaction index to be executed by the main execution
     /// loop. Prewarm workers skip transactions below this index.
     executed_tx_index: Arc<AtomicUsize>,
+    /// Shared cancellation state for BAL prefetching and hashed-state streaming.
+    cancelled: Arc<AtomicBool>,
     /// Metrics for the execution cache.
     cache_metrics: Option<CachedStateMetrics>,
 }
@@ -598,19 +603,47 @@ impl<R: Send + Sync + 'static> CacheTaskHandle<R> {
     ///
     /// If the [`BlockExecutionOutput`] is provided it will update the shared cache using its
     /// bundle state. Using `Arc<ExecutionOutcome>` avoids cloning the expensive `BundleState`.
-    #[must_use = "sender must be used and notified on block validation success"]
+    #[must_use = "guard must be notified on block validation success"]
     pub fn terminate_caching(
         &mut self,
         execution_outcome: Option<Arc<BlockExecutionOutput<R>>>,
-    ) -> Option<mpsc::Sender<()>> {
+    ) -> Option<CacheValidationGuard> {
         if let Some(tx) = self.to_prewarm_task.take() {
             let (valid_block_tx, valid_block_rx) = mpsc::channel();
             let event = PrewarmTaskEvent::Terminate { execution_outcome, valid_block_rx };
             let _ = tx.send(event);
 
-            Some(valid_block_tx)
+            Some(CacheValidationGuard {
+                valid_block_tx: Some(valid_block_tx),
+                cancelled: Arc::clone(&self.cancelled),
+            })
         } else {
             None
+        }
+    }
+}
+
+/// Keeps post-execution cancellation armed until a block passes every validation step.
+#[derive(Debug)]
+#[must_use = "dropping this guard marks the block's remaining prewarm work as cancelled"]
+pub struct CacheValidationGuard {
+    valid_block_tx: Option<mpsc::Sender<()>>,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl CacheValidationGuard {
+    /// Confirms that the block is valid and allows its warmed cache to be published.
+    pub fn notify_valid(mut self) {
+        if let Some(valid_block_tx) = self.valid_block_tx.take() {
+            let _ = valid_block_tx.send(());
+        }
+    }
+}
+
+impl Drop for CacheValidationGuard {
+    fn drop(&mut self) {
+        if self.valid_block_tx.is_some() {
+            self.cancelled.store(true, std::sync::atomic::Ordering::Relaxed);
         }
     }
 }
@@ -629,6 +662,7 @@ impl<R> Drop for CacheTaskHandle<R> {
 
 #[cfg(test)]
 mod tests {
+    use super::CacheValidationGuard;
     use crate::tree::{
         payload_processor::PayloadProcessor, precompile_cache::PrecompileCacheMap, ExecutionCache,
         PayloadExecutionCache, SavedCache, TreeConfig,
@@ -641,11 +675,44 @@ mod tests {
     use reth_execution_cache::CachedStatus;
     use reth_revm::db::BundleState;
     use revm::state::AccountInfo;
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    };
 
     fn make_saved_cache(hash: B256) -> SavedCache {
         let execution_cache = ExecutionCache::new(1_000);
         SavedCache::new(hash, execution_cache)
+    }
+
+    #[test]
+    fn validation_guard_cancels_until_notified() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let (valid_block_tx, valid_block_rx) = mpsc::channel();
+        let guard = CacheValidationGuard {
+            valid_block_tx: Some(valid_block_tx),
+            cancelled: Arc::clone(&cancelled),
+        };
+
+        drop(guard);
+
+        assert!(cancelled.load(Ordering::Relaxed));
+        assert!(valid_block_rx.recv().is_err());
+    }
+
+    #[test]
+    fn validation_guard_notification_disarms_cancellation() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let (valid_block_tx, valid_block_rx) = mpsc::channel();
+        let guard = CacheValidationGuard {
+            valid_block_tx: Some(valid_block_tx),
+            cancelled: Arc::clone(&cancelled),
+        };
+
+        guard.notify_valid();
+
+        assert!(!cancelled.load(Ordering::Relaxed));
+        assert_eq!(valid_block_rx.recv(), Ok(()));
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -381,6 +381,7 @@ where
             cache_metrics: self.cache_metrics.clone(),
             cache_state_metrics: self.cache_state_metrics.clone(),
             terminate_execution: Arc::new(AtomicBool::new(false)),
+            cancelled: Arc::new(AtomicBool::new(false)),
             executed_tx_index: Arc::clone(&executed_tx_index),
             precompile_cache_disabled: self.precompile_cache_disabled,
             precompile_cache_map: self.precompile_cache_map.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -27,7 +27,7 @@ use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, RecoveredTx,
 use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
-    AccountReader, BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory,
+    AccountReader, BlockExecutionOutput, BlockNumReader, DatabaseProviderFactory, ProviderResult,
     PruneCheckpointReader, StageCheckpointReader, StorageSettingsCache,
     TryIntoHistoricalStateProvider,
 };
@@ -352,12 +352,21 @@ where
         let bal = decoded_bal.as_bal();
         if bal.is_empty() {
             if let Some(hashed_update_stream) = hashed_update_stream {
-                hashed_update_stream.finish();
+                if ctx.is_cancelled() {
+                    drop(hashed_update_stream);
+                } else {
+                    hashed_update_stream.finish();
+                }
             }
-            let _ =
-                actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
+            if !ctx.is_cancelled() {
+                let _ = actions_tx
+                    .send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
+            }
             return;
         }
+
+        // Clear per-thread providers on every exit, including unwinding from either prewarm half.
+        let pool_cleanup = PrewarmPoolCleanup(executor.clone());
 
         trace!(
             target: "engine::tree::payload_processor::prewarm",
@@ -390,12 +399,19 @@ where
                     WorkerPool::with_worker_mut(|worker| {
                         let provider =
                             worker.get_or_init::<Option<Box<dyn AccountReader>>>(|| None);
-                        ctx.send_bal_hashed_state(
+                        if let Err(err) = ctx.send_bal_hashed_state(
                             &parent_span,
                             provider,
                             account_changes,
                             &hashed_update_stream,
-                        );
+                        ) {
+                            warn!(
+                                target: "engine::tree::payload_processor::prewarm",
+                                ?err,
+                                "Failed to build complete BAL hashed-state stream"
+                            );
+                            ctx.cancel();
+                        }
                     });
                 });
 
@@ -414,6 +430,7 @@ where
 
         if let Some(saved_cache) = &ctx.saved_cache &&
             !ctx.disable_bal_batch_io &&
+            !ctx.is_cancelled() &&
             let Some(pool) = ctx.bal_prewarm_pool.as_ref()
         {
             // If
@@ -432,31 +449,50 @@ where
             let provider_builder = ctx.provider.clone();
             let build = Arc::new(move || provider_builder.build());
 
-            pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
-            for account in prefetch_bal.as_bal() {
+            let block = pool.begin_block(
+                build,
+                caches,
+                ctx.env.txpool_snapshot.clone(),
+                ctx.cancelled.clone(),
+            );
+            'accounts: for account in prefetch_bal.as_bal() {
                 if ctx.is_cancelled() {
                     break;
                 }
-                pool.warm_account(account.address);
+                block.warm_account(account.address);
                 for change in &account.storage_changes {
-                    pool.warm_storage(account.address, change.slot.into());
+                    if ctx.is_cancelled() {
+                        break 'accounts;
+                    }
+                    block.warm_storage(account.address, change.slot.into());
                 }
                 for &slot in &account.storage_reads {
-                    pool.warm_storage(account.address, slot.into());
+                    if ctx.is_cancelled() {
+                        break 'accounts;
+                    }
+                    block.warm_storage(account.address, slot.into());
                 }
             }
-            pool.end_block();
+            if !block.finish() {
+                ctx.cancel();
+            }
         }
 
-        stream_rx
-            .blocking_recv()
-            .expect("BAL hashed-state streaming task dropped without signaling completion");
+        if stream_rx.blocking_recv().is_err() {
+            warn!(
+                target: "engine::tree::payload_processor::prewarm",
+                "BAL hashed-state streaming task dropped without signaling completion"
+            );
+            ctx.cancel();
+        }
 
         // Drop the per-thread providers
-        executor.bal_streaming_pool().clear();
-        executor.prewarming_pool().clear();
+        drop(pool_cleanup);
 
-        let _ = actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
+        if !ctx.is_cancelled() {
+            let _ =
+                actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
+        }
     }
 
     /// Executes the task.
@@ -540,8 +576,16 @@ where
 
         debug!(target: "engine::tree::payload_processor::prewarm", "Completed prewarm execution");
 
+        if !finished_execution {
+            // The producer disappeared without its completion marker, for example after a panic.
+            // Do not publish a cache from a run that skipped its cleanup/completion barrier.
+            self.ctx.cancel();
+        }
+
         // save caches and finish using the shared ExecutionOutcome
-        if let Some(Some((execution_outcome, valid_block_rx))) = final_execution_outcome {
+        if finished_execution &&
+            let Some(Some((execution_outcome, valid_block_rx))) = final_execution_outcome
+        {
             self.save_cache(execution_outcome, valid_block_rx);
         }
     }
@@ -707,16 +751,16 @@ where
         provider: &mut Option<Box<dyn AccountReader>>,
         account_changes: &alloy_eip7928::AccountChanges,
         hashed_update_stream: &StateRootUpdateStream,
-    ) {
+    ) -> ProviderResult<()> {
         if self.disable_bal_parallel_state_root {
-            return;
+            return Ok(())
         }
         let address = account_changes.address;
         let mut hashed_address = None;
         let account_fields = BalAccountStateFields::from_changes(account_changes);
 
         if !bal_account_changes_state_root(account_changes, account_fields) {
-            return;
+            return Ok(())
         }
 
         // If there are any storage changes we can assume that the resulting account info will be
@@ -748,17 +792,7 @@ where
                 )
                 .entered();
 
-                let inner = match self.provider.build() {
-                    Ok(p) => p,
-                    Err(err) => {
-                        warn!(
-                            target: "engine::tree::payload_processor::prewarm",
-                            ?err,
-                            "Failed to build provider for BAL account reads"
-                        );
-                        return;
-                    }
-                };
+                let inner = self.provider.build()?;
                 let boxed: Box<dyn AccountReader> =
                     match (self.disable_bal_batch_io, &self.saved_cache) {
                         (false, Some(saved)) => {
@@ -773,7 +807,7 @@ where
                 *provider = Some(boxed);
             }
             let account_reader = provider.as_ref().expect("provider just initialized");
-            account_reader.basic_account(&address).ok().flatten()
+            account_reader.basic_account(&address)?
         } else {
             None
         };
@@ -797,6 +831,17 @@ where
         let mut hashed_state = reth_trie::HashedPostState::default();
         hashed_state.accounts.insert(hashed_address, account);
         hashed_update_stream.on_hashed_state_update(hashed_state);
+        Ok(())
+    }
+}
+
+/// Clears worker-local BAL providers before the producer publishes its completion marker.
+struct PrewarmPoolCleanup(Runtime);
+
+impl Drop for PrewarmPoolCleanup {
+    fn drop(&mut self) {
+        self.0.bal_streaming_pool().clear();
+        self.0.prewarming_pool().clear();
     }
 }
 
@@ -871,7 +916,7 @@ fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProof
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree::payload_processor::StateRootSink;
+    use crate::tree::{payload_processor::StateRootSink, ExecutionCache};
     use alloy_consensus::transaction::Recovered;
     use alloy_eip7928::{
         bal::Bal, AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange,
@@ -883,25 +928,31 @@ mod tests {
     use reth_evm::{execute::WithTxEnv, TxEnvFor};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_provider::test_utils::MockEthProvider;
+    use reth_stages_api::{StageCheckpoint, StageId};
     use reth_storage_overlay::OverlayManager;
     use reth_trie::HashedPostState;
     use revm::state::EvmState;
 
-    /// Builds a prewarm context without caches or a BAL prefetch pool, sharing the given flags.
+    /// Builds a prewarm context with the default BAL batch-I/O path enabled.
     fn test_ctx(
         terminate_execution: Arc<AtomicBool>,
         cancelled: Arc<AtomicBool>,
     ) -> PrewarmContext<EthPrimitives, MockEthProvider, EthEvmConfig> {
+        let provider = MockEthProvider::default();
+        provider.enable_database_provider();
+        provider.add_header(B256::ZERO, Default::default());
+        provider.add_stage_checkpoint(StageId::Finish, StageCheckpoint::new(0));
+
         PrewarmContext {
             env: ExecutionEnv::test_default(),
             evm_config: EthEvmConfig::new(Arc::new(ChainSpec::default())),
-            saved_cache: None,
+            saved_cache: Some(SavedCache::new(B256::ZERO, ExecutionCache::new(1_000))),
             provider: StateProviderBuilder::<EthPrimitives, _>::new(
-                MockEthProvider::default(),
+                provider,
                 B256::ZERO,
                 OverlayManager::default(),
             ),
-            bal_prewarm_pool: None,
+            bal_prewarm_pool: Some(BalPrewarmPool::new(1)),
             metrics: PrewarmMetrics::default(),
             cache_metrics: None,
             cache_state_metrics: None,
@@ -1011,6 +1062,41 @@ mod tests {
         let (updates, finished) = run_bal_prewarm_to_sink(ACCOUNTS, true);
         assert_eq!(updates, 0);
         assert!(!finished, "a cancelled stream must not be finished");
+    }
+
+    #[test]
+    fn bal_provider_error_leaves_stream_unfinished() {
+        let changes = AccountChanges::new(address!("0000000000000000000000000000000000000001"))
+            .with_storage_change(SlotChanges::new(
+                U256::from(1),
+                vec![StorageChange::new(BlockAccessIndex::new(1), U256::from(2))],
+            ));
+        let bal = Bal::from(vec![changes]);
+        let raw = alloy_rlp::encode(&bal).into();
+        let bal = Arc::new(DecodedBal::new(bal, raw));
+
+        let sink = Arc::new(CountingSink::default());
+        let updates = StateRootUpdateStream::new(sink.clone());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let mut ctx = test_ctx(Arc::new(AtomicBool::new(false)), Arc::clone(&cancelled));
+        // This mock rejects database-provider creation, forcing the parent account read to fail.
+        ctx.provider = StateProviderBuilder::new(
+            MockEthProvider::default(),
+            B256::ZERO,
+            OverlayManager::default(),
+        );
+        let runtime = Runtime::test();
+        let (task, actions_tx) =
+            PrewarmCacheTask::new(runtime.clone(), PayloadExecutionCache::default(), ctx);
+
+        task.run::<WithTxEnv<TxEnvFor<EthEvmConfig>, Recovered<TransactionSigned>>>(
+            PrewarmMode::BlockAccessList { bal, updates: Some(updates) },
+            actions_tx,
+        );
+        runtime.spawn_blocking_named("prewarm-bal", || {}).get();
+
+        assert!(cancelled.load(Ordering::Relaxed));
+        assert!(!sink.finished.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -331,16 +331,20 @@ where
         }
     }
 
-    /// Runs BAL-based prewarming and state-root streaming inline.
+    /// Runs BAL-based prewarming and state-root streaming.
     ///
     /// Spawns two halves concurrently on separate pools, then waits for both to complete:
     /// 1. Hashed state streaming on the BAL streaming pool so storage updates can reach the
     ///    state-root job before account reads finish.
     /// 2. Storage prefetch on the prewarming pool to populate the execution cache, unless BAL batch
     ///    I/O is disabled.
+    ///
+    /// Both halves stop early once the block is cancelled. The update stream is then dropped
+    /// unfinished, so the state-root task cannot compute a root from partial updates.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn run_bal_prewarm(
-        &self,
+        ctx: PrewarmContext<N, P, Evm>,
+        executor: Runtime,
         decoded_bal: Arc<DecodedBal>,
         actions_tx: Sender<PrewarmTaskEvent<N::Receipt>>,
         hashed_update_stream: Option<StateRootUpdateStream>,
@@ -361,8 +365,6 @@ where
             "Starting BAL prewarm"
         );
 
-        let ctx = self.ctx.clone();
-        let executor = self.executor.clone();
         let parent_span = Span::current();
         let stream_parent_span = parent_span;
         let prefetch_bal = Arc::clone(&decoded_bal);
@@ -382,6 +384,9 @@ where
                 let _span = branch_span.entered();
 
                 stream_bal.as_bal().par_iter().for_each(|account_changes| {
+                    if ctx.is_cancelled() {
+                        return;
+                    }
                     WorkerPool::with_worker_mut(|worker| {
                         let provider =
                             worker.get_or_init::<Option<Box<dyn AccountReader>>>(|| None);
@@ -394,14 +399,20 @@ where
                     });
                 });
 
-                hashed_update_stream.finish();
+                if ctx.is_cancelled() {
+                    // Leave the stream unfinished: the updates are incomplete and the state-root
+                    // task must not compute a root from them.
+                    drop(hashed_update_stream);
+                } else {
+                    hashed_update_stream.finish();
+                }
                 let _ = stream_tx.send(());
             });
         } else {
             let _ = stream_tx.send(());
         }
 
-        if let Some(saved_cache) = ctx.saved_cache &&
+        if let Some(saved_cache) = &ctx.saved_cache &&
             !ctx.disable_bal_batch_io &&
             let Some(pool) = ctx.bal_prewarm_pool.as_ref()
         {
@@ -423,6 +434,9 @@ where
 
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
             for account in prefetch_bal.as_bal() {
+                if ctx.is_cancelled() {
+                    break;
+                }
                 pool.warm_account(account.address);
                 for change in &account.storage_changes {
                     pool.warm_storage(account.address, change.slot.into());
@@ -468,7 +482,13 @@ where
                 self.spawn_txs_prewarm(pending, actions_tx, hints);
             }
             PrewarmMode::BlockAccessList { bal, updates } => {
-                self.run_bal_prewarm(bal, actions_tx, updates);
+                let ctx = self.ctx.clone();
+                let executor = self.executor.clone();
+                let span = Span::current();
+                self.executor.spawn_blocking_named("prewarm-bal", move || {
+                    let _enter = span.entered();
+                    Self::run_bal_prewarm(ctx, executor, bal, actions_tx, updates);
+                });
             }
             PrewarmMode::Skipped => {
                 let _ = actions_tx
@@ -490,6 +510,11 @@ where
                     // `Terminate` can arrive without `TerminateTransactionExecution` when the
                     // handle is dropped on an execution error, so stop workers before waiting.
                     self.ctx.stop();
+                    // No outcome means the handle was dropped without one: the block was
+                    // abandoned and the BAL hashed-state stream is no longer needed either.
+                    if execution_outcome.is_none() {
+                        self.ctx.cancel();
+                    }
                     final_execution_outcome =
                         Some(execution_outcome.map(|outcome| (outcome, valid_block_rx)));
 
@@ -549,6 +574,9 @@ where
     pub cache_state_metrics: Option<CachedStateCacheMetrics>,
     /// An atomic bool that tells prewarm tasks to not start any more execution.
     pub terminate_execution: Arc<AtomicBool>,
+    /// An atomic bool set once the block is abandoned, which also aborts the BAL hashed-state
+    /// stream. See [`Self::cancel`].
+    pub cancelled: Arc<AtomicBool>,
     /// Shared counter tracking the next transaction index to be executed by the main execution
     /// loop. Prewarm workers skip transactions with `index < counter` since those have already
     /// been executed.
@@ -646,6 +674,22 @@ where
     #[inline]
     pub fn stop(&self) {
         self.terminate_execution.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if the block was abandoned and remaining BAL work should be dropped.
+    #[inline]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Relaxed)
+    }
+
+    /// Signals that the block was abandoned.
+    ///
+    /// Unlike [`Self::stop`], which is also called once execution completes and only ends
+    /// speculative transaction prewarming, this aborts the BAL hashed-state stream the state-root
+    /// task depends on, so it must only be set once the state root is no longer needed.
+    #[inline]
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
     }
 
     /// Hashes and streams a single BAL account's state to the state-root job's hashed-update
@@ -827,23 +871,28 @@ fn multiproof_targets_from_withdrawals(withdrawals: &[Withdrawal]) -> MultiProof
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tree::payload_processor::StateRootSink;
     use alloy_consensus::transaction::Recovered;
     use alloy_eip7928::{
-        AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
-        StorageChange,
+        bal::Bal, AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange,
+        SlotChanges, StorageChange,
     };
-    use alloy_primitives::{address, bytes};
+    use alloy_primitives::{address, bytes, Address};
     use reth_chainspec::ChainSpec;
     use reth_ethereum_primitives::{EthPrimitives, TransactionSigned};
     use reth_evm::{execute::WithTxEnv, TxEnvFor};
     use reth_evm_ethereum::EthEvmConfig;
     use reth_provider::test_utils::MockEthProvider;
     use reth_storage_overlay::OverlayManager;
+    use reth_trie::HashedPostState;
+    use revm::state::EvmState;
 
-    #[test]
-    fn terminate_event_stops_transaction_execution() {
-        let terminate_execution = Arc::new(AtomicBool::new(false));
-        let ctx = PrewarmContext {
+    /// Builds a prewarm context without caches or a BAL prefetch pool, sharing the given flags.
+    fn test_ctx(
+        terminate_execution: Arc<AtomicBool>,
+        cancelled: Arc<AtomicBool>,
+    ) -> PrewarmContext<EthPrimitives, MockEthProvider, EthEvmConfig> {
+        PrewarmContext {
             env: ExecutionEnv::test_default(),
             evm_config: EthEvmConfig::new(Arc::new(ChainSpec::default())),
             saved_cache: None,
@@ -856,13 +905,82 @@ mod tests {
             metrics: PrewarmMetrics::default(),
             cache_metrics: None,
             cache_state_metrics: None,
-            terminate_execution: Arc::clone(&terminate_execution),
+            terminate_execution,
+            cancelled,
             executed_tx_index: Arc::new(AtomicUsize::new(0)),
             precompile_cache_disabled: false,
             precompile_cache_map: PrecompileCacheMap::default(),
             disable_bal_parallel_state_root: false,
             disable_bal_batch_io: false,
-        };
+        }
+    }
+
+    /// Records what a BAL prewarm run streams to the state-root task.
+    #[derive(Default)]
+    struct CountingSink {
+        updates: AtomicUsize,
+        finished: AtomicBool,
+    }
+
+    impl StateRootSink for CountingSink {
+        fn on_state_update(&self, _state: EvmState) {}
+
+        fn on_hashed_state_update(&self, _state: HashedPostState) {
+            self.updates.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn on_updates_finished(&self) {
+            self.finished.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Runs BAL prewarm over `accounts` accounts whose changes carry every leaf field, so no
+    /// parent reads are needed, and returns how many hashed-state updates were streamed and
+    /// whether the stream was finished.
+    fn run_bal_prewarm_to_sink(accounts: u64, cancelled: bool) -> (usize, bool) {
+        let mut changes: Vec<AccountChanges> = (0..accounts)
+            .map(|i| {
+                AccountChanges::new(Address::from_word(keccak256(i.to_be_bytes())))
+                    .with_balance_change(BalanceChange::new(
+                        BlockAccessIndex::new(1),
+                        U256::from(i + 1),
+                    ))
+                    .with_nonce_change(NonceChange::new(BlockAccessIndex::new(1), 1))
+                    .with_code_change(CodeChange::new(
+                        BlockAccessIndex::new(1),
+                        bytes!("6001600155"),
+                    ))
+            })
+            .collect();
+        changes.sort_by_key(|account| account.address);
+        let bal = Bal::from(changes);
+        let raw = alloy_rlp::encode(&bal).into();
+        let bal = Arc::new(DecodedBal::new(bal, raw));
+
+        let sink = Arc::new(CountingSink::default());
+        let updates = StateRootUpdateStream::new(sink.clone());
+        let ctx = test_ctx(Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(cancelled)));
+        let runtime = Runtime::test();
+        let (task, actions_tx) =
+            PrewarmCacheTask::new(runtime.clone(), PayloadExecutionCache::default(), ctx);
+
+        // The producer drops the last event sender once it has streamed the BAL, which ends the
+        // event loop without an explicit terminate.
+        task.run::<WithTxEnv<TxEnvFor<EthEvmConfig>, Recovered<TransactionSigned>>>(
+            PrewarmMode::BlockAccessList { bal, updates: Some(updates) },
+            actions_tx,
+        );
+        // Named blocking tasks run serially, so this returns once the producer thread is done.
+        runtime.spawn_blocking_named("prewarm-bal", || {}).get();
+
+        (sink.updates.load(Ordering::Relaxed), sink.finished.load(Ordering::Relaxed))
+    }
+
+    #[test]
+    fn terminate_event_stops_transaction_execution() {
+        let terminate_execution = Arc::new(AtomicBool::new(false));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let ctx = test_ctx(Arc::clone(&terminate_execution), Arc::clone(&cancelled));
         let (task, actions_tx) =
             PrewarmCacheTask::new(Runtime::test(), PayloadExecutionCache::default(), ctx);
         actions_tx
@@ -878,6 +996,21 @@ mod tests {
         );
 
         assert!(terminate_execution.load(Ordering::Relaxed));
+        // A teardown without an outcome means the block was abandoned.
+        assert!(cancelled.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn cancelled_bal_prewarm_leaves_stream_unfinished() {
+        const ACCOUNTS: u64 = 64;
+
+        let (updates, finished) = run_bal_prewarm_to_sink(ACCOUNTS, false);
+        assert_eq!(updates, ACCOUNTS as usize);
+        assert!(finished);
+
+        let (updates, finished) = run_bal_prewarm_to_sink(ACCOUNTS, true);
+        assert_eq!(updates, 0);
+        assert!(!finished, "a cancelled stream must not be finished");
     }
 
     #[test]
@@ -950,7 +1083,8 @@ pub enum PrewarmTaskEvent<R> {
     /// Sent when execution completed successfully (carrying the output to save) or when the task
     /// handle is dropped (carrying no output, e.g. after an execution error). Handling this event
     /// also stops the workers, since a teardown may arrive without a preceding
-    /// [`TerminateTransactionExecution`](Self::TerminateTransactionExecution).
+    /// [`TerminateTransactionExecution`](Self::TerminateTransactionExecution). Without an output
+    /// the block was abandoned, so the BAL hashed-state stream is cancelled as well.
     Terminate {
         /// The final execution outcome, or `None` when the task is torn down without one (e.g. a
         /// dropped handle). Using `Arc` allows sharing with the main execution path without

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -896,7 +896,7 @@ where
         });
 
         if let Some(valid_block_tx) = valid_block_tx {
-            let _ = valid_block_tx.send(());
+            valid_block_tx.notify_valid();
         }
 
         let executed_block =

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -539,6 +539,7 @@ impl DefaultStateRootStrategy {
         } = options;
         let (updates_tx, from_multi_proof) = crossbeam_channel::unbounded();
         let (cancel_guard, cancel_rx) = StateRootTaskCancelGuard::channel();
+        let proof_cancellation = cancel_guard.cancellation_token();
         let (proof_result_tx, proof_result_rx) =
             crossbeam_channel::unbounded::<ProofResultMessage>();
 
@@ -564,6 +565,7 @@ impl DefaultStateRootStrategy {
             hashed_state_tx,
             from_multi_proof,
             cancel_rx,
+            proof_cancellation,
             SparseTrieTaskOptions {
                 parent_header,
                 preserved_sparse_trie,
@@ -598,6 +600,7 @@ impl DefaultStateRootStrategy {
         hashed_state_tx: mpsc::Sender<Arc<HashedPostState>>,
         from_multi_proof: CrossbeamReceiver<StateRootMessage>,
         cancel_rx: CrossbeamReceiver<()>,
+        proof_cancellation: reth_trie_parallel::proof_task::ProofCancellationToken,
         options: SparseTrieTaskOptions<N>,
     ) {
         let SparseTrieTaskOptions {
@@ -671,6 +674,7 @@ impl DefaultStateRootStrategy {
                 &executor,
                 from_multi_proof,
                 cancel_rx,
+                proof_cancellation,
                 hashed_state_tx,
                 proof_worker_handle,
                 proof_result_tx,

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -22,8 +22,8 @@ use reth_trie_common::{MultiProofTargetsV2, ProofV2Target, ProofV2TargetParent};
 use reth_trie_parallel::{
     error::StateRootTaskError,
     proof_task::{
-        AccountMultiproofInput, ProofResultContext, ProofResultMessage, ProofResultSender,
-        ProofWorkerHandle,
+        AccountMultiproofInput, ProofCancellationToken, ProofResultContext, ProofResultMessage,
+        ProofResultSender, ProofWorkerHandle,
     },
 };
 use reth_trie_sparse::{
@@ -45,6 +45,8 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// waiting for the result anymore. This is the teardown path for a task whose pending
     /// work never drains, since the updates channel closing is a normal end of stream.
     cancel_rx: CrossbeamReceiver<()>,
+    /// Shared cancellation state attached to every proof job dispatched by this task.
+    proof_cancellation: ProofCancellationToken,
     /// Sender half for the channel to send final hashed state to.
     final_hashed_state_tx: Option<std::sync::mpsc::Sender<Arc<HashedPostState>>>,
     /// `SparseStateTrie` used for computing the state root.
@@ -135,6 +137,7 @@ where
         executor: &Runtime,
         updates: CrossbeamReceiver<StateRootMessage>,
         cancel_rx: CrossbeamReceiver<()>,
+        proof_cancellation: ProofCancellationToken,
         final_hashed_state_tx: std::sync::mpsc::Sender<Arc<HashedPostState>>,
         proof_worker_handle: ProofWorkerHandle,
         proof_result_tx: ProofResultSender,
@@ -159,6 +162,7 @@ where
             proof_result_rx,
             updates: hashed_state_rx,
             cancel_rx,
+            proof_cancellation,
             proof_worker_handle,
             final_hashed_state_tx: Some(final_hashed_state_tx),
             trie,
@@ -259,6 +263,14 @@ where
         skip_all
     )]
     pub(super) fn run(&mut self) -> Result<StateRootComputeOutcome, StateRootTaskError> {
+        let result = self.run_inner();
+        if result.is_err() {
+            self.proof_cancellation.cancel();
+        }
+        result
+    }
+
+    fn run_inner(&mut self) -> Result<StateRootComputeOutcome, StateRootTaskError> {
         let now = Instant::now();
 
         let mut total_idle_time = std::time::Duration::ZERO;
@@ -860,6 +872,9 @@ where
     }
 
     fn dispatch_pending_targets(&mut self) -> Result<(), StateRootTaskError> {
+        if self.proof_cancellation.is_cancelled() {
+            return Err(StateRootTaskError::Canceled)
+        }
         if self.pending_targets.is_empty() {
             return Ok(())
         }
@@ -876,18 +891,22 @@ where
             self.proof_worker_handle.has_multiple_idle_storage_workers(),
             MultiProofTargetsV2::chunks,
             |proof_targets| {
-                if dispatch_error.is_some() {
+                if dispatch_error.is_some() || self.proof_cancellation.is_cancelled() {
+                    dispatch_error.get_or_insert(StateRootTaskError::Canceled);
                     return;
                 }
 
-                match self.proof_worker_handle.dispatch_account_multiproof(AccountMultiproofInput {
-                    targets: proof_targets,
-                    proof_result_sender: ProofResultContext::new(
-                        self.proof_result_tx.clone(),
-                        HashedPostState::default(),
-                        Instant::now(),
+                match self.proof_worker_handle.dispatch_account_multiproof(
+                    AccountMultiproofInput::new(
+                        proof_targets,
+                        ProofResultContext::new(
+                            self.proof_result_tx.clone(),
+                            HashedPostState::default(),
+                            Instant::now(),
+                        ),
+                        self.proof_cancellation.clone(),
                     ),
-                }) {
+                ) {
                     Ok(()) => {
                         self.in_flight_proof_batches += 1;
                     }
@@ -1258,6 +1277,7 @@ mod tests {
             &runtime,
             updates_rx,
             cancel_rx,
+            Default::default(),
             std::sync::mpsc::channel().0,
             proof_worker_handle,
             proof_result_tx,
@@ -1312,6 +1332,7 @@ mod tests {
             &runtime,
             updates_rx,
             cancel_rx,
+            Default::default(),
             std::sync::mpsc::channel().0,
             proof_worker_handle,
             proof_result_tx,
@@ -1400,6 +1421,7 @@ mod tests {
             &runtime,
             updates_rx,
             cancel_rx,
+            Default::default(),
             std::sync::mpsc::channel().0,
             proof_worker_handle,
             proof_result_tx,
@@ -1453,6 +1475,7 @@ mod tests {
             &runtime,
             updates_rx,
             cancel_rx,
+            Default::default(),
             std::sync::mpsc::channel().0,
             proof_worker_handle,
             proof_result_tx,
@@ -1526,6 +1549,7 @@ mod tests {
             &runtime,
             updates_rx,
             cancel_rx,
+            Default::default(),
             std::sync::mpsc::channel().0,
             proof_worker_handle,
             proof_result_tx,

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -271,7 +271,10 @@ where
         // marker means they died without finishing the stream.
         while !self.finished_state_updates {
             let mut t = Instant::now();
+            // Cancellation goes first so it wins over queued work; the cancel channel is never
+            // ready while the consumer is alive, so this costs nothing in normal operation.
             crossbeam_channel::select_biased! {
+                recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
                 recv(self.updates) -> message => {
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
@@ -300,7 +303,6 @@ where
                     };
                     self.on_proof_results(result, &mut t)?;
                 },
-                recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
 
             done = self.make_progress()?;
@@ -314,6 +316,7 @@ where
         while !done {
             let mut t = Instant::now();
             crossbeam_channel::select_biased! {
+                recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
                 recv(self.proof_result_rx) -> message => {
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
@@ -327,7 +330,6 @@ where
                     };
                     self.on_proof_results(result, &mut t)?;
                 },
-                recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
 
             done = self.make_progress()?;
@@ -1415,6 +1417,79 @@ mod tests {
 
         let error = task.run().expect_err("canceled task must return an error");
         assert!(matches!(error, StateRootTaskError::Canceled));
+
+        drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
+    }
+
+    #[test]
+    fn run_cancels_before_draining_queued_updates() {
+        let runtime = reth_tasks::Runtime::test();
+        let provider_factory = create_test_provider_factory();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
+        let overlay_factory = OverlayStateProviderFactory::new(
+            provider_factory,
+            OverlayManager::<reth_chain_state::EthPrimitives>::default()
+                .overlay_builder(anchor_hash),
+        );
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(overlay_factory),
+            false,
+            proof_result_tx.clone(),
+        );
+
+        let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
+        let trie = SparseStateTrie::default()
+            .with_accounts_trie(default_trie.clone())
+            .with_default_storage_trie(default_trie)
+            .with_updates(true);
+
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (cancel_guard, cancel_rx) = crossbeam_channel::bounded::<()>(0);
+        let mut task = SparseTrieCacheTask::new_with_trie(
+            &runtime,
+            updates_rx,
+            cancel_rx,
+            std::sync::mpsc::channel().0,
+            proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
+            SparseTrieTaskMetrics::default(),
+            trie,
+            B256::from([0x55; 32]),
+            TrieNodeEpoch::UNMODIFIED,
+            1,
+        );
+
+        const QUEUED: usize = 64;
+        for i in 0..QUEUED {
+            let mut hashed_state = HashedPostState::default();
+            hashed_state.accounts.insert(
+                keccak256(U256::from(i).to_be_bytes::<32>()),
+                Some(Account { balance: U256::from(i + 1), nonce: 1, bytecode_hash: None }),
+            );
+            updates_tx.send(StateRootMessage::HashedStateUpdate(hashed_state)).unwrap();
+        }
+
+        let wait_start = std::time::Instant::now();
+        while task.updates.len() < QUEUED {
+            assert!(
+                wait_start.elapsed() < std::time::Duration::from_secs(1),
+                "hashing task did not queue the test messages"
+            );
+            std::thread::yield_now();
+        }
+
+        // The consumer abandons the computation while updates are still queued: cancellation
+        // must win instead of the task draining (and dispatching proofs for) the queue first.
+        drop(cancel_guard);
+
+        let error = task.run().expect_err("canceled task must return an error");
+        assert!(matches!(error, StateRootTaskError::Canceled));
+        assert_eq!(task.updates.len(), QUEUED, "cancellation must not drain queued updates");
 
         drop(updates_tx);
         drop(task);

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -344,6 +344,9 @@ impl ProofWorkerHandle {
         input: StorageProofInput,
         proof_result_sender: CrossbeamSender<StorageProofResultMessage>,
     ) -> Result<(), ProviderError> {
+        if input.is_cancelled() {
+            return Ok(())
+        }
         let hashed_address = input.hashed_address;
         self.storage_work_tx
             .send(StorageWorkerJob::StorageProof { input, proof_result_sender })
@@ -367,6 +370,9 @@ impl ProofWorkerHandle {
         &self,
         input: AccountMultiproofInput,
     ) -> Result<(), ProviderError> {
+        if input.is_cancelled() {
+            return Ok(())
+        }
         self.account_work_tx
             .send(AccountWorkerJob::AccountMultiproof { input: Box::new(input) })
             .map_err(|err| {
@@ -385,6 +391,25 @@ impl ProofWorkerHandle {
 
                 error
             })
+    }
+}
+
+/// Shared cancellation state for proof work belonging to one state-root computation.
+///
+/// Proof worker queues outlive the sparse-trie task that submitted to them. Carrying this token
+/// with every job lets workers discard buffered work once its consumer has gone away.
+#[derive(Clone, Debug, Default)]
+pub struct ProofCancellationToken(Arc<AtomicBool>);
+
+impl ProofCancellationToken {
+    /// Marks all work associated with this token as cancelled.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns whether the associated state-root computation was cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
     }
 }
 
@@ -446,7 +471,7 @@ where
         TC: TrieStorageCursor,
         HC: HashedStorageCursor<Value = U256>,
     {
-        let StorageProofInput { hashed_address, mut targets, needs_root } = input;
+        let StorageProofInput { hashed_address, mut targets, needs_root, cancellation: _ } = input;
 
         let span = debug_span!(
             target: "trie::proof_task",
@@ -696,6 +721,16 @@ where
 
             match job {
                 StorageWorkerJob::StorageProof { input, proof_result_sender } => {
+                    if input.is_cancelled() {
+                        trace!(
+                            target: "trie::proof_task",
+                            worker_id = self.worker_id,
+                            "Discarding cancelled storage proof"
+                        );
+                        self.availability.mark_idle(self.worker_id);
+                        idle_start = Instant::now();
+                        continue
+                    }
                     self.process_storage_proof(
                         &proof_tx,
                         &mut v2_calculator,
@@ -947,6 +982,16 @@ where
 
             match job {
                 AccountWorkerJob::AccountMultiproof { input } => {
+                    if input.is_cancelled() {
+                        trace!(
+                            target: "trie::proof_task",
+                            worker_id = self.worker_id,
+                            "Discarding cancelled account proof"
+                        );
+                        self.availability.mark_idle(self.worker_id);
+                        idle_start = Instant::now();
+                        continue
+                    }
                     let value_encoder_stats = self.process_account_multiproof::<Factory::Provider>(
                         &mut v2_account_calculator,
                         v2_storage_calculator.clone(),
@@ -991,6 +1036,7 @@ where
         v2_account_calculator: &mut V2AccountProofCalculator<'a, Provider>,
         v2_storage_calculator: Rc<RefCell<V2StorageProofCalculator<'a, Provider>>>,
         targets: MultiProofTargetsV2,
+        cancellation: &ProofCancellationToken,
     ) -> Result<(DecodedMultiProofV2, ValueEncoderStats), StateRootTaskError>
     where
         Provider: TrieCursorFactory + HashedCursorFactory + 'a,
@@ -1007,8 +1053,16 @@ where
 
         trace!(target: "trie::proof_task", "Processing V2 account multiproof");
 
-        let storage_proof_receivers =
-            dispatch_v2_storage_proofs(&self.storage_work_tx, &account_targets, storage_targets)?;
+        let storage_proof_receivers = dispatch_v2_storage_proofs(
+            &self.storage_work_tx,
+            &account_targets,
+            storage_targets,
+            cancellation,
+        )?;
+
+        if cancellation.is_cancelled() {
+            return Err(StateRootTaskError::Canceled)
+        }
 
         let mut value_encoder = AsyncAccountValueEncoder::new(
             storage_proof_receivers,
@@ -1041,11 +1095,12 @@ where
     {
         let proof_start = Instant::now();
 
-        let AccountMultiproofInput { targets, proof_result_sender } = input;
+        let AccountMultiproofInput { targets, proof_result_sender, cancellation } = input;
         let (result, value_encoder_stats) = match self.compute_v2_account_multiproof::<Provider>(
             v2_account_calculator,
             v2_storage_calculator,
             targets,
+            &cancellation,
         ) {
             Ok((proof, stats)) => (Ok(proof), stats),
             Err(e) => (Err(e), ValueEncoderStats::default()),
@@ -1091,6 +1146,7 @@ fn dispatch_v2_storage_proofs(
     storage_work_tx: &CrossbeamSender<StorageWorkerJob>,
     account_targets: &[ProofV2Target],
     storage_targets: B256Map<Vec<ProofV2Target>>,
+    cancellation: &ProofCancellationToken,
 ) -> Result<B256Map<CrossbeamReceiver<StorageProofResultMessage>>, StateRootTaskError> {
     if storage_targets.is_empty() {
         return Ok(B256Map::default())
@@ -1110,10 +1166,14 @@ fn dispatch_v2_storage_proofs(
 
     // Dispatch all proofs for targeted storage slots
     for (hashed_address, targets) in sorted_storage_targets {
+        if cancellation.is_cancelled() {
+            return Err(StateRootTaskError::Canceled)
+        }
         // Create channel for receiving StorageProofResultMessage
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
         let needs_root = account_target_addresses.contains(&hashed_address);
-        let input = StorageProofInput::new(hashed_address, targets, needs_root);
+        let input = StorageProofInput::new(hashed_address, targets, needs_root)
+            .with_cancellation(cancellation.clone());
 
         storage_work_tx
             .send(StorageWorkerJob::StorageProof { input, proof_result_sender: result_tx })
@@ -1138,12 +1198,25 @@ pub struct StorageProofInput {
     pub targets: Vec<ProofV2Target>,
     /// Whether the account proof needs the storage root for leaf encoding.
     pub needs_root: bool,
+    /// Cancellation state for the state-root computation that requested this proof.
+    cancellation: ProofCancellationToken,
 }
 
 impl StorageProofInput {
     /// Creates a new [`StorageProofInput`] with the given hashed address and target slots.
-    pub const fn new(hashed_address: B256, targets: Vec<ProofV2Target>, needs_root: bool) -> Self {
-        Self { hashed_address, targets, needs_root }
+    pub fn new(hashed_address: B256, targets: Vec<ProofV2Target>, needs_root: bool) -> Self {
+        Self { hashed_address, targets, needs_root, cancellation: Default::default() }
+    }
+
+    /// Associates this input with a state-root cancellation token.
+    pub fn with_cancellation(mut self, cancellation: ProofCancellationToken) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
+    /// Returns whether the requesting state-root computation was cancelled.
+    fn is_cancelled(&self) -> bool {
+        self.cancellation.is_cancelled()
     }
 }
 
@@ -1154,9 +1227,25 @@ pub struct AccountMultiproofInput {
     pub targets: MultiProofTargetsV2,
     /// Context for sending the proof result.
     pub proof_result_sender: ProofResultContext,
+    /// Cancellation state for the state-root computation that requested this proof.
+    cancellation: ProofCancellationToken,
 }
 
 impl AccountMultiproofInput {
+    /// Creates account multiproof input associated with a state-root cancellation token.
+    pub const fn new(
+        targets: MultiProofTargetsV2,
+        proof_result_sender: ProofResultContext,
+        cancellation: ProofCancellationToken,
+    ) -> Self {
+        Self { targets, proof_result_sender, cancellation }
+    }
+
+    /// Returns whether the requesting state-root computation was cancelled.
+    fn is_cancelled(&self) -> bool {
+        self.cancellation.is_cancelled()
+    }
+
     /// Returns the [`ProofResultContext`] for this input, consuming the input.
     fn into_proof_result_sender(self) -> ProofResultContext {
         self.proof_result_sender
@@ -1184,6 +1273,52 @@ mod tests {
         ProofTaskCtx::new(factory)
     }
 
+    #[derive(Clone, Default)]
+    struct NoopProofFactory;
+
+    impl DatabaseProviderROFactory for NoopProofFactory {
+        type Provider = NoopProofProvider;
+
+        fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
+            Ok(NoopProofProvider)
+        }
+    }
+
+    struct NoopProofProvider;
+
+    impl TrieCursorFactory for NoopProofProvider {
+        type AccountTrieCursor<'a> = reth_trie::trie_cursor::noop::NoopAccountTrieCursor;
+        type StorageTrieCursor<'a> = reth_trie::trie_cursor::noop::NoopStorageTrieCursor;
+
+        fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
+            Ok(Default::default())
+        }
+
+        fn storage_trie_cursor(
+            &self,
+            _hashed_address: B256,
+        ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
+            Ok(Default::default())
+        }
+    }
+
+    impl HashedCursorFactory for NoopProofProvider {
+        type AccountCursor<'a> =
+            reth_trie::hashed_cursor::noop::NoopHashedCursor<reth_primitives_traits::Account>;
+        type StorageCursor<'a> = reth_trie::hashed_cursor::noop::NoopHashedCursor<U256>;
+
+        fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+            Ok(Default::default())
+        }
+
+        fn hashed_storage_cursor(
+            &self,
+            _hashed_address: B256,
+        ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+            Ok(Default::default())
+        }
+    }
+
     /// Ensures `ProofWorkerHandle::new` spawns workers correctly.
     #[test]
     fn spawn_proof_workers_creates_handle() {
@@ -1208,5 +1343,67 @@ mod tests {
 
         // Workers shut down automatically when handle is dropped
         drop(proof_handle);
+    }
+
+    #[test]
+    fn cancelled_proofs_are_not_queued() {
+        let (storage_work_tx, _storage_work_rx) = unbounded();
+        let (account_work_tx, _account_work_rx) = unbounded();
+        let proof_handle = ProofWorkerHandle {
+            storage_work_tx,
+            account_work_tx,
+            storage_availability: Arc::new(AvailabilitySheet::new(1)),
+            account_availability: Arc::new(AvailabilitySheet::new(1)),
+            storage_worker_count: 1,
+            account_worker_count: 1,
+        };
+        let cancellation = ProofCancellationToken::default();
+        cancellation.cancel();
+
+        let (proof_result_tx, _) = unbounded();
+        let account_input = AccountMultiproofInput::new(
+            Default::default(),
+            ProofResultContext::new(proof_result_tx, HashedPostState::default(), Instant::now()),
+            cancellation.clone(),
+        );
+        proof_handle.dispatch_account_multiproof(account_input).unwrap();
+
+        let (storage_result_tx, _) = unbounded();
+        let storage_input =
+            StorageProofInput::new(B256::ZERO, Vec::new(), false).with_cancellation(cancellation);
+        proof_handle.dispatch_storage_proof(storage_input, storage_result_tx).unwrap();
+
+        assert_eq!(proof_handle.pending_account_tasks(), 0);
+        assert_eq!(proof_handle.pending_storage_tasks(), 0);
+    }
+
+    #[test]
+    fn storage_worker_discards_buffered_proof_after_cancellation() {
+        let (work_tx, work_rx) = unbounded();
+        let availability = Arc::new(AvailabilitySheet::new(1));
+        let worker = StorageProofWorker::new(
+            test_ctx(NoopProofFactory),
+            work_rx,
+            0,
+            availability,
+            Arc::new(DashMap::default()),
+            #[cfg(feature = "metrics")]
+            ProofTaskTrieMetrics::default(),
+            #[cfg(feature = "metrics")]
+            ProofTaskCursorMetrics::new(),
+        );
+        let cancellation = ProofCancellationToken::default();
+        let (result_tx, result_rx) = unbounded();
+        let input = StorageProofInput::new(B256::ZERO, Vec::new(), false)
+            .with_cancellation(cancellation.clone());
+        work_tx
+            .send(StorageWorkerJob::StorageProof { input, proof_result_sender: result_tx })
+            .unwrap();
+        cancellation.cancel();
+        drop(work_tx);
+
+        worker.run().unwrap();
+
+        assert!(result_rx.recv().is_err());
     }
 }

--- a/crates/trie/parallel/src/state_root_task.rs
+++ b/crates/trie/parallel/src/state_root_task.rs
@@ -7,7 +7,7 @@
 //! that await its result. The per-block strategy abstraction that decides whether and how the
 //! task runs lives in `reth-engine-tree` under `tree::state_root_strategy`.
 
-use crate::error::StateRootTaskError;
+use crate::{error::StateRootTaskError, proof_task::ProofCancellationToken};
 use alloy_evm::block::OnStateHook;
 use alloy_primitives::{keccak256, map::B256Map, B256};
 use reth_trie::{
@@ -196,13 +196,30 @@ impl StateRootHandle {
 /// dropping disconnects the channel, which the task treats as the consumer abandoning the
 /// computation (for example on a timeout fallback or when a payload job is dropped unused).
 #[derive(Debug)]
-pub struct StateRootTaskCancelGuard(#[allow(dead_code)] crossbeam_channel::Sender<()>);
+pub struct StateRootTaskCancelGuard {
+    #[allow(dead_code)]
+    sender: crossbeam_channel::Sender<()>,
+    cancellation: ProofCancellationToken,
+}
 
 impl StateRootTaskCancelGuard {
     /// Creates a guard and the receiver a task watches for cancellation.
     pub fn channel() -> (Self, crossbeam_channel::Receiver<()>) {
         let (tx, rx) = crossbeam_channel::bounded(0);
-        (Self(tx), rx)
+        (Self { sender: tx, cancellation: Default::default() }, rx)
+    }
+
+    /// Returns the cancellation token shared with work queued by this state-root task.
+    pub fn cancellation_token(&self) -> ProofCancellationToken {
+        self.cancellation.clone()
+    }
+}
+
+impl Drop for StateRootTaskCancelGuard {
+    fn drop(&mut self) {
+        // Set the token before `sender` is dropped so queued workers can observe cancellation by
+        // the time the sparse-trie task wakes on channel disconnection.
+        self.cancellation.cancel();
     }
 }
 
@@ -752,6 +769,7 @@ mod tests {
     fn payload_state_root_receiver_retains_cancellation() {
         let (updates_tx, _updates_rx) = crossbeam_channel::unbounded();
         let (cancel_guard, cancel_rx) = StateRootTaskCancelGuard::channel();
+        let cancellation = cancel_guard.cancellation_token();
         let (_state_root_tx, state_root_rx) = std::sync::mpsc::channel();
         let (_hashed_state_tx, hashed_state_rx) = std::sync::mpsc::channel();
         let mut handle = StateRootHandle::new(
@@ -769,8 +787,10 @@ mod tests {
             Err(std::sync::mpsc::RecvTimeoutError::Timeout)
         ));
         assert!(matches!(cancel_rx.try_recv(), Err(crossbeam_channel::TryRecvError::Empty)));
+        assert!(!cancellation.is_cancelled());
 
         drop(handle);
+        assert!(cancellation.is_cancelled());
         assert!(matches!(
             cancel_rx.recv_timeout(Duration::from_secs(1)),
             Err(crossbeam_channel::RecvTimeoutError::Disconnected)


### PR DESCRIPTION
Follow-up to #26703 for the BAL path: the BAL prewarm work did not observe the task's teardown, and the sparse trie task checked cancellation only after queued updates. The BAL work now runs off the event loop and stops on a teardown without an outcome, leaving the update stream unfinished, and the sparse trie task checks cancellation first.
