### PR TITLE
fix(static-file): return 0 for empty reversed SegmentRangeInclusive

### DIFF
--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -646,7 +646,11 @@ impl SegmentRangeInclusive {
 
     /// Returns the length of the inclusive range.
     pub const fn len(&self) -> u64 {
-        self.end.saturating_sub(self.start).saturating_add(1)
+        if self.is_empty() {
+            0
+        } else {
+            self.end.saturating_sub(self.start).saturating_add(1)
+        }
     }
 
     /// Returns true if the range is empty.
@@ -871,5 +875,31 @@ mod tests {
                 segment.as_short_str()
             );
         }
+    }
+
+    #[test]
+    fn test_segment_range_inclusive_len() {
+        let reversed = SegmentRangeInclusive::new(2, 1);
+        assert!(reversed.is_empty());
+        assert!(!reversed.contains(1));
+        assert!(!reversed.contains(2));
+        assert_eq!(reversed.len(), 0);
+
+        let max_reversed = SegmentRangeInclusive::new(u64::MAX, 0);
+        assert!(max_reversed.is_empty());
+        assert_eq!(max_reversed.len(), 0);
+
+        let singleton = SegmentRangeInclusive::new(5, 5);
+        assert!(!singleton.is_empty());
+        assert_eq!(singleton.len(), 1);
+        assert!(singleton.contains(5));
+
+        let ordinary = SegmentRangeInclusive::new(0, 9);
+        assert!(!ordinary.is_empty());
+        assert_eq!(ordinary.len(), 10);
+
+        let full = SegmentRangeInclusive::new(0, u64::MAX);
+        assert!(!full.is_empty());
+        assert_eq!(full.len(), u64::MAX);
     }
 }


### PR DESCRIPTION
## Summary

Fix `SegmentRangeInclusive::len()` returning `1` when `start > end` (empty reversed range).

## Root Cause

`SegmentRangeInclusive::len()` computed length as `self.end.saturating_sub(self.start).saturating_add(1)`. When `start > end`, `saturating_sub` evaluated to `0`, which after `saturating_add(1)` produced `1` even though `self.is_empty()` evaluated to `true` (`start > end`).

## Solution

Check `self.is_empty()` in `SegmentRangeInclusive::len()` and return `0` if empty, preserving the inclusive saturating addition for valid non-empty ranges.

## Testing

Added unit tests in `crates/static-file/types/src/segment.rs` covering:
- Empty reversed ranges (`SegmentRangeInclusive::new(2, 1)`, `SegmentRangeInclusive::new(u64::MAX, 0)`)
- Singleton ranges (`5..=5`)
- Ordinary ranges (`0..=9`)
- Saturated maximum domain (`0..=u64::MAX`)

Ran `cargo test -p reth-static-file-types` locally: all 15 tests pass.