### PR TITLE
fix(trie): materialize destroyed storage trie nodes

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -186,7 +186,7 @@ where
     }
 }
 
-/// Builder for [`NetworkConfig`](struct.NetworkConfig.html).
+/// Builder for [`NetworkConfig`].
 #[derive(Debug)]
 pub struct NetworkConfigBuilder<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The node's secret key, from which the node's identity is derived.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4910,6 +4910,7 @@ mod tests {
         assert!(storage_entries.is_empty());
     }
 
+    #[test]
     fn test_save_blocks_partial_cycles_do_not_duplicate_static_file_writes() {
         let factory = create_test_provider_factory();
         let mut test_block_builder = TestBlockBuilder::eth().with_state();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4932,57 +4932,6 @@ mod tests {
 
     #[cfg(feature = "partial-persistence")]
     #[test]
-    fn test_save_blocks_batches_transient_storage_wipe() {
-        use alloy_primitives::map::B256Set;
-        use reth_trie::{updates::TrieUpdates, HashBuilder, HashedPostStateSorted};
-
-        let factory = create_test_provider_factory();
-        factory.set_storage_settings_cache(StorageSettings::v2());
-
-        let mut test_block_builder = TestBlockBuilder::eth().with_state();
-        let genesis = test_block_builder.get_executed_blocks(0..1).next().unwrap();
-        let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..4).collect();
-
-        let provider_rw = factory.provider_rw().unwrap();
-        save_genesis(&provider_rw, &genesis).unwrap();
-        provider_rw.commit().unwrap();
-
-        // A contract created and self-destructed in the same transaction leaves an empty whole-
-        // storage wipe in the trie updates, even though the account never reaches persisted state.
-        let ephemeral_account = B256::with_last_byte(0x57);
-        let hashed_state = HashedPostStateSorted::default();
-        let mut trie_updates = TrieUpdates::default();
-        trie_updates.finalize(
-            HashBuilder::default(),
-            Default::default(),
-            B256Set::from_iter([ephemeral_account]),
-        );
-        let trie_updates = trie_updates.into_sorted();
-        assert!(trie_updates.storage_tries_ref()[&ephemeral_account].is_deleted);
-        let selfdestruct_block = ExecutedBlock::new(
-            Arc::clone(&blocks[2].recovered_block),
-            Arc::clone(&blocks[2].execution_output),
-            ComputedTrieData::new(Arc::new(hashed_state), Arc::new(trie_updates)),
-        );
-
-        let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(
-            vec![blocks[0].clone(), blocks[1].clone(), selfdestruct_block],
-            0,
-            0,
-            3,
-            3,
-        );
-        provider_rw.save_blocks(&input).unwrap();
-        provider_rw.commit().unwrap();
-
-        let checkpoint =
-            factory.provider().unwrap().get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
-        assert_eq!(checkpoint.block_number, 3);
-    }
-
-    #[cfg(feature = "partial-persistence")]
-    #[test]
     fn test_save_blocks_partial_cycles_do_not_duplicate_static_file_writes() {
         let factory = create_test_provider_factory();
         let mut test_block_builder = TestBlockBuilder::eth().with_state();

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -915,12 +915,7 @@ mod tests {
         let actual =
             reth_trie_db::compute_range_trie_changesets(&*provider, &state_trie_provider, 1..=3, 3)
                 .unwrap();
-        let storage_revert = actual
-            .storage_tries_ref()
-            .get(&hashed_address)
-            .expect("created account storage trie should be deleted by range revert");
-        assert!(storage_revert.is_deleted());
-        assert!(storage_revert.storage_nodes_ref().is_empty());
+        assert!(actual.storage_tries_ref().get(&hashed_address).is_none());
 
         let cache = ChangesetCache::new();
         let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -7,7 +7,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_primitives::{
-    map::{B256Map, B256Set, HashMap, HashSet},
+    map::{B256Map, HashMap, HashSet},
     FixedBytes, B256,
 };
 
@@ -141,7 +141,7 @@ impl TrieUpdates {
         &mut self,
         hash_builder: HashBuilder,
         removed_keys: HashSet<Nibbles>,
-        destroyed_accounts: B256Set,
+        destroyed_storage_trie_nodes: B256Map<Vec<Nibbles>>,
     ) {
         // Retrieve updated nodes from hash builder.
         let (_, updated_nodes) = hash_builder.split();
@@ -150,9 +150,13 @@ impl TrieUpdates {
         // Add deleted node paths.
         self.removed_nodes.extend(exclude_empty(removed_keys));
 
-        // Add deleted storage tries for destroyed accounts.
-        for destroyed in destroyed_accounts {
-            self.storage_tries.entry(destroyed).or_default().set_deleted(true);
+        // Add removed storage trie nodes for destroyed accounts.
+        for (hashed_address, removed_nodes) in destroyed_storage_trie_nodes {
+            let storage_updates = self.storage_tries.entry(hashed_address).or_default();
+            storage_updates.removed_nodes.extend(removed_nodes);
+            storage_updates
+                .storage_nodes
+                .retain(|path, _| !storage_updates.removed_nodes.contains(path));
         }
     }
 

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -154,9 +154,6 @@ impl TrieUpdates {
         for (hashed_address, removed_nodes) in destroyed_storage_trie_nodes {
             let storage_updates = self.storage_tries.entry(hashed_address).or_default();
             storage_updates.removed_nodes.extend(removed_nodes);
-            storage_updates
-                .storage_nodes
-                .retain(|path, _| !storage_updates.removed_nodes.contains(path));
         }
     }
 
@@ -945,6 +942,34 @@ impl From<StorageTrieUpdatesSorted> for StorageTrieUpdates {
 mod tests {
     use super::*;
     use alloy_primitives::B256;
+
+    #[test]
+    fn test_finalize_keeps_storage_updates_after_destroyed_node_removal() {
+        let hashed_address = B256::with_last_byte(1);
+        let path = Nibbles::from_nibbles_unchecked([0x01]);
+        let node = BranchNodeCompact::default();
+        let mut updates = TrieUpdates {
+            storage_tries: B256Map::from_iter([(
+                hashed_address,
+                StorageTrieUpdates {
+                    storage_nodes: HashMap::from_iter([(path, node.clone())]),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        updates.finalize(
+            HashBuilder::default(),
+            Default::default(),
+            B256Map::from_iter([(hashed_address, vec![path])]),
+        );
+
+        assert_eq!(
+            updates.into_sorted().storage_tries[&hashed_address].storage_nodes,
+            vec![(path, Some(node))]
+        );
+    }
 
     #[test]
     fn test_trie_updates_sorted_extend_ref() {

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -2,14 +2,18 @@
 
 use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{
-    address, b256, hex_literal::hex, keccak256, map::HashMap, Address, B256, U256,
+    address, b256,
+    hex_literal::hex,
+    keccak256,
+    map::{B256Set, HashMap},
+    Address, B256, U256,
 };
 use alloy_rlp::Encodable;
 use proptest::{prelude::ProptestConfig, proptest};
 use proptest_arbitrary_interop::arb;
 use reth_db::{tables, test_utils::TempDatabase, DatabaseEnv};
 use reth_db_api::{
-    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     transaction::{DbTx, DbTxMut},
 };
 use reth_primitives_traits::{Account, StorageEntry};
@@ -270,6 +274,90 @@ fn cleared_storage_emits_node_removals_without_deleted_flag() {
         assert!(!updates.is_deleted());
         assert!(!updates.removed_nodes_ref().is_empty());
     });
+}
+
+#[test]
+fn destroyed_account_storage_emits_node_removals() {
+    let factory = create_test_provider_factory();
+    let tx = factory.provider_rw().unwrap();
+    let hashed_address = B256::random();
+    tx.tx_ref().put::<tables::HashedAccounts>(hashed_address, Account::default()).unwrap();
+    for hashed_slot in [
+        hex!("30af561000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af569000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af650000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af6f0000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af8f0000000000000000000000000000000000000000000000000000000000"),
+        hex!("3100000000000000000000000000000000000000000000000000000000000000"),
+    ] {
+        tx.tx_ref()
+            .put::<tables::HashedStorages>(
+                hashed_address,
+                StorageEntry { key: B256::new(hashed_slot), value: U256::ONE },
+            )
+            .unwrap();
+    }
+
+    let initial_updates = reth_trie_db::with_adapter!(tx, |A| {
+        DbStateRoot::<_, A>::from_tx(tx.tx_ref()).root_with_updates().unwrap().1
+    });
+    tx.write_trie_updates(initial_updates).unwrap();
+
+    let initial_storage_updates = reth_trie_db::with_adapter!(tx, |A| {
+        DbStorageRoot::<_, A>::from_tx_hashed(tx.tx_ref(), hashed_address)
+            .root_with_updates()
+            .unwrap()
+            .2
+    });
+    let mut expected_removed_nodes: Vec<_> =
+        initial_storage_updates.storage_nodes_ref().keys().copied().collect();
+    expected_removed_nodes.sort_unstable();
+    assert!(!expected_removed_nodes.is_empty());
+    let initial_storage_updates = initial_storage_updates.into_sorted();
+    tx.write_storage_trie_updates_sorted(core::iter::once((
+        &hashed_address,
+        &initial_storage_updates,
+    )))
+    .unwrap();
+
+    let mut account_cursor = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
+    account_cursor.seek_exact(hashed_address).unwrap();
+    account_cursor.delete_current().unwrap();
+    drop(account_cursor);
+
+    let mut storage_cursor = tx.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+    storage_cursor.seek_exact(hashed_address).unwrap();
+    storage_cursor.delete_current_duplicates().unwrap();
+    drop(storage_cursor);
+
+    let mut account_prefix_set = PrefixSetMut::default();
+    account_prefix_set.insert(Nibbles::unpack(hashed_address));
+    let (root, updates) = reth_trie_db::with_adapter!(tx, |A| {
+        DbStateRoot::<_, A>::from_tx(tx.tx_ref())
+            .with_prefix_sets(TriePrefixSets {
+                account_prefix_set: account_prefix_set.freeze(),
+                destroyed_accounts: B256Set::from_iter([hashed_address]),
+                ..Default::default()
+            })
+            .root_with_updates()
+            .unwrap()
+    });
+
+    assert_eq!(root, EMPTY_ROOT_HASH);
+    let storage_updates = &updates.storage_tries_ref()[&hashed_address];
+    assert!(!storage_updates.is_deleted());
+    let mut removed_nodes: Vec<_> = storage_updates.removed_nodes_ref().iter().copied().collect();
+    removed_nodes.sort_unstable();
+    assert_eq!(removed_nodes, expected_removed_nodes);
+
+    tx.write_trie_updates(updates).unwrap();
+    assert!(tx
+        .tx_ref()
+        .cursor_dup_read::<tables::StoragesTrie>()
+        .unwrap()
+        .seek_exact(hashed_address)
+        .unwrap()
+        .is_none());
 }
 
 #[test]

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -7,13 +7,13 @@ use crate::{
         StateRootProgress, StorageRootProgress,
     },
     stats::TrieTracker,
-    trie_cursor::{TrieCursor, TrieCursorFactory, TrieStorageCursor},
+    trie_cursor::{TrieCursor, TrieCursorFactory, TrieCursorIter, TrieStorageCursor},
     updates::{StorageTrieUpdates, TrieUpdates},
     walker::TrieWalker,
     HashBuilder, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_primitives::{keccak256, Address, B256, U256};
+use alloy_primitives::{keccak256, map::B256Map, Address, B256, U256};
 use alloy_rlp::{BufMut, Encodable};
 use alloy_trie::proof::AddedRemovedKeys;
 use reth_execution_errors::{StateRootError, StorageRootError};
@@ -352,9 +352,28 @@ where
 
         let root = hash_builder.root();
 
+        let mut destroyed_storage_trie_nodes = B256Map::default();
+        if !self.prefix_sets.destroyed_accounts.is_empty() {
+            let mut storage_trie_cursor = match storage_trie_cursor {
+                Some(cursor) => cursor,
+                None => self.trie_cursor_factory.storage_trie_cursor(B256::ZERO)?,
+            };
+
+            for hashed_address in &self.prefix_sets.destroyed_accounts {
+                storage_trie_cursor.set_hashed_address(*hashed_address);
+                let nodes = TrieCursorIter::new(&mut storage_trie_cursor)
+                    .map(|node| node.map(|(path, _)| path))
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                if !nodes.is_empty() {
+                    destroyed_storage_trie_nodes.insert(*hashed_address, nodes);
+                }
+            }
+        }
+
         let removed_keys = account_node_iter.walker.take_removed_keys();
         let StateRootContext { mut trie_updates, hashed_entries_walked, .. } = storage_ctx;
-        trie_updates.finalize(hash_builder, removed_keys, self.prefix_sets.destroyed_accounts);
+        trie_updates.finalize(hash_builder, removed_keys, destroyed_storage_trie_nodes);
 
         let stats = tracker.finish();
 

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -353,7 +353,7 @@ where
         let root = hash_builder.root();
 
         let mut destroyed_storage_trie_nodes = B256Map::default();
-        if !self.prefix_sets.destroyed_accounts.is_empty() {
+        if retain_updates && !self.prefix_sets.destroyed_accounts.is_empty() {
             let mut storage_trie_cursor = match storage_trie_cursor {
                 Some(cursor) => cursor,
                 None => self.trie_cursor_factory.storage_trie_cursor(B256::ZERO)?,


### PR DESCRIPTION
Materializes every persisted storage-trie node path for destroyed accounts and records it as an ordinary removal. This replaces the the setting of the `is_deleted` flag on StorageTrieUpdates.

## Testing

* Ran pipeline sync from genesis through block 75k, which contains at least one SELFDESTRUCT of a non-empty account

* Ran engine sync with serial fallback across a recent block which has CREATE2+SELFDESTRUCT