### PR TITLE
refactor(trie): remove storage wipe markers

### DIFF
--- a/crates/engine/invalid-block-hooks/src/witness.rs
+++ b/crates/engine/invalid-block-hooks/src/witness.rs
@@ -12,7 +12,7 @@ use reth_revm::{
 };
 use reth_rpc_api::DebugApiClient;
 use reth_tracing::tracing::warn;
-use reth_trie::{updates::TrieUpdates, HashedStorage};
+use reth_trie::updates::TrieUpdates;
 use revm::{
     bytecode::Bytecode,
     database::{
@@ -138,10 +138,7 @@ fn collect_execution_data(
 
         if let Some(account_data) = account.account {
             preimages.insert(hashed_address, alloy_rlp::encode(address).into());
-            let storage = hashed_state
-                .storages
-                .entry(hashed_address)
-                .or_insert_with(|| HashedStorage::new(false));
+            let storage = hashed_state.storages.entry(hashed_address).or_default();
 
             for (slot, value) in account_data.storage {
                 let slot_bytes = B256::from(slot);

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -680,7 +680,7 @@ where
         // changes to start processing them before potentially hitting the db in the next step.
         if !account_changes.storage_changes.is_empty() {
             let hashed_address = *hashed_address.get_or_insert_with(|| keccak256(address));
-            let mut storage_map = reth_trie::HashedStorage::new(false);
+            let mut storage_map = reth_trie::HashedStorage::default();
 
             for slot_changes in &account_changes.storage_changes {
                 let hashed_slot = keccak256(slot_changes.slot.to_be_bytes::<32>());

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1146,7 +1146,7 @@ mod tests {
             address,
             Some(Account { balance: U256::from(100), nonce: 1, bytecode_hash: None }),
         );
-        let mut storage = reth_trie::HashedStorage::new(false);
+        let mut storage = reth_trie::HashedStorage::default();
         storage.storage.insert(slot, value);
         hashed_state.storages.insert(address, storage);
 

--- a/crates/engine/tree/src/tree/trie_updates.rs
+++ b/crates/engine/tree/src/tree/trie_updates.rs
@@ -59,28 +59,16 @@ impl TrieUpdatesDiff {
 
 #[derive(Debug, Default)]
 struct StorageTrieUpdatesDiff {
-    is_deleted: Option<EntryDiff<bool>>,
     storage_nodes: HashMap<Nibbles, EntryDiff<Option<BranchNodeCompact>>>,
     removed_nodes: HashMap<Nibbles, EntryDiff<bool>>,
 }
 
 impl StorageTrieUpdatesDiff {
     fn has_differences(&self) -> bool {
-        self.is_deleted.is_some() ||
-            !self.storage_nodes.is_empty() ||
-            !self.removed_nodes.is_empty()
+        !self.storage_nodes.is_empty() || !self.removed_nodes.is_empty()
     }
 
     fn log_differences(&self, address: B256) {
-        if let Some(EntryDiff {
-            task: task_deleted,
-            regular: regular_deleted,
-            database: database_not_exists,
-        }) = self.is_deleted
-        {
-            warn!(target: "engine::tree", ?address, ?task_deleted, ?regular_deleted, ?database_not_exists, "Difference in storage trie deletion");
-        }
-
         for (path, EntryDiff { task, regular, database }) in &self.storage_nodes {
             warn!(target: "engine::tree", ?address, ?path, ?task, ?regular, ?database, "Difference in storage trie updates");
         }
@@ -192,20 +180,7 @@ fn compare_storage_trie_updates<C: TrieCursor>(
     task: &mut StorageTrieUpdates,
     regular: &mut StorageTrieUpdates,
 ) -> Result<StorageTrieUpdatesDiff, DatabaseError> {
-    // Check if the storage trie exists by seeking to the first entry
-    let database_not_exists = trie_cursor()?.seek(Nibbles::default())?.is_none();
-    let mut diff = StorageTrieUpdatesDiff {
-        // If the deletion is a no-op, meaning that the entry is not in the
-        // database, do not add it to the diff.
-        is_deleted: (task.is_deleted != regular.is_deleted && !database_not_exists).then_some(
-            EntryDiff {
-                task: task.is_deleted,
-                regular: regular.is_deleted,
-                database: database_not_exists,
-            },
-        ),
-        ..Default::default()
-    };
+    let mut diff = StorageTrieUpdatesDiff::default();
 
     // compare storage nodes
     let mut storage_trie_cursor = trie_cursor()?;

--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -275,7 +275,6 @@ mod tests {
             storage_tries: HashMap::from_iter([(
                 hashed_address,
                 StorageTrieUpdates {
-                    is_deleted: false,
                     storage_nodes: HashMap::from_iter([(
                         Nibbles::from_nibbles_unchecked([0x04]),
                         BranchNodeCompact::default(),
@@ -292,10 +291,7 @@ mod tests {
             )]),
             storages: HashMap::from_iter([(
                 hashed_address,
-                HashedStorage {
-                    wiped: false,
-                    storage: HashMap::from_iter([(storage_key, U256::from(101))]),
-                },
+                HashedStorage { storage: HashMap::from_iter([(storage_key, U256::from(101))]) },
             )]),
         };
 

--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -188,8 +188,10 @@ mod tests {
     use reth_provider::Chain;
     use reth_testing_utils::generators::{self, random_block};
     use reth_trie_common::{
-        updates::{StorageTrieUpdates, TrieUpdates},
-        BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, LazyTrieData, Nibbles,
+        serde_bincode_compat,
+        updates::{StorageTrieUpdates, StorageTrieUpdatesSorted, TrieUpdates},
+        BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, HashedStorageSorted,
+        LazyTrieData, Nibbles,
     };
     use std::{collections::BTreeMap, fs::File, sync::Arc};
 
@@ -216,6 +218,26 @@ mod tests {
             deserialized_notification.map(|(notification, _)| notification),
             Some(notification)
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_legacy_sorted_trie_data() -> eyre::Result<()> {
+        let storage_nodes =
+            vec![(Nibbles::from_nibbles_unchecked([0x01]), Some(BranchNodeCompact::default()))];
+        let encoded = rmp_serde::encode::to_vec(&(false, &storage_nodes))?;
+        let decoded: serde_bincode_compat::updates::StorageTrieUpdatesSorted<'_> =
+            rmp_serde::decode::from_slice(&encoded)?;
+        let decoded: StorageTrieUpdatesSorted = decoded.into();
+        assert_eq!(decoded.storage_nodes, storage_nodes);
+
+        let storage_slots = vec![(B256::from([1; 32]), U256::from(1))];
+        let encoded = rmp_serde::encode::to_vec(&(&storage_slots, false))?;
+        let decoded: serde_bincode_compat::hashed_state::HashedStorageSorted<'_> =
+            rmp_serde::decode::from_slice(&encoded)?;
+        let decoded: HashedStorageSorted = decoded.into();
+        assert_eq!(decoded.storage_slots, storage_slots);
 
         Ok(())
     }

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -186,7 +186,7 @@ where
     }
 }
 
-/// Builder for [`NetworkConfig`](struct.NetworkConfig.html).
+/// Builder for [`NetworkConfig`].
 #[derive(Debug)]
 pub struct NetworkConfigBuilder<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The node's secret key, from which the node's identity is derived.

--- a/crates/revm/src/witness.rs
+++ b/crates/revm/src/witness.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use alloy_primitives::{keccak256, Bytes, B256};
-use reth_trie::{ExecutionWitnessMode, HashedPostState, HashedStorage};
+use reth_trie::{ExecutionWitnessMode, HashedPostState};
 use revm::database::State;
 
 /// Borrows finalized execution state for witness generation.
@@ -106,10 +106,7 @@ impl<'a, DB> ExecutionWitnessRecord<'a, DB> {
                 .accounts
                 .insert(hashed_address, account.account.as_ref().map(|a| (&a.info).into()));
 
-            let storage = hashed_state
-                .storages
-                .entry(hashed_address)
-                .or_insert_with(|| HashedStorage::new(false));
+            let storage = hashed_state.storages.entry(hashed_address).or_default();
 
             if let Some(account) = &account.account {
                 keys.push(address.to_vec().into());
@@ -138,6 +135,7 @@ mod tests {
     use alloy_primitives::{Address, U256};
     use reth_storage_api::HashedPostStateProvider;
     use reth_storage_errors::provider::ProviderResult;
+    use reth_trie::HashedStorage;
     use revm::{
         database::{states::CacheAccount, AccountStatus, BundleAccount, EmptyDB},
         state::AccountInfo,
@@ -157,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn destroyed_account_storage_is_zero_expanded_without_wipe() {
+    fn destroyed_account_storage_is_zero_expanded() {
         let address = Address::with_last_byte(1);
         let hashed_address = keccak256(address);
         let hashed_slot = B256::with_last_byte(2);
@@ -184,7 +182,6 @@ mod tests {
         let (hashed_state, _) =
             ExecutionWitnessRecord::new(&state).hashed_post_state(&provider).unwrap();
         let storage = hashed_state.storages.get(&hashed_address).unwrap();
-        assert!(!storage.wiped);
         assert_eq!(storage.storage.get(&hashed_slot), Some(&U256::ZERO));
     }
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1534,7 +1534,6 @@ mod tests {
         let hashed_state = provider.hashed_post_state(&bundle_state).unwrap();
         let storage = &hashed_state.storages[&hashed_address];
 
-        assert!(!storage.wiped);
         assert_eq!(storage.storage[&hashed_old_slot], U256::ZERO);
         assert_eq!(storage.storage[&hashed_new_slot], new_value);
     }

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -846,7 +846,6 @@ mod tests {
         let hashed_state = provider.latest().hashed_post_state(&state.bundle).unwrap();
 
         let storage = &hashed_state.storages[&hashed_address];
-        assert!(!storage.wiped);
         assert_eq!(storage.storage[&first_slot], U256::ZERO);
         assert_eq!(storage.storage[&second_slot], U256::ZERO);
         assert!(state.bundle.reverts.is_empty());

--- a/crates/stages/stages/tests/preimage.rs
+++ b/crates/stages/stages/tests/preimage.rs
@@ -159,10 +159,10 @@ async fn test_pipeline_v2_selfdestruct_changesets_use_plain_slots() -> eyre::Res
 
 /// Prefunding ensures the CREATE2 target has original account state, while its init code performs
 /// no `SSTORE`. This verifies that destruction alone does not create an otherwise-empty
-/// [`reth_trie::HashedStorage`] solely to carry `wiped = true`.
+/// [`reth_trie::HashedStorage`] update.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_pipeline_v2_prefunded_create2_selfdestruct_does_not_wipe_storage() -> eyre::Result<()>
-{
+async fn test_pipeline_v2_prefunded_create2_selfdestruct_does_not_create_storage_update(
+) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let scenario = setup_create2_selfdestruct_scenario()?;
@@ -193,8 +193,8 @@ async fn test_pipeline_v2_prefunded_create2_selfdestruct_does_not_wipe_storage()
 }
 
 /// Scenario coverage:
-/// 1. Single execution batch (`1..=2`) where block 1 writes and block 2 wipes.
-/// 2. Block-by-block storage changesets still contain plain keys for wipe entries.
+/// 1. Single execution batch (`1..=2`) where block 1 writes and block 2 destroys the account.
+/// 2. Block-by-block storage changesets still contain plain keys for destroyed entries.
 ///
 /// Regression coverage for single execution-batch behavior.
 #[tokio::test(flavor = "multi_thread")]
@@ -228,11 +228,11 @@ async fn test_pipeline_v2_single_batch_write_then_selfdestruct_changesets_plain_
 
 /// Scenario coverage:
 /// 1. A slot appears only in intermediate reverts (not final bundle state).
-/// 2. A later block in the same execution batch wipes the account.
-/// 3. Wipe changesets still contain the required plain slot key/value.
+/// 2. A later block in the same execution batch destroys the account.
+/// 3. Destroyed-storage changesets still contain the required plain slot key/value.
 ///
 /// Covers the edge case where a slot appears in intermediate block reverts but not in the final
-/// bundle state, then gets wiped by a later selfdestruct in the same execution batch.
+/// bundle state, then is destroyed by a later selfdestruct in the same execution batch.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pipeline_v2_single_batch_reverted_slot_then_selfdestruct_changesets_plain_slots(
 ) -> eyre::Result<()> {

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4910,6 +4910,7 @@ mod tests {
         assert!(storage_entries.is_empty());
     }
 
+    #[test]
     fn test_save_blocks_partial_cycles_do_not_duplicate_static_file_writes() {
         let factory = create_test_provider_factory();
         let mut test_block_builder = TestBlockBuilder::eth().with_state();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -786,25 +786,8 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 let start = Instant::now();
                 let batch = ExecutedBlock::trie_updates_refs(state_trie_blocks);
                 let mask = ExecutedBlock::trie_updates_refs(state_trie_masking_blocks);
-                // Sparse-trie streaming emits node updates, while the serial state-root path,
-                // including fallback, can emit a whole storage-trie wipe. `disjointed_merge_batch`
-                // rejects wipes, so use the ordered merge. Persisting updates shadowed by the
-                // masking suffix is redundant but safe: the in-memory overlay still takes
-                // precedence.
-                //
-                // With a revm release containing bluealloy/revm#3863, post-Cancun selfdestructs
-                // will no longer result in `storage.is_deleted` in serial trie updates. The flag
-                // remains valid `save_blocks` input when processing pre-Cancun historical data.
-                let contains_storage_wipe = batch.iter().chain(&mask).any(|updates| {
-                    updates.storage_tries_ref().values().any(|storage| storage.is_deleted)
-                });
-                let merged_trie = if contains_storage_wipe {
-                    TrieUpdatesSorted::merge_batch(
-                        state_trie_blocks.iter().rev().map(|block| block.trie_updates()),
-                    )
-                } else {
-                    Arc::new(TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask))
-                };
+                let merged_trie =
+                    Arc::new(TrieUpdatesSorted::disjointed_merge_batch(&batch, &mask));
                 if !merged_trie.is_empty() {
                     self.write_trie_updates_sorted(&merged_trie)?;
                 }
@@ -2832,10 +2815,6 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
         let mut hashed_storage_cursor =
             self.tx_ref().cursor_dup_write::<tables::HashedStorages>()?;
         for (hashed_address, storage) in sorted_storages {
-            if storage.is_wiped() && hashed_storage_cursor.seek_exact(*hashed_address)?.is_some() {
-                hashed_storage_cursor.delete_current_duplicates()?;
-            }
-
             for (hashed_slot, value) in storage.storage_slots_ref() {
                 let entry = StorageEntry { key: *hashed_slot, value: *value };
 
@@ -4474,14 +4453,14 @@ mod tests {
                 )
                 .unwrap();
 
-            // Add storage nodes for address2 (will be wiped)
+            // Add storage nodes for address2.
             storage_cursor
                 .upsert(
                     storage_address2,
                     &StorageTrieEntry {
                         nibbles: StoredNibblesSubKey(Nibbles::from_nibbles([0xa, 0xb])),
                         node: BranchNodeCompact::new(
-                            0b1100_1100_1100_1100, // will be wiped
+                            0b1100_1100_1100_1100,
                             0b0000_0000_0000_0000,
                             0b0000_0000_0000_0000,
                             vec![],
@@ -4496,7 +4475,7 @@ mod tests {
                     &StorageTrieEntry {
                         nibbles: StoredNibblesSubKey(Nibbles::from_nibbles([0xc, 0xd])),
                         node: BranchNodeCompact::new(
-                            0b0011_1100_0011_1100, // will be wiped
+                            0b0011_1100_0011_1100,
                             0b0000_0000_0000_0000,
                             0b0000_0000_0000_0000,
                             vec![],
@@ -4534,7 +4513,6 @@ mod tests {
 
         // Create sorted storage trie updates
         let storage_trie1 = StorageTrieUpdatesSorted {
-            is_deleted: false,
             storage_nodes: vec![
                 (
                     Nibbles::from_nibbles([0x1, 0x0]),
@@ -4551,8 +4529,10 @@ mod tests {
         };
 
         let storage_trie2 = StorageTrieUpdatesSorted {
-            is_deleted: true, // Wipe all storage for this address
-            storage_nodes: vec![],
+            storage_nodes: vec![
+                (Nibbles::from_nibbles([0xa, 0xb]), None),
+                (Nibbles::from_nibbles([0xc, 0xd]), None),
+            ],
         };
 
         let mut storage_tries = B256Map::default();
@@ -4564,9 +4544,9 @@ mod tests {
         // Write the sorted trie updates
         let num_entries = provider_rw.write_trie_updates_sorted(&trie_updates).unwrap();
 
-        // We should have 2 account insertions + 1 account deletion + 1 storage insertion + 1
-        // storage deletion = 5
-        assert_eq!(num_entries, 5);
+        // We should have 2 account insertions + 1 account deletion + 1 storage insertion + 3
+        // storage deletions = 7
+        assert_eq!(num_entries, 7);
 
         // Verify account trie updates were written correctly
         let tx = provider_rw.tx_ref();
@@ -4613,13 +4593,13 @@ mod tests {
             "Remaining entry should be [0x1, 0x0]"
         );
 
-        // Check storage for address2 was wiped
+        // Check storage for address2 was removed
         let storage_entries2: Vec<_> = storage_cursor
             .walk_dup(Some(storage_address2), None)
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
-        assert_eq!(storage_entries2.len(), 0, "Storage address2 should be empty after wipe");
+        assert_eq!(storage_entries2.len(), 0, "Storage address2 should be empty after removal");
 
         provider_rw.commit().unwrap();
     }
@@ -4667,17 +4647,11 @@ mod tests {
             B256Map::from_iter([
                 (
                     kept_storage,
-                    HashedStorageSorted {
-                        wiped: false,
-                        storage_slots: vec![(kept_slot, U256::from(1))],
-                    },
+                    HashedStorageSorted { storage_slots: vec![(kept_slot, U256::from(1))] },
                 ),
                 (
                     masked_storage,
-                    HashedStorageSorted {
-                        wiped: false,
-                        storage_slots: vec![(masked_slot, U256::from(2))],
-                    },
+                    HashedStorageSorted { storage_slots: vec![(masked_slot, U256::from(2))] },
                 ),
             ]),
         );
@@ -4690,14 +4664,12 @@ mod tests {
                 (
                     kept_storage,
                     StorageTrieUpdatesSorted {
-                        is_deleted: false,
                         storage_nodes: vec![(kept_storage_node, Some(branch(0b1010)))],
                     },
                 ),
                 (
                     masked_storage,
                     StorageTrieUpdatesSorted {
-                        is_deleted: false,
                         storage_nodes: vec![(masked_storage_node, Some(branch(0b0101)))],
                     },
                 ),
@@ -4717,10 +4689,7 @@ mod tests {
             vec![(masked_account, Some(Account { nonce: 3, ..Default::default() }))],
             B256Map::from_iter([(
                 masked_storage,
-                HashedStorageSorted {
-                    wiped: false,
-                    storage_slots: vec![(masked_slot, U256::from(4))],
-                },
+                HashedStorageSorted { storage_slots: vec![(masked_slot, U256::from(4))] },
             )]),
         );
         let deferred_trie_updates = TrieUpdatesSorted::new(
@@ -4728,7 +4697,6 @@ mod tests {
             B256Map::from_iter([(
                 masked_storage,
                 StorageTrieUpdatesSorted {
-                    is_deleted: false,
                     storage_nodes: vec![(masked_storage_node, Some(branch(0b1100)))],
                 },
             )]),
@@ -4843,71 +4811,6 @@ mod tests {
             .unwrap();
         assert_eq!(masked_entries.len(), 1);
         assert_eq!(masked_entries[0].1.nibbles.0, masked_storage_node);
-    }
-
-    #[test]
-    fn test_save_blocks_merges_storage_wipe_in_multi_block_batch() {
-        use reth_trie::{
-            updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
-            BranchNodeCompact, HashedPostStateSorted,
-        };
-
-        let factory = create_test_provider_factory();
-        factory.set_storage_settings_cache(StorageSettings::v2());
-
-        let mut test_block_builder = TestBlockBuilder::eth().with_state();
-        let genesis = test_block_builder.get_executed_blocks(0..1).next().unwrap();
-        let mut blocks: Vec<_> = test_block_builder.get_executed_blocks(1..4).collect();
-        let address = B256::with_last_byte(1);
-        let storage_path = Nibbles::from_nibbles([0x1, 0x2]);
-
-        let provider_rw = factory.provider_rw().unwrap();
-        save_genesis(&provider_rw, &genesis).unwrap();
-        provider_rw
-            .write_trie_updates_sorted(&TrieUpdatesSorted::new(
-                vec![],
-                B256Map::from_iter([(
-                    address,
-                    StorageTrieUpdatesSorted {
-                        is_deleted: false,
-                        storage_nodes: vec![(storage_path, Some(BranchNodeCompact::default()))],
-                    },
-                )]),
-            ))
-            .unwrap();
-        provider_rw.commit().unwrap();
-
-        let wipe = TrieUpdatesSorted::new(
-            vec![],
-            B256Map::from_iter([(
-                address,
-                StorageTrieUpdatesSorted { is_deleted: true, storage_nodes: vec![] },
-            )]),
-        );
-        let wipe_block = &blocks[2];
-        blocks[2] = ExecutedBlock::new(
-            Arc::clone(&wipe_block.recovered_block),
-            Arc::clone(&wipe_block.execution_output),
-            ComputedTrieData::new(Arc::new(HashedPostStateSorted::default()), Arc::new(wipe)),
-        );
-
-        let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(blocks, 0, 0, 3, 3);
-        provider_rw.save_blocks(&input).unwrap();
-        provider_rw.commit().unwrap();
-
-        let provider = factory.provider().unwrap();
-        let checkpoint = provider.get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
-        assert_eq!(checkpoint.block_number, 3);
-        let storage_entries = provider
-            .tx_ref()
-            .cursor_dup_read::<tables::StoragesTrie>()
-            .unwrap()
-            .walk_dup(Some(address), None)
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        assert!(storage_entries.is_empty());
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -4932,57 +4932,6 @@ mod tests {
 
     #[cfg(feature = "partial-persistence")]
     #[test]
-    fn test_save_blocks_batches_transient_storage_wipe() {
-        use alloy_primitives::map::B256Set;
-        use reth_trie::{updates::TrieUpdates, HashBuilder, HashedPostStateSorted};
-
-        let factory = create_test_provider_factory();
-        factory.set_storage_settings_cache(StorageSettings::v2());
-
-        let mut test_block_builder = TestBlockBuilder::eth().with_state();
-        let genesis = test_block_builder.get_executed_blocks(0..1).next().unwrap();
-        let blocks: Vec<_> = test_block_builder.get_executed_blocks(1..4).collect();
-
-        let provider_rw = factory.provider_rw().unwrap();
-        save_genesis(&provider_rw, &genesis).unwrap();
-        provider_rw.commit().unwrap();
-
-        // A contract created and self-destructed in the same transaction leaves an empty whole-
-        // storage wipe in the trie updates, even though the account never reaches persisted state.
-        let ephemeral_account = B256::with_last_byte(0x57);
-        let hashed_state = HashedPostStateSorted::default();
-        let mut trie_updates = TrieUpdates::default();
-        trie_updates.finalize(
-            HashBuilder::default(),
-            Default::default(),
-            B256Set::from_iter([ephemeral_account]),
-        );
-        let trie_updates = trie_updates.into_sorted();
-        assert!(trie_updates.storage_tries_ref()[&ephemeral_account].is_deleted);
-        let selfdestruct_block = ExecutedBlock::new(
-            Arc::clone(&blocks[2].recovered_block),
-            Arc::clone(&blocks[2].execution_output),
-            ComputedTrieData::new(Arc::new(hashed_state), Arc::new(trie_updates)),
-        );
-
-        let provider_rw = factory.provider_rw().unwrap();
-        let input = SaveBlocksInput::new(
-            vec![blocks[0].clone(), blocks[1].clone(), selfdestruct_block],
-            0,
-            0,
-            3,
-            3,
-        );
-        provider_rw.save_blocks(&input).unwrap();
-        provider_rw.commit().unwrap();
-
-        let checkpoint =
-            factory.provider().unwrap().get_stage_checkpoint(StageId::Finish).unwrap().unwrap();
-        assert_eq!(checkpoint.block_number, 3);
-    }
-
-    #[cfg(feature = "partial-persistence")]
-    #[test]
     fn test_save_blocks_partial_cycles_do_not_duplicate_static_file_writes() {
         let factory = create_test_provider_factory();
         let mut test_block_builder = TestBlockBuilder::eth().with_state();

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -35,7 +35,7 @@ mod tests {
     use std::{collections::BTreeMap, str::FromStr};
 
     #[test]
-    fn wiped_entries_are_removed() {
+    fn zeroed_entries_are_removed() {
         let provider_factory = create_test_provider_factory();
 
         let addresses = (0..10).map(|_| Address::random()).collect::<Vec<_>>();
@@ -67,7 +67,10 @@ mod tests {
 
         let mut hashed_state = HashedPostState::default();
         hashed_state.accounts.insert(destroyed_address_hashed, None);
-        hashed_state.storages.insert(destroyed_address_hashed, HashedStorage::new(true));
+        hashed_state.storages.insert(
+            destroyed_address_hashed,
+            HashedStorage::from_iter([(hashed_slot, U256::ZERO)]),
+        );
 
         let provider_rw = provider_factory.provider_rw().unwrap();
         assert!(matches!(provider_rw.write_hashed_state(&hashed_state.into_sorted()), Ok(())));
@@ -1170,7 +1173,9 @@ mod tests {
             .into_iter()
             .map(|str| (B256::from_str(str).unwrap(), U256::from(1))),
         );
-        updated_storage.wiped = true;
+        updated_storage
+            .storage
+            .extend(init_storage.storage.keys().map(|hashed_slot| (*hashed_slot, U256::ZERO)));
         let mut state = HashedPostState::default();
         state.storages.insert(hashed_address, updated_storage.clone());
         provider_rw.write_hashed_state(&state.clone().into_sorted()).unwrap();

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -101,7 +101,7 @@ pub trait HashedPostStateProvider {
     /// updates for parent storage of accounts that were destroyed but remain in the post-state.
     ///
     /// Providers backed by an exact parent-state view also materialize terminally destroyed
-    /// accounts so the result can be persisted without storage wipe markers.
+    /// accounts with explicit zero-valued storage updates.
     fn hashed_post_state(&self, bundle_state: &BundleState) -> ProviderResult<HashedPostState>;
 }
 

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -915,12 +915,7 @@ mod tests {
         let actual =
             reth_trie_db::compute_range_trie_changesets(&*provider, &state_trie_provider, 1..=3, 3)
                 .unwrap();
-        let storage_revert = actual
-            .storage_tries_ref()
-            .get(&hashed_address)
-            .expect("created account storage trie should be deleted by range revert");
-        assert!(storage_revert.is_deleted());
-        assert!(storage_revert.storage_nodes_ref().is_empty());
+        assert!(actual.storage_tries_ref().get(&hashed_address).is_none());
 
         let cache = ChangesetCache::new();
         let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -155,10 +155,7 @@ where
             storage_nodes.push((*nibbles, node_value));
         }
 
-        storage_tries.insert(
-            *hashed_address,
-            StorageTrieUpdatesSorted { storage_nodes, is_deleted: storage_changeset.is_deleted },
-        );
+        storage_tries.insert(*hashed_address, StorageTrieUpdatesSorted { storage_nodes });
     }
 
     Ok(TrieUpdatesSorted::new(account_nodes, storage_tries))

--- a/crates/trie/common/src/added_removed_keys.rs
+++ b/crates/trie/common/src/added_removed_keys.rs
@@ -44,14 +44,6 @@ impl MultiAddedRemovedKeys {
                 .map(|entry| entry.unwrap_or_default())
                 .unwrap_or_default();
 
-            if storage.wiped {
-                self.storages.remove(hashed_address);
-                if account.is_empty() {
-                    self.account.insert_removed(*hashed_address);
-                }
-                continue
-            }
-
             let storage_removed_keys =
                 self.storages.entry(*hashed_address).or_insert_with(default_added_removed_keys);
 
@@ -129,32 +121,6 @@ mod tests {
     }
 
     #[test]
-    fn test_update_with_state_wiped_storage() {
-        let mut multi_keys = MultiAddedRemovedKeys::new();
-        let mut update = HashedPostState::default();
-
-        let addr = B256::random();
-        let slot1 = B256::random();
-
-        // First add some removed keys
-        let mut storage = HashedStorage::default();
-        storage.storage.insert(slot1, U256::ZERO);
-        update.storages.insert(addr, storage);
-        multi_keys.update_with_state(&update);
-        assert!(multi_keys.get_storage(&addr).is_some());
-
-        // Now wipe the storage
-        let mut update2 = HashedPostState::default();
-        let wiped_storage = HashedStorage::new(true);
-        update2.storages.insert(addr, wiped_storage);
-        multi_keys.update_with_state(&update2);
-
-        // Storage and account should be removed
-        assert!(multi_keys.get_storage(&addr).is_none());
-        assert!(multi_keys.get_accounts().is_removed(&addr));
-    }
-
-    #[test]
     fn test_update_with_state_account_tracking() {
         let mut multi_keys = MultiAddedRemovedKeys::new();
         let mut update = HashedPostState::default();
@@ -204,17 +170,6 @@ mod tests {
         multi_keys.update_with_state(&update);
 
         // Account should not be marked as removed because it has balance
-        assert!(!multi_keys.get_accounts().is_removed(&addr));
-
-        // Now wipe the storage
-        let mut update2 = HashedPostState::default();
-        let wiped_storage = HashedStorage::new(true);
-        update2.storages.insert(addr, wiped_storage);
-        update2.accounts.insert(addr, Some(account));
-        multi_keys.update_with_state(&update2);
-
-        // Storage should be None, but account should not be removed.
-        assert!(multi_keys.get_storage(&addr).is_none());
         assert!(!multi_keys.get_accounts().is_removed(&addr));
     }
 }

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -172,9 +172,6 @@ impl HashedPostState {
     /// Partition the state update into two state updates:
     /// - First with accounts and storages slots that are present in the provided targets.
     /// - Second with all other.
-    ///
-    /// CAUTION: The state updates are expected to be applied in order, so that the storage wipes
-    /// are done correctly.
     pub fn partition_by_targets(
         mut self,
         targets: &MultiProofTargets,
@@ -199,17 +196,7 @@ impl HashedPostState {
                         false
                     });
 
-                    // We do not check the wiped flag here, because targets only contain addresses
-                    // and storage slots. So if there are no storage slots left, the storage update
-                    // can be fully removed.
                     let retain = !storage.storage.is_empty();
-
-                    // Since state updates are expected to be applied in order, we can only set the
-                    // wiped flag in the second storage update if the first storage update is empty
-                    // and will not be retained.
-                    if !retain {
-                        storage_not_in_targets.wiped = storage.wiped;
-                    }
 
                     (
                         retain,
@@ -247,10 +234,7 @@ impl HashedPostState {
     /// Returns the number of items that will be considered during chunking in `[Self::chunks]`.
     pub fn chunking_length(&self) -> usize {
         self.accounts.len() +
-            self.storages
-                .values()
-                .map(|storage| if storage.wiped { 1 } else { 0 } + storage.storage.len())
-                .sum::<usize>()
+            self.storages.values().map(|storage| storage.storage.len()).sum::<usize>()
     }
 
     /// Extend this hashed post state with contents of another.
@@ -316,7 +300,7 @@ impl HashedPostState {
         for (hashed_address, sorted_storage) in &sorted.storages {
             match self.storages.entry(*hashed_address) {
                 hash_map::Entry::Vacant(entry) => {
-                    let mut new_storage = HashedStorage::new(false);
+                    let mut new_storage = HashedStorage::default();
                     new_storage.extend_from_sorted(sorted_storage);
                     entry.insert(new_storage);
                 }
@@ -423,27 +407,20 @@ impl FromParallelIterator<(B256, Option<Account>, Option<HashedStorage>)> for Ha
 #[derive(PartialEq, Eq, Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HashedStorage {
-    /// Flag indicating whether the storage was wiped or not.
-    pub wiped: bool,
     /// Mapping of hashed storage slot to storage value.
     pub storage: B256Map<U256>,
 }
 
 impl HashedStorage {
-    /// Create new instance of [`HashedStorage`].
-    pub fn new(wiped: bool) -> Self {
-        Self { wiped, storage: HashMap::default() }
-    }
-
     /// Check if self is empty.
     pub fn is_empty(&self) -> bool {
-        !self.wiped && self.storage.is_empty()
+        self.storage.is_empty()
     }
 
     /// Create new hashed storage from iterator.
     #[expect(clippy::should_implement_trait)]
     pub fn from_iter(iter: impl IntoIterator<Item = (B256, U256)>) -> Self {
-        Self { wiped: false, storage: HashMap::from_iter(iter) }
+        Self { storage: HashMap::from_iter(iter) }
     }
 
     /// Create new hashed storage from plain storage.
@@ -455,24 +432,16 @@ impl HashedStorage {
 
     /// Construct [`PrefixSetMut`] from hashed storage.
     pub fn construct_prefix_set(&self) -> PrefixSetMut {
-        if self.wiped {
-            PrefixSetMut::all()
-        } else {
-            let mut prefix_set = PrefixSetMut::with_capacity(self.storage.len());
-            for hashed_slot in self.storage.keys() {
-                prefix_set.insert(Nibbles::unpack(hashed_slot));
-            }
-            prefix_set
+        let mut prefix_set = PrefixSetMut::with_capacity(self.storage.len());
+        for hashed_slot in self.storage.keys() {
+            prefix_set.insert(Nibbles::unpack(hashed_slot));
         }
+        prefix_set
     }
 
     /// Extend hashed storage with contents of other.
     /// The entries in second hashed storage take precedence.
     pub fn extend(&mut self, other: &Self) {
-        if other.wiped {
-            self.wiped = true;
-            self.storage.clear();
-        }
         self.storage.extend(other.storage.iter().map(|(&k, &v)| (k, v)));
     }
 
@@ -480,11 +449,6 @@ impl HashedStorage {
     /// representation. This is more efficient than first converting to `HashedStorage` and
     /// then extending, as it avoids creating intermediate `HashMap` allocations.
     pub fn extend_from_sorted(&mut self, sorted: &HashedStorageSorted) {
-        if sorted.wiped {
-            self.wiped = true;
-            self.storage.clear();
-        }
-
         // Reserve capacity for all slots
         self.storage.reserve(sorted.storage_slots.len());
 
@@ -499,7 +463,7 @@ impl HashedStorage {
         let mut storage_slots: Vec<_> = self.storage.into_iter().collect();
         storage_slots.sort_unstable_by_key(|(key, _)| *key);
 
-        HashedStorageSorted { storage_slots, wiped: self.wiped }
+        HashedStorageSorted { storage_slots }
     }
 
     /// Creates a sorted copy without consuming self.
@@ -508,7 +472,7 @@ impl HashedStorage {
         let mut storage_slots: Vec<_> = self.storage.iter().map(|(&k, &v)| (k, v)).collect();
         storage_slots.sort_unstable_by_key(|(key, _)| *key);
 
-        HashedStorageSorted { storage_slots, wiped: self.wiped }
+        HashedStorageSorted { storage_slots }
     }
 }
 
@@ -570,20 +534,13 @@ impl HashedPostStateSorted {
         for (hashed_address, hashed_storage) in &self.storages {
             // Ensure account trie covers storage overlays even if account map is empty.
             account_prefix_set.insert(Nibbles::unpack(hashed_address));
-
-            let prefix_set = if hashed_storage.wiped {
-                PrefixSetMut::all()
-            } else {
-                let mut prefix_set =
-                    PrefixSetMut::with_capacity(hashed_storage.storage_slots.len());
-                prefix_set.extend_keys(
-                    hashed_storage
-                        .storage_slots
-                        .iter()
-                        .map(|(hashed_slot, _)| Nibbles::unpack(hashed_slot)),
-                );
-                prefix_set
-            };
+            let mut prefix_set = PrefixSetMut::with_capacity(hashed_storage.storage_slots.len());
+            prefix_set.extend_keys(
+                hashed_storage
+                    .storage_slots
+                    .iter()
+                    .map(|(hashed_slot, _)| Nibbles::unpack(hashed_slot)),
+            );
 
             storage_prefix_sets.insert(*hashed_address, prefix_set);
         }
@@ -652,8 +609,6 @@ impl HashedPostStateSorted {
         let accounts = kway_merge_sorted(items.iter().map(|i| i.as_ref().accounts.as_slice()));
 
         struct StorageAcc<'a> {
-            wiped: bool,
-            sealed: bool,
             slices: Vec<&'a [(B256, U256)]>,
         }
 
@@ -661,21 +616,8 @@ impl HashedPostStateSorted {
 
         for item in items {
             for (addr, storage) in &item.as_ref().storages {
-                let entry = acc.entry(*addr).or_insert_with(|| StorageAcc {
-                    wiped: false,
-                    sealed: false,
-                    slices: Vec::new(),
-                });
-
-                if entry.sealed {
-                    continue;
-                }
-
+                let entry = acc.entry(*addr).or_insert_with(|| StorageAcc { slices: Vec::new() });
                 entry.slices.push(storage.storage_slots.as_slice());
-                if storage.wiped {
-                    entry.wiped = true;
-                    entry.sealed = true;
-                }
             }
         }
 
@@ -683,7 +625,7 @@ impl HashedPostStateSorted {
             .into_iter()
             .map(|(addr, entry)| {
                 let storage_slots = kway_merge_sorted(entry.slices);
-                (addr, HashedStorageSorted { wiped: entry.wiped, storage_slots })
+                (addr, HashedStorageSorted { storage_slots })
             })
             .collect();
 
@@ -697,10 +639,6 @@ impl HashedPostStateSorted {
     /// level. For duplicate keys in the batch, later items take precedence over earlier ones. An
     /// overlapping entry is retained if any mask value is equal to the merged batch value. The
     /// order of the mask does not matter. An empty mask merges the batch without filtering.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any batch or mask entry wipes an entire storage.
     pub fn disjointed_merge_batch<'a>(batch: &[&'a Self], mask: &[&'a Self]) -> Self {
         let account_count = batch.iter().map(|item| item.accounts.len()).sum();
         let mut accounts = Vec::with_capacity(account_count);
@@ -726,10 +664,6 @@ impl HashedPostStateSorted {
 
         for item in batch.iter().rev() {
             for (hashed_address, storage) in &item.storages {
-                assert!(
-                    !storage.wiped,
-                    "storage wipes are not supported by disjointed_merge_batch"
-                );
                 let entry = storages
                     .entry(*hashed_address)
                     .or_insert_with(|| StorageAcc { slot_count: 0, slices: Vec::new() });
@@ -744,10 +678,6 @@ impl HashedPostStateSorted {
         );
         for item in mask {
             for (hashed_address, storage) in &item.storages {
-                assert!(
-                    !storage.wiped,
-                    "storage wipes are not supported by disjointed_merge_batch"
-                );
                 let entry = storage_masks.entry(*hashed_address).or_default();
                 entry.slices.push(storage.storage_slots.as_slice());
             }
@@ -769,10 +699,8 @@ impl HashedPostStateSorted {
                     None => kway_merge_sorted(entry.slices),
                 };
 
-                (!storage_slots.is_empty() || mask.is_empty()).then_some((
-                    hashed_address,
-                    HashedStorageSorted { wiped: false, storage_slots },
-                ))
+                (!storage_slots.is_empty() || mask.is_empty())
+                    .then_some((hashed_address, HashedStorageSorted { storage_slots }))
             })
             .collect();
 
@@ -798,16 +726,9 @@ impl AsRef<Self> for HashedPostStateSorted {
 pub struct HashedStorageSorted {
     /// Sorted collection of updated storage slots. [`U256::ZERO`] indicates a deleted value.
     pub storage_slots: Vec<(B256, U256)>,
-    /// Flag indicating whether the storage was wiped or not.
-    pub wiped: bool,
 }
 
 impl HashedStorageSorted {
-    /// Returns `true` if the account was wiped.
-    pub const fn is_wiped(&self) -> bool {
-        self.wiped
-    }
-
     /// Returns reference to updated storage slots.
     pub fn storage_slots_ref(&self) -> &[(B256, U256)] {
         &self.storage_slots
@@ -824,35 +745,16 @@ impl HashedStorageSorted {
     }
 
     /// Extends the storage slots updates with another set of sorted updates.
-    ///
-    /// If `other` is marked as deleted, this will be marked as deleted and all slots cleared.
-    /// Otherwise, nodes are merged with `other`'s values taking precedence for duplicates.
     pub fn extend_ref(&mut self, other: &Self) {
-        if other.wiped {
-            // If other is wiped, clear everything and copy from other
-            self.wiped = true;
-            self.storage_slots.clear();
-            self.storage_slots.extend(other.storage_slots.iter().copied());
-            return;
-        }
-
-        // Extend the sorted non-zero valued slots
         extend_sorted_vec(&mut self.storage_slots, &other.storage_slots);
     }
 
     /// Batch-merge sorted hashed storage. Iterator yields **newest to oldest**.
-    /// If any update is wiped, prior data is discarded.
     pub fn merge_batch<'a>(updates: impl IntoIterator<Item = &'a Self>) -> Self {
         let updates: Vec<_> = updates.into_iter().collect();
-        if updates.is_empty() {
-            return Self::default();
+        Self {
+            storage_slots: kway_merge_sorted(updates.iter().map(|u| u.storage_slots.as_slice())),
         }
-
-        let wipe_idx = updates.iter().position(|u| u.wiped);
-        let relevant = wipe_idx.map_or(&updates[..], |idx| &updates[..=idx]);
-        let storage_slots = kway_merge_sorted(relevant.iter().map(|u| u.storage_slots.as_slice()));
-
-        Self { wiped: wipe_idx.is_some(), storage_slots }
     }
 }
 
@@ -865,7 +767,7 @@ impl From<HashedStorageSorted> for HashedStorage {
             storage.insert(slot, value);
         }
 
-        Self { wiped: sorted.wiped, storage }
+        Self { storage }
     }
 }
 
@@ -893,10 +795,7 @@ impl From<HashedPostStateSorted> for HashedPostState {
 /// An iterator that yields chunks of the state updates of at most `size` account and storage
 /// targets.
 ///
-/// # Notes
-/// 1. Chunks are expected to be applied in order, because of storage wipes. If applied out of
-///    order, it's possible to wipe more storage than in the original state update.
-/// 2. For each account, chunks with storage updates come first, followed by account updates.
+/// Storage updates for each account are yielded before its account update.
 #[derive(Debug)]
 pub struct ChunkedHashedPostState {
     flattened: alloc::vec::IntoIter<(B256, FlattenedHashedPostStateItem)>,
@@ -904,10 +803,9 @@ pub struct ChunkedHashedPostState {
 }
 
 /// Order discriminant for sorting flattened state items.
-/// Ordering: `StorageWipe` < `StorageUpdate` (by slot) < `Account`
+/// Ordering: `StorageUpdate` (by slot) < `Account`
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum FlattenedStateOrder {
-    StorageWipe,
     StorageUpdate(B256),
     Account,
 }
@@ -915,14 +813,12 @@ enum FlattenedStateOrder {
 #[derive(Debug)]
 enum FlattenedHashedPostStateItem {
     Account(Option<Account>),
-    StorageWipe,
     StorageUpdate { slot: B256, value: U256 },
 }
 
 impl FlattenedHashedPostStateItem {
     const fn order(&self) -> FlattenedStateOrder {
         match self {
-            Self::StorageWipe => FlattenedStateOrder::StorageWipe,
             Self::StorageUpdate { slot, .. } => FlattenedStateOrder::StorageUpdate(*slot),
             Self::Account(_) => FlattenedStateOrder::Account,
         }
@@ -935,21 +831,16 @@ impl ChunkedHashedPostState {
             .storages
             .into_iter()
             .flat_map(|(address, storage)| {
-                storage
-                    .wiped
-                    .then_some((address, FlattenedHashedPostStateItem::StorageWipe))
-                    .into_iter()
-                    .chain(storage.storage.into_iter().map(move |(slot, value)| {
-                        (address, FlattenedHashedPostStateItem::StorageUpdate { slot, value })
-                    }))
+                storage.storage.into_iter().map(move |(slot, value)| {
+                    (address, FlattenedHashedPostStateItem::StorageUpdate { slot, value })
+                })
             })
             .chain(hashed_post_state.accounts.into_iter().map(|(address, account)| {
                 (address, FlattenedHashedPostStateItem::Account(account))
             }))
             // Sort by address, then by item order to ensure correct application sequence:
-            // 1. Storage wipes (must come first to clear storage)
-            // 2. Storage updates (sorted by slot for determinism)
-            // 3. Account updates (can be applied last)
+            // 1. Storage updates (sorted by slot for determinism)
+            // 2. Account updates (can be applied last)
             .sorted_unstable_by_key(|(address, item)| (*address, item.order()));
 
         Self { flattened, size }
@@ -969,9 +860,6 @@ impl Iterator for ChunkedHashedPostState {
             match item {
                 FlattenedHashedPostStateItem::Account(account) => {
                     chunk.accounts.insert(address, account);
-                }
-                FlattenedHashedPostStateItem::StorageWipe => {
-                    chunk.storages.entry(address).or_default().wiped = true;
                 }
                 FlattenedHashedPostStateItem::StorageUpdate { slot, value } => {
                     chunk.storages.entry(address).or_default().storage.insert(slot, value);
@@ -1008,80 +896,6 @@ mod tests {
 
     fn changed_storage(original: U256, present: U256) -> StorageWithOriginalValues {
         core::iter::once((U256::from(1), StorageSlot::new_changed(original, present))).collect()
-    }
-
-    #[test]
-    fn hashed_state_wiped_extension() {
-        let hashed_address = B256::default();
-        let hashed_slot = B256::with_last_byte(64);
-        let hashed_slot2 = B256::with_last_byte(65);
-
-        // Initialize post state storage
-        let original_slot_value = U256::from(123);
-        let mut hashed_state = HashedPostState::default().with_storages([(
-            hashed_address,
-            HashedStorage::from_iter([
-                (hashed_slot, original_slot_value),
-                (hashed_slot2, original_slot_value),
-            ]),
-        )]);
-
-        // Update single slot value
-        let updated_slot_value = U256::from(321);
-        let extension = HashedPostState::default().with_storages([(
-            hashed_address,
-            HashedStorage::from_iter([(hashed_slot, updated_slot_value)]),
-        )]);
-        hashed_state.extend(extension);
-
-        let account_storage = hashed_state.storages.get(&hashed_address);
-        assert_eq!(
-            account_storage.and_then(|st| st.storage.get(&hashed_slot)),
-            Some(&updated_slot_value)
-        );
-        assert_eq!(
-            account_storage.and_then(|st| st.storage.get(&hashed_slot2)),
-            Some(&original_slot_value)
-        );
-        assert_eq!(account_storage.map(|st| st.wiped), Some(false));
-
-        // Wipe account storage
-        let wiped_extension =
-            HashedPostState::default().with_storages([(hashed_address, HashedStorage::new(true))]);
-        hashed_state.extend(wiped_extension);
-
-        let account_storage = hashed_state.storages.get(&hashed_address);
-        assert_eq!(account_storage.map(|st| st.storage.is_empty()), Some(true));
-        assert_eq!(account_storage.map(|st| st.wiped), Some(true));
-
-        // Reinitialize single slot value
-        hashed_state.extend(HashedPostState::default().with_storages([(
-            hashed_address,
-            HashedStorage::from_iter([(hashed_slot, original_slot_value)]),
-        )]));
-        let account_storage = hashed_state.storages.get(&hashed_address);
-        assert_eq!(
-            account_storage.and_then(|st| st.storage.get(&hashed_slot)),
-            Some(&original_slot_value)
-        );
-        assert_eq!(account_storage.and_then(|st| st.storage.get(&hashed_slot2)), None);
-        assert_eq!(account_storage.map(|st| st.wiped), Some(true));
-
-        // Reinitialize single slot value
-        hashed_state.extend(HashedPostState::default().with_storages([(
-            hashed_address,
-            HashedStorage::from_iter([(hashed_slot2, updated_slot_value)]),
-        )]));
-        let account_storage = hashed_state.storages.get(&hashed_address);
-        assert_eq!(
-            account_storage.and_then(|st| st.storage.get(&hashed_slot)),
-            Some(&original_slot_value)
-        );
-        assert_eq!(
-            account_storage.and_then(|st| st.storage.get(&hashed_slot2)),
-            Some(&updated_slot_value)
-        );
-        assert_eq!(account_storage.map(|st| st.wiped), Some(true));
     }
 
     #[test]
@@ -1143,7 +957,7 @@ mod tests {
     }
 
     #[test]
-    fn destroyed_accounts_emit_zero_storage_changes_without_wipe() {
+    fn destroyed_accounts_emit_zero_storage_changes() {
         let existing_contract =
             AccountInfo { code_hash: B256::repeat_byte(0x01), ..Default::default() };
         let legacy_empty_account = AccountInfo::default();
@@ -1161,13 +975,12 @@ mod tests {
 
             let storage = bundle_hashed_storage(&account).unwrap();
             let hashed_slot = keccak256(B256::from(U256::from(1)));
-            assert!(!storage.wiped);
             assert_eq!(storage.storage[&hashed_slot], U256::ZERO);
         }
     }
 
     #[test]
-    fn destroyed_recreated_accounts_preserve_storage_without_wipe() {
+    fn destroyed_recreated_accounts_preserve_storage() {
         let value = U256::from(2);
         let new_account = BundleAccount::new(
             None,
@@ -1187,9 +1000,6 @@ mod tests {
         let new_storage = bundle_hashed_storage(&new_account).unwrap();
         let existing_storage = bundle_hashed_storage(&existing_account).unwrap();
         let hashed_slot = keccak256(B256::from(U256::from(1)));
-
-        assert!(!new_storage.wiped);
-        assert!(!existing_storage.wiped);
         assert_eq!(new_storage.storage[&hashed_slot], value);
         assert_eq!(existing_storage.storage[&hashed_slot], value);
     }
@@ -1227,8 +1037,8 @@ mod tests {
         let address_1 = Address::random();
         let address_2 = Address::random();
 
-        let storage_1 = (keccak256(address_1), HashedStorage::new(false));
-        let storage_2 = (keccak256(address_2), HashedStorage::new(true));
+        let storage_1 = (keccak256(address_1), HashedStorage::default());
+        let storage_2 = (keccak256(address_2), HashedStorage::default());
 
         // Add storages to the hashed post state.
         let hashed_state = HashedPostState::default().with_storages(vec![storage_1, storage_2]);
@@ -1426,7 +1236,6 @@ mod tests {
             storages: B256Map::from_iter([(
                 addr1,
                 HashedStorage {
-                    wiped: true,
                     storage: B256Map::from_iter([(slot1, U256::ZERO), (slot2, U256::from(1))]),
                 },
             )]),
@@ -1442,10 +1251,7 @@ mod tests {
                 accounts: B256Map::from_iter([(addr1, Some(Default::default()))]),
                 storages: B256Map::from_iter([(
                     addr1,
-                    HashedStorage {
-                        wiped: true,
-                        storage: B256Map::from_iter([(slot1, U256::ZERO)])
-                    }
+                    HashedStorage { storage: B256Map::from_iter([(slot1, U256::ZERO)]) }
                 )]),
             }
         );
@@ -1455,110 +1261,10 @@ mod tests {
                 accounts: B256Map::from_iter([(addr2, Some(Default::default()))]),
                 storages: B256Map::from_iter([(
                     addr1,
-                    HashedStorage {
-                        wiped: false,
-                        storage: B256Map::from_iter([(slot2, U256::from(1))])
-                    }
+                    HashedStorage { storage: B256Map::from_iter([(slot2, U256::from(1))]) }
                 )]),
             }
         );
-    }
-
-    #[test]
-    fn test_chunks() {
-        let addr1 = B256::from([1; 32]);
-        let addr2 = B256::from([2; 32]);
-        let slot1 = B256::from([1; 32]);
-        let slot2 = B256::from([2; 32]);
-
-        let state = HashedPostState {
-            accounts: B256Map::from_iter([
-                (addr1, Some(Default::default())),
-                (addr2, Some(Default::default())),
-            ]),
-            storages: B256Map::from_iter([(
-                addr2,
-                HashedStorage {
-                    wiped: true,
-                    storage: B256Map::from_iter([(slot1, U256::ZERO), (slot2, U256::from(1))]),
-                },
-            )]),
-        };
-
-        let mut chunks = state.chunks(2);
-        assert_eq!(
-            chunks.next(),
-            Some(HashedPostState {
-                accounts: B256Map::from_iter([(addr1, Some(Default::default()))]),
-                storages: B256Map::from_iter([(addr2, HashedStorage::new(true)),])
-            })
-        );
-        assert_eq!(
-            chunks.next(),
-            Some(HashedPostState {
-                accounts: B256Map::default(),
-                storages: B256Map::from_iter([(
-                    addr2,
-                    HashedStorage {
-                        wiped: false,
-                        storage: B256Map::from_iter([(slot1, U256::ZERO), (slot2, U256::from(1))]),
-                    },
-                )])
-            })
-        );
-        assert_eq!(
-            chunks.next(),
-            Some(HashedPostState {
-                accounts: B256Map::from_iter([(addr2, Some(Default::default()))]),
-                storages: B256Map::default()
-            })
-        );
-        assert_eq!(chunks.next(), None);
-    }
-
-    #[test]
-    fn test_chunks_ordering_guarantee() {
-        // Test that chunks preserve the ordering: wipe -> storage updates -> account
-        // Use chunk size of 1 to verify each item comes out in the correct order
-        let addr = B256::from([1; 32]);
-        let slot1 = B256::from([1; 32]);
-        let slot2 = B256::from([2; 32]);
-
-        let state = HashedPostState {
-            accounts: B256Map::from_iter([(addr, Some(Default::default()))]),
-            storages: B256Map::from_iter([(
-                addr,
-                HashedStorage {
-                    wiped: true,
-                    storage: B256Map::from_iter([(slot1, U256::from(1)), (slot2, U256::from(2))]),
-                },
-            )]),
-        };
-
-        let chunks: Vec<_> = state.chunks(1).collect();
-
-        // Should have 4 chunks: 1 wipe + 2 storage updates + 1 account
-        assert_eq!(chunks.len(), 4);
-
-        // First chunk must be the storage wipe
-        assert!(chunks[0].accounts.is_empty());
-        assert_eq!(chunks[0].storages.len(), 1);
-        assert!(chunks[0].storages.get(&addr).unwrap().wiped);
-        assert!(chunks[0].storages.get(&addr).unwrap().storage.is_empty());
-
-        // Next two chunks must be storage updates (order between them doesn't matter)
-        assert!(chunks[1].accounts.is_empty());
-        assert!(!chunks[1].storages.get(&addr).unwrap().wiped);
-        assert_eq!(chunks[1].storages.get(&addr).unwrap().storage.len(), 1);
-
-        assert!(chunks[2].accounts.is_empty());
-        assert!(!chunks[2].storages.get(&addr).unwrap().wiped);
-        assert_eq!(chunks[2].storages.get(&addr).unwrap().storage.len(), 1);
-
-        // Last chunk must be the account update
-        assert_eq!(chunks[3].accounts.len(), 1);
-        assert!(chunks[3].accounts.contains_key(&addr));
-        assert!(chunks[3].storages.is_empty());
     }
 
     #[test]
@@ -1607,7 +1313,6 @@ mod tests {
                 (B256::from([3; 32]), U256::from(30)),
                 (B256::from([5; 32]), U256::ZERO),
             ],
-            wiped: false,
         };
 
         let storage2 = HashedStorageSorted {
@@ -1617,7 +1322,6 @@ mod tests {
                 (B256::from([4; 32]), U256::from(40)),
                 (B256::from([6; 32]), U256::ZERO),
             ],
-            wiped: false,
         };
 
         storage1.extend_ref(&storage2);
@@ -1635,34 +1339,6 @@ mod tests {
         assert_eq!(storage1.storage_slots[4].1, U256::ZERO);
         assert_eq!(storage1.storage_slots[5].0, B256::from([6; 32]));
         assert_eq!(storage1.storage_slots[5].1, U256::ZERO);
-        assert!(!storage1.wiped);
-
-        // Test wiped storage
-        let mut storage3 = HashedStorageSorted {
-            storage_slots: vec![
-                (B256::from([1; 32]), U256::from(10)),
-                (B256::from([2; 32]), U256::ZERO),
-            ],
-            wiped: false,
-        };
-
-        let storage4 = HashedStorageSorted {
-            storage_slots: vec![
-                (B256::from([3; 32]), U256::from(30)),
-                (B256::from([4; 32]), U256::ZERO),
-            ],
-            wiped: true,
-        };
-
-        storage3.extend_ref(&storage4);
-
-        assert!(storage3.wiped);
-        // When wiped, should only have storage4's values
-        assert_eq!(storage3.storage_slots.len(), 2);
-        assert_eq!(storage3.storage_slots[0].0, B256::from([3; 32]));
-        assert_eq!(storage3.storage_slots[0].1, U256::from(30));
-        assert_eq!(storage3.storage_slots[1].0, B256::from([4; 32]));
-        assert_eq!(storage3.storage_slots[1].1, U256::ZERO);
     }
 
     /// Test extending with sorted accounts merges correctly into `HashMap`
@@ -1716,7 +1392,7 @@ mod tests {
             vec![(kept_account, Some(account(1))), (removed_account, Some(account(10)))],
             B256Map::from_iter([(
                 kept_storage,
-                HashedStorageSorted { wiped: false, storage_slots: vec![(slot1, U256::from(1))] },
+                HashedStorageSorted { storage_slots: vec![(slot1, U256::from(1))] },
             )]),
         );
 
@@ -1725,7 +1401,6 @@ mod tests {
             B256Map::from_iter([(
                 kept_storage,
                 HashedStorageSorted {
-                    wiped: false,
                     storage_slots: vec![(slot1, U256::from(3)), (slot2, U256::from(4))],
                 },
             )]),
@@ -1735,7 +1410,7 @@ mod tests {
             vec![(removed_account, None)],
             B256Map::from_iter([(
                 kept_storage,
-                HashedStorageSorted { wiped: false, storage_slots: vec![(slot2, U256::ZERO)] },
+                HashedStorageSorted { storage_slots: vec![(slot2, U256::ZERO)] },
             )]),
         );
 
@@ -1753,10 +1428,7 @@ mod tests {
         assert_eq!(result.storages.len(), 1);
         assert_eq!(
             result.storages.get(&kept_storage),
-            Some(&HashedStorageSorted {
-                wiped: false,
-                storage_slots: vec![(slot1, U256::from(3))],
-            })
+            Some(&HashedStorageSorted { storage_slots: vec![(slot1, U256::from(3))] })
         );
     }
 
@@ -1769,13 +1441,7 @@ mod tests {
         let older = HashedPostStateSorted::new(
             vec![(address, Some(Account { nonce: 1, ..Default::default() }))],
             B256Map::from_iter([
-                (
-                    storage,
-                    HashedStorageSorted {
-                        wiped: false,
-                        storage_slots: vec![(slot, U256::from(1))],
-                    },
-                ),
+                (storage, HashedStorageSorted { storage_slots: vec![(slot, U256::from(1))] }),
                 (empty_storage, HashedStorageSorted::default()),
             ]),
         );
@@ -1783,7 +1449,7 @@ mod tests {
             vec![(address, Some(Account { nonce: 2, ..Default::default() }))],
             B256Map::from_iter([(
                 storage,
-                HashedStorageSorted { wiped: false, storage_slots: vec![(slot, U256::from(2))] },
+                HashedStorageSorted { storage_slots: vec![(slot, U256::from(2))] },
             )]),
         );
         let expected = HashedPostStateSorted::merge_batch(vec![newer.clone(), older.clone()]);
@@ -1834,38 +1500,20 @@ mod tests {
         let batch = HashedPostStateSorted::new(
             vec![(address, Some(account(1))), (deleted_address, None)],
             B256Map::from_iter([
-                (
-                    storage,
-                    HashedStorageSorted {
-                        wiped: false,
-                        storage_slots: vec![(slot, U256::from(1))],
-                    },
-                ),
+                (storage, HashedStorageSorted { storage_slots: vec![(slot, U256::from(1))] }),
                 (
                     deleted_storage,
-                    HashedStorageSorted {
-                        wiped: false,
-                        storage_slots: vec![(deleted_slot, U256::ZERO)],
-                    },
+                    HashedStorageSorted { storage_slots: vec![(deleted_slot, U256::ZERO)] },
                 ),
             ]),
         );
         let different_mask = HashedPostStateSorted::new(
             vec![(address, Some(account(2))), (deleted_address, Some(account(3)))],
             B256Map::from_iter([
-                (
-                    storage,
-                    HashedStorageSorted {
-                        wiped: false,
-                        storage_slots: vec![(slot, U256::from(2))],
-                    },
-                ),
+                (storage, HashedStorageSorted { storage_slots: vec![(slot, U256::from(2))] }),
                 (
                     deleted_storage,
-                    HashedStorageSorted {
-                        wiped: false,
-                        storage_slots: vec![(deleted_slot, U256::from(3))],
-                    },
+                    HashedStorageSorted { storage_slots: vec![(deleted_slot, U256::from(3))] },
                 ),
             ]),
         );
@@ -1893,28 +1541,25 @@ mod tests {
             vec![],
             B256Map::from_iter([(
                 storage,
-                HashedStorageSorted { wiped: false, storage_slots: vec![(slot, U256::from(1))] },
+                HashedStorageSorted { storage_slots: vec![(slot, U256::from(1))] },
             )]),
         );
         let mask = HashedPostStateSorted::new(
             vec![],
-            B256Map::from_iter([(
-                storage,
-                HashedStorageSorted { wiped: false, storage_slots: vec![] },
-            )]),
+            B256Map::from_iter([(storage, HashedStorageSorted { storage_slots: vec![] })]),
         );
 
         let result = HashedPostStateSorted::disjointed_merge_batch(&[&batch], &[&mask]);
 
         assert_eq!(
             result.storages.get(&storage),
-            Some(&HashedStorageSorted { wiped: false, storage_slots: vec![(slot, U256::from(1))] })
+            Some(&HashedStorageSorted { storage_slots: vec![(slot, U256::from(1))] })
         );
     }
 
-    /// Test non-wiped storage merges both zero and non-zero valued slots
+    /// Test storage merges both zero and non-zero valued slots
     #[test]
-    fn test_hashed_storage_extend_from_sorted_non_wiped() {
+    fn test_hashed_storage_extend_from_sorted() {
         let slot1 = B256::random();
         let slot2 = B256::random();
         let slot3 = B256::random();
@@ -1923,35 +1568,13 @@ mod tests {
 
         let sorted = HashedStorageSorted {
             storage_slots: vec![(slot2, U256::from(200)), (slot3, U256::ZERO)],
-            wiped: false,
         };
 
         storage.extend_from_sorted(&sorted);
-
-        assert!(!storage.wiped);
         assert_eq!(storage.storage.len(), 3);
         assert_eq!(storage.storage.get(&slot1), Some(&U256::from(100)));
         assert_eq!(storage.storage.get(&slot2), Some(&U256::from(200)));
         assert_eq!(storage.storage.get(&slot3), Some(&U256::ZERO));
-    }
-
-    /// Test wiped=true clears existing storage and only keeps new slots (critical edge case)
-    #[test]
-    fn test_hashed_storage_extend_from_sorted_wiped() {
-        let slot1 = B256::random();
-        let slot2 = B256::random();
-
-        let mut storage = HashedStorage::from_iter([(slot1, U256::from(100))]);
-
-        let sorted =
-            HashedStorageSorted { storage_slots: vec![(slot2, U256::from(200))], wiped: true };
-
-        storage.extend_from_sorted(&sorted);
-
-        assert!(storage.wiped);
-        // After wipe, old storage should be cleared and only new storage remains
-        assert_eq!(storage.storage.len(), 1);
-        assert_eq!(storage.storage.get(&slot2), Some(&U256::from(200)));
     }
 
     #[test]
@@ -1970,7 +1593,6 @@ mod tests {
                 (
                     addr1,
                     HashedStorage {
-                        wiped: false,
                         storage: B256Map::from_iter([
                             (slot1, U256::ZERO),
                             (slot2, U256::ZERO),
@@ -1981,7 +1603,6 @@ mod tests {
                 (
                     addr2,
                     HashedStorage {
-                        wiped: true,
                         storage: B256Map::from_iter([
                             (slot1, U256::ZERO),
                             (slot2, U256::ZERO),
@@ -1992,7 +1613,6 @@ mod tests {
                 (
                     addr3,
                     HashedStorage {
-                        wiped: false,
                         storage: B256Map::from_iter([
                             (slot1, U256::ZERO),
                             (slot2, U256::ZERO),
@@ -2034,20 +1654,13 @@ mod tests {
                 (
                     addr1,
                     HashedStorage {
-                        wiped: false,
                         storage: B256Map::from_iter([
                             (slot1, U256::from(10)),
                             (slot2, U256::from(20)),
                         ]),
                     },
                 ),
-                (
-                    addr2,
-                    HashedStorage {
-                        wiped: true,
-                        storage: B256Map::from_iter([(slot3, U256::ZERO)]),
-                    },
-                ),
+                (addr2, HashedStorage { storage: B256Map::from_iter([(slot3, U256::ZERO)]) }),
             ]),
         };
 
@@ -2069,7 +1682,6 @@ mod tests {
         let slot3 = B256::from([3; 32]);
 
         let storage = HashedStorage {
-            wiped: true,
             storage: B256Map::from_iter([
                 (slot1, U256::from(100)),
                 (slot2, U256::ZERO),
@@ -2085,7 +1697,6 @@ mod tests {
 
         // Verify the original storage is not consumed
         assert_eq!(storage.storage.len(), 3);
-        assert!(storage.wiped);
     }
 }
 
@@ -2175,19 +1786,18 @@ pub mod serde_bincode_compat {
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
     pub struct HashedStorage<'a> {
-        wiped: bool,
         storage: Cow<'a, B256Map<U256>>,
     }
 
     impl<'a> From<&'a super::HashedStorage> for HashedStorage<'a> {
         fn from(value: &'a super::HashedStorage) -> Self {
-            Self { wiped: value.wiped, storage: Cow::Borrowed(&value.storage) }
+            Self { storage: Cow::Borrowed(&value.storage) }
         }
     }
 
     impl<'a> From<HashedStorage<'a>> for super::HashedStorage {
         fn from(value: HashedStorage<'a>) -> Self {
-            Self { wiped: value.wiped, storage: value.storage.into_owned() }
+            Self { storage: value.storage.into_owned() }
         }
     }
 
@@ -2287,18 +1897,17 @@ pub mod serde_bincode_compat {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct HashedStorageSorted<'a> {
         storage_slots: Cow<'a, [(B256, U256)]>,
-        wiped: bool,
     }
 
     impl<'a> From<&'a super::HashedStorageSorted> for HashedStorageSorted<'a> {
         fn from(value: &'a super::HashedStorageSorted) -> Self {
-            Self { storage_slots: Cow::Borrowed(&value.storage_slots), wiped: value.wiped }
+            Self { storage_slots: Cow::Borrowed(&value.storage_slots) }
         }
     }
 
     impl<'a> From<HashedStorageSorted<'a>> for super::HashedStorageSorted {
         fn from(value: HashedStorageSorted<'a>) -> Self {
-            Self { storage_slots: value.storage_slots.into_owned(), wiped: value.wiped }
+            Self { storage_slots: value.storage_slots.into_owned() }
         }
     }
 
@@ -2375,11 +1984,6 @@ pub mod serde_bincode_compat {
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
             assert_eq!(decoded, data);
 
-            data.hashed_storage.wiped = true;
-            let encoded = bincode::serialize(&data).unwrap();
-            let decoded: Data = bincode::deserialize(&encoded).unwrap();
-            assert_eq!(decoded, data);
-
             data.hashed_storage.storage.insert(B256::random(), U256::from(1));
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
@@ -2410,10 +2014,7 @@ pub mod serde_bincode_compat {
 
             data.hashed_state.storages.insert(
                 B256::random(),
-                HashedStorageSorted {
-                    storage_slots: vec![(B256::from([1; 32]), U256::from(10))],
-                    wiped: false,
-                },
+                HashedStorageSorted { storage_slots: vec![(B256::from([1; 32]), U256::from(10))] },
             );
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
@@ -2429,14 +2030,8 @@ pub mod serde_bincode_compat {
                 hashed_storage: HashedStorageSorted,
             }
 
-            let mut data = Data {
-                hashed_storage: HashedStorageSorted { storage_slots: Vec::new(), wiped: false },
-            };
-            let encoded = bincode::serialize(&data).unwrap();
-            let decoded: Data = bincode::deserialize(&encoded).unwrap();
-            assert_eq!(decoded, data);
-
-            data.hashed_storage.wiped = true;
+            let mut data =
+                Data { hashed_storage: HashedStorageSorted { storage_slots: Vec::new() } };
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
             assert_eq!(decoded, data);

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -1704,9 +1704,13 @@ mod tests {
 #[cfg(feature = "serde-bincode-compat")]
 pub mod serde_bincode_compat {
     use super::Account;
-    use alloc::borrow::Cow;
+    use alloc::{borrow::Cow, vec::Vec};
     use alloy_primitives::{map::B256Map, B256, U256};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use core::fmt;
+    use serde::{
+        de::{Error as _, SeqAccess, Visitor},
+        Deserialize, Deserializer, Serialize, Serializer,
+    };
     use serde_with::{DeserializeAs, SerializeAs};
 
     /// Bincode-compatible [`super::HashedPostState`] serde implementation.
@@ -1894,9 +1898,52 @@ pub mod serde_bincode_compat {
     ///     hashed_storage: HashedStorageSorted,
     /// }
     /// ```
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize)]
     pub struct HashedStorageSorted<'a> {
         storage_slots: Cow<'a, [(B256, U256)]>,
+    }
+
+    impl<'de, 'a> Deserialize<'de> for HashedStorageSorted<'a> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct HashedStorageSortedVisitor;
+
+            impl<'de> Visitor<'de> for HashedStorageSortedVisitor {
+                type Value = Vec<(B256, U256)>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("hashed storage with an optional legacy wipe marker")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>,
+                {
+                    let len = seq.size_hint().unwrap_or_default();
+                    if !matches!(len, 1 | 2) {
+                        return Err(A::Error::invalid_length(len, &self))
+                    }
+
+                    let storage_slots =
+                        seq.next_element()?.ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                    if len == 2 {
+                        let _: bool = seq
+                            .next_element()?
+                            .ok_or_else(|| A::Error::invalid_length(1, &self))?;
+                    }
+
+                    Ok(storage_slots)
+                }
+            }
+
+            // Bincode uses the supplied tuple length for the current format, while MessagePack
+            // exposes the encoded sequence length so legacy ExEx WAL entries can still be read.
+            deserializer
+                .deserialize_tuple(1, HashedStorageSortedVisitor)
+                .map(|storage_slots| Self { storage_slots: Cow::Owned(storage_slots) })
+        }
     }
 
     impl<'a> From<&'a super::HashedStorageSorted> for HashedStorageSorted<'a> {

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -7,7 +7,7 @@ use alloc::{
     vec::Vec,
 };
 use alloy_primitives::{
-    map::{B256Map, B256Set, HashMap, HashSet},
+    map::{B256Map, HashMap, HashSet},
     FixedBytes, B256,
 };
 
@@ -141,7 +141,7 @@ impl TrieUpdates {
         &mut self,
         hash_builder: HashBuilder,
         removed_keys: HashSet<Nibbles>,
-        destroyed_accounts: B256Set,
+        destroyed_storage_trie_nodes: B256Map<Vec<Nibbles>>,
     ) {
         // Retrieve updated nodes from hash builder.
         let (_, updated_nodes) = hash_builder.split();
@@ -150,9 +150,13 @@ impl TrieUpdates {
         // Add deleted node paths.
         self.removed_nodes.extend(exclude_empty(removed_keys));
 
-        // Add deleted storage tries for destroyed accounts.
-        for destroyed in destroyed_accounts {
-            self.storage_tries.entry(destroyed).or_default().set_deleted(true);
+        // Add removed storage trie nodes for destroyed accounts.
+        for (hashed_address, removed_nodes) in destroyed_storage_trie_nodes {
+            let storage_updates = self.storage_tries.entry(hashed_address).or_default();
+            storage_updates.removed_nodes.extend(removed_nodes);
+            storage_updates
+                .storage_nodes
+                .retain(|path, _| !storage_updates.removed_nodes.contains(path));
         }
     }
 

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -1267,9 +1267,13 @@ mod tests {
 #[cfg(feature = "serde-bincode-compat")]
 pub mod serde_bincode_compat {
     use crate::{BranchNodeCompact, Nibbles};
-    use alloc::borrow::Cow;
+    use alloc::{borrow::Cow, vec::Vec};
     use alloy_primitives::map::{B256Map, HashMap, HashSet};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use core::fmt;
+    use serde::{
+        de::{Error as _, SeqAccess, Visitor},
+        Deserialize, Deserializer, Serialize, Serializer,
+    };
     use serde_with::{DeserializeAs, SerializeAs};
 
     /// Bincode-compatible [`super::TrieUpdates`] serde implementation.
@@ -1475,9 +1479,53 @@ pub mod serde_bincode_compat {
     ///     trie_updates: StorageTrieUpdatesSorted,
     /// }
     /// ```
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize)]
     pub struct StorageTrieUpdatesSorted<'a> {
         storage_nodes: Cow<'a, [(Nibbles, Option<BranchNodeCompact>)]>,
+    }
+
+    impl<'de, 'a> Deserialize<'de> for StorageTrieUpdatesSorted<'a> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct StorageTrieUpdatesSortedVisitor;
+
+            impl<'de> Visitor<'de> for StorageTrieUpdatesSortedVisitor {
+                type Value = Vec<(Nibbles, Option<BranchNodeCompact>)>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("storage trie updates with an optional legacy wipe marker")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>,
+                {
+                    let len = seq.size_hint().unwrap_or_default();
+                    let storage_nodes = match len {
+                        1 => {
+                            seq.next_element()?.ok_or_else(|| A::Error::invalid_length(0, &self))?
+                        }
+                        2 => {
+                            let _: bool = seq
+                                .next_element()?
+                                .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                            seq.next_element()?.ok_or_else(|| A::Error::invalid_length(1, &self))?
+                        }
+                        _ => return Err(A::Error::invalid_length(len, &self)),
+                    };
+
+                    Ok(storage_nodes)
+                }
+            }
+
+            // Bincode uses the supplied tuple length for the current format, while MessagePack
+            // exposes the encoded sequence length so legacy ExEx WAL entries can still be read.
+            deserializer
+                .deserialize_tuple(1, StorageTrieUpdatesSortedVisitor)
+                .map(|storage_nodes| Self { storage_nodes: Cow::Owned(storage_nodes) })
+        }
     }
 
     impl<'a> From<&'a super::StorageTrieUpdatesSorted> for StorageTrieUpdatesSorted<'a> {

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -154,9 +154,6 @@ impl TrieUpdates {
         for (hashed_address, removed_nodes) in destroyed_storage_trie_nodes {
             let storage_updates = self.storage_tries.entry(hashed_address).or_default();
             storage_updates.removed_nodes.extend(removed_nodes);
-            storage_updates
-                .storage_nodes
-                .retain(|path, _| !storage_updates.removed_nodes.contains(path));
         }
     }
 
@@ -945,6 +942,34 @@ impl From<StorageTrieUpdatesSorted> for StorageTrieUpdates {
 mod tests {
     use super::*;
     use alloy_primitives::B256;
+
+    #[test]
+    fn test_finalize_keeps_storage_updates_after_destroyed_node_removal() {
+        let hashed_address = B256::with_last_byte(1);
+        let path = Nibbles::from_nibbles_unchecked([0x01]);
+        let node = BranchNodeCompact::default();
+        let mut updates = TrieUpdates {
+            storage_tries: B256Map::from_iter([(
+                hashed_address,
+                StorageTrieUpdates {
+                    storage_nodes: HashMap::from_iter([(path, node.clone())]),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        updates.finalize(
+            HashBuilder::default(),
+            Default::default(),
+            B256Map::from_iter([(hashed_address, vec![path])]),
+        );
+
+        assert_eq!(
+            updates.into_sorted().storage_tries[&hashed_address].storage_nodes,
+            vec![(path, Some(node))]
+        );
+    }
 
     #[test]
     fn test_trie_updates_sorted_extend_ref() {

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -234,8 +234,6 @@ impl TrieUpdates {
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageTrieUpdates {
-    /// Flag indicating whether the trie was deleted.
-    pub is_deleted: bool,
     /// Collection of updated storage trie nodes.
     #[cfg_attr(any(test, feature = "serde"), serde(with = "serde_nibbles_map"))]
     pub storage_nodes: HashMap<Nibbles, BranchNodeCompact>,
@@ -246,30 +244,16 @@ pub struct StorageTrieUpdates {
 
 #[cfg(feature = "test-utils")]
 impl StorageTrieUpdates {
-    /// Creates a new storage trie updates that are not marked as deleted.
+    /// Creates storage trie updates from the provided nodes.
     pub fn new(updates: impl IntoIterator<Item = (Nibbles, BranchNodeCompact)>) -> Self {
         Self { storage_nodes: exclude_empty_from_pair(updates).collect(), ..Default::default() }
     }
 }
 
 impl StorageTrieUpdates {
-    /// Returns empty storage trie updates with `deleted` set to `true`.
-    pub fn deleted() -> Self {
-        Self {
-            is_deleted: true,
-            storage_nodes: HashMap::default(),
-            removed_nodes: HashSet::default(),
-        }
-    }
-
     /// Returns the length of updated nodes.
     pub fn len(&self) -> usize {
-        (self.is_deleted as usize) + self.storage_nodes.len() + self.removed_nodes.len()
-    }
-
-    /// Returns `true` if the trie was deleted.
-    pub const fn is_deleted(&self) -> bool {
-        self.is_deleted
+        self.storage_nodes.len() + self.removed_nodes.len()
     }
 
     /// Returns reference to updated storage nodes.
@@ -284,12 +268,7 @@ impl StorageTrieUpdates {
 
     /// Returns `true` if storage updates are empty.
     pub fn is_empty(&self) -> bool {
-        !self.is_deleted && self.storage_nodes.is_empty() && self.removed_nodes.is_empty()
-    }
-
-    /// Sets `deleted` flag on the storage trie.
-    pub const fn set_deleted(&mut self, deleted: bool) {
-        self.is_deleted = deleted;
+        self.storage_nodes.is_empty() && self.removed_nodes.is_empty()
     }
 
     /// Extends storage trie updates.
@@ -311,11 +290,6 @@ impl StorageTrieUpdates {
     }
 
     fn extend_common(&mut self, other: &Self) {
-        if other.is_deleted {
-            self.storage_nodes.clear();
-            self.removed_nodes.clear();
-        }
-        self.is_deleted |= other.is_deleted;
         self.storage_nodes.retain(|nibbles, _| !other.removed_nodes.contains(nibbles));
     }
 
@@ -326,12 +300,6 @@ impl StorageTrieUpdates {
     ///
     /// This is invoked from [`TrieUpdates::extend_from_sorted`] for each account.
     pub fn extend_from_sorted(&mut self, sorted: &StorageTrieUpdatesSorted) {
-        if sorted.is_deleted {
-            self.storage_nodes.clear();
-            self.removed_nodes.clear();
-        }
-        self.is_deleted |= sorted.is_deleted;
-
         // Reserve capacity for storage nodes
         let new_nodes_count = sorted.storage_nodes.len();
         self.storage_nodes.reserve(new_nodes_count);
@@ -376,7 +344,7 @@ impl StorageTrieUpdates {
         storage_nodes.extend(self.removed_nodes.into_iter().map(|path| (path, None)));
         storage_nodes.sort_unstable_by_key(|a| a.0);
 
-        StorageTrieUpdatesSorted { is_deleted: self.is_deleted, storage_nodes }
+        StorageTrieUpdatesSorted { storage_nodes }
     }
 
     /// Creates a sorted copy without consuming self.
@@ -397,13 +365,12 @@ impl StorageTrieUpdates {
         );
         storage_nodes.sort_unstable_by_key(|a| a.0);
 
-        StorageTrieUpdatesSorted { is_deleted: self.is_deleted, storage_nodes }
+        StorageTrieUpdatesSorted { storage_nodes }
     }
 
     /// Convert storage trie updates into [`StorageTrieUpdatesSortedRef`].
     pub fn into_sorted_ref(&self) -> StorageTrieUpdatesSortedRef<'_> {
         StorageTrieUpdatesSortedRef {
-            is_deleted: self.is_deleted,
             removed_nodes: self.removed_nodes.iter().collect::<BTreeSet<_>>(),
             storage_nodes: self.storage_nodes.iter().collect::<BTreeMap<_, _>>(),
         }
@@ -673,8 +640,6 @@ impl TrieUpdatesSorted {
             kway_merge_sorted(items.iter().map(|i| i.as_ref().account_nodes.as_slice()));
 
         struct StorageAcc<'a> {
-            is_deleted: bool,
-            sealed: bool,
             slices: Vec<&'a [(Nibbles, Option<BranchNodeCompact>)]>,
         }
 
@@ -682,22 +647,8 @@ impl TrieUpdatesSorted {
 
         for item in items {
             for (addr, storage) in &item.as_ref().storage_tries {
-                let entry = acc.entry(*addr).or_insert_with(|| StorageAcc {
-                    is_deleted: false,
-                    sealed: false,
-                    slices: Vec::new(),
-                });
-
-                if entry.sealed {
-                    continue;
-                }
-
+                let entry = acc.entry(*addr).or_insert_with(|| StorageAcc { slices: Vec::new() });
                 entry.slices.push(storage.storage_nodes.as_slice());
-
-                if storage.is_deleted {
-                    entry.is_deleted = true;
-                    entry.sealed = true;
-                }
             }
         }
 
@@ -705,7 +656,7 @@ impl TrieUpdatesSorted {
             .into_iter()
             .map(|(addr, entry)| {
                 let storage_nodes = kway_merge_sorted(entry.slices);
-                (addr, StorageTrieUpdatesSorted { is_deleted: entry.is_deleted, storage_nodes })
+                (addr, StorageTrieUpdatesSorted { storage_nodes })
             })
             .collect();
 
@@ -719,10 +670,6 @@ impl TrieUpdatesSorted {
     /// node level. For duplicate keys in the batch, later items take precedence over earlier ones.
     /// An overlapping entry is retained if any mask value is equal to the merged batch value. The
     /// order of the mask does not matter. An empty mask merges the batch without filtering.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any batch or mask entry deletes an entire storage trie.
     pub fn disjointed_merge_batch<'a>(batch: &[&'a Self], mask: &[&'a Self]) -> Self {
         let account_node_count = batch.iter().map(|item| item.account_nodes.len()).sum();
         let mut account_nodes = Vec::with_capacity(account_node_count);
@@ -748,10 +695,6 @@ impl TrieUpdatesSorted {
 
         for item in batch.iter().rev() {
             for (hashed_address, storage_trie) in &item.storage_tries {
-                assert!(
-                    !storage_trie.is_deleted,
-                    "storage wipes are not supported by disjointed_merge_batch"
-                );
                 let entry = storage_tries
                     .entry(*hashed_address)
                     .or_insert_with(|| StorageAcc { node_count: 0, slices: Vec::new() });
@@ -766,10 +709,6 @@ impl TrieUpdatesSorted {
         );
         for item in mask {
             for (hashed_address, storage_trie) in &item.storage_tries {
-                assert!(
-                    !storage_trie.is_deleted,
-                    "storage wipes are not supported by disjointed_merge_batch"
-                );
                 let entry = storage_masks.entry(*hashed_address).or_default();
                 entry.slices.push(storage_trie.storage_nodes.as_slice());
             }
@@ -791,10 +730,8 @@ impl TrieUpdatesSorted {
                     None => kway_merge_sorted(entry.slices),
                 };
 
-                (!storage_nodes.is_empty() || mask.is_empty()).then_some((
-                    hashed_address,
-                    StorageTrieUpdatesSorted { is_deleted: false, storage_nodes },
-                ))
+                (!storage_nodes.is_empty() || mask.is_empty())
+                    .then_some((hashed_address, StorageTrieUpdatesSorted { storage_nodes }))
             })
             .collect();
 
@@ -835,8 +772,6 @@ impl From<TrieUpdatesSorted> for TrieUpdates {
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize))]
 pub struct StorageTrieUpdatesSortedRef<'a> {
-    /// Flag indicating whether the trie has been deleted/wiped.
-    pub is_deleted: bool,
     /// Sorted collection of updated storage nodes with corresponding paths.
     pub storage_nodes: BTreeMap<&'a Nibbles, &'a BranchNodeCompact>,
     /// The set of removed storage node keys.
@@ -847,19 +782,12 @@ pub struct StorageTrieUpdatesSortedRef<'a> {
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 pub struct StorageTrieUpdatesSorted {
-    /// Flag indicating whether the trie has been deleted/wiped.
-    pub is_deleted: bool,
     /// Sorted collection of updated storage nodes with corresponding paths. None indicates a node
     /// is removed.
     pub storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
 }
 
 impl StorageTrieUpdatesSorted {
-    /// Returns `true` if the trie was deleted.
-    pub const fn is_deleted(&self) -> bool {
-        self.is_deleted
-    }
-
     /// Returns reference to updated storage nodes.
     pub fn storage_nodes_ref(&self) -> &[(Nibbles, Option<BranchNodeCompact>)] {
         &self.storage_nodes
@@ -876,36 +804,16 @@ impl StorageTrieUpdatesSorted {
     }
 
     /// Extends the storage trie updates with another set of sorted updates.
-    ///
-    /// If `other` is marked as deleted, this will be marked as deleted and all nodes cleared.
-    /// Otherwise, nodes are merged with `other`'s values taking precedence for duplicates.
     pub fn extend_ref(&mut self, other: &Self) {
-        if other.is_deleted {
-            self.is_deleted = true;
-            self.storage_nodes.clear();
-            self.storage_nodes.extend(other.storage_nodes.iter().cloned());
-            return;
-        }
-
-        // Extend storage nodes
         extend_sorted_vec(&mut self.storage_nodes, &other.storage_nodes);
-        self.is_deleted = self.is_deleted || other.is_deleted;
     }
 
     /// Batch-merge sorted storage trie updates. Iterator yields **newest to oldest**.
-    /// If any update is deleted, older data is discarded.
     pub fn merge_batch<'a>(updates: impl IntoIterator<Item = &'a Self>) -> Self {
         let updates: Vec<_> = updates.into_iter().collect();
-        if updates.is_empty() {
-            return Self::default();
+        Self {
+            storage_nodes: kway_merge_sorted(updates.iter().map(|u| u.storage_nodes.as_slice())),
         }
-
-        // Discard updates older than the first deletion since the trie was wiped at that point.
-        let del_idx = updates.iter().position(|u| u.is_deleted);
-        let relevant = del_idx.map_or(&updates[..], |idx| &updates[..=idx]);
-        let storage_nodes = kway_merge_sorted(relevant.iter().map(|u| u.storage_nodes.as_slice()));
-
-        Self { is_deleted: del_idx.is_some(), storage_nodes }
     }
 }
 
@@ -934,7 +842,7 @@ impl From<StorageTrieUpdatesSorted> for StorageTrieUpdates {
             }
         }
 
-        Self { is_deleted: sorted.is_deleted, storage_nodes, removed_nodes }
+        Self { storage_nodes, removed_nodes }
     }
 }
 
@@ -1006,14 +914,12 @@ mod tests {
 
         // Test extending storage tries
         let storage_trie1 = StorageTrieUpdatesSorted {
-            is_deleted: false,
             storage_nodes: vec![(
                 Nibbles::from_nibbles_unchecked([0x0a]),
                 Some(BranchNodeCompact::default()),
             )],
         };
         let storage_trie2 = StorageTrieUpdatesSorted {
-            is_deleted: false,
             storage_nodes: vec![(Nibbles::from_nibbles_unchecked([0x0b]), None)],
         };
 
@@ -1041,61 +947,6 @@ mod tests {
     }
 
     #[test]
-    fn test_storage_trie_updates_sorted_extend_ref_deleted() {
-        // Test case 1: Extending with a deleted storage trie that has nodes
-        let mut storage1 = StorageTrieUpdatesSorted {
-            is_deleted: false,
-            storage_nodes: vec![
-                (Nibbles::from_nibbles_unchecked([0x01]), Some(BranchNodeCompact::default())),
-                (Nibbles::from_nibbles_unchecked([0x02]), None),
-            ],
-        };
-
-        let storage2 = StorageTrieUpdatesSorted {
-            is_deleted: true,
-            storage_nodes: vec![
-                (Nibbles::from_nibbles_unchecked([0x03]), Some(BranchNodeCompact::default())),
-                (Nibbles::from_nibbles_unchecked([0x04]), None),
-            ],
-        };
-
-        storage1.extend_ref(&storage2);
-
-        // Should be marked as deleted
-        assert!(storage1.is_deleted);
-        // Original nodes should be cleared, but other's nodes should be added
-        assert_eq!(storage1.storage_nodes.len(), 2);
-        assert_eq!(storage1.storage_nodes[0].0, Nibbles::from_nibbles_unchecked([0x03]));
-        assert_eq!(storage1.storage_nodes[1].0, Nibbles::from_nibbles_unchecked([0x04]));
-
-        // Test case 2: Extending a deleted storage trie with more nodes
-        let mut storage3 = StorageTrieUpdatesSorted {
-            is_deleted: true,
-            storage_nodes: vec![(
-                Nibbles::from_nibbles_unchecked([0x05]),
-                Some(BranchNodeCompact::default()),
-            )],
-        };
-
-        let storage4 = StorageTrieUpdatesSorted {
-            is_deleted: true,
-            storage_nodes: vec![
-                (Nibbles::from_nibbles_unchecked([0x06]), Some(BranchNodeCompact::default())),
-                (Nibbles::from_nibbles_unchecked([0x07]), None),
-            ],
-        };
-
-        storage3.extend_ref(&storage4);
-
-        // Should remain deleted
-        assert!(storage3.is_deleted);
-        // Should have nodes from other (original cleared then extended)
-        assert_eq!(storage3.storage_nodes.len(), 2);
-        assert_eq!(storage3.storage_nodes[0].0, Nibbles::from_nibbles_unchecked([0x06]));
-        assert_eq!(storage3.storage_nodes[1].0, Nibbles::from_nibbles_unchecked([0x07]));
-    }
-
-    #[test]
     fn test_trie_updates_sorted_disjointed_merge_batch() {
         let kept_node = Nibbles::from_nibbles_unchecked([0x01]);
         let removed_node = Nibbles::from_nibbles_unchecked([0x02]);
@@ -1107,7 +958,7 @@ mod tests {
             vec![(kept_node, Some(BranchNodeCompact::default())), (removed_node, None)],
             B256Map::from_iter([(
                 kept_storage,
-                StorageTrieUpdatesSorted { is_deleted: false, storage_nodes: vec![(slot1, None)] },
+                StorageTrieUpdatesSorted { storage_nodes: vec![(slot1, None)] },
             )]),
         );
 
@@ -1116,7 +967,6 @@ mod tests {
             B256Map::from_iter([(
                 kept_storage,
                 StorageTrieUpdatesSorted {
-                    is_deleted: false,
                     storage_nodes: vec![(slot1, Some(BranchNodeCompact::default())), (slot2, None)],
                 },
             )]),
@@ -1127,7 +977,6 @@ mod tests {
             B256Map::from_iter([(
                 kept_storage,
                 StorageTrieUpdatesSorted {
-                    is_deleted: false,
                     storage_nodes: vec![(slot2, Some(BranchNodeCompact::default()))],
                 },
             )]),
@@ -1146,7 +995,6 @@ mod tests {
         assert_eq!(
             result.storage_tries.get(&kept_storage),
             Some(&StorageTrieUpdatesSorted {
-                is_deleted: false,
                 storage_nodes: vec![(slot1, Some(BranchNodeCompact::default()))],
             })
         );
@@ -1161,13 +1009,7 @@ mod tests {
         let older = TrieUpdatesSorted::new(
             vec![(node, Some(BranchNodeCompact::default()))],
             B256Map::from_iter([
-                (
-                    storage,
-                    StorageTrieUpdatesSorted {
-                        is_deleted: false,
-                        storage_nodes: vec![(storage_node, None)],
-                    },
-                ),
+                (storage, StorageTrieUpdatesSorted { storage_nodes: vec![(storage_node, None)] }),
                 (empty_storage, StorageTrieUpdatesSorted::default()),
             ]),
         );
@@ -1176,7 +1018,6 @@ mod tests {
             B256Map::from_iter([(
                 storage,
                 StorageTrieUpdatesSorted {
-                    is_deleted: false,
                     storage_nodes: vec![(storage_node, Some(BranchNodeCompact::default()))],
                 },
             )]),
@@ -1227,14 +1068,12 @@ mod tests {
                 (
                     storage,
                     StorageTrieUpdatesSorted {
-                        is_deleted: false,
                         storage_nodes: vec![(storage_node_path, Some(branch(0b0011_1100)))],
                     },
                 ),
                 (
                     deleted_storage,
                     StorageTrieUpdatesSorted {
-                        is_deleted: false,
                         storage_nodes: vec![(deleted_storage_node_path, None)],
                     },
                 ),
@@ -1249,14 +1088,12 @@ mod tests {
                 (
                     storage,
                     StorageTrieUpdatesSorted {
-                        is_deleted: false,
                         storage_nodes: vec![(storage_node_path, Some(branch(0b1100_0011)))],
                     },
                 ),
                 (
                     deleted_storage,
                     StorageTrieUpdatesSorted {
-                        is_deleted: false,
                         storage_nodes: vec![(deleted_storage_node_path, Some(branch(0b0000_1111)))],
                     },
                 ),
@@ -1290,7 +1127,6 @@ mod tests {
             B256Map::from_iter([(
                 hashed_address,
                 StorageTrieUpdatesSorted {
-                    is_deleted: false,
                     storage_nodes: vec![
                         (grandparent, Some(BranchNodeCompact::default())),
                         (parent, Some(BranchNodeCompact::default())),
@@ -1307,7 +1143,6 @@ mod tests {
             B256Map::from_iter([(
                 hashed_address,
                 StorageTrieUpdatesSorted {
-                    is_deleted: false,
                     storage_nodes: vec![
                         (grandparent, Some(different_node.clone())),
                         (parent, Some(different_node)),
@@ -1322,7 +1157,6 @@ mod tests {
         assert_eq!(
             result.storage_tries.get(&hashed_address),
             Some(&StorageTrieUpdatesSorted {
-                is_deleted: false,
                 storage_nodes: vec![(child, Some(BranchNodeCompact::default()))],
             })
         );
@@ -1338,17 +1172,13 @@ mod tests {
             B256Map::from_iter([(
                 storage,
                 StorageTrieUpdatesSorted {
-                    is_deleted: false,
                     storage_nodes: vec![(slot, Some(BranchNodeCompact::default()))],
                 },
             )]),
         );
         let mask = TrieUpdatesSorted::new(
             vec![],
-            B256Map::from_iter([(
-                storage,
-                StorageTrieUpdatesSorted { is_deleted: false, storage_nodes: vec![] },
-            )]),
+            B256Map::from_iter([(storage, StorageTrieUpdatesSorted { storage_nodes: vec![] })]),
         );
 
         let result = TrieUpdatesSorted::disjointed_merge_batch(&[&batch], &[&mask]);
@@ -1356,7 +1186,6 @@ mod tests {
         assert_eq!(
             result.storage_tries.get(&storage),
             Some(&StorageTrieUpdatesSorted {
-                is_deleted: false,
                 storage_nodes: vec![(slot, Some(BranchNodeCompact::default()))],
             })
         );
@@ -1370,7 +1199,6 @@ mod tests {
         let mut updates = TrieUpdates::default();
 
         let storage_trie = StorageTrieUpdatesSorted {
-            is_deleted: false,
             storage_nodes: vec![
                 (Nibbles::from_nibbles_unchecked([0x0a]), Some(BranchNodeCompact::default())),
                 (Nibbles::from_nibbles_unchecked([0x0b]), None),
@@ -1386,56 +1214,14 @@ mod tests {
 
         assert_eq!(updates.storage_tries.len(), 1);
         let storage = updates.storage_tries.get(&hashed_address).unwrap();
-        assert!(!storage.is_deleted);
         assert_eq!(storage.storage_nodes.len(), 1);
         assert!(storage.removed_nodes.contains(&Nibbles::from_nibbles_unchecked([0x0b])));
     }
 
-    /// Test deleted=true clears old storage nodes before adding new ones (critical edge case)
-    #[test]
-    fn test_trie_updates_extend_from_sorted_with_deleted_storage() {
-        let hashed_address = B256::from([1; 32]);
-
-        let mut updates = TrieUpdates::default();
-        updates.storage_tries.insert(
-            hashed_address,
-            StorageTrieUpdates {
-                is_deleted: false,
-                storage_nodes: HashMap::from_iter([(
-                    Nibbles::from_nibbles_unchecked([0x01]),
-                    BranchNodeCompact::default(),
-                )]),
-                removed_nodes: Default::default(),
-            },
-        );
-
-        let storage_trie = StorageTrieUpdatesSorted {
-            is_deleted: true,
-            storage_nodes: vec![(
-                Nibbles::from_nibbles_unchecked([0x0a]),
-                Some(BranchNodeCompact::default()),
-            )],
-        };
-
-        let sorted = TrieUpdatesSorted {
-            account_nodes: vec![],
-            storage_tries: B256Map::from_iter([(hashed_address, storage_trie)]),
-        };
-
-        updates.extend_from_sorted(&sorted);
-
-        let storage = updates.storage_tries.get(&hashed_address).unwrap();
-        assert!(storage.is_deleted);
-        // After deletion, old nodes should be cleared
-        assert_eq!(storage.storage_nodes.len(), 1);
-        assert!(storage.storage_nodes.contains_key(&Nibbles::from_nibbles_unchecked([0x0a])));
-    }
-
-    /// Test non-deleted storage merges nodes and tracks removed nodes
+    /// Test storage merges nodes and tracks removed nodes
     #[test]
     fn test_storage_trie_updates_extend_from_sorted_non_deleted() {
         let mut storage = StorageTrieUpdates {
-            is_deleted: false,
             storage_nodes: HashMap::from_iter([(
                 Nibbles::from_nibbles_unchecked([0x01]),
                 BranchNodeCompact::default(),
@@ -1444,7 +1230,6 @@ mod tests {
         };
 
         let sorted = StorageTrieUpdatesSorted {
-            is_deleted: false,
             storage_nodes: vec![
                 (Nibbles::from_nibbles_unchecked([0x02]), Some(BranchNodeCompact::default())),
                 (Nibbles::from_nibbles_unchecked([0x03]), None),
@@ -1452,38 +1237,8 @@ mod tests {
         };
 
         storage.extend_from_sorted(&sorted);
-
-        assert!(!storage.is_deleted);
         assert_eq!(storage.storage_nodes.len(), 2);
         assert!(storage.removed_nodes.contains(&Nibbles::from_nibbles_unchecked([0x03])));
-    }
-
-    /// Test deleted=true clears old nodes before extending (edge case)
-    #[test]
-    fn test_storage_trie_updates_extend_from_sorted_deleted() {
-        let mut storage = StorageTrieUpdates {
-            is_deleted: false,
-            storage_nodes: HashMap::from_iter([(
-                Nibbles::from_nibbles_unchecked([0x01]),
-                BranchNodeCompact::default(),
-            )]),
-            removed_nodes: Default::default(),
-        };
-
-        let sorted = StorageTrieUpdatesSorted {
-            is_deleted: true,
-            storage_nodes: vec![(
-                Nibbles::from_nibbles_unchecked([0x0a]),
-                Some(BranchNodeCompact::default()),
-            )],
-        };
-
-        storage.extend_from_sorted(&sorted);
-
-        assert!(storage.is_deleted);
-        // Old nodes should be cleared when deleted
-        assert_eq!(storage.storage_nodes.len(), 1);
-        assert!(storage.storage_nodes.contains_key(&Nibbles::from_nibbles_unchecked([0x0a])));
     }
 
     /// Test empty nibbles are filtered out during conversion (edge case bug)
@@ -1598,7 +1353,6 @@ pub mod serde_bincode_compat {
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
     pub struct StorageTrieUpdates<'a> {
-        is_deleted: bool,
         storage_nodes: Cow<'a, HashMap<Nibbles, BranchNodeCompact>>,
         removed_nodes: Cow<'a, HashSet<Nibbles>>,
     }
@@ -1606,7 +1360,6 @@ pub mod serde_bincode_compat {
     impl<'a> From<&'a super::StorageTrieUpdates> for StorageTrieUpdates<'a> {
         fn from(value: &'a super::StorageTrieUpdates) -> Self {
             Self {
-                is_deleted: value.is_deleted,
                 storage_nodes: Cow::Borrowed(&value.storage_nodes),
                 removed_nodes: Cow::Borrowed(&value.removed_nodes),
             }
@@ -1616,7 +1369,6 @@ pub mod serde_bincode_compat {
     impl<'a> From<StorageTrieUpdates<'a>> for super::StorageTrieUpdates {
         fn from(value: StorageTrieUpdates<'a>) -> Self {
             Self {
-                is_deleted: value.is_deleted,
                 storage_nodes: value.storage_nodes.into_owned(),
                 removed_nodes: value.removed_nodes.into_owned(),
             }
@@ -1725,22 +1477,18 @@ pub mod serde_bincode_compat {
     /// ```
     #[derive(Debug, Serialize, Deserialize)]
     pub struct StorageTrieUpdatesSorted<'a> {
-        is_deleted: bool,
         storage_nodes: Cow<'a, [(Nibbles, Option<BranchNodeCompact>)]>,
     }
 
     impl<'a> From<&'a super::StorageTrieUpdatesSorted> for StorageTrieUpdatesSorted<'a> {
         fn from(value: &'a super::StorageTrieUpdatesSorted) -> Self {
-            Self {
-                is_deleted: value.is_deleted,
-                storage_nodes: Cow::Borrowed(&value.storage_nodes),
-            }
+            Self { storage_nodes: Cow::Borrowed(&value.storage_nodes) }
         }
     }
 
     impl<'a> From<StorageTrieUpdatesSorted<'a>> for super::StorageTrieUpdatesSorted {
         fn from(value: StorageTrieUpdatesSorted<'a>) -> Self {
-            Self { is_deleted: value.is_deleted, storage_nodes: value.storage_nodes.into_owned() }
+            Self { storage_nodes: value.storage_nodes.into_owned() }
         }
     }
 
@@ -1905,11 +1653,6 @@ pub mod serde_bincode_compat {
             data.trie_updates
                 .storage_nodes
                 .push((Nibbles::from_nibbles_unchecked([0x0a, 0x0a, 0x0a, 0x0a]), None));
-            let encoded = bincode::serialize(&data).unwrap();
-            let decoded: Data = bincode::deserialize(&encoded).unwrap();
-            assert_eq!(decoded, data);
-
-            data.trie_updates.is_deleted = true;
             let encoded = bincode::serialize(&data).unwrap();
             let decoded: Data = bincode::deserialize(&encoded).unwrap();
             assert_eq!(decoded, data);

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -325,7 +325,7 @@ impl DatabaseHashedPostState for HashedPostStateSorted {
             .into_iter()
             .map(|(address, mut slots)| {
                 slots.sort_unstable_by_key(|(slot, _)| *slot);
-                (address, HashedStorageSorted { storage_slots: slots, wiped: false })
+                (address, HashedStorageSorted { storage_slots: slots })
             })
             .collect();
 

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -36,7 +36,7 @@ pub fn hashed_storage_from_reverts_with_provider<P>(
 where
     P: StorageChangeSetReader + BlockNumReader,
 {
-    let mut storage = HashedStorage::new(false);
+    let mut storage = HashedStorage::default();
     let tip = provider.last_block_number()?;
 
     if from > tip {

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -281,11 +281,6 @@ where
         &mut self,
         updates: &StorageTrieUpdatesSorted,
     ) -> Result<usize, DatabaseError> {
-        // The storage trie for this account has to be deleted.
-        if updates.is_deleted() && self.cursor.seek_exact(self.hashed_address)?.is_some() {
-            self.cursor.delete_current_duplicates()?;
-        }
-
         let mut num_entries = 0;
         for (nibbles, maybe_updated) in updates.storage_nodes.iter().filter(|(n, _)| !n.is_empty())
         {

--- a/crates/trie/db/tests/fuzz_in_memory_nodes.rs
+++ b/crates/trie/db/tests/fuzz_in_memory_nodes.rs
@@ -2,11 +2,7 @@
 
 use alloy_primitives::{B256, U256};
 use proptest::prelude::*;
-use reth_db::{
-    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRW},
-    tables,
-    transaction::DbTxMut,
-};
+use reth_db::{cursor::DbCursorRW, tables, transaction::DbTxMut};
 use reth_primitives_traits::{Account, StorageEntry};
 use reth_provider::test_utils::create_test_provider_factory;
 use reth_storage_api::StorageSettingsCache;
@@ -85,7 +81,7 @@ proptest! {
     }
 
     #[test]
-    fn fuzz_in_memory_storage_nodes(mut init_storage: BTreeMap<B256, U256>, storage_updates: [(bool, BTreeMap<B256, U256>); 10]) {
+    fn fuzz_in_memory_storage_nodes(mut init_storage: BTreeMap<B256, U256>, storage_updates: [BTreeMap<B256, U256>; 10]) {
         let hashed_address = B256::random();
         let factory = create_test_provider_factory();
         let provider = factory.provider_rw().unwrap();
@@ -105,12 +101,9 @@ proptest! {
                 DbStorageRoot::<_, A>::from_tx_hashed(provider.tx_ref(), hashed_address).root_with_updates().unwrap();
 
             let mut storage = init_storage;
-            for (is_deleted, mut storage_update) in storage_updates {
+            for mut storage_update in storage_updates {
                 // Insert state updates into database
-                if is_deleted && hashed_storage_cursor.seek_exact(hashed_address).unwrap().is_some() {
-                    hashed_storage_cursor.delete_current_duplicates().unwrap();
-                }
-                let mut hashed_storage = HashedStorage::new(is_deleted);
+                let mut hashed_storage = HashedStorage::default();
                 for (hashed_slot, value) in storage_update.clone() {
                     hashed_storage_cursor
                         .upsert(hashed_address, &StorageEntry { key: hashed_slot, value })
@@ -134,9 +127,6 @@ proptest! {
                 storage_trie_nodes.extend(trie_updates);
 
                 // Verify the result
-                if is_deleted {
-                    storage.clear();
-                }
                 storage.append(&mut storage_update);
                 let expected_root = storage_root_prehashed(storage.clone());
                 assert_eq!(expected_root, storage_root);

--- a/crates/trie/db/tests/post_state.rs
+++ b/crates/trie/db/tests/post_state.rs
@@ -208,18 +208,7 @@ fn fuzz_hashed_account_cursor() {
     );
 }
 
-/// Tests `is_storage_empty()` correctly distinguishes wiped storage from storage with zero values.
-///
-/// Key distinction:
-/// - `wiped = true`: Storage cleared/deleted → empty
-/// - `wiped = false` with zeros: Explicit zero values → not empty
-///
-/// Test cases:
-/// 1. No entries → empty
-/// 2. Non-zero values → not empty
-/// 3. Some zero values, not wiped → not empty
-/// 4. Wiped + zero post-state → empty
-/// 5. Wiped + non-zero post-state → not empty
+/// Tests `is_storage_empty()` with empty, database-backed, and zero-value overlays.
 #[test]
 fn storage_is_empty() {
     let address = B256::random();
@@ -256,61 +245,10 @@ fn storage_is_empty() {
         assert!(!cursor.is_storage_empty().unwrap());
     }
 
-    // Some zero values, but not wiped
+    // Some zero values
     {
-        let wiped = false;
-        let mut hashed_storage = HashedStorage::new(wiped);
+        let mut hashed_storage = HashedStorage::default();
         hashed_storage.storage.insert(B256::with_last_byte(0), U256::ZERO);
-
-        let mut hashed_post_state = HashedPostState::default();
-        hashed_post_state.storages.insert(address, hashed_storage);
-
-        let sorted = hashed_post_state.into_sorted();
-        let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
-        let mut cursor = factory.hashed_storage_cursor(address).unwrap();
-        assert!(!cursor.is_storage_empty().unwrap());
-    }
-
-    // wiped storage, must be empty
-    {
-        let wiped = true;
-        let hashed_storage = HashedStorage::new(wiped);
-
-        let mut hashed_post_state = HashedPostState::default();
-        hashed_post_state.storages.insert(address, hashed_storage);
-
-        let sorted = hashed_post_state.into_sorted();
-        let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
-        let mut cursor = factory.hashed_storage_cursor(address).unwrap();
-        assert!(cursor.is_storage_empty().unwrap());
-    }
-
-    // wiped storage, but post state has zero-value entries
-    {
-        let wiped = true;
-        let mut hashed_storage = HashedStorage::new(wiped);
-        hashed_storage.storage.insert(B256::random(), U256::ZERO);
-
-        let mut hashed_post_state = HashedPostState::default();
-        hashed_post_state.storages.insert(address, hashed_storage);
-
-        let sorted = hashed_post_state.into_sorted();
-        let tx = db.tx().unwrap();
-        let factory =
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
-        let mut cursor = factory.hashed_storage_cursor(address).unwrap();
-        assert!(cursor.is_storage_empty().unwrap());
-    }
-
-    // wiped storage, but post state has non-zero entries
-    {
-        let wiped = true;
-        let mut hashed_storage = HashedStorage::new(wiped);
-        hashed_storage.storage.insert(B256::random(), U256::from(1));
 
         let mut hashed_post_state = HashedPostState::default();
         hashed_post_state.storages.insert(address, hashed_storage);
@@ -343,8 +281,7 @@ fn storage_cursor_correct_order() {
     })
     .unwrap();
 
-    let wiped = false;
-    let mut hashed_storage = HashedStorage::new(wiped);
+    let mut hashed_storage = HashedStorage::default();
     for (slot, value) in &post_state_storage {
         hashed_storage.storage.insert(*slot, *value);
     }
@@ -383,8 +320,7 @@ fn zero_value_storage_entries_are_discarded() {
     })
     .unwrap();
 
-    let wiped = false;
-    let mut hashed_storage = HashedStorage::new(wiped);
+    let mut hashed_storage = HashedStorage::default();
     for (slot, value) in &post_state_storage {
         hashed_storage.storage.insert(*slot, *value);
     }
@@ -399,40 +335,6 @@ fn zero_value_storage_entries_are_discarded() {
         address,
         post_state_storage.into_iter().filter(|(_, value)| *value > U256::ZERO).collect(),
     ));
-    assert_storage_cursor_order(&factory, expected);
-}
-
-#[test]
-fn wiped_storage_is_discarded() {
-    let address = B256::random();
-    let db_storage =
-        (1..11).map(|key| (B256::with_last_byte(key), U256::from(key))).collect::<BTreeMap<_, _>>();
-    let post_state_storage = (11..21)
-        .map(|key| (B256::with_last_byte(key), U256::from(key)))
-        .collect::<BTreeMap<_, _>>();
-
-    let db = create_test_rw_db();
-    db.update(|tx| {
-        for (slot, value) in db_storage {
-            // insert zero value accounts to the database
-            tx.put::<tables::HashedStorages>(address, StorageEntry { key: slot, value }).unwrap();
-        }
-    })
-    .unwrap();
-
-    let wiped = true;
-    let mut hashed_storage = HashedStorage::new(wiped);
-    for (slot, value) in &post_state_storage {
-        hashed_storage.storage.insert(*slot, *value);
-    }
-
-    let mut hashed_post_state = HashedPostState::default();
-    hashed_post_state.storages.insert(address, hashed_storage);
-
-    let sorted = hashed_post_state.into_sorted();
-    let tx = db.tx().unwrap();
-    let factory = HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(&tx), &sorted);
-    let expected = std::iter::once((address, post_state_storage));
     assert_storage_cursor_order(&factory, expected);
 }
 
@@ -455,8 +357,7 @@ fn post_state_storages_take_precedence() {
     })
     .unwrap();
 
-    let wiped = false;
-    let mut hashed_storage = HashedStorage::new(wiped);
+    let mut hashed_storage = HashedStorage::default();
     for (slot, value) in &storage {
         hashed_storage.storage.insert(*slot, *value);
     }
@@ -476,7 +377,7 @@ fn fuzz_hashed_storage_cursor() {
     proptest!(ProptestConfig::with_cases(10),
         |(
             db_storages: BTreeMap<B256, BTreeMap<B256, U256>>,
-            post_state_storages: BTreeMap<B256, (bool, BTreeMap<B256, U256>)>
+            post_state_storages: BTreeMap<B256, BTreeMap<B256, U256>>
         )|
     {
         let db = create_test_rw_db();
@@ -492,8 +393,8 @@ fn fuzz_hashed_storage_cursor() {
 
         let mut hashed_post_state = HashedPostState::default();
 
-        for (address, (wiped, storage)) in &post_state_storages {
-            let mut hashed_storage = HashedStorage::new(*wiped);
+        for (address, storage) in &post_state_storages {
+            let mut hashed_storage = HashedStorage::default();
             for (slot, value) in storage {
                 hashed_storage.storage.insert(*slot, *value);
             }
@@ -503,12 +404,8 @@ fn fuzz_hashed_storage_cursor() {
 
         let mut expected = db_storages;
         // overwrite or remove accounts from the expected result
-        for (key, (wiped, storage)) in post_state_storages {
-            let entry = expected.entry(key).or_default();
-            if wiped {
-                entry.clear();
-            }
-            entry.extend(storage);
+        for (key, storage) in post_state_storages {
+            expected.entry(key).or_default().extend(storage);
         }
 
         let sorted = hashed_post_state.into_sorted();
@@ -519,9 +416,8 @@ fn fuzz_hashed_storage_cursor() {
 }
 
 #[test]
-fn all_storage_slots_deleted_not_wiped_exact_keys() {
+fn all_storage_slots_deleted_exact_keys() {
     // This test reproduces an edge case where:
-    // - wiped = false
     // - All post state entries are deletions (None values)
     // - Database has corresponding entries
     // - Expected: NO leaves should be returned (all deleted)
@@ -550,7 +446,7 @@ fn all_storage_slots_deleted_not_wiped_exact_keys() {
     .unwrap();
 
     // Create post state with same keys but all Zero values (deletions)
-    let mut hashed_storage = HashedStorage::new(false);
+    let mut hashed_storage = HashedStorage::default();
     for (key, _) in &db_entries {
         hashed_storage.storage.insert(*key, U256::ZERO); // Zero value = deletion
     }

--- a/crates/trie/db/tests/post_state.rs
+++ b/crates/trie/db/tests/post_state.rs
@@ -460,6 +460,8 @@ fn all_storage_slots_deleted_exact_keys() {
 
     let mut cursor = factory.hashed_storage_cursor(address).unwrap();
 
+    assert!(cursor.is_storage_empty().unwrap());
+
     // Seek to beginning should return None (all slots are deleted)
     let result = cursor.seek(B256::ZERO).unwrap();
     assert_eq!(

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -2,14 +2,18 @@
 
 use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_primitives::{
-    address, b256, hex_literal::hex, keccak256, map::HashMap, Address, B256, U256,
+    address, b256,
+    hex_literal::hex,
+    keccak256,
+    map::{B256Set, HashMap},
+    Address, B256, U256,
 };
 use alloy_rlp::Encodable;
 use proptest::{prelude::ProptestConfig, proptest};
 use proptest_arbitrary_interop::arb;
 use reth_db::{tables, test_utils::TempDatabase, DatabaseEnv};
 use reth_db_api::{
-    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
+    cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     transaction::{DbTx, DbTxMut},
 };
 use reth_primitives_traits::{Account, StorageEntry};
@@ -270,6 +274,90 @@ fn cleared_storage_emits_node_removals_without_deleted_flag() {
         assert!(!updates.is_deleted());
         assert!(!updates.removed_nodes_ref().is_empty());
     });
+}
+
+#[test]
+fn destroyed_account_storage_emits_node_removals() {
+    let factory = create_test_provider_factory();
+    let tx = factory.provider_rw().unwrap();
+    let hashed_address = B256::random();
+    tx.tx_ref().put::<tables::HashedAccounts>(hashed_address, Account::default()).unwrap();
+    for hashed_slot in [
+        hex!("30af561000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af569000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af650000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af6f0000000000000000000000000000000000000000000000000000000000"),
+        hex!("30af8f0000000000000000000000000000000000000000000000000000000000"),
+        hex!("3100000000000000000000000000000000000000000000000000000000000000"),
+    ] {
+        tx.tx_ref()
+            .put::<tables::HashedStorages>(
+                hashed_address,
+                StorageEntry { key: B256::new(hashed_slot), value: U256::ONE },
+            )
+            .unwrap();
+    }
+
+    let initial_updates = reth_trie_db::with_adapter!(tx, |A| {
+        DbStateRoot::<_, A>::from_tx(tx.tx_ref()).root_with_updates().unwrap().1
+    });
+    tx.write_trie_updates(initial_updates).unwrap();
+
+    let initial_storage_updates = reth_trie_db::with_adapter!(tx, |A| {
+        DbStorageRoot::<_, A>::from_tx_hashed(tx.tx_ref(), hashed_address)
+            .root_with_updates()
+            .unwrap()
+            .2
+    });
+    let mut expected_removed_nodes: Vec<_> =
+        initial_storage_updates.storage_nodes_ref().keys().copied().collect();
+    expected_removed_nodes.sort_unstable();
+    assert!(!expected_removed_nodes.is_empty());
+    let initial_storage_updates = initial_storage_updates.into_sorted();
+    tx.write_storage_trie_updates_sorted(core::iter::once((
+        &hashed_address,
+        &initial_storage_updates,
+    )))
+    .unwrap();
+
+    let mut account_cursor = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
+    account_cursor.seek_exact(hashed_address).unwrap();
+    account_cursor.delete_current().unwrap();
+    drop(account_cursor);
+
+    let mut storage_cursor = tx.tx_ref().cursor_dup_write::<tables::HashedStorages>().unwrap();
+    storage_cursor.seek_exact(hashed_address).unwrap();
+    storage_cursor.delete_current_duplicates().unwrap();
+    drop(storage_cursor);
+
+    let mut account_prefix_set = PrefixSetMut::default();
+    account_prefix_set.insert(Nibbles::unpack(hashed_address));
+    let (root, updates) = reth_trie_db::with_adapter!(tx, |A| {
+        DbStateRoot::<_, A>::from_tx(tx.tx_ref())
+            .with_prefix_sets(TriePrefixSets {
+                account_prefix_set: account_prefix_set.freeze(),
+                destroyed_accounts: B256Set::from_iter([hashed_address]),
+                ..Default::default()
+            })
+            .root_with_updates()
+            .unwrap()
+    });
+
+    assert_eq!(root, EMPTY_ROOT_HASH);
+    let storage_updates = &updates.storage_tries_ref()[&hashed_address];
+    assert!(!storage_updates.is_deleted());
+    let mut removed_nodes: Vec<_> = storage_updates.removed_nodes_ref().iter().copied().collect();
+    removed_nodes.sort_unstable();
+    assert_eq!(removed_nodes, expected_removed_nodes);
+
+    tx.write_trie_updates(updates).unwrap();
+    assert!(tx
+        .tx_ref()
+        .cursor_dup_read::<tables::StoragesTrie>()
+        .unwrap()
+        .seek_exact(hashed_address)
+        .unwrap()
+        .is_none());
 }
 
 #[test]

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -218,7 +218,7 @@ fn test_empty_storage_root() {
 }
 
 #[test]
-fn cleared_storage_emits_node_removals_without_deleted_flag() {
+fn cleared_storage_emits_node_removals() {
     let factory = create_test_provider_factory();
     let tx = factory.provider_rw().unwrap();
     let hashed_address = B256::random();
@@ -271,7 +271,6 @@ fn cleared_storage_emits_node_removals_without_deleted_flag() {
             .root_with_updates()
             .unwrap();
         assert_eq!(root, EMPTY_ROOT_HASH);
-        assert!(!updates.is_deleted());
         assert!(!updates.removed_nodes_ref().is_empty());
     });
 }
@@ -345,7 +344,6 @@ fn destroyed_account_storage_emits_node_removals() {
 
     assert_eq!(root, EMPTY_ROOT_HASH);
     let storage_updates = &updates.storage_tries_ref()[&hashed_address];
-    assert!(!storage_updates.is_deleted());
     let mut removed_nodes: Vec<_> = storage_updates.removed_nodes_ref().iter().copied().collect();
     removed_nodes.sort_unstable();
     assert_eq!(removed_nodes, expected_removed_nodes);

--- a/crates/trie/db/tests/witness.rs
+++ b/crates/trie/db/tests/witness.rs
@@ -148,7 +148,10 @@ fn includes_nodes_for_destroyed_storage_nodes() {
         )
         .compute(HashedPostState {
             accounts: HashMap::from_iter([(hashed_address, Some(Account::default()))]),
-            storages: HashMap::from_iter([(hashed_address, HashedStorage::new(true))]), // destroyed
+            storages: HashMap::from_iter([(
+                hashed_address,
+                HashedStorage::from_iter([(hashed_slot, U256::ZERO)]),
+            )]),
         })
         .unwrap();
         assert!(witness.contains_key(&state_root));

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1052,7 +1052,6 @@ impl ArenaParallelSparseTrie {
     ) {
         if let Some(dst_updates) = dst.as_mut() {
             let src_updates = src.as_mut().expect("updates are enabled");
-            debug_assert!(!src_updates.wiped, "subtrie updates should never have wiped=true");
 
             // Source insertions cancel destination removals.
             for path in src_updates.updated_nodes.keys() {
@@ -2620,14 +2619,6 @@ impl SparseTrie for ArenaParallelSparseTrie {
             }
             None => SparseTrieUpdates::default(),
         }
-    }
-
-    #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
-    fn wipe(&mut self) {
-        trace!(target: TRACE_TARGET, "Wiping arena trie");
-        self.clear();
-        *self.upper_arena[self.root].state_mut() = ArenaSparseNodeState::Dirty;
-        self.buffers.updates = self.buffers.updates.is_some().then(SparseTrieUpdates::wiped);
     }
 
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -341,14 +341,6 @@ where
         any_err
     }
 
-    /// Wipe the storage trie at the provided address.
-    pub fn wipe_storage(&mut self, address: B256) -> SparseStateTrieResult<()> {
-        if let Some(trie) = self.storage.tries.get_mut(&address) {
-            trie.wipe()?;
-        }
-        Ok(())
-    }
-
     /// Calculates the hashes of subtries.
     ///
     /// If the trie has not been revealed, this function does nothing.
@@ -413,7 +405,6 @@ where
                 let trie = trie.as_revealed_mut().unwrap();
                 let updates = trie.take_updates();
                 let updates = StorageTrieUpdates {
-                    is_deleted: updates.wiped,
                     storage_nodes: updates.updated_nodes,
                     removed_nodes: updates.removed_nodes,
                 };
@@ -1053,7 +1044,7 @@ mod tests {
         let address_2 = b256!("0x1100000000000000000000000000000000000000000000000000000000000000");
         let address_path_2 = Nibbles::unpack(address_2);
         let account_2 = Account::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();
-        let mut trie_account_2 = account_2.into_trie_account(EMPTY_ROOT_HASH);
+        let trie_account_2 = account_2.into_trie_account(EMPTY_ROOT_HASH);
 
         let mut hash_builder = HashBuilder::default()
             .with_proof_retainer(ProofRetainer::from_iter([address_path_1, address_path_2]));
@@ -1125,14 +1116,6 @@ mod tests {
             LeafUpdate::Changed(alloy_rlp::encode(trie_account_1)),
         );
 
-        sparse.wipe_storage(address_2).unwrap();
-        trie_account_2.storage_root = sparse.storage_root(&address_2, epoch(0)).unwrap();
-        apply_account_update(
-            &mut sparse,
-            address_2,
-            LeafUpdate::Changed(alloy_rlp::encode(trie_account_2)),
-        );
-
         sparse.root(epoch(0)).unwrap();
 
         let sparse_updates = sparse.take_trie_updates().unwrap();
@@ -1141,24 +1124,13 @@ mod tests {
             sparse_updates,
             TrieUpdates {
                 account_nodes: HashMap::default(),
-                storage_tries: HashMap::from_iter([
-                    (
-                        b256!("0x1000000000000000000000000000000000000000000000000000000000000000"),
-                        StorageTrieUpdates {
-                            is_deleted: false,
-                            storage_nodes: HashMap::default(),
-                            removed_nodes: HashSet::from_iter([Nibbles::from_nibbles([0x1])])
-                        }
-                    ),
-                    (
-                        b256!("0x1100000000000000000000000000000000000000000000000000000000000000"),
-                        StorageTrieUpdates {
-                            is_deleted: true,
-                            storage_nodes: HashMap::default(),
-                            removed_nodes: HashSet::default()
-                        }
-                    )
-                ]),
+                storage_tries: HashMap::from_iter([(
+                    b256!("0x1000000000000000000000000000000000000000000000000000000000000000"),
+                    StorageTrieUpdates {
+                        storage_nodes: HashMap::default(),
+                        removed_nodes: HashSet::from_iter([Nibbles::from_nibbles([0x1])])
+                    }
+                )]),
                 removed_nodes: HashSet::default()
             }
         );

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -206,15 +206,6 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// The accumulated updates, or an empty set if updates weren't being tracked.
     fn take_updates(&mut self) -> SparseTrieUpdates;
 
-    /// Removes all nodes and values from the trie, resetting it to a blank state
-    /// with only an empty root node. This is used when a storage root is deleted.
-    ///
-    /// This should not be used when intending to reuse the trie for a fresh account/storage root;
-    /// use `clear` for that.
-    ///
-    /// Note: All previously tracked changes to the trie are also removed.
-    fn wipe(&mut self);
-
     /// This clears all data structures in the sparse trie, keeping the backing data structures
     /// allocated. An empty root node is inserted at the root.
     ///
@@ -277,8 +268,6 @@ pub struct SparseTrieUpdates {
     pub updated_nodes: HashMap<Nibbles, BranchNodeCompact>,
     /// Collection of removed intermediate nodes indexed by full path.
     pub removed_nodes: HashSet<Nibbles>,
-    /// Flag indicating whether the trie was wiped.
-    pub wiped: bool,
 }
 
 impl SparseTrieUpdates {
@@ -287,7 +276,6 @@ impl SparseTrieUpdates {
         Self {
             updated_nodes: HashMap::with_capacity_and_hasher(num_updated_nodes, Default::default()),
             removed_nodes: HashSet::with_capacity_and_hasher(num_removed_nodes, Default::default()),
-            wiped: false,
         }
     }
 }

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -159,16 +159,6 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
         }
     }
 
-    /// Wipes the trie by removing all nodes and values,
-    /// and resetting the trie to only contain an empty root node.
-    ///
-    /// Note: This method will error if the trie is blinded.
-    pub fn wipe(&mut self) -> SparseTrieResult<()> {
-        let revealed = self.as_revealed_mut().ok_or(SparseTrieErrorKind::Blind)?;
-        revealed.wipe();
-        Ok(())
-    }
-
     /// Calculates the root hash of the trie.
     ///
     /// This will update any remaining dirty nodes before computing the root hash.
@@ -470,24 +460,15 @@ pub struct RlpNodeStackItem {
 }
 
 impl SparseTrieUpdates {
-    /// Create new wiped sparse trie updates.
-    pub fn wiped() -> Self {
-        Self { wiped: true, ..Default::default() }
-    }
-
     /// Clears the updates, but keeps the backing data structures allocated.
-    ///
-    /// Sets `wiped` to `false`.
     pub fn clear(&mut self) {
         self.updated_nodes.clear();
         self.removed_nodes.clear();
-        self.wiped = false;
     }
 
     /// Extends the updates with another set of updates.
     pub fn extend(&mut self, other: Self) {
         self.updated_nodes.extend(other.updated_nodes);
         self.removed_nodes.extend(other.removed_nodes);
-        self.wiped |= other.wiped;
     }
 }

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -12,7 +12,7 @@
 //! - [`root`]: Tests for `root()` hash computation
 //! - [`take_updates`]: Tests for `take_updates`
 //! - [`prune`]: Tests for `prune`
-//! - [`wipe_clear`]: Tests for `wipe` and `clear`
+//! - [`wipe_clear`]: Tests for `clear`
 //! - [`get_leaf_value`]: Tests for `get_leaf_value`
 //! - [`find_leaf`]: Tests for `find_leaf`
 //! - [`lifecycle`]: Integration tests exercising multiple methods together
@@ -285,10 +285,8 @@ sparse_trie_tests! {
     test_prune_only_descends_into_branch_root,
     test_prune_handles_small_subtrie_root_nodes,
 
-    // wipe / clear
-    test_wipe_resets_to_empty_root,
+    // clear
     test_clear_resets_trie_but_preserves_update_tracking,
-    test_wipe_produces_wiped_updates,
     test_clear_then_reuse_trie,
 
     // get_leaf_value

--- a/crates/trie/sparse/tests/suite/wipe_clear.rs
+++ b/crates/trie/sparse/tests/suite/wipe_clear.rs
@@ -1,33 +1,8 @@
 use super::*;
 
-/// Calling `wipe()` resets the trie so that
-/// `root()` returns `EMPTY_ROOT_HASH`.
-pub(super) fn test_wipe_resets_to_empty_root<T: SparseTrie>(new_trie: fn() -> T) {
-    let storage: BTreeMap<B256, U256> = BTreeMap::from([
-        (B256::with_last_byte(0x10), U256::from(1)),
-        (B256::with_last_byte(0x20), U256::from(2)),
-        (B256::with_last_byte(0x30), U256::from(3)),
-        (B256::with_last_byte(0x40), U256::from(4)),
-        (B256::with_last_byte(0x50), U256::from(5)),
-    ]);
-
-    let harness = SuiteTestHarness::new(storage);
-    let mut trie: T = harness.init_trie_fully_revealed(false, new_trie);
-
-    // Compute root to confirm the trie is populated.
-    let root_before = trie.root(epoch(0));
-    assert_eq!(root_before, harness.original_root());
-    assert_ne!(root_before, EMPTY_ROOT_HASH);
-
-    // Wipe and verify empty root.
-    trie.wipe();
-    let root_after = trie.root(epoch(0));
-    assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
-}
-
 /// `clear()` resets the trie to empty but preserves
 /// update tracking mode. After clear, `root()` returns `EMPTY_ROOT_HASH` and
-/// `take_updates()` returns empty (non-wiped) updates.
+/// `take_updates()` returns empty updates.
 pub(super) fn test_clear_resets_trie_but_preserves_update_tracking<T: SparseTrie>(
     new_trie: fn() -> T,
 ) {
@@ -51,42 +26,10 @@ pub(super) fn test_clear_resets_trie_but_preserves_update_tracking<T: SparseTrie
     let root_after = trie.root(epoch(0));
     assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after clear");
 
-    // take_updates should return empty (non-wiped) updates since tracking is preserved.
+    // take_updates should return empty updates since tracking is preserved.
     let updates = trie.take_updates();
-    assert!(!updates.wiped, "clear should not produce wiped updates");
     assert!(updates.updated_nodes.is_empty(), "clear should produce empty updated_nodes");
     assert!(updates.removed_nodes.is_empty(), "clear should produce empty removed_nodes");
-}
-
-/// `wipe()` produces special "wiped" updates distinct
-/// from normal empty updates. After wipe, `take_updates()` returns updates with
-/// the wiped flag set and `root()` returns `EMPTY_ROOT_HASH`.
-pub(super) fn test_wipe_produces_wiped_updates<T: SparseTrie>(new_trie: fn() -> T) {
-    let storage: BTreeMap<B256, U256> = BTreeMap::from([
-        (B256::with_last_byte(0x10), U256::from(1)),
-        (B256::with_last_byte(0x20), U256::from(2)),
-        (B256::with_last_byte(0x30), U256::from(3)),
-    ]);
-
-    let harness = SuiteTestHarness::new(storage);
-    // retain_updates = true so update tracking is active
-    let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
-
-    // Compute root to populate the trie fully.
-    let root_before = trie.root(epoch(0));
-    assert_eq!(root_before, harness.original_root());
-    assert_ne!(root_before, EMPTY_ROOT_HASH);
-
-    // Wipe the trie.
-    trie.wipe();
-
-    // Root should be EMPTY_ROOT_HASH after wipe.
-    let root_after = trie.root(epoch(0));
-    assert_eq!(root_after, EMPTY_ROOT_HASH, "root must be EMPTY_ROOT_HASH after wipe");
-
-    // take_updates should return updates with the wiped flag set.
-    let updates = trie.take_updates();
-    assert!(updates.wiped, "wipe should produce wiped updates");
 }
 
 /// A cleared trie can be fully re-initialized and used

--- a/crates/trie/trie/benches/proof_v2.rs
+++ b/crates/trie/trie/benches/proof_v2.rs
@@ -43,10 +43,8 @@ fn generate_test_data(
 
     // Create HashedPostState with single account's storage
     let mut storages = B256Map::default();
-    let hashed_storage = HashedStorage {
-        wiped: false,
-        storage: storage_map.iter().map(|(k, v)| (*k, *v)).collect(),
-    };
+    let hashed_storage =
+        HashedStorage { storage: storage_map.iter().map(|(k, v)| (*k, *v)).collect() };
     storages.insert(hashed_address, hashed_storage);
 
     let hashed_post_state = HashedPostState { accounts: B256Map::default(), storages };

--- a/crates/trie/trie/src/changesets.rs
+++ b/crates/trie/trie/src/changesets.rs
@@ -18,17 +18,13 @@
 //!
 //! And returns `TrieUpdatesSorted` containing the old node values.
 
-use crate::trie_cursor::TrieCursorIter;
+use crate::trie_cursor::{TrieCursor, TrieCursorFactory, TrieStorageCursor};
 use alloy_primitives::{map::B256Map, B256};
-use itertools::{merge_join_by, EitherOrBoth};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie_common::{
     updates::{StorageTrieUpdatesSorted, TrieUpdatesSorted},
     BranchNodeCompact, Nibbles,
 };
-use std::cmp::Ordering;
-
-use crate::trie_cursor::{TrieCursor, TrieCursorFactory, TrieStorageCursor};
 
 /// Result type for changeset operations.
 pub type ChangesetResult<T> = Result<T, DatabaseError>;
@@ -66,21 +62,12 @@ where
     for (hashed_address, storage_updates) in trie_updates.storage_tries_ref() {
         storage_cursor.set_hashed_address(*hashed_address);
 
-        let storage_changesets = if storage_updates.is_deleted() {
-            // Handle wiped storage
-            compute_wiped_storage_changesets(&mut storage_cursor, storage_updates)?
-        } else {
-            // Handle normal storage updates
-            compute_storage_changesets(&mut storage_cursor, storage_updates)?
-        };
+        let storage_changesets = compute_storage_changesets(&mut storage_cursor, storage_updates)?;
 
         if !storage_changesets.is_empty() {
             storage_tries.insert(
                 *hashed_address,
-                StorageTrieUpdatesSorted {
-                    is_deleted: storage_updates.is_deleted(),
-                    storage_nodes: storage_changesets,
-                },
+                StorageTrieUpdatesSorted { storage_nodes: storage_changesets },
             );
         }
     }
@@ -139,99 +126,6 @@ fn compute_storage_changesets(
     }
 
     Ok(storage_changesets)
-}
-
-/// Handles wiped storage trie changeset computation.
-///
-/// When an account's storage is completely wiped (e.g., account is destroyed),
-/// we need to capture not just the changed nodes, but ALL existing nodes in
-/// the storage trie, since they all will be deleted.
-///
-/// This uses an iterator-based approach to avoid allocating an intermediate Vec.
-/// It merges two sorted iterators:
-/// - Current values of changed paths
-/// - All existing nodes in the storage trie
-///
-/// # Arguments
-///
-/// * `changed_cursor` - Cursor for looking up changed node values
-/// * `wiped_cursor` - Cursor for iterating all nodes in the storage trie
-/// * `hashed_address` - The hashed address of the account
-/// * `storage_updates` - Storage trie updates for this account
-fn compute_wiped_storage_changesets(
-    cursor: &mut impl TrieStorageCursor,
-    storage_updates: &StorageTrieUpdatesSorted,
-) -> ChangesetResult<Vec<(Nibbles, Option<BranchNodeCompact>)>> {
-    // Set the hashed address for this account's storage trie
-    // Create an iterator that yields all nodes in the storage trie
-    let all_nodes = TrieCursorIter::new(cursor);
-
-    // Merge the two sorted iterators
-    let merged = storage_trie_wiped_changeset_iter(
-        storage_updates.storage_nodes.iter().map(|e| e.0),
-        all_nodes,
-    )?;
-
-    // Collect into a Vec
-    let mut storage_changesets = Vec::new();
-    for result in merged {
-        storage_changesets.push(result?);
-    }
-
-    Ok(storage_changesets)
-}
-
-/// Returns an iterator which produces the changeset values for an account whose storage was wiped
-/// during a block.
-///
-/// ## Arguments
-///
-/// - `curr_values_of_changed` is an iterator over the current values of all trie nodes modified by
-///   the block, ordered by path.
-/// - `all_nodes` is an iterator over all existing trie nodes for the account, ordered by path.
-///
-/// ## Returns
-///
-/// An iterator of trie node paths and a `Some(node)` (indicating the node was wiped) or a `None`
-/// (indicating the node was modified in the block but didn't previously exist). The iterator's
-/// results will be ordered by path.
-pub fn storage_trie_wiped_changeset_iter(
-    changed_paths: impl Iterator<Item = Nibbles>,
-    all_nodes: impl Iterator<Item = Result<(Nibbles, BranchNodeCompact), DatabaseError>>,
-) -> Result<
-    impl Iterator<Item = Result<(Nibbles, Option<BranchNodeCompact>), DatabaseError>>,
-    DatabaseError,
-> {
-    let all_nodes = all_nodes.map(|e| e.map(|(nibbles, node)| (nibbles, Some(node))));
-
-    let merged = merge_join_by(changed_paths, all_nodes, |a, b| match (a, b) {
-        (_, Err(_)) => Ordering::Greater,
-        (a, Ok(b)) => a.cmp(&b.0),
-    });
-
-    Ok(merged.map(|either_or| match either_or {
-        EitherOrBoth::Left(changed) => {
-            // A path of a changed node which was not found in the database. The current value of
-            // this path must be None, otherwise it would have also been returned by the `all_nodes`
-            // iter.
-            Ok((changed, None))
-        }
-        EitherOrBoth::Right(wiped) => {
-            // A node was found in the db (indicating it was wiped) but was not a changed node.
-            // Return it as-is.
-            wiped
-        }
-        EitherOrBoth::Both(_changed, wiped) => {
-            // A path of a changed node was found with a previous value in the database. If the
-            // changed node had no previous value (None) it wouldn't be returned by `all_nodes` and
-            // so would be in the Left branch.
-            //
-            // Due to the ordering closure passed to `merge_join_by` it's not possible for wrapped
-            // to be an error here.
-            debug_assert!(wiped.is_ok(), "unreachable error condition: {wiped:?}");
-            wiped
-        }
-    }))
 }
 
 #[cfg(test)]
@@ -334,7 +228,6 @@ mod tests {
         storage_updates.insert(
             hashed_address,
             StorageTrieUpdatesSorted {
-                is_deleted: false,
                 storage_nodes: vec![(path1, Some(new_node1)), (path3, Some(new_node3))],
             },
         );
@@ -347,7 +240,6 @@ mod tests {
         // Check storage changesets
         assert_eq!(changesets.storage_tries_ref().len(), 1);
         let storage_changesets = changesets.storage_tries_ref().get(&hashed_address).unwrap();
-        assert!(!storage_changesets.is_deleted);
         assert_eq!(storage_changesets.storage_nodes.len(), 2);
 
         // path1 should have the old node1 value
@@ -357,120 +249,5 @@ mod tests {
         // path3 should have None (it didn't exist before)
         assert_eq!(storage_changesets.storage_nodes[1].0, path3);
         assert_eq!(storage_changesets.storage_nodes[1].1, None);
-    }
-
-    #[test]
-    fn test_wiped_storage() {
-        let hashed_address = B256::from([2u8; 32]);
-
-        // Create initial storage trie with multiple nodes
-        let path1 = Nibbles::from_nibbles([0x1, 0x2]);
-        let path2 = Nibbles::from_nibbles([0x3, 0x4]);
-        let path3 = Nibbles::from_nibbles([0x5, 0x6]);
-        let node1 = BranchNodeCompact::new(0b1111, 0b0011, 0, vec![], None);
-        let node2 = BranchNodeCompact::new(0b1111, 0b0101, 0, vec![], None);
-        let node3 = BranchNodeCompact::new(0b1111, 0b1001, 0, vec![], None);
-
-        let mut storage_nodes = BTreeMap::new();
-        storage_nodes.insert(path1, node1.clone());
-        storage_nodes.insert(path2, node2.clone());
-        storage_nodes.insert(path3, node3.clone());
-
-        let mut storage_tries = B256Map::default();
-        storage_tries.insert(B256::default(), BTreeMap::new()); // For cursor creation
-        storage_tries.insert(hashed_address, storage_nodes);
-
-        let factory = MockTrieCursorFactory::new(BTreeMap::new(), storage_tries);
-
-        // Create updates that modify path1 and mark storage as wiped
-        let new_node1 = BranchNodeCompact::new(0b1111, 0b1000, 0, vec![], None);
-
-        let mut storage_updates = B256Map::default();
-        storage_updates.insert(
-            hashed_address,
-            StorageTrieUpdatesSorted {
-                is_deleted: true,
-                storage_nodes: vec![(path1, Some(new_node1))],
-            },
-        );
-
-        let updates = TrieUpdatesSorted::new(vec![], storage_updates);
-
-        // Compute changesets
-        let changesets = compute_trie_changesets(&factory, &updates).unwrap();
-
-        // Check storage changesets
-        assert_eq!(changesets.storage_tries_ref().len(), 1);
-        let storage_changesets = changesets.storage_tries_ref().get(&hashed_address).unwrap();
-        assert!(storage_changesets.is_deleted);
-
-        // Should include all three nodes (changed path1 + wiped path2 and path3)
-        assert_eq!(storage_changesets.storage_nodes.len(), 3);
-
-        // All paths should be present in sorted order
-        assert_eq!(storage_changesets.storage_nodes[0].0, path1);
-        assert_eq!(storage_changesets.storage_nodes[1].0, path2);
-        assert_eq!(storage_changesets.storage_nodes[2].0, path3);
-
-        // All should have their old values
-        assert_eq!(storage_changesets.storage_nodes[0].1, Some(node1));
-        assert_eq!(storage_changesets.storage_nodes[1].1, Some(node2));
-        assert_eq!(storage_changesets.storage_nodes[2].1, Some(node3));
-    }
-
-    #[test]
-    fn test_wiped_storage_with_new_path() {
-        let hashed_address = B256::from([3u8; 32]);
-
-        // Create initial storage trie with two nodes
-        let path1 = Nibbles::from_nibbles([0x1, 0x2]);
-        let path3 = Nibbles::from_nibbles([0x5, 0x6]);
-        let node1 = BranchNodeCompact::new(0b1111, 0b0011, 0, vec![], None);
-        let node3 = BranchNodeCompact::new(0b1111, 0b1001, 0, vec![], None);
-
-        let mut storage_nodes = BTreeMap::new();
-        storage_nodes.insert(path1, node1.clone());
-        storage_nodes.insert(path3, node3.clone());
-
-        let mut storage_tries = B256Map::default();
-        storage_tries.insert(B256::default(), BTreeMap::new()); // For cursor creation
-        storage_tries.insert(hashed_address, storage_nodes);
-
-        let factory = MockTrieCursorFactory::new(BTreeMap::new(), storage_tries);
-
-        // Create updates that add a new path2 that didn't exist before
-        let path2 = Nibbles::from_nibbles([0x3, 0x4]);
-        let new_node2 = BranchNodeCompact::new(0b1111, 0b0101, 0, vec![], None);
-
-        let mut storage_updates = B256Map::default();
-        storage_updates.insert(
-            hashed_address,
-            StorageTrieUpdatesSorted {
-                is_deleted: true,
-                storage_nodes: vec![(path2, Some(new_node2))],
-            },
-        );
-
-        let updates = TrieUpdatesSorted::new(vec![], storage_updates);
-
-        // Compute changesets
-        let changesets = compute_trie_changesets(&factory, &updates).unwrap();
-
-        // Check storage changesets
-        let storage_changesets = changesets.storage_tries_ref().get(&hashed_address).unwrap();
-        assert!(storage_changesets.is_deleted);
-
-        // Should include all three paths: existing path1, new path2, existing path3
-        assert_eq!(storage_changesets.storage_nodes.len(), 3);
-
-        // Check sorted order
-        assert_eq!(storage_changesets.storage_nodes[0].0, path1);
-        assert_eq!(storage_changesets.storage_nodes[1].0, path2);
-        assert_eq!(storage_changesets.storage_nodes[2].0, path3);
-
-        // path1 and path3 have old values, path2 has None (didn't exist)
-        assert_eq!(storage_changesets.storage_nodes[0].1, Some(node1));
-        assert_eq!(storage_changesets.storage_nodes[1].1, None);
-        assert_eq!(storage_changesets.storage_nodes[2].1, Some(node3));
     }
 }

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -188,7 +188,7 @@ where
     C: HashedCursor<Value = V::NonZero>,
     V: HashedPostStateCursorValue,
 {
-    fn get_cursor_mut(&mut self) -> &mut C {
+    const fn get_cursor_mut(&mut self) -> &mut C {
         &mut self.cursor
     }
 

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -111,22 +111,13 @@ enum DbCursorState<V> {
     NeedsPosition,
     Positioned((B256, V)),
     Exhausted,
-    Wiped,
 }
 
 impl<V> DbCursorState<V> {
-    const fn new(cursor_wiped: bool) -> Self {
-        if cursor_wiped {
-            Self::Wiped
-        } else {
-            Self::NeedsPosition
-        }
-    }
-
     const fn entry(&self) -> Option<&(B256, V)> {
         match self {
             Self::Positioned(entry) => Some(entry),
-            Self::NeedsPosition | Self::Exhausted | Self::Wiped => None,
+            Self::NeedsPosition | Self::Exhausted => None,
         }
     }
 
@@ -168,11 +159,10 @@ where
         post_state: &'a HashedPostStateSorted,
         hashed_address: B256,
     ) -> Self {
-        let (post_state_cursor, cursor_wiped) =
-            Self::get_storage_overlay(post_state, hashed_address);
+        let post_state_cursor = Self::get_storage_overlay(post_state, hashed_address);
         Self {
             cursor,
-            db_cursor_state: DbCursorState::new(cursor_wiped),
+            db_cursor_state: DbCursorState::NeedsPosition,
             post_state_cursor,
             last_key: None,
             #[cfg(debug_assertions)]
@@ -181,16 +171,15 @@ where
         }
     }
 
-    /// Returns the storage overlay for `hashed_address` and whether it was wiped.
+    /// Returns the storage overlay for `hashed_address`.
     fn get_storage_overlay(
         post_state: &'a HashedPostStateSorted,
         hashed_address: B256,
-    ) -> (ForwardInMemoryCursor<'a, B256, U256>, bool) {
+    ) -> ForwardInMemoryCursor<'a, B256, U256> {
         let post_state_storage = post_state.storages.get(&hashed_address);
-        let cursor_wiped = post_state_storage.is_some_and(|u| u.is_wiped());
         let storage_slots = post_state_storage.map(|u| u.storage_slots_ref()).unwrap_or(&[]);
 
-        (ForwardInMemoryCursor::new(storage_slots), cursor_wiped)
+        ForwardInMemoryCursor::new(storage_slots)
     }
 }
 
@@ -199,9 +188,8 @@ where
     C: HashedCursor<Value = V::NonZero>,
     V: HashedPostStateCursorValue,
 {
-    /// Returns a mutable reference to the underlying cursor if it's not wiped, None otherwise.
-    fn get_cursor_mut(&mut self) -> Option<&mut C> {
-        (!matches!(self.db_cursor_state, DbCursorState::Wiped)).then_some(&mut self.cursor)
+    fn get_cursor_mut(&mut self) -> &mut C {
+        &mut self.cursor
     }
 
     /// Asserts that the next entry to be returned from the cursor is not previous to the last entry
@@ -225,11 +213,11 @@ where
         let should_seek = match &self.db_cursor_state {
             DbCursorState::NeedsPosition => true,
             DbCursorState::Positioned((entry_key, _)) => entry_key < &key,
-            DbCursorState::Exhausted | DbCursorState::Wiped => false,
+            DbCursorState::Exhausted => false,
         };
 
         if should_seek {
-            let entry = self.get_cursor_mut().map(|c| c.seek(key)).transpose()?.flatten();
+            let entry = self.get_cursor_mut().seek(key)?;
             self.db_cursor_state.set_entry(entry);
         }
 
@@ -245,7 +233,7 @@ where
 
         // Exhausted DB state is stable; only advance when the DB cursor is positioned at an entry.
         if matches!(self.db_cursor_state, DbCursorState::Positioned(_)) {
-            let entry = self.get_cursor_mut().map(|c| c.next()).transpose()?.flatten();
+            let entry = self.get_cursor_mut().next()?;
             self.db_cursor_state.set_entry(entry);
         }
 
@@ -418,17 +406,16 @@ where
         }
 
         // If no non-zero slots in post state, check the database.
-        // Returns true if cursor is wiped.
-        self.get_cursor_mut().map_or(Ok(true), |c| c.is_storage_empty())
+        self.get_cursor_mut().is_storage_empty()
     }
 
     fn set_hashed_address(&mut self, hashed_address: B256) {
         self.reset();
         self.cursor.set_hashed_address(hashed_address);
-        let (post_state_cursor, cursor_wiped) =
+        let post_state_cursor =
             HashedPostStateCursor::<C, U256>::get_storage_overlay(self.post_state, hashed_address);
         self.post_state_cursor = post_state_cursor;
-        self.db_cursor_state = DbCursorState::new(cursor_wiped);
+        self.db_cursor_state = DbCursorState::NeedsPosition;
     }
 }
 
@@ -444,7 +431,7 @@ mod tests {
     }
 
     fn storage_post_state(storage_slots: Vec<(B256, U256)>) -> HashedPostStateSorted {
-        let storage_sorted = reth_trie_common::HashedStorageSorted { storage_slots, wiped: false };
+        let storage_sorted = reth_trie_common::HashedStorageSorted { storage_slots };
         let mut storages = alloy_primitives::map::B256Map::default();
         storages.insert(B256::ZERO, storage_sorted);
         HashedPostStateSorted::new(Vec::new(), storages)
@@ -630,7 +617,6 @@ mod tests {
                 let hashed_address = B256::ZERO;
                 let storage_sorted = reth_trie_common::HashedStorageSorted {
                     storage_slots: post_state_nodes,
-                    wiped: false,
                 };
                 let mut storages = alloy_primitives::map::B256Map::default();
                 storages.insert(hashed_address, storage_sorted);

--- a/crates/trie/trie/src/hashed_cursor/post_state.rs
+++ b/crates/trie/trie/src/hashed_cursor/post_state.rs
@@ -400,13 +400,9 @@ where
     /// This function should be called before attempting to call [`HashedCursor::seek`] or
     /// [`HashedCursor::next`].
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
-        // Storage is not empty if it has non-zero slots.
-        if self.post_state_cursor.has_any(|(_, value)| !value.is_zero()) {
-            return Ok(false);
-        }
-
-        // If no non-zero slots in post state, check the database.
-        self.get_cursor_mut().is_storage_empty()
+        let is_empty = self.seek(B256::ZERO)?.is_none();
+        self.reset();
+        Ok(is_empty)
     }
 
     fn set_hashed_address(&mut self, hashed_address: B256) {

--- a/crates/trie/trie/src/test_utils.rs
+++ b/crates/trie/trie/src/test_utils.rs
@@ -271,12 +271,7 @@ impl TrieTestHarness {
     ///
     /// A storage node is redundant if it exists in the starting set with the same value.
     /// A removed node is redundant if it was already absent from the starting set.
-    /// The `is_deleted` flag is cleared if it matches the starting value.
     pub fn minimize_trie_updates(&self, updates: &mut StorageTrieUpdates) {
-        if updates.is_deleted == self.storage_trie_updates.is_deleted {
-            updates.is_deleted = false;
-        }
-
         // StorageTrieUpdates::finalize can leave the same path in both storage_nodes
         // and removed_nodes. Per into_sorted, updated nodes take precedence over
         // removed ones. Record which paths had an update before minimization so we

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -7,13 +7,13 @@ use crate::{
         StateRootProgress, StorageRootProgress,
     },
     stats::TrieTracker,
-    trie_cursor::{TrieCursor, TrieCursorFactory, TrieStorageCursor},
+    trie_cursor::{TrieCursor, TrieCursorFactory, TrieCursorIter, TrieStorageCursor},
     updates::{StorageTrieUpdates, TrieUpdates},
     walker::TrieWalker,
     HashBuilder, Nibbles, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_primitives::{keccak256, Address, B256, U256};
+use alloy_primitives::{keccak256, map::B256Map, Address, B256, U256};
 use alloy_rlp::{BufMut, Encodable};
 use alloy_trie::proof::AddedRemovedKeys;
 use reth_execution_errors::{StateRootError, StorageRootError};
@@ -352,9 +352,28 @@ where
 
         let root = hash_builder.root();
 
+        let mut destroyed_storage_trie_nodes = B256Map::default();
+        if !self.prefix_sets.destroyed_accounts.is_empty() {
+            let mut storage_trie_cursor = match storage_trie_cursor {
+                Some(cursor) => cursor,
+                None => self.trie_cursor_factory.storage_trie_cursor(B256::ZERO)?,
+            };
+
+            for hashed_address in &self.prefix_sets.destroyed_accounts {
+                storage_trie_cursor.set_hashed_address(*hashed_address);
+                let nodes = TrieCursorIter::new(&mut storage_trie_cursor)
+                    .map(|node| node.map(|(path, _)| path))
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                if !nodes.is_empty() {
+                    destroyed_storage_trie_nodes.insert(*hashed_address, nodes);
+                }
+            }
+        }
+
         let removed_keys = account_node_iter.walker.take_removed_keys();
         let StateRootContext { mut trie_updates, hashed_entries_walked, .. } = storage_ctx;
-        trie_updates.finalize(hash_builder, removed_keys, self.prefix_sets.destroyed_accounts);
+        trie_updates.finalize(hash_builder, removed_keys, destroyed_storage_trie_nodes);
 
         let stats = tracker.finish();
 

--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -353,7 +353,7 @@ where
         let root = hash_builder.root();
 
         let mut destroyed_storage_trie_nodes = B256Map::default();
-        if !self.prefix_sets.destroyed_accounts.is_empty() {
+        if retain_updates && !self.prefix_sets.destroyed_accounts.is_empty() {
             let mut storage_trie_cursor = match storage_trie_cursor {
                 Some(cursor) => cursor,
                 None => self.trie_cursor_factory.storage_trie_cursor(B256::ZERO)?,

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -74,22 +74,13 @@ enum DbCursorState {
     NeedsPosition,
     Positioned((Nibbles, BranchNodeCompact)),
     Exhausted,
-    Wiped,
 }
 
 impl DbCursorState {
-    const fn new(cursor_wiped: bool) -> Self {
-        if cursor_wiped {
-            Self::Wiped
-        } else {
-            Self::NeedsPosition
-        }
-    }
-
     const fn entry(&self) -> Option<&(Nibbles, BranchNodeCompact)> {
         match self {
             Self::Positioned(entry) => Some(entry),
-            Self::NeedsPosition | Self::Exhausted | Self::Wiped => None,
+            Self::NeedsPosition | Self::Exhausted => None,
         }
     }
 
@@ -123,11 +114,10 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
         trie_updates: &'a TrieUpdatesSorted,
         hashed_address: B256,
     ) -> Self {
-        let (in_memory_cursor, cursor_wiped) =
-            Self::get_storage_overlay(trie_updates, hashed_address);
+        let in_memory_cursor = Self::get_storage_overlay(trie_updates, hashed_address);
         Self {
             cursor,
-            db_cursor_state: DbCursorState::new(cursor_wiped),
+            db_cursor_state: DbCursorState::NeedsPosition,
             in_memory_cursor,
             last_key: None,
             #[cfg(debug_assertions)]
@@ -136,21 +126,19 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
         }
     }
 
-    /// Returns the storage overlay for `hashed_address` and whether it was deleted.
+    /// Returns the storage overlay for `hashed_address`.
     fn get_storage_overlay(
         trie_updates: &'a TrieUpdatesSorted,
         hashed_address: B256,
-    ) -> (ForwardInMemoryCursor<'a, Nibbles, Option<BranchNodeCompact>>, bool) {
+    ) -> ForwardInMemoryCursor<'a, Nibbles, Option<BranchNodeCompact>> {
         let storage_trie_updates = trie_updates.storage_tries_ref().get(&hashed_address);
-        let cursor_wiped = storage_trie_updates.is_some_and(|u| u.is_deleted());
         let storage_nodes = storage_trie_updates.map(|u| u.storage_nodes_ref()).unwrap_or(&[]);
 
-        (ForwardInMemoryCursor::new(storage_nodes), cursor_wiped)
+        ForwardInMemoryCursor::new(storage_nodes)
     }
 
-    /// Returns a mutable reference to the underlying cursor if it's not wiped, None otherwise.
-    fn get_cursor_mut(&mut self) -> Option<&mut C> {
-        (!matches!(self.db_cursor_state, DbCursorState::Wiped)).then_some(&mut self.cursor)
+    fn get_cursor_mut(&mut self) -> &mut C {
+        &mut self.cursor
     }
 
     /// Asserts that the next entry to be returned from the cursor is not previous to the last entry
@@ -174,11 +162,11 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
         let should_seek = match &self.db_cursor_state {
             DbCursorState::NeedsPosition => true,
             DbCursorState::Positioned((entry_key, _)) => entry_key < &key,
-            DbCursorState::Exhausted | DbCursorState::Wiped => false,
+            DbCursorState::Exhausted => false,
         };
 
         if should_seek {
-            let entry = self.get_cursor_mut().map(|c| c.seek(key)).transpose()?.flatten();
+            let entry = self.get_cursor_mut().seek(key)?;
             self.db_cursor_state.set_entry(entry);
         }
 
@@ -193,10 +181,10 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
             debug_assert!(!matches!(self.db_cursor_state, DbCursorState::NeedsPosition));
         }
 
-        // Exhausted and wiped states are stable; only advance if the DB cursor currently points to
-        // an entry.
+        // The exhausted state is stable; only advance if the DB cursor currently points to an
+        // entry.
         if matches!(self.db_cursor_state, DbCursorState::Positioned(_)) {
-            let entry = self.get_cursor_mut().map(|c| c.next()).transpose()?.flatten();
+            let entry = self.get_cursor_mut().next()?;
             self.db_cursor_state.set_entry(entry);
         }
 
@@ -364,7 +352,7 @@ impl<C: TrieCursor> TrieCursor for InMemoryTrieCursor<'_, C> {
     fn current(&mut self) -> Result<Option<Nibbles>, DatabaseError> {
         match &self.last_key {
             Some(key) => Ok(Some(*key)),
-            None => Ok(self.get_cursor_mut().map(|c| c.current()).transpose()?.flatten()),
+            None => self.get_cursor_mut().current(),
         }
     }
 
@@ -385,10 +373,9 @@ impl<C: TrieStorageCursor> TrieStorageCursor for InMemoryTrieCursor<'_, C> {
     fn set_hashed_address(&mut self, hashed_address: B256) {
         self.reset();
         self.cursor.set_hashed_address(hashed_address);
-        let (in_memory_cursor, cursor_wiped) =
-            Self::get_storage_overlay(self.trie_updates, hashed_address);
+        let in_memory_cursor = Self::get_storage_overlay(self.trie_updates, hashed_address);
         self.in_memory_cursor = in_memory_cursor;
-        self.db_cursor_state = DbCursorState::new(cursor_wiped);
+        self.db_cursor_state = DbCursorState::NeedsPosition;
     }
 }
 
@@ -805,12 +792,12 @@ mod tests {
     }
 
     #[test]
-    fn test_all_storage_slots_deleted_not_wiped_exact_keys() {
+    fn test_all_storage_nodes_deleted_exact_keys() {
         use tracing::debug;
         reth_tracing::init_test_tracing();
 
         // This test reproduces an edge case where:
-        // - cursor is not None (not wiped)
+        // - cursor is available
         // - All in-memory entries are deletions (None values)
         // - Database has corresponding entries
         // - Expected: NO leaves should be returned (all deleted)

--- a/crates/trie/trie/src/trie_cursor/in_memory.rs
+++ b/crates/trie/trie/src/trie_cursor/in_memory.rs
@@ -137,7 +137,7 @@ impl<'a, C: TrieCursor> InMemoryTrieCursor<'a, C> {
         ForwardInMemoryCursor::new(storage_nodes)
     }
 
-    fn get_cursor_mut(&mut self) -> &mut C {
+    const fn get_cursor_mut(&mut self) -> &mut C {
         &mut self.cursor
     }
 

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -1,15 +1,11 @@
 use crate::{
-    hashed_cursor::{HashedCursor, HashedCursorFactory},
-    prefix_set::TriePrefixSetsMut,
-    proof::Proof,
-    proof_v2,
-    trie_cursor::TrieCursorFactory,
-    TRIE_ACCOUNT_RLP_MAX_SIZE,
+    hashed_cursor::HashedCursorFactory, prefix_set::TriePrefixSetsMut, proof::Proof, proof_v2,
+    trie_cursor::TrieCursorFactory, TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
 use alloy_primitives::{
     keccak256,
     map::{B256Map, HashMap},
-    Bytes, B256, U256,
+    Bytes, B256,
 };
 use alloy_rlp::{Encodable, EMPTY_STRING_CODE};
 use alloy_trie::{nodes::BranchNodeRef, EMPTY_ROOT_HASH};
@@ -109,18 +105,11 @@ where
     /// # Arguments
     ///
     /// `state` - state transition containing both modified and touched accounts and storage slots.
-    pub fn compute(
-        mut self,
-        mut state: HashedPostState,
-    ) -> Result<B256Map<Bytes>, TrieWitnessError> {
+    pub fn compute(mut self, state: HashedPostState) -> Result<B256Map<Bytes>, TrieWitnessError> {
         let is_state_empty = state.is_empty();
         if is_state_empty && !self.always_include_root_node {
             return Ok(Default::default())
         }
-
-        // Expand wiped storages into explicit zero-value entries for every existing slot,
-        // so that downstream code can treat all storages uniformly.
-        self.expand_wiped_storages(&mut state)?;
 
         let proof_targets = if is_state_empty {
             MultiProofTargetsV2 {
@@ -376,28 +365,8 @@ where
         Ok(root_hash)
     }
 
-    /// Expand wiped storages into explicit zero-value entries for every existing slot in the
-    /// database. After this, all storages can be treated uniformly without special wiped handling.
-    fn expand_wiped_storages(&self, state: &mut HashedPostState) -> Result<(), StateProofError> {
-        for (hashed_address, storage) in &mut state.storages {
-            if !storage.wiped {
-                continue;
-            }
-            let mut storage_cursor =
-                self.hashed_cursor_factory.hashed_storage_cursor(*hashed_address)?;
-            let mut current_entry = storage_cursor.seek(B256::ZERO)?;
-            while let Some((hashed_slot, _)) = current_entry {
-                storage.storage.entry(hashed_slot).or_insert(U256::ZERO);
-                current_entry = storage_cursor.next()?;
-            }
-            storage.wiped = false;
-        }
-        Ok(())
-    }
-
     /// Retrieve proof targets for incoming hashed state.
-    /// Aggregates all accounts and slots present in the state. Wiped storages must have been
-    /// expanded via [`Self::expand_wiped_storages`] before calling this.
+    /// Aggregates all accounts and slots present in the state.
     fn get_proof_targets(state: &HashedPostState) -> MultiProofTargetsV2 {
         let mut targets = MultiProofTargetsV2::default();
         for &hashed_address in state.accounts.keys() {


### PR DESCRIPTION
Removes obsolete whole-storage wipe markers from hashed post-state and trie updates. Destroyed storage is represented by explicit zero-valued slots and removed trie nodes, so sparse trie and cursor paths no longer need wipe handling.