### PR TITLE
feat(engine): remove partial persistence feature flag

### DIFF
--- a/.github/scripts/verify_image_arch.sh
+++ b/.github/scripts/verify_image_arch.sh
@@ -42,7 +42,6 @@ verify_image() {
 
 if [[ "$TARGETS" == *"nightly"* ]]; then
     verify_image "${REGISTRY}/reth:nightly" amd64 arm64
-    verify_image "${REGISTRY}/reth:nightly-partial-persistence" amd64 arm64
     verify_image "${REGISTRY}/reth:nightly-profiling" amd64
     verify_image "${REGISTRY}/reth:nightly-edge-profiling" amd64
 else

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,7 +96,6 @@ jobs:
               echo "ethereum.tags=${REGISTRY}/reth:nightly"
               echo "ethereum.args.RETH_ENGINE_TXPOOL_PREWARMING=true"
               echo "ethereum.args.RETH_ENGINE_SENDER_RECOVERY_CACHE=true"
-              echo "ethereum-partial-persistence.tags=${REGISTRY}/reth:nightly-partial-persistence"
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
 

--- a/bin/reth-bb/Cargo.toml
+++ b/bin/reth-bb/Cargo.toml
@@ -122,8 +122,6 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-partial-persistence = ["reth-node-core/partial-persistence"]
-
 [[bin]]
 name = "reth-bb"
 path = "src/main.rs"

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -199,7 +199,6 @@ min-trace-logs = [
     "reth-node-core/min-trace-logs",
 ]
 
-partial-persistence = ["reth-node-core/partial-persistence"]
 trie-debug = ["reth-node-builder/trie-debug", "reth-node-core/trie-debug"]
 
 [[bin]]

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -386,8 +386,7 @@ impl<C, Pool> TestnetHandle<C, Pool> {
 
         // add all peers to each other
         for (idx, handle) in self.peers.iter().enumerate().take(self.peers.len() - 1) {
-            for idx in (idx + 1)..self.peers.len() {
-                let neighbour = &self.peers[idx];
+            for neighbour in &self.peers[idx + 1..] {
                 handle.network.add_peer(*neighbour.peer_id(), neighbour.local_addr());
             }
         }

--- a/crates/net/network/src/transactions/fetcher.rs
+++ b/crates/net/network/src/transactions/fetcher.rs
@@ -184,10 +184,7 @@ impl<N: NetworkPrimitives> TransactionFetcher<N> {
     #[inline]
     pub fn is_idle(&self, peer_id: &PeerId) -> bool {
         let Some(inflight_count) = self.active_peers.peek(peer_id) else { return true };
-        if *inflight_count < self.info.max_inflight_requests_per_peer {
-            return true
-        }
-        false
+        *inflight_count < self.info.max_inflight_requests_per_peer
     }
 
     /// Returns any idle peer for the given hash.

--- a/crates/node/core/Cargo.toml
+++ b/crates/node/core/Cargo.toml
@@ -90,8 +90,6 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
-partial-persistence = ["reth-stages-types/partial-persistence"]
-
 # Debug recording for sparse trie mutations
 trie-debug = ["reth-engine-primitives/trie-debug"]
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -326,18 +326,11 @@ pub struct EngineArgs {
     #[arg(long = "engine.persistence-backpressure-threshold")]
     pub persistence_backpressure_threshold: Option<u64>,
 
-    /// Configure how many of the blocks being persisted should only mask state/trie writes instead
-    /// of durably persisting their state/trie updates in the current cycle.
-    #[cfg_attr(
-        feature = "partial-persistence",
-        arg(
-            long = "engine.num-state-masking-blocks",
-            default_value_t = DefaultEngineValues::get_global().num_state_masking_blocks
-        )
-    )]
-    #[cfg_attr(
-        not(feature = "partial-persistence"),
-        arg(skip = DefaultEngineValues::get_global().num_state_masking_blocks)
+    /// EXPERIMENTAL: Configure how many of the blocks being persisted should only mask state/trie
+    /// writes instead of durably persisting their state/trie updates in the current cycle.
+    #[arg(
+        long = "engine.num-state-masking-blocks",
+        default_value_t = DefaultEngineValues::get_global().num_state_masking_blocks
     )]
     pub num_state_masking_blocks: u64,
 
@@ -994,7 +987,6 @@ mod tests {
         assert!(err.contains("engine.persistence-threshold"));
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn test_parse_num_state_masking_blocks() {
         let args = CommandParser::<EngineArgs>::parse_from([
@@ -1007,17 +999,6 @@ mod tests {
         .args;
 
         assert_eq!(args.tree_config().num_state_masking_blocks(), 7);
-    }
-
-    #[cfg(not(feature = "partial-persistence"))]
-    #[test]
-    fn num_state_masking_blocks_is_hidden_without_partial_persistence() {
-        assert!(CommandParser::<EngineArgs>::try_parse_from([
-            "reth",
-            "--engine.num-state-masking-blocks",
-            "1",
-        ])
-        .is_err());
     }
 
     #[test]

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -1081,11 +1081,7 @@ impl DiscoveryArgs {
     ///
     /// Discv5 is enabled by default and can be disabled with `--disable-discv5-discovery`.
     const fn should_enable_discv5(&self) -> bool {
-        if self.disable_discovery || self.disable_discv5_discovery {
-            return false;
-        }
-
-        true
+        !(self.disable_discovery || self.disable_discv5_discovery)
     }
 
     /// Set the discovery ports to zero, to allow the OS to assign random unused ports when

--- a/crates/stages/types/Cargo.toml
+++ b/crates/stages/types/Cargo.toml
@@ -35,7 +35,6 @@ modular-bitfield.workspace = true
 
 [features]
 default = ["std"]
-partial-persistence = []
 std = [
     "alloy-primitives/std",
     "bytes?/std",

--- a/crates/stages/types/src/checkpoints.rs
+++ b/crates/stages/types/src/checkpoints.rs
@@ -442,14 +442,8 @@ reth_codecs::impl_compression_for_compact!(StageCheckpoint);
 /// Saves the progress of the Finish stage.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "test-utils"), derive(arbitrary::Arbitrary))]
-#[cfg_attr(
-    all(any(test, feature = "reth-codec"), feature = "partial-persistence"),
-    derive(reth_codecs::Compact)
-)]
-#[cfg_attr(
-    all(any(test, feature = "reth-codec"), feature = "partial-persistence"),
-    reth_codecs::add_arbitrary_tests(compact)
-)]
+#[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FinishCheckpoint {
     /// The highest block with a partially persisted state and trie.
@@ -457,30 +451,9 @@ pub struct FinishCheckpoint {
 }
 
 impl FinishCheckpoint {
-    /// Returns the highest block with a partially persisted state and trie, if enabled.
+    /// Returns the highest block with a partially persisted state and trie.
     pub const fn partial_state_trie(&self) -> Option<BlockNumber> {
-        #[cfg(feature = "partial-persistence")]
-        {
-            self.partial_state_trie
-        }
-        #[cfg(not(feature = "partial-persistence"))]
-        {
-            None
-        }
-    }
-}
-
-#[cfg(all(any(test, feature = "reth-codec"), not(feature = "partial-persistence")))]
-impl reth_codecs::Compact for FinishCheckpoint {
-    fn to_compact<B>(&self, _buf: &mut B) -> usize
-    where
-        B: bytes::BufMut + AsMut<[u8]>,
-    {
-        panic!("serializing FinishCheckpoint requires the `partial-persistence` feature")
-    }
-
-    fn from_compact(_buf: &[u8], _len: usize) -> (Self, &[u8]) {
-        panic!("deserializing FinishCheckpoint requires the `partial-persistence` feature")
+        self.partial_state_trie
     }
 }
 
@@ -511,10 +484,6 @@ pub enum StageUnitCheckpoint {
     /// The `MerkleChangeSets` stage has been removed.
     MerkleChangeSets(MerkleChangeSetsCheckpoint),
     /// Saves the progress of the Finish stage.
-    #[cfg_attr(
-        all(any(test, feature = "test-utils"), not(feature = "partial-persistence")),
-        arbitrary(skip)
-    )]
     Finish(FinishCheckpoint),
 }
 
@@ -725,7 +694,6 @@ mod tests {
         assert_eq!(decoded, checkpoint);
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn finish_checkpoint_roundtrip() {
         let finish_checkpoint = FinishCheckpoint { partial_state_trie: Some(21) };
@@ -737,27 +705,5 @@ mod tests {
 
         assert_eq!(decoded, checkpoint);
         assert_eq!(decoded.finish_stage_checkpoint().unwrap().partial_state_trie(), Some(21));
-    }
-
-    #[cfg(not(feature = "partial-persistence"))]
-    #[test]
-    #[should_panic(
-        expected = "serializing FinishCheckpoint requires the `partial-persistence` feature"
-    )]
-    fn finish_checkpoint_serialization_requires_partial_persistence() {
-        let finish_checkpoint = FinishCheckpoint { partial_state_trie: Some(21) };
-        assert_eq!(finish_checkpoint.partial_state_trie(), None);
-
-        let checkpoint = StageCheckpoint::new(42).with_finish_stage_checkpoint(finish_checkpoint);
-        checkpoint.to_compact(&mut Vec::new());
-    }
-
-    #[cfg(not(feature = "partial-persistence"))]
-    #[test]
-    #[should_panic(
-        expected = "deserializing FinishCheckpoint requires the `partial-persistence` feature"
-    )]
-    fn finish_checkpoint_deserialization_requires_partial_persistence() {
-        let _ = FinishCheckpoint::from_compact(&[], 0);
     }
 }

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -88,10 +88,6 @@ tokio-stream = { workspace = true, features = ["sync"] }
 
 [features]
 jemalloc = ["rocksdb/jemalloc"]
