### PR TITLE
fix(exex): decode legacy trie wipe markers

### DIFF
--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -188,8 +188,10 @@ mod tests {
     use reth_provider::Chain;
     use reth_testing_utils::generators::{self, random_block};
     use reth_trie_common::{
-        updates::{StorageTrieUpdates, TrieUpdates},
-        BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, LazyTrieData, Nibbles,
+        serde_bincode_compat,
+        updates::{StorageTrieUpdates, StorageTrieUpdatesSorted, TrieUpdates},
+        BranchNodeCompact, ComputedTrieData, HashedPostState, HashedStorage, HashedStorageSorted,
+        LazyTrieData, Nibbles,
     };
     use std::{collections::BTreeMap, fs::File, sync::Arc};
 
@@ -216,6 +218,26 @@ mod tests {
             deserialized_notification.map(|(notification, _)| notification),
             Some(notification)
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_legacy_sorted_trie_data() -> eyre::Result<()> {
+        let storage_nodes =
+            vec![(Nibbles::from_nibbles_unchecked([0x01]), Some(BranchNodeCompact::default()))];
+        let encoded = rmp_serde::encode::to_vec(&(false, &storage_nodes))?;
+        let decoded: serde_bincode_compat::updates::StorageTrieUpdatesSorted<'_> =
+            rmp_serde::decode::from_slice(&encoded)?;
+        let decoded: StorageTrieUpdatesSorted = decoded.into();
+        assert_eq!(decoded.storage_nodes, storage_nodes);
+
+        let storage_slots = vec![(B256::from([1; 32]), U256::from(1))];
+        let encoded = rmp_serde::encode::to_vec(&(&storage_slots, false))?;
+        let decoded: serde_bincode_compat::hashed_state::HashedStorageSorted<'_> =
+            rmp_serde::decode::from_slice(&encoded)?;
+        let decoded: HashedStorageSorted = decoded.into();
+        assert_eq!(decoded.storage_slots, storage_slots);
 
         Ok(())
     }

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -1704,9 +1704,13 @@ mod tests {
 #[cfg(feature = "serde-bincode-compat")]
 pub mod serde_bincode_compat {
     use super::Account;
-    use alloc::borrow::Cow;
+    use alloc::{borrow::Cow, vec::Vec};
     use alloy_primitives::{map::B256Map, B256, U256};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use core::fmt;
+    use serde::{
+        de::{Error as _, SeqAccess, Visitor},
+        Deserialize, Deserializer, Serialize, Serializer,
+    };
     use serde_with::{DeserializeAs, SerializeAs};
 
     /// Bincode-compatible [`super::HashedPostState`] serde implementation.
@@ -1894,9 +1898,52 @@ pub mod serde_bincode_compat {
     ///     hashed_storage: HashedStorageSorted,
     /// }
     /// ```
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize)]
     pub struct HashedStorageSorted<'a> {
         storage_slots: Cow<'a, [(B256, U256)]>,
+    }
+
+    impl<'de, 'a> Deserialize<'de> for HashedStorageSorted<'a> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct HashedStorageSortedVisitor;
+
+            impl<'de> Visitor<'de> for HashedStorageSortedVisitor {
+                type Value = Vec<(B256, U256)>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("hashed storage with an optional legacy wipe marker")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>,
+                {
+                    let len = seq.size_hint().unwrap_or_default();
+                    if !matches!(len, 1 | 2) {
+                        return Err(A::Error::invalid_length(len, &self))
+                    }
+
+                    let storage_slots =
+                        seq.next_element()?.ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                    if len == 2 {
+                        let _: bool = seq
+                            .next_element()?
+                            .ok_or_else(|| A::Error::invalid_length(1, &self))?;
+                    }
+
+                    Ok(storage_slots)
+                }
+            }
+
+            // Bincode uses the supplied tuple length for the current format, while MessagePack
+            // exposes the encoded sequence length so legacy ExEx WAL entries can still be read.
+            deserializer
+                .deserialize_tuple(1, HashedStorageSortedVisitor)
+                .map(|storage_slots| Self { storage_slots: Cow::Owned(storage_slots) })
+        }
     }
 
     impl<'a> From<&'a super::HashedStorageSorted> for HashedStorageSorted<'a> {

--- a/crates/trie/common/src/updates.rs
+++ b/crates/trie/common/src/updates.rs
@@ -1267,9 +1267,13 @@ mod tests {
 #[cfg(feature = "serde-bincode-compat")]
 pub mod serde_bincode_compat {
     use crate::{BranchNodeCompact, Nibbles};
-    use alloc::borrow::Cow;
+    use alloc::{borrow::Cow, vec::Vec};
     use alloy_primitives::map::{B256Map, HashMap, HashSet};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use core::fmt;
+    use serde::{
+        de::{Error as _, SeqAccess, Visitor},
+        Deserialize, Deserializer, Serialize, Serializer,
+    };
     use serde_with::{DeserializeAs, SerializeAs};
 
     /// Bincode-compatible [`super::TrieUpdates`] serde implementation.
@@ -1475,9 +1479,53 @@ pub mod serde_bincode_compat {
     ///     trie_updates: StorageTrieUpdatesSorted,
     /// }
     /// ```
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, Serialize)]
     pub struct StorageTrieUpdatesSorted<'a> {
         storage_nodes: Cow<'a, [(Nibbles, Option<BranchNodeCompact>)]>,
+    }
+
+    impl<'de, 'a> Deserialize<'de> for StorageTrieUpdatesSorted<'a> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct StorageTrieUpdatesSortedVisitor;
+
+            impl<'de> Visitor<'de> for StorageTrieUpdatesSortedVisitor {
+                type Value = Vec<(Nibbles, Option<BranchNodeCompact>)>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("storage trie updates with an optional legacy wipe marker")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: SeqAccess<'de>,
+                {
+                    let len = seq.size_hint().unwrap_or_default();
+                    let storage_nodes = match len {
+                        1 => {
+                            seq.next_element()?.ok_or_else(|| A::Error::invalid_length(0, &self))?
+                        }
+                        2 => {
+                            let _: bool = seq
+                                .next_element()?
+                                .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                            seq.next_element()?.ok_or_else(|| A::Error::invalid_length(1, &self))?
+                        }
+                        _ => return Err(A::Error::invalid_length(len, &self)),
+                    };
+
+                    Ok(storage_nodes)
+                }
+            }
+
+            // Bincode uses the supplied tuple length for the current format, while MessagePack
+            // exposes the encoded sequence length so legacy ExEx WAL entries can still be read.
+            deserializer
+                .deserialize_tuple(1, StorageTrieUpdatesSortedVisitor)
+                .map(|storage_nodes| Self { storage_nodes: Cow::Owned(storage_nodes) })
+        }
     }
 
     impl<'a> From<&'a super::StorageTrieUpdatesSorted> for StorageTrieUpdatesSorted<'a> {


### PR DESCRIPTION
Keeps the new bool-free encoding from #26811 while accepting the deprecated boolean fields when decoding existing ExEx WAL notifications. Adds regression coverage for both legacy sorted-storage sequence layouts.