### PR TITLE
fix(exex): support sparse WAL file IDs

### DIFF
--- a/crates/exex/exex/src/wal/mod.rs
+++ b/crates/exex/exex/src/wal/mod.rs
@@ -113,13 +113,14 @@ where
     /// Fills the block cache with the notifications from the storage.
     #[instrument(skip(self))]
     fn fill_block_cache(&self) -> WalResult<()> {
-        let Some(files_range) = self.storage.files_range()? else { return Ok(()) };
-        self.next_file_id.store(files_range.end() + 1, Ordering::Relaxed);
+        let file_ids = self.storage.file_ids()?;
+        let Some(last_file_id) = file_ids.last() else { return Ok(()) };
+        self.next_file_id.store(last_file_id + 1, Ordering::Relaxed);
 
         let mut block_cache = self.block_cache.write();
         let mut notifications_size = 0;
 
-        for entry in self.storage.iter_notifications(files_range) {
+        for entry in self.storage.iter_notifications(file_ids) {
             let (file_id, size, notification) = entry?;
 
             notifications_size += size;
@@ -198,11 +199,9 @@ where
     fn iter_notifications(
         &self,
     ) -> WalResult<Box<dyn Iterator<Item = WalResult<ExExNotification<N>>> + '_>> {
-        let Some(range) = self.storage.files_range()? else {
-            return Ok(Box::new(std::iter::empty()))
-        };
-
-        Ok(Box::new(self.storage.iter_notifications(range).map(|entry| Ok(entry?.2))))
+        Ok(Box::new(
+            self.storage.iter_notifications(self.storage.file_ids()?).map(|entry| Ok(entry?.2)),
+        ))
     }
 }
 
@@ -238,6 +237,7 @@ mod tests {
     use crate::wal::{cache::CachedBlock, error::WalResult, Wal};
     use alloy_primitives::B256;
     use itertools::Itertools;
+    use reth_ethereum_primitives::EthPrimitives;
     use reth_exex_types::ExExNotification;
     use reth_provider::Chain;
     use reth_testing_utils::generators::{
@@ -246,13 +246,11 @@ mod tests {
     use std::{collections::BTreeMap, sync::Arc};
 
     fn read_notifications(wal: &Wal) -> WalResult<Vec<ExExNotification>> {
-        wal.inner.storage.files_range()?.map_or(Ok(Vec::new()), |range| {
-            wal.inner
-                .storage
-                .iter_notifications(range)
-                .map(|entry| entry.map(|(_, _, n)| n))
-                .collect()
-        })
+        wal.inner
+            .storage
+            .iter_notifications(wal.inner.storage.file_ids()?)
+            .map(|entry| entry.map(|(_, _, n)| n))
+            .collect()
     }
 
     fn sort_committed_blocks(
@@ -519,6 +517,46 @@ mod tests {
             )
         );
         assert_eq!(read_notifications(&wal)?, vec![committed_notification_2, reorged_notification]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_finalize_with_sparse_file_ids() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+
+        let temp_dir = tempfile::tempdir()?;
+        let wal = Wal::<EthPrimitives>::new(&temp_dir)?;
+
+        let blocks = random_block_range(&mut rng, 0..=5, BlockRangeParams::default())
+            .into_iter()
+            .map(|block| block.try_recover())
+            .collect::<Result<Vec<_>, _>>()?;
+        let chain = |range: std::ops::RangeInclusive<usize>| {
+            Arc::new(Chain::new(blocks[range].to_vec(), Default::default(), BTreeMap::new()))
+        };
+
+        let commit_to_four = ExExNotification::ChainCommitted { new: chain(1..=4) };
+        let revert_to_two = ExExNotification::ChainReverted { old: chain(2..=4) };
+        let commit_two = ExExNotification::ChainCommitted { new: chain(2..=2) };
+        let commit_to_five = ExExNotification::ChainCommitted { new: chain(3..=5) };
+
+        wal.commit(&commit_to_four)?;
+        wal.commit(&revert_to_two)?;
+        wal.commit(&commit_two)?;
+        wal.commit(&commit_to_five)?;
+        assert_eq!(wal.inner.storage.file_ids()?, vec![0, 1, 2, 3]);
+
+        // File 2 has a lower maximum block than the surrounding notifications, so finalizing it
+        // leaves a gap in the file ID sequence.
+        wal.finalize((blocks[2].number, blocks[2].hash()).into())?;
+        assert_eq!(wal.inner.storage.file_ids()?, vec![0, 1, 3]);
+
+        let wal = Wal::<EthPrimitives>::new(&temp_dir)?;
+        assert_eq!(read_notifications(&wal)?, vec![commit_to_four, revert_to_two, commit_to_five]);
+
+        wal.commit(&commit_two)?;
+        assert_eq!(wal.inner.storage.file_ids()?, vec![0, 1, 3, 4]);
 
         Ok(())
     }

--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -1,6 +1,5 @@
 use std::{
     fs::File,
-    ops::RangeInclusive,
     path::{Path, PathBuf},
 };
 
@@ -69,12 +68,9 @@ where
         }
     }
 
-    /// Returns the range of file IDs in the storage.
-    ///
-    /// If there are no files in the storage, returns `None`.
-    pub(super) fn files_range(&self) -> WalResult<Option<RangeInclusive<u32>>> {
-        let mut min_id = None;
-        let mut max_id = None;
+    /// Returns the file IDs in the storage in ascending order.
+    pub(super) fn file_ids(&self) -> WalResult<Vec<u32>> {
+        let mut file_ids = Vec::new();
 
         for entry in reth_fs_util::read_dir(&self.path)? {
             let entry = entry.map_err(|err| WalError::DirEntry(self.path.clone(), err))?;
@@ -82,13 +78,12 @@ where
             if entry.path().extension() == Some(FILE_EXTENSION.as_ref()) {
                 let file_name = entry.file_name();
                 let file_id = Self::parse_filename(&file_name.to_string_lossy())?;
-
-                min_id = min_id.map_or(Some(file_id), |min_id: u32| Some(min_id.min(file_id)));
-                max_id = max_id.map_or(Some(file_id), |max_id: u32| Some(max_id.max(file_id)));
+                file_ids.push(file_id);
             }
         }
 
-        Ok(min_id.zip(max_id).map(|(min_id, max_id)| min_id..=max_id))
+        file_ids.sort_unstable();
+        Ok(file_ids)
     }
 
     /// Removes notifications from the storage according to the given list of file IDs.
@@ -113,11 +108,11 @@ where
         Ok((deleted_total, deleted_size))
     }
 
-    pub(super) fn iter_notifications(
-        &self,
-        range: RangeInclusive<u32>,
-    ) -> impl Iterator<Item = WalResult<(u32, u64, ExExNotification<N>)>> + '_ {
-        range.map(move |id| {
+    pub(super) fn iter_notifications<'a>(
+        &'a self,
+        file_ids: impl IntoIterator<Item = u32> + 'a,
+    ) -> impl Iterator<Item = WalResult<(u32, u64, ExExNotification<N>)>> + 'a {
+        file_ids.into_iter().map(move |id| {
             let (notification, size) =
                 self.read_notification(id)?.ok_or(WalError::FileNotFound(id))?;
 
@@ -316,21 +311,20 @@ mod tests {
     }
 
     #[test]
-    fn test_files_range() -> eyre::Result<()> {
+    fn test_file_ids() -> eyre::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let storage: Storage = Storage::new(&temp_dir)?;
 
         // Create WAL files
         File::create(storage.file_path(1))?;
-        File::create(storage.file_path(2))?;
         File::create(storage.file_path(3))?;
 
         // Create non-WAL files that should be ignored
         File::create(temp_dir.path().join("0.tmp"))?;
         File::create(temp_dir.path().join("4.tmp"))?;
 
-        // Check files range
-        assert_eq!(storage.files_range()?, Some(1..=3));
+        // Check existing file IDs are returned in order without filling the gap
+        assert_eq!(storage.file_ids()?, vec![1, 3]);
 
         Ok(())
     }


### PR DESCRIPTION
Closes #26813

Enumerates the WAL notification files that actually exist instead of expanding the minimum and maximum IDs into a dense range, allowing startup to recover after finalization leaves gaps. Preserves monotonic allocation from the highest surviving ID and adds regression coverage for recovery, notification order, and the subsequent write.

This overlaps #26817; submitted as an alternative that removes the obsolete range API and covers the full post-recovery behavior.