-partial-persistence = [
-    "reth-stages-types/partial-persistence",
-    "reth-storage-overlay/partial-persistence",
-]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4233,14 +4233,10 @@ mod tests {
                 StateWriteConfig::default(),
             )
             .unwrap();
-        for i in 0..3 {
-            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+        for (block, outcome) in data.blocks.iter().take(3) {
+            provider_rw.insert_block(block).unwrap();
             provider_rw
-                .write_state(
-                    &data.blocks[i].1,
-                    crate::OriginalValuesKnown::No,
-                    StateWriteConfig::default(),
-                )
+                .write_state(outcome, crate::OriginalValuesKnown::No, StateWriteConfig::default())
                 .unwrap();
         }
         provider_rw.commit().unwrap();
@@ -4272,14 +4268,10 @@ mod tests {
             .unwrap();
 
         // insert blocks 1-3 with receipts
-        for i in 0..3 {
-            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+        for (block, outcome) in data.blocks.iter().take(3) {
+            provider_rw.insert_block(block).unwrap();
             provider_rw
-                .write_state(
-                    &data.blocks[i].1,
-                    crate::OriginalValuesKnown::No,
-                    StateWriteConfig::default(),
-                )
+                .write_state(outcome, crate::OriginalValuesKnown::No, StateWriteConfig::default())
                 .unwrap();
         }
         provider_rw.commit().unwrap();
@@ -4308,14 +4300,10 @@ mod tests {
                 StateWriteConfig::default(),
             )
             .unwrap();
-        for i in 0..3 {
-            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+        for (block, outcome) in data.blocks.iter().take(3) {
+            provider_rw.insert_block(block).unwrap();
             provider_rw
-                .write_state(
-                    &data.blocks[i].1,
-                    crate::OriginalValuesKnown::No,
-                    StateWriteConfig::default(),
-                )
+                .write_state(outcome, crate::OriginalValuesKnown::No, StateWriteConfig::default())
                 .unwrap();
         }
         provider_rw.commit().unwrap();
@@ -4378,14 +4366,10 @@ mod tests {
                 StateWriteConfig::default(),
             )
             .unwrap();
-        for i in 0..3 {
-            provider_rw.insert_block(&data.blocks[i].0).unwrap();
+        for (block, outcome) in data.blocks.iter().take(3) {
+            provider_rw.insert_block(block).unwrap();
             provider_rw
-                .write_state(
-                    &data.blocks[i].1,
-                    crate::OriginalValuesKnown::No,
-                    StateWriteConfig::default(),
-                )
+                .write_state(outcome, crate::OriginalValuesKnown::No, StateWriteConfig::default())
                 .unwrap();
         }
         provider_rw.commit().unwrap();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4089,9 +4089,7 @@ mod tests {
         map::{AddressMap, B256Map},
         U256,
     };
-    #[cfg(feature = "partial-persistence")]
-    use reth_chain_state::test_utils::TestBlockBuilder;
-    use reth_chain_state::ExecutedBlock;
+    use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_db_api::models::StorageSettings;
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::{AccountRevertInit, BlockExecutionOutput, BlockExecutionResult};
@@ -4642,7 +4640,6 @@ mod tests {
         provider_rw.commit().unwrap();
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn test_save_blocks_only_masks_trie_with_deferred_blocks() {
         use reth_trie::{
@@ -4864,7 +4861,6 @@ mod tests {
         assert_eq!(masked_entries[0].1.nibbles.0, masked_storage_node);
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn test_save_blocks_merges_storage_wipe_in_multi_block_batch() {
         use reth_trie::{
@@ -4930,7 +4926,6 @@ mod tests {
         assert!(storage_entries.is_empty());
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn test_save_blocks_batches_transient_storage_wipe() {
         use alloy_primitives::map::B256Set;
@@ -4981,7 +4976,6 @@ mod tests {
         assert_eq!(checkpoint.block_number, 3);
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn test_save_blocks_partial_cycles_do_not_duplicate_static_file_writes() {
         let factory = create_test_provider_factory();
@@ -5030,7 +5024,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn remove_block_and_execution_above_returns_persistence_frontiers() {
         let factory = create_test_provider_factory();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -5036,6 +5036,10 @@ mod tests {
         save_genesis(&provider_rw, &genesis).unwrap();
         provider_rw.commit().unwrap();
 
+        for block in &blocks[2..] {
+            factory.overlay_manager().insert_block(block.clone());
+        }
+
         let provider_rw = factory.provider_rw().unwrap();
         let input = SaveBlocksInput::new(blocks, 0, 0, 4, 2);
         provider_rw.save_blocks(&input).unwrap();

--- a/crates/storage/storage-overlay/Cargo.toml
+++ b/crates/storage/storage-overlay/Cargo.toml
@@ -50,5 +50,4 @@ reth-trie = { workspace = true, features = ["test-utils"] }
 alloy-consensus.workspace = true
 
 [features]
-partial-persistence = ["reth-stages-types/partial-persistence"]
 rayon = ["dep:rayon", "dep:reth-tasks"]

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -764,11 +764,6 @@ mod tests {
                 panic!("persisted parent below Finish must require reverts")
             }
         }
-
-        let overlay = builder.build_overlay(&provider).unwrap();
-
-        assert!(overlay.hashed_post_state.is_empty());
-        assert!(overlay.trie_updates.is_empty());
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -610,15 +610,11 @@ mod tests {
     use alloy_primitives::U256;
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
-    #[cfg(feature = "partial-persistence")]
     use reth_provider::{
         test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
         BlockWriter, ProviderFactory,
     };
-    #[cfg(feature = "partial-persistence")]
-    #[cfg(feature = "partial-persistence")]
     use reth_stages_types::{FinishCheckpoint, StageCheckpoint};
-    #[cfg(feature = "partial-persistence")]
     use reth_storage_api::StageCheckpointWriter;
     use reth_trie::{BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, Nibbles};
 
@@ -658,7 +654,6 @@ mod tests {
             .collect()
     }
 
-    #[cfg(feature = "partial-persistence")]
     fn setup_frontiers(
         state_trie_tip_index: usize,
         finish_tip_index: usize,
@@ -683,17 +678,14 @@ mod tests {
         (factory, blocks)
     }
 
-    #[cfg(feature = "partial-persistence")]
     fn account_keys(overlay: &Overlay) -> Vec<B256> {
         overlay.hashed_post_state.accounts.iter().map(|(key, _)| *key).collect()
     }
 
-    #[cfg(feature = "partial-persistence")]
     fn account_node_paths(overlay: &Overlay) -> Vec<Nibbles> {
         overlay.trie_updates.account_nodes_ref().iter().map(|(path, _)| *path).collect()
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn managed_overlay_starts_at_state_trie_frontier() {
         let (factory, blocks) = setup_frontiers(1, 3);
@@ -724,7 +716,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn managed_overlay_skips_when_finish_is_the_anchor() {
         let (factory, blocks) = setup_frontiers(3, 3);
@@ -742,7 +733,6 @@ mod tests {
         assert!(overlay.trie_updates.is_empty());
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn no_reverts_errors_when_reverts_are_required() {
         let (factory, blocks) = setup_frontiers(2, 3);
@@ -757,7 +747,6 @@ mod tests {
         assert!(error.to_string().contains("reverts are disabled"));
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn managed_overlay_uses_persisted_parent_even_if_retained() {
         let (factory, blocks) = setup_frontiers(2, 3);
@@ -782,7 +771,6 @@ mod tests {
         assert!(overlay.trie_updates.is_empty());
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn overlay_after_state_trie_frontier_requires_managed_coverage() {
         let (factory, blocks) = setup_frontiers(1, 3);
@@ -799,7 +787,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "partial-persistence")]
     #[test]
     fn managed_overlay_errors_if_parent_is_not_persisted_or_managed_across_frontiers() {
         let (factory, blocks) = setup_frontiers(1, 3);

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -250,7 +250,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "partial-persistence"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::OverlayManager;

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,7 +35,7 @@ group "default" {
 }
 
 group "nightly" {
-  targets = ["ethereum", "ethereum-profiling", "ethereum-partial-persistence"]
+  targets = ["ethereum", "ethereum-profiling"]
 }
 
 // Base target with shared configuration
@@ -69,16 +69,6 @@ target "ethereum" {
     MANIFEST_PATH = "bin/reth"
   }
   tags = ["${REGISTRY}/reth:${TAG}"]
-}
-
-target "ethereum-partial-persistence" {
-  inherits = ["_base"]
-  args = {
-    BINARY        = "reth"
-    MANIFEST_PATH = "bin/reth"
-    FEATURES      = "partial-persistence"
-  }
-  tags = ["${REGISTRY}/reth:nightly-partial-persistence"]
 }
 
 target "ethereum-profiling" {

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1011,6 +1011,11 @@ Engine:
 
           This value must be greater than `--engine.persistence-threshold`.
 
+      --engine.num-state-masking-blocks <NUM_STATE_MASKING_BLOCKS>
+          EXPERIMENTAL: Configure how many of the blocks being persisted should only mask state/trie writes instead of durably persisting their state/trie updates in the current cycle
+
+          [default: 0]
+
       --engine.memory-block-buffer-target <MEMORY_BLOCK_BUFFER_TARGET>
           Configure the target number of blocks to keep in memory.
 


### PR DESCRIPTION
Compiles partial persistence unconditionally and removes the dedicated Cargo feature and nightly image. Exposes `--engine.num-state-masking-blocks` with an `EXPERIMENTAL` warning in CLI help and generated docs.

Prompted by: @mediocregopher