### PR TITLE
feat(net): allow updating the fork filter at runtime

### DIFF
--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -776,6 +776,10 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
                     self.swarm.state_mut().update_fork_id(transition.current);
                 }
             }
+            NetworkHandleMessage::SetForkFilter { fork_filter } => {
+                let fork_id = self.swarm.sessions_mut().set_fork_filter(fork_filter);
+                self.swarm.state_mut().update_fork_id(fork_id);
+            }
             NetworkHandleMessage::GetPeerInfos(tx) => {
                 let _ = tx.send(self.get_peer_infos());
             }

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -12,7 +12,7 @@ use reth_eth_wire::{
     BlockRangeUpdate, BroadcastPoolTransactions, DisconnectReason, EthNetworkPrimitives,
     NetworkPrimitives, NewPooledTransactionHashes, SharedTransactions,
 };
-use reth_ethereum_forks::Head;
+use reth_ethereum_forks::{ForkFilter, Head};
 use reth_network_api::{
     events::{NetworkPeersEvents, PeerEvent, PeerEventStream},
     test_utils::{PeersHandle, PeersHandleProvider},
@@ -110,6 +110,18 @@ impl<N: NetworkPrimitives> NetworkHandle<N> {
     /// Update the status of the node.
     pub fn update_status(&self, head: Head) {
         self.send_message(NetworkHandleMessage::StatusUpdate { head });
+    }
+
+    /// Replaces the network's active [`ForkFilter`] with `fork_filter`, re-deriving the advertised
+    /// [`ForkId`](reth_ethereum_forks::ForkId) for future handshakes and updating the discovery
+    /// ENR entry.
+    ///
+    /// This lets a running node adopt a fork schedule that changed at runtime (e.g. an
+    /// L1-signalled upgrade) without a restart. The caller must build `fork_filter` from the
+    /// updated chain spec advanced to the node's current head, and should do so before the fork's
+    /// activation timestamp so the node announces the upcoming fork ahead of time.
+    pub fn set_fork_filter(&self, fork_filter: ForkFilter) {
+        self.send_message(NetworkHandleMessage::SetForkFilter { fork_filter });
     }
 
     /// Announce a block over devp2p
@@ -497,6 +509,11 @@ impl<N: NetworkPrimitives> NetworkSyncUpdater for NetworkHandle<N> {
     fn update_block_range(&self, update: reth_eth_wire::BlockRangeUpdate) {
         self.send_message(NetworkHandleMessage::InternalBlockRangeUpdate(update));
     }
+
+    /// Replaces the active fork filter to adopt a runtime fork-schedule change.
+    fn set_fork_filter(&self, fork_filter: ForkFilter) {
+        self.send_message(NetworkHandleMessage::SetForkFilter { fork_filter });
+    }
 }
 
 impl<N: NetworkPrimitives> BlockDownloaderProvider for NetworkHandle<N> {
@@ -613,6 +630,11 @@ pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives
     StatusUpdate {
         /// The head status to apply.
         head: Head,
+    },
+    /// Replaces the active fork filter to adopt a runtime fork-schedule change.
+    SetForkFilter {
+        /// The new fork filter, built from the updated chain spec advanced to the current head.
+        fork_filter: ForkFilter,
     },
     /// Retrieves the current status via a oneshot sender.
     GetStatus(oneshot::Sender<NetworkStatus>),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -263,6 +263,23 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         transition
     }
 
+    /// Replaces the active [`ForkFilter`] with a newly derived one and returns the resulting
+    /// [`ForkId`].
+    ///
+    /// This is used to adopt a fork schedule that changed at runtime (e.g. an L1-signalled
+    /// upgrade) without restarting the node. The caller is expected to build `fork_filter` from
+    /// the updated chain spec already advanced to the node's current head, so that
+    /// [`ForkFilter::current`] reflects the correct [`ForkId`] immediately.
+    ///
+    /// Every subsequent handshake clones this filter and advertises the returned [`ForkId`], so
+    /// the node's advertised fork identity stays aligned with the rules it now enforces. Existing
+    /// active sessions are not revalidated here; see [`SessionManager::active_sessions`].
+    pub(crate) fn set_fork_filter(&mut self, fork_filter: ForkFilter) -> ForkId {
+        self.fork_filter = fork_filter;
+        self.status.forkid = self.fork_filter.current();
+        self.status.forkid
+    }
+
     /// An incoming TCP connection was received. This starts the authentication process to turn this
     /// stream into an active peer session.
     ///

--- a/crates/net/p2p/src/sync.rs
+++ b/crates/net/p2p/src/sync.rs
@@ -1,6 +1,6 @@
 //! Traits used when interacting with the sync status of the network.
 
-use alloy_eips::eip2124::Head;
+use alloy_eips::eip2124::{ForkFilter, Head};
 use reth_eth_wire_types::BlockRangeUpdate;
 
 /// A type that provides information about whether the node is currently syncing and the network is
@@ -31,6 +31,17 @@ pub trait NetworkSyncUpdater: std::fmt::Debug + Send + Sync + 'static {
 
     /// Updates the advertised block range.
     fn update_block_range(&self, update: BlockRangeUpdate);
+
+    /// Replaces the node's active [`ForkFilter`] to adopt a fork schedule that changed at runtime
+    /// (e.g. an L1-signalled upgrade) without a restart.
+    ///
+    /// The caller must build `fork_filter` from the updated chain spec advanced to the node's
+    /// current head, and should do so before the fork's activation timestamp so the node
+    /// announces the upcoming fork ahead of time. Defaults to a no-op for updaters that do not
+    /// track a fork filter.
+    fn set_fork_filter(&self, fork_filter: ForkFilter) {
+        let _ = fork_filter;
+    }
 }
 
 /// The state the network is currently in when it comes to synchronization.


### PR DESCRIPTION
At Base we are adding a way for a network to adopt an upgrade schedule that is signalled on L1 instead of baked into the node binary. A running node reads the activation timestamps from a contract and applies them without shipping a new release. Execution already follows this because our chain spec reads the live schedule, but the P2P layer does not. reth builds the `ForkFilter` once at startup and only advances its head, so a node that learns about a fork at runtime keeps advertising its old fork id, looks stale to fresh peers once the fork activates, and gets partitioned even though it is enforcing the new rules. Statically scheduled forks avoid this because every node has the fork in its filter before it starts and announces it ahead of time.

This adds a way to replace the active fork filter on a running node without a restart. `NetworkHandle` gains a `set_fork_filter` method and `NetworkSyncUpdater` gains a matching defaulted trait method, following the existing `update_status` pattern. It sends a new internal `SetForkFilter` message, the manager swaps the session manager's filter, re-derives the advertised fork id, and updates the discovery ENR through the existing `update_fork_id` path. Every later handshake clones the new filter. The caller builds the filter from the updated chain spec at the current head and applies it before activation so the node announces the upcoming fork and EIP-2124 bridges the transition. Opening as a draft for early feedback before adding tests.
