### PR TITLE
fix(downloader): address account range review feedback

### DIFF
--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -86,4 +86,5 @@ test-utils = [
     "dep:reth-ethereum-primitives",
     "reth-ethereum-primitives?/test-utils",
     "reth-tasks/test-utils",
+    "reth-trie-common/test-utils",
 ]

--- a/crates/net/downloaders/Cargo.toml
+++ b/crates/net/downloaders/Cargo.toml
@@ -86,5 +86,4 @@ test-utils = [
     "dep:reth-ethereum-primitives",
     "reth-ethereum-primitives?/test-utils",
     "reth-tasks/test-utils",
-    "reth-trie-common/test-utils",
 ]

--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -26,7 +26,6 @@ const MAX_RETRIES: u8 = 2;
 ///
 /// Invalid responses penalize their peer and retry at high priority. Proof verification runs on
 /// the blocking pool.
-#[derive(Debug)]
 pub struct AccountRangeDownloader<C: SnapClient> {
     client: C,
     runtime: Runtime,
@@ -34,6 +33,17 @@ pub struct AccountRangeDownloader<C: SnapClient> {
     fut: C::Output,
     verification: Option<VerificationTask>,
     retries: u8,
+}
+
+impl<C: SnapClient> std::fmt::Debug for AccountRangeDownloader<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AccountRangeDownloader")
+            .field("client", &self.client)
+            .field("request", &self.request)
+            .field("verification", &self.verification)
+            .field("retries", &self.retries)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<C: SnapClient> AccountRangeDownloader<C> {
@@ -78,6 +88,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
                 Ok(Some(AccountRangeOutcome::Verified(VerifiedAccountRange {
                     accounts: Vec::new(),
                     has_more: false,
+                    next: None,
                 })))
             } else {
                 Ok(Some(AccountRangeOutcome::Unavailable { peer_id }))
@@ -164,7 +175,7 @@ impl<C: SnapClient> AccountRangeDownloader<C> {
 
 impl<C> Future for AccountRangeDownloader<C>
 where
-    C: SnapClient + Unpin + 'static,
+    C: SnapClient + Unpin,
 {
     type Output = Result<AccountRangeOutcome, RequestError>;
 
@@ -217,8 +228,15 @@ struct VerificationTask {
 pub struct VerifiedAccountRange {
     /// Accounts in strictly increasing hashed-key order.
     pub accounts: Vec<(B256, TrieAccount)>,
-    /// Whether another request is needed to complete the requested interval.
+    /// Whether another request may be needed to complete the requested interval.
+    ///
+    /// Conservative: [`Self::next`] is only a lower bound when the trie continues inside a
+    /// subtree the proof left unexpanded, so this can be `true` for an interval that is already
+    /// complete.
     pub has_more: bool,
+    /// Authenticated lower bound for the first key after the response, or `None` when the range
+    /// exhausted the trie.
+    pub next: Option<B256>,
 }
 
 // Authenticate the full response before trimming its optional boundary account.
@@ -249,7 +267,7 @@ fn verify_account_range(
     accounts.truncate(accounts.partition_point(|(hash, _)| *hash <= request.limit_hash));
     let has_more = next.is_some_and(|next| next <= request.limit_hash);
 
-    Ok(VerifiedAccountRange { accounts, has_more })
+    Ok(VerifiedAccountRange { accounts, has_more, next })
 }
 
 // Re-encode decoded accounts so the proof authenticates their canonical trie values.
@@ -259,18 +277,21 @@ fn verify_proof(
     proof: &[alloy_primitives::Bytes],
 ) -> Result<Option<B256>, RequestError> {
     let leaves = accounts.iter().map(|(hash, account)| (*hash, alloy_rlp::encode(account)));
-    verify_range_proof(request.root_hash, request.starting_hash, leaves, proof).map_err(|error| {
-        debug!(target: "downloaders::snap", %error, "Invalid account range proof");
-        RequestError::BadResponse
-    })
+    verify_range_proof(request.root_hash, request.starting_hash, request.limit_hash, leaves, proof)
+        .map_err(|error| {
+            debug!(target: "downloaders::snap", %error, "Invalid account range proof");
+            RequestError::BadResponse
+        })
 }
 
 /// An account-range request whose origin exceeds its limit.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 #[error("account range origin {origin} exceeds limit {limit}")]
 pub struct InvalidAccountRange {
-    origin: B256,
-    limit: B256,
+    /// Inclusive origin the range was requested from.
+    pub origin: B256,
+    /// Inclusive limit the range was requested to.
+    pub limit: B256,
 }
 
 #[cfg(test)]
@@ -446,7 +467,11 @@ mod tests {
 
         assert_eq!(
             outcome,
-            AccountRangeOutcome::Verified(VerifiedAccountRange { accounts, has_more: false })
+            AccountRangeOutcome::Verified(VerifiedAccountRange {
+                accounts,
+                has_more: false,
+                next: None,
+            })
         );
         assert!(client.reported.lock().unwrap().is_empty());
         assert_eq!(*client.priorities.lock().unwrap(), [Priority::Normal]);
@@ -533,6 +558,7 @@ mod tests {
             AccountRangeOutcome::Verified(VerifiedAccountRange {
                 accounts: vec![accounts[0]],
                 has_more: false,
+                next: Some(key(4)),
             })
         );
         assert!(client.reported.lock().unwrap().is_empty());
@@ -588,6 +614,7 @@ mod tests {
             AccountRangeOutcome::Verified(VerifiedAccountRange {
                 accounts: accounts[..2].to_vec(),
                 has_more: false,
+                next: Some(key(3)),
             })
         );
         assert!(client.reported.lock().unwrap().is_empty());
@@ -616,6 +643,31 @@ mod tests {
             AccountRangeOutcome::Verified(VerifiedAccountRange {
                 accounts: Vec::new(),
                 has_more: false,
+                next: None,
+            })
+        );
+        assert!(client.reported.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_interval_is_proven_without_a_boundary_account() {
+        let accounts = vec![(key(1), account(7)), (key(9), account(8))];
+        let (root_hash, proof) = root_and_proof(&accounts, &[key(3), key(5)]);
+        let peer = PeerId::random();
+        let message = AccountRangeMessage { request_id: 1, accounts: Vec::new(), proof };
+        let client = Arc::new(TestSnapClient::new([response(peer, message)]));
+        let mut request = request(root_hash);
+        request.starting_hash = key(3);
+        request.limit_hash = key(5);
+
+        let outcome = downloader(Arc::clone(&client), request).unwrap().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            AccountRangeOutcome::Verified(VerifiedAccountRange {
+                accounts: Vec::new(),
+                has_more: false,
+                next: Some(key(9)),
             })
         );
         assert!(client.reported.lock().unwrap().is_empty());
@@ -643,6 +695,7 @@ mod tests {
             AccountRangeOutcome::Verified(VerifiedAccountRange {
                 accounts: vec![accounts[0]],
                 has_more: false,
+                next: Some(key(9)),
             })
         );
     }
@@ -668,6 +721,7 @@ mod tests {
             AccountRangeOutcome::Verified(VerifiedAccountRange {
                 accounts: vec![accounts[0]],
                 has_more: true,
+                next: Some(key(3)),
             })
         );
     }

--- a/crates/trie/common/src/range_proof.rs
+++ b/crates/trie/common/src/range_proof.rs
@@ -11,7 +11,6 @@ use alloy_primitives::{keccak256, map::B256Map, Bytes, B256};
 use alloy_rlp::Decodable;
 
 const KEY_NIBBLES: usize = B256::len_bytes() * 2;
-const MAX_HASH: B256 = B256::new([0xff; B256::len_bytes()]);
 
 // Coordinates proof traversal and root reconstruction through one shared frontier.
 struct RangeProofVerifier<'a> {
@@ -150,7 +149,7 @@ impl<'a> RangeProofVerifier<'a> {
 struct ProofRange {
     // Inclusive origin paired with the proof's left boundary path.
     left: Nibbles,
-    // Inclusive last leaf, or the maximum key when an empty response proves exhaustion.
+    // Inclusive last leaf, or the requested limit when the response is empty.
     right: Nibbles,
 }
 
@@ -384,12 +383,16 @@ pub enum RangeProofError {
     Rlp(#[from] alloy_rlp::Error),
 }
 
-/// Verifies a consecutive leaf range against `root`, starting at `origin`.
+/// Verifies a consecutive leaf range against `root`, from `origin` through `limit`.
+///
+/// When `leaves` is empty, `limit` supplies the response's right boundary so an empty interval can
+/// be authenticated without requiring a leaf past the limit.
 ///
 /// Returns a lower bound for the next key, or `None` if the range exhausts the trie.
 pub fn verify_range_proof<I, V>(
     root: B256,
     origin: B256,
+    limit: B256,
     leaves: I,
     proof: &[Bytes],
 ) -> Result<Option<B256>, RangeProofError>
@@ -408,7 +411,7 @@ where
         return Ok(None)
     }
 
-    RangeProofVerifier::new(origin, last_key.unwrap_or(MAX_HASH), proof, frontier).verify(root)
+    RangeProofVerifier::new(origin, last_key.unwrap_or(limit), proof, frontier).verify(root)
 }
 
 // Keeps path mutation behind one checked API because external `Nibbles` cannot have inherent
@@ -477,6 +480,21 @@ mod tests {
     use super::*;
     use crate::{proof::ProofRetainer, BranchNode, ExtensionNode, TrieMask, EMPTY_ROOT_HASH};
     use alloc::{vec, vec::Vec};
+
+    const MAX_HASH: B256 = B256::new([0xff; B256::len_bytes()]);
+
+    fn verify_range_proof<I, V>(
+        root: B256,
+        origin: B256,
+        leaves: I,
+        proof: &[Bytes],
+    ) -> Result<Option<B256>, RangeProofError>
+    where
+        I: IntoIterator<Item = (B256, V)>,
+        V: Into<Vec<u8>>,
+    {
+        super::verify_range_proof(root, origin, MAX_HASH, leaves, proof)
+    }
 
     fn key(value: u64) -> B256 {
         B256::left_padding_from(&value.to_be_bytes())
@@ -702,6 +720,17 @@ mod tests {
             verify_range_proof(root, key(2), core::iter::empty::<(B256, Vec<u8>)>(), &proof,),
             Err(RangeProofError::RootMismatch { .. })
         ));
+    }
+
+    #[test]
+    fn empty_interval_is_authenticated_through_its_limit() {
+        let leaves = vec![(key(1), value(1)), (key(3), value(3))];
+        let (root, proof) = build_proof(&leaves, &[key(2)]);
+
+        assert_eq!(
+            super::verify_range_proof(root, key(2), key(2), no_leaves(), &proof).unwrap(),
+            Some(key(3))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #26657. Addresses the remaining account-range review feedback, including generic Debug support, authenticated continuation bounds, public range-error fields, and direct empty-interval verification.

Empty responses now authenticate the requested interval instead of requiring a boundary account past the limit.

Prompted by: @mattsse