### PR TITLE
fix(rpc): compare selections in are_identical when custom modules exist

### DIFF
--- a/crates/rpc/rpc-server-types/src/module.rs
+++ b/crates/rpc/rpc-server-types/src/module.rs
@@ -133,11 +133,6 @@ impl RpcModuleSelection {
     /// Returns true if both selections are identical.
     pub fn are_identical(http: Option<&Self>, ws: Option<&Self>) -> bool {
         match (http, ws) {
-            // Shortcut for common case to avoid iterating later
-            (Some(Self::All), Some(other)) | (Some(other), Some(Self::All)) => {
-                other.len() == RethRpcModule::variant_count()
-            }
-
             // If either side is disabled, then the other must be empty
             (Some(some), None) | (None, Some(some)) => some.is_empty(),
 
@@ -673,6 +668,25 @@ mod test {
         let full_selection =
             RpcModuleSelection::from(RethRpcModule::modules().into_iter().collect::<HashSet<_>>());
         assert!(RpcModuleSelection::are_identical(Some(&all_modules), Some(&full_selection)));
+
+        // Test scenario: `All` vs a same-sized selection containing a custom module
+        //
+        // `variant_count` only counts the standard variants, so a selection that drops a standard
+        // module and adds an `Other` module has the same length as `All` without selecting the
+        // same modules. It must not be considered identical to `All`.
+        let mut same_len_with_custom = RpcModuleSelection::all_modules();
+        same_len_with_custom.remove(&RethRpcModule::Eth);
+        same_len_with_custom.insert(RethRpcModule::Other("custom".to_string()));
+        let same_len_with_custom = RpcModuleSelection::from(same_len_with_custom);
+        assert_eq!(same_len_with_custom.len(), all_modules.len());
+        assert!(!RpcModuleSelection::are_identical(
+            Some(&all_modules),
+            Some(&same_len_with_custom)
+        ));
+        assert!(!RpcModuleSelection::are_identical(
+            Some(&same_len_with_custom),
+            Some(&all_modules)
+        ));
 
         // Test scenario: different non-empty selections
         //


### PR DESCRIPTION
## Problem

`RpcModuleSelection::are_identical` short-circuits a comparison against `All` into a length check:

```rust
// Shortcut for common case to avoid iterating later
(Some(Self::All), Some(other)) | (Some(other), Some(Self::All)) => {
    other.len() == RethRpcModule::variant_count()
}
```

This was sound while `RethRpcModule` was a closed set of unit variants: a selection holding `variant_count()` distinct modules could only be all of them.

Since `Other(String)` was added, the set is open, and `variant_count()` counts only the standard variants. A selection that drops a standard module and adds a custom one therefore has the same length as `All` while selecting a different set, and the shortcut reports the two as identical.

## Impact

`TransportRpcModuleConfig::ensure_ws_http_identical` uses this to decide whether HTTP and WS configured on a shared port can be merged into a single server. A false positive lets the merge proceed instead of returning `WsHttpSamePortError::ConflictingModules`. The merged server is then built from the HTTP module set:

```rust
if let Some(module) = modules.http.as_ref().or(modules.ws.as_ref()) {
    let handle = server.start(module.clone());
```

so both transports share one handle and the WS side silently serves the namespaces configured for HTTP. Configuring `--http.api all` alongside a WS selection that swaps one standard namespace for a custom one gives WS clients access to namespaces its own configuration excluded, with no error and no warning.

## Fix

Drop the shortcut and compare the selections on every path.

Behavior is unchanged for any selection without a custom module: there a length match already implied a set match, so the shortcut and the full comparison always agreed. The comparison runs once during server setup, so the saved iteration does not justify the false positive.

## Test

Extends `test_rpc_module_selection_are_identical` with a selection built from `all_modules()` that removes `Eth` and inserts `Other("custom")`. The test asserts the length still equals `All`'s, then asserts the two are not identical in both argument orders. It fails on `main` and passes with this change.

`cargo test -p reth-rpc-server-types` — 25 unit tests and 3 doctests pass.