### PR TITLE
fix(rpc): reject a chainId that is not the node's

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -507,6 +507,18 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             }
 
             let chain_id = self.chain_id();
+            // A caller that pins `chainId` is asserting which chain it means to sign for.
+            // Silently rewriting it would sign and submit on a different chain than asked
+            // for, so reject the mismatch instead. Matches geth's `setDefaults`.
+            if let Some(request_chain_id) = request.as_ref().chain_id() &&
+                request_chain_id != chain_id.to::<u64>()
+            {
+                return Err(EthApiError::InvalidParams(format!(
+                    "chainId does not match node's (have={request_chain_id}, want={})",
+                    chain_id.to::<u64>()
+                ))
+                .into())
+            }
             request.as_mut().set_chain_id(chain_id.to());
 
             if request.as_ref().gas_limit().is_none() {
@@ -556,6 +568,18 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             }
 
             let chain_id = self.chain_id();
+            // A caller that pins `chainId` is asserting which chain it means to sign for.
+            // Silently rewriting it would sign and submit on a different chain than asked
+            // for, so reject the mismatch instead. Matches geth's `setDefaults`.
+            if let Some(request_chain_id) = request.as_ref().chain_id() &&
+                request_chain_id != chain_id.to::<u64>()
+            {
+                return Err(EthApiError::InvalidParams(format!(
+                    "chainId does not match node's (have={request_chain_id}, want={})",
+                    chain_id.to::<u64>()
+                ))
+                .into())
+            }
             request.as_mut().set_chain_id(chain_id.to());
 
             if request.as_ref().has_eip4844_fields() &&

--- a/crates/rpc/rpc/src/eth/helpers/transaction.rs
+++ b/crates/rpc/rpc/src/eth/helpers/transaction.rs
@@ -319,6 +319,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_transaction_rejects_mismatched_chain_id() {
+        let signers = DevSigner::random_signers(1);
+        let address = signers[0].accounts()[0];
+        let accounts = AddressMap::from_iter([(
+            address,
+            ExtendedAccount::new(0, U256::from(10_000_000_000_000_000_000u64)),
+        )]);
+        let eth_api = mock_eth_api(accounts);
+        eth_api.signers().write().extend(signers);
+
+        // The mock node is mainnet (chain id 1); the caller pins a different chain.
+        let tx_req = TransactionRequest {
+            from: Some(address),
+            to: Some(address.into()),
+            gas: Some(90_000),
+            gas_price: Some(1_000_000_000),
+            chain_id: Some(999),
+            ..Default::default()
+        };
+
+        let err = eth_api
+            .send_transaction_request(tx_req)
+            .await
+            .expect_err("a chain id that is not the node's must be rejected, not rewritten");
+        assert!(
+            err.to_string().contains("chainId does not match node's"),
+            "unexpected error: {err}"
+        );
+        assert!(eth_api.pool().is_empty(), "no transaction should have been submitted");
+    }
+
+    #[tokio::test]
+    async fn send_transaction_accepts_matching_chain_id() {
+        let signers = DevSigner::random_signers(1);
+        let address = signers[0].accounts()[0];
+        let accounts = AddressMap::from_iter([(
+            address,
+            ExtendedAccount::new(0, U256::from(10_000_000_000_000_000_000u64)),
+        )]);
+        let eth_api = mock_eth_api(accounts);
+        eth_api.signers().write().extend(signers);
+
+        let tx_req = TransactionRequest {
+            from: Some(address),
+            to: Some(address.into()),
+            gas: Some(90_000),
+            gas_price: Some(1_000_000_000),
+            chain_id: Some(1),
+            ..Default::default()
+        };
+
+        let hash = eth_api
+            .send_transaction_request(tx_req)
+            .await
+            .expect("a matching chain id must still be accepted");
+        let pooled = eth_api.pool().get(&hash).expect("transaction should be in the pool");
+        assert_eq!(pooled.transaction.chain_id(), Some(1));
+    }
+
+    #[tokio::test]
     async fn test_fill_transaction_fills_chain_id() {
         let address = Address::random();
         let accounts = AddressMap::from_iter([(


### PR DESCRIPTION
Follow-up in spirit to #26743.

`send_transaction_request` and `fill_transaction` overwrite a caller-supplied `chainId` with the node's own:

```rust
let chain_id = self.chain_id();
request.as_mut().set_chain_id(chain_id.to());
```

`fill_transaction` is a *fill the defaults* function, and every other field in it is applied only when the caller left it unset:

| field | behavior |
| --- | --- |
| `value` | set if `is_none()` |
| `nonce` | set if `is_none()` |
| `max_fee_per_blob_gas` | set if `is_none()` |
| blob hashes | populated if `is_none()` |
| `gas_limit` | estimated if `is_none()` — since #26743 |
| `gas_price` | set if `is_none()` |
| **`chain_id`** | **always overwritten** |

`chain_id` is the one field that overrides the request rather than filling it.

## Impact

A caller that pins `chainId` is asserting which chain it means to sign for. Today that assertion is discarded: the transaction is re-signed for whatever chain the node is actually on and submitted, with no error. A wallet or backend that mixes up endpoints gets a transaction **sent on the wrong network** instead of a failed request — and because the value is rewritten before signing, the signature commits to a chain the caller never asked for.

`eth_signTransaction` / `eth_fillTransaction` go through `fill_transaction` and have the same behavior, so the returned signed payload is bound to a different chain than requested.

## geth

`TransactionArgs::setDefaults` rejects the mismatch rather than rewriting it ([`internal/ethapi/transaction_args.go`](https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/transaction_args.go)):

```go
want := b.ChainConfig().ChainID
if args.ChainID != nil {
    if have := (*big.Int)(args.ChainID); have.Cmp(want) != 0 {
        return fmt.Errorf("chainId does not match node's (have=%v, want=%v)", have, want)
    }
}
args.ChainID = (*hexutil.Big)(want)
```

It does the same again in the fill path further down the file.

## Change

Reject a `chainId` that is not the node's with `-32602` and geth's message; keep filling the field when the caller omits it. Applied at both sites. The diff is additive (+24/-0 in the helper) — the existing `set_chain_id` still runs for the matching and omitted cases, so nothing changes for callers that agree with the node or say nothing.

## Test plan

Two tests in `crates/rpc/rpc/src/eth/helpers/transaction.rs`, alongside the one #26743 added:

- `send_transaction_rejects_mismatched_chain_id` — without the fix this **fails**, because the call succeeds instead of erroring:

```
panicked at crates/rpc/rpc/src/eth/helpers/transaction.rs:345:14:
a chain id that is not the node's must be rejected, not rewritten:
0x7244853449f6de50640b4932cbde082e55a74bbbe2f46a9fa275f3014a0a8e55
```

  i.e. the node signed and submitted on chain 1 for a request that asked for chain 999.

- `send_transaction_accepts_matching_chain_id` — regression guard; passes with and without the change by design.

Verified by reverting only `crates/rpc/rpc-eth-api/src/helpers/transaction.rs` and re-running. The full `eth::helpers::transaction` module passes (15 tests), including the pre-existing `test_fill_transaction_fills_chain_id` and `test_fill_transaction_preserves_provided_fields`. `cargo +nightly fmt` and `cargo clippy -p reth-rpc-eth-api -p reth-rpc --all-targets` are clean.

---
🤖 Written with [Claude Code](https://claude.com/claude-code). All results above are from a local build and test run.
