### PR TITLE
fix(static-file): return 0 for empty reversed SegmentRangeInclusive len

### DIFF
--- a/crates/static-file/types/src/segment.rs
+++ b/crates/static-file/types/src/segment.rs
@@ -646,7 +646,11 @@ impl SegmentRangeInclusive {
 
     /// Returns the length of the inclusive range.
     pub const fn len(&self) -> u64 {
-        self.end.saturating_sub(self.start).saturating_add(1)
+        if self.is_empty() {
+            0
+        } else {
+            self.end.saturating_sub(self.start).saturating_add(1)
+        }
     }
 
     /// Returns true if the range is empty.
@@ -871,5 +875,33 @@ mod tests {
                 segment.as_short_str()
             );
         }
+    }
+
+    #[test]
+    fn test_segment_range_inclusive_len() {
+        // Normal range
+        let normal = SegmentRangeInclusive::new(2, 5);
+        assert_eq!(normal.len(), 4);
+        assert!(!normal.is_empty());
+
+        // Single element
+        let single = SegmentRangeInclusive::new(2, 2);
+        assert_eq!(single.len(), 1);
+        assert!(!single.is_empty());
+
+        // Empty reversed range
+        let empty = SegmentRangeInclusive::new(2, 1);
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+
+        // Empty reversed range with MAX
+        let empty_max = SegmentRangeInclusive::new(u64::MAX, 0);
+        assert!(empty_max.is_empty());
+        assert_eq!(empty_max.len(), 0);
+
+        // Saturated full domain
+        let full = SegmentRangeInclusive::new(0, u64::MAX);
+        assert_eq!(full.len(), u64::MAX);
+        assert!(!full.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Fixes an issue where `SegmentRangeInclusive::len()` returned `1` for empty reversed ranges (such as `SegmentRangeInclusive::new(2, 1)` or `SegmentRangeInclusive::new(u64::MAX, 0)`).

### Root Cause
Previously, `len()` computed `self.end.saturating_sub(self.start).saturating_add(1)`. When `self.start > self.end` (where `is_empty()` returns `true`), `end.saturating_sub(start)` evaluates to `0`, and adding `1` caused `len()` to return `1`.

### Fix
In `SegmentRangeInclusive::len()`, check `if self.is_empty()` and return `0`, otherwise calculate `self.end.saturating_sub(self.start).saturating_add(1)`.

### Testing
Added comprehensive regression test cases covering:
- Standard range (`2..=5` -> len 4)
- Single element range (`2..=2` -> len 1)
- Empty reversed range (`2..=1` -> len 0)
- Empty reversed range with `u64::MAX` (`u64::MAX..=0` -> len 0)
- Saturated full domain (`0..=u64::MAX` -> len `u64::MAX`)