### PR TITLE
fix(engine): separate malformed input from fatal errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8017,7 +8017,6 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",

--- a/crates/consensus/consensus/Cargo.toml
+++ b/crates/consensus/consensus/Cargo.toml
@@ -18,7 +18,6 @@ reth-primitives-traits.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
-alloy-rlp.workspace = true
 alloy-eip7928.workspace = true
 
 # misc
@@ -34,6 +33,5 @@ std = [
     "reth-execution-types/std",
     "thiserror/std",
     "alloy-eip7928/std",
-    "alloy-rlp/std",
 ]
 test-utils = ["reth-primitives-traits/test-utils"]

--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -498,12 +498,6 @@ pub enum ConsensusError {
     /// EIP-7928: Error when the block access list hash doesn't match the expected value.
     #[error("block access list hash mismatch: {0}")]
     BlockAccessListHashMismatch(GotExpectedBoxed<B256>),
-    /// EIP-7928: Error when the raw block access list bytes cannot be RLP-decoded.
-    ///
-    /// Note: this is not a block validity error, the received block access list bytes themselves
-    /// are malformed request params.
-    #[error("failed to decode block access list: {0}")]
-    BlockAccessListDecode(alloy_rlp::Error),
     /// EIP-7928: Error when the block access list cannot be decoded or converted.
     #[error("invalid block access list: {0}")]
     BlockAccessListInvalid(String),

--- a/crates/engine/primitives/src/error.rs
+++ b/crates/engine/primitives/src/error.rs
@@ -32,9 +32,15 @@ impl BeaconOnNewPayloadError {
 
 impl From<InsertBlockFatalError> for BeaconOnNewPayloadError {
     fn from(error: InsertBlockFatalError) -> Self {
+        Self::internal(error)
+    }
+}
+
+impl From<InsertBlockProcessingError> for BeaconOnNewPayloadError {
+    fn from(error: InsertBlockProcessingError) -> Self {
         match error {
-            InsertBlockFatalError::InvalidParams(err) => Self::InvalidParams(err),
-            error => Self::internal(error),
+            InsertBlockProcessingError::MalformedInput(error) => Self::InvalidParams(error),
+            InsertBlockProcessingError::Fatal(error) => Self::internal(error),
         }
     }
 }
@@ -69,6 +75,9 @@ pub enum InsertBlockErrorKind {
     /// Block violated consensus rules.
     #[error(transparent)]
     Consensus(#[from] ConsensusError),
+    /// Supplemental block access list bytes could not be decoded.
+    #[error(transparent)]
+    BlockAccessListDecode(#[from] BlockAccessListDecodeError),
     /// Block execution failed.
     #[error(transparent)]
     Execution(#[from] BlockExecutionError),
@@ -86,53 +95,71 @@ impl InsertBlockErrorKind {
         matches!(self, Self::Consensus(_) | Self::Execution(BlockExecutionError::Validation(_)))
     }
 
-    /// Returns an [`InsertBlockValidationError`] if the error is caused by an invalid block.
+    /// Returns an [`InsertBlockValidationError`] if the failure invalidates the block, or an
+    /// [`InsertBlockProcessingError`] if the failure is not attributable to the block itself.
     ///
-    /// Returns an [`InsertBlockFatalError`] if the failure is not attributable to the block
-    /// itself, either an internal error or malformed request params.
-    ///
-    /// This split decides how `newPayload` responds: validation errors become an `INVALID`
-    /// payload status and mark the block hash as invalid, while fatal errors are returned as
-    /// actual errors to the caller. This distinction is required because responding `INVALID`
-    /// has consensus meaning (the block is rejected and its hash cached as invalid), which must
-    /// not happen for failures the block is not responsible for.
+    /// This distinction controls whether the block may be returned as `INVALID` and its hash cached
+    /// as invalid. Because `INVALID` has consensus meaning, malformed supplemental input and
+    /// internal failures must remain processing errors instead.
     pub fn ensure_validation_error(
         self,
-    ) -> Result<InsertBlockValidationError, InsertBlockFatalError> {
+    ) -> Result<InsertBlockValidationError, InsertBlockProcessingError> {
         match self {
-            // Undecodable block access list bytes are malformed request params, not an invalid
-            // block, and must be rejected with an invalid params error instead of an `INVALID`
-            // payload status.
-            Self::Consensus(ConsensusError::BlockAccessListDecode(err)) => {
-                Err(InsertBlockFatalError::InvalidParams(Box::new(err)))
+            Self::BlockAccessListDecode(error) => {
+                Err(InsertBlockProcessingError::MalformedInput(Box::new(error)))
             }
             Self::Consensus(err) => Ok(InsertBlockValidationError::Consensus(err)),
             Self::Execution(err) => match err {
                 BlockExecutionError::Validation(err) => {
                     Ok(InsertBlockValidationError::Validation(err))
                 }
-                BlockExecutionError::Internal(error) => {
-                    Err(InsertBlockFatalError::BlockExecutionError(error))
-                }
+                BlockExecutionError::Internal(error) => Err(InsertBlockProcessingError::Fatal(
+                    InsertBlockFatalError::BlockExecutionError(error),
+                )),
             },
-            Self::Provider(err) => Err(InsertBlockFatalError::Provider(err)),
-            Self::Other(err) => Err(InternalBlockExecutionError::Other(err).into()),
+            Self::Provider(err) => {
+                Err(InsertBlockProcessingError::Fatal(InsertBlockFatalError::Provider(err)))
+            }
+            Self::Other(err) => Err(InsertBlockProcessingError::Fatal(
+                InternalBlockExecutionError::Other(err).into(),
+            )),
         }
     }
 }
 
-/// Error variants that are not caused by invalid blocks.
+/// Error decoding supplemental block access list bytes.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to decode block access list: {0}")]
+pub struct BlockAccessListDecodeError(#[source] Box<dyn core::error::Error + Send + Sync>);
+
+impl BlockAccessListDecodeError {
+    /// Creates a new block access list decode error.
+    pub fn new<E>(error: E) -> Self
+    where
+        E: core::error::Error + Send + Sync + 'static,
+    {
+        Self(Box::new(error))
+    }
+}
+
+/// An error that occurs while processing a block but does not invalidate the block itself.
 ///
-/// "Fatal" means block processing failed for a reason other than the block itself being invalid.
-/// This includes errors caused by additional payload data that is not part of the block, such as
-/// undecodable block access list bytes: their malformation says nothing about the validity of
-/// the block and is therefore treated differently with respect to the `PayloadStatus`.
-///
-/// These failures must not be answered with an `INVALID` payload status or mark the block hash
-/// as invalid. Instead they are propagated as actual errors: for `newPayload` they convert into
-/// [`BeaconOnNewPayloadError`] and are returned as a JSON-RPC error object instead of a
-/// `PayloadStatus` result, [`Self::InvalidParams`] as invalid params (`-32602`) and all other
-/// variants as internal error (`-32603`).
+/// These errors must not produce an `INVALID`
+/// [`PayloadStatus`](alloy_rpc_types_engine::PayloadStatus) or cause the block hash to be cached as
+/// invalid. Malformed supplemental input remains distinct from fatal processing failures so
+/// `newPayload` can reject it as invalid params, while internal ingestion paths can discard it
+/// without terminating the engine task.
+#[derive(Debug, thiserror::Error)]
+pub enum InsertBlockProcessingError {
+    /// Supplemental input is malformed, but the block itself is not known to be invalid.
+    #[error(transparent)]
+    MalformedInput(Box<dyn core::error::Error + Send + Sync>),
+    /// Block processing cannot continue because of an internal failure.
+    #[error(transparent)]
+    Fatal(#[from] InsertBlockFatalError),
+}
+
+/// Internal errors that prevent block processing from continuing.
 #[derive(Debug, thiserror::Error)]
 pub enum InsertBlockFatalError {
     /// A provider error.
@@ -141,10 +168,6 @@ pub enum InsertBlockFatalError {
     /// An internal or fatal block execution error.
     #[error(transparent)]
     BlockExecutionError(#[from] InternalBlockExecutionError),
-    /// The payload params are malformed, e.g. undecodable block access list bytes, and the
-    /// request must be rejected with an invalid params error.
-    #[error(transparent)]
-    InvalidParams(Box<dyn core::error::Error + Send + Sync>),
 }
 
 /// Error variants that are caused by invalid blocks.
@@ -165,19 +188,25 @@ mod tests {
     // Undecodable block access list bytes are malformed request params and must not be treated
     // as a block validation error.
     #[test]
-    fn bal_decode_error_is_invalid_params() {
-        let err = InsertBlockErrorKind::Consensus(ConsensusError::BlockAccessListDecode(
+    fn ensure_insert_block_validation_error() {
+        let err = InsertBlockErrorKind::BlockAccessListDecode(BlockAccessListDecodeError::new(
             alloy_rlp::Error::UnexpectedString,
         ));
         assert!(matches!(
             err.ensure_validation_error(),
-            Err(InsertBlockFatalError::InvalidParams(_))
+            Err(InsertBlockProcessingError::MalformedInput(_))
         ));
+
         assert!(matches!(
-            BeaconOnNewPayloadError::from(InsertBlockFatalError::InvalidParams(Box::new(
-                alloy_rlp::Error::UnexpectedString
-            ))),
-            BeaconOnNewPayloadError::InvalidParams(_)
+            InsertBlockErrorKind::Consensus(ConsensusError::BlockAccessListHashMissing)
+                .ensure_validation_error(),
+            Ok(InsertBlockValidationError::Consensus(_))
+        ));
+
+        assert!(matches!(
+            InsertBlockErrorKind::Provider(ProviderError::BestBlockNotFound)
+                .ensure_validation_error(),
+            Err(InsertBlockProcessingError::Fatal(InsertBlockFatalError::Provider(_)))
         ));
     }
 }

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -4,7 +4,8 @@ use crate::tree::payload_processor::bal::BalExecutionError;
 use alloy_consensus::BlockHeader;
 use reth_consensus::ConsensusError;
 pub use reth_engine_primitives::{
-    InsertBlockErrorKind, InsertBlockFatalError, InsertBlockValidationError,
+    BlockAccessListDecodeError, InsertBlockErrorKind, InsertBlockFatalError,
+    InsertBlockProcessingError, InsertBlockValidationError,
 };
 use reth_errors::ProviderError;
 use reth_payload_primitives::NewPayloadError;

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -1,6 +1,6 @@
-use crate::tree::{error::InsertBlockFatalError, TreeOutcome};
+use crate::tree::TreeOutcome;
 use alloy_rpc_types_engine::{PayloadStatus, PayloadStatusEnum};
-use reth_engine_primitives::{ForkchoiceStatus, OnForkChoiceUpdated};
+use reth_engine_primitives::{ForkchoiceStatus, InsertBlockProcessingError, OnForkChoiceUpdated};
 use reth_errors::ProviderError;
 use reth_evm::metrics::ExecutorMetrics;
 use reth_execution_types::BlockExecutionOutput;
@@ -443,7 +443,7 @@ impl NewPayloadStatusMetrics {
         &mut self,
         start: Instant,
         latest_forkchoice_updated_at: &mut Option<Instant>,
-        result: &Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError>,
+        result: &Result<TreeOutcome<PayloadStatus>, InsertBlockProcessingError>,
         gas_used: u64,
     ) {
         let finish = Instant::now();

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -11,7 +11,9 @@ use alloy_primitives::{map::B256Map, B256};
 use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
-use error::{InsertBlockError, InsertBlockFatalError, InsertBlockValidationError};
+use error::{
+    InsertBlockError, InsertBlockFatalError, InsertBlockProcessingError, InsertBlockValidationError,
+};
 use reth_chain_state::{
     CanonicalInMemoryState, ExecutedBlock, ExecutionTimingStats, MemoryOverlayStateProvider,
     NewCanonicalChain,
@@ -837,7 +839,7 @@ where
     fn on_new_payload(
         &mut self,
         payload: T::ExecutionData,
-    ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockFatalError> {
+    ) -> Result<TreeOutcome<PayloadStatus>, InsertBlockProcessingError> {
         let _thread_resource_usage =
             self.metrics.engine.new_payload.measure_thread_resource_usage();
         trace!(target: "engine::tree", "invoked new payload");
@@ -913,7 +915,7 @@ where
     fn try_insert_payload(
         &mut self,
         payload: T::ExecutionData,
-    ) -> Result<TryInsertPayloadResult, InsertBlockFatalError> {
+    ) -> Result<TryInsertPayloadResult, InsertBlockProcessingError> {
         let block_hash = payload.block_hash();
         let num_hash = payload.num_hash();
         let parent_hash = payload.parent_hash();
@@ -948,9 +950,9 @@ where
             Err(error) => {
                 let status = match error {
                     InsertPayloadError::Block(error) => self.on_insert_block_error(error)?,
-                    InsertPayloadError::Payload(error) => {
-                        self.on_new_payload_error(error, num_hash, parent_hash)?
-                    }
+                    InsertPayloadError::Payload(error) => self
+                        .on_new_payload_error(error, num_hash, parent_hash)
+                        .map_err(InsertBlockFatalError::from)?,
                 };
 
                 Ok(TryInsertPayloadResult { status, already_seen: false })
@@ -969,7 +971,7 @@ where
     fn try_buffer_payload(
         &mut self,
         payload: T::ExecutionData,
-    ) -> Result<PayloadStatus, InsertBlockFatalError> {
+    ) -> Result<PayloadStatus, InsertBlockProcessingError> {
         let parent_hash = payload.parent_hash();
         let num_hash = payload.num_hash();
 
@@ -977,12 +979,14 @@ where
             // if the block is well-formed, buffer it for later
             Ok(block) => {
                 if let Err(error) = self.buffer_block(block) {
-                    Ok(self.on_insert_block_error(error)?)
+                    self.on_insert_block_error(error)
                 } else {
                     Ok(PayloadStatus::from_status(PayloadStatusEnum::Syncing))
                 }
             }
-            Err(error) => Ok(self.on_new_payload_error(error, num_hash, parent_hash)?),
+            Err(error) => Ok(self
+                .on_new_payload_error(error, num_hash, parent_hash)
+                .map_err(InsertBlockFatalError::from)?),
         }
     }
 
@@ -2717,7 +2721,7 @@ where
                 Err(err) => {
                     if let InsertPayloadError::Block(err) = err {
                         debug!(target: "engine::tree", ?err, "failed to connect buffered block to tree");
-                        if let Err(fatal) = self.on_insert_block_error(err) {
+                        if let Err(fatal) = self.on_internal_insert_block_error(err) {
                             warn!(target: "engine::tree", %fatal, "fatal error occurred while connecting buffered blocks");
                             return Err(fatal)
                         }
@@ -3092,7 +3096,7 @@ where
             Err(err) => {
                 if let InsertPayloadError::Block(err) = err {
                     debug!(target: "engine::tree", err=%err.kind(), "failed to insert downloaded block");
-                    if let Err(fatal) = self.on_insert_block_error(err) {
+                    if let Err(fatal) = self.on_internal_insert_block_error(err) {
                         warn!(target: "engine::tree", %fatal, "fatal error occurred while inserting downloaded block");
                         return Err(fatal)
                     }
@@ -3294,11 +3298,9 @@ where
     fn on_insert_block_error(
         &mut self,
         error: InsertBlockError<N::Block>,
-    ) -> Result<PayloadStatus, InsertBlockFatalError> {
+    ) -> Result<PayloadStatus, InsertBlockProcessingError> {
         let (block, error) = error.split();
 
-        // if invalid block, we check the validation error. Otherwise return the fatal
-        // error.
         let validation_err = error.ensure_validation_error()?;
 
         // If the error was due to an invalid payload, the payload is added to the
@@ -3311,7 +3313,9 @@ where
             %validation_err,
             "Invalid block error on new payload",
         );
-        let latest_valid_hash = self.latest_valid_hash_for_invalid_payload(block.parent_hash())?;
+        let latest_valid_hash = self
+            .latest_valid_hash_for_invalid_payload(block.parent_hash())
+            .map_err(InsertBlockFatalError::from)?;
 
         // keep track of the invalid header unless the consensus impl considers it transient
         let is_transient = match &validation_err {
@@ -3338,6 +3342,17 @@ where
             PayloadStatusEnum::Invalid { validation_error: validation_err.to_string() },
             latest_valid_hash,
         ))
+    }
+
+    /// Handles an insertion error from a non-RPC source, where malformed input can be discarded.
+    fn on_internal_insert_block_error(
+        &mut self,
+        error: InsertBlockError<N::Block>,
+    ) -> Result<(), InsertBlockFatalError> {
+        match self.on_insert_block_error(error) {
+            Ok(_) | Err(InsertBlockProcessingError::MalformedInput(_)) => Ok(()),
+            Err(InsertBlockProcessingError::Fatal(error)) => Err(error),
+        }
     }
 
     /// Handles a [`NewPayloadError`] by converting it to a [`PayloadStatus`].

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -96,7 +96,9 @@
 //! `INVALID_PAYLOAD_ATTRIBUTES` without rolling back the forkchoice update.
 
 use crate::tree::{
-    error::{InsertBlockError, InsertBlockErrorKind, InsertPayloadError},
+    error::{
+        BlockAccessListDecodeError, InsertBlockError, InsertBlockErrorKind, InsertPayloadError,
+    },
     instrumented_state::{InstrumentedStateProvider, StateProviderMetrics, StateProviderStats},
     payload_processor::PayloadProcessor,
     precompile_cache::{CachedPrecompile, CachedPrecompileMetrics, PrecompileCacheMap},
@@ -570,10 +572,9 @@ where
 
         // Extract the decoded BAL, if present. Undecodable block access list bytes are malformed
         // request params, not an invalid block.
-        let decoded_bal = ensure_ok!(input
-            .try_decoded_access_list()
-            .map_err(ConsensusError::BlockAccessListDecode))
-        .map(Arc::new);
+        let decoded_bal =
+            ensure_ok!(input.try_decoded_access_list().map_err(BlockAccessListDecodeError::new))
+                .map(Arc::new);
 
         if let Some(decoded_bal) = decoded_bal.as_deref() {
             // Reject oversized BAL sidecars before executing the block.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{
     persistence::PersistenceAction,
     tree::{
+        error::{BlockAccessListDecodeError, InsertBlockErrorKind},
         payload_validator::{BasicEngineValidator, TreeCtx, ValidationOutcome},
         persistence_state::CurrentPersistenceAction,
         PersistTarget, TreeConfig,
@@ -564,6 +565,22 @@ fn test_tree_persist_block_batch() {
         }
         _ => panic!("unexpected message: {msg:#?}"),
     }
+}
+
+#[test]
+fn malformed_input_is_non_fatal_insert_outcome() {
+    let mut test_harness = TestHarness::new(MAINNET.clone());
+    let block = test_harness.block_builder.generate_random_block(1, B256::ZERO);
+    let error = InsertBlockError::new(
+        block,
+        InsertBlockErrorKind::BlockAccessListDecode(BlockAccessListDecodeError::new(
+            alloy_rlp::Error::UnexpectedString,
+        )),
+    );
+    assert_matches!(
+        test_harness.tree.on_insert_block_error(error),
+        Err(InsertBlockProcessingError::MalformedInput(_))
+    );
 }
 
 #[tokio::test]

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -726,8 +726,7 @@ impl From<ValidationApiError> for ErrorObject<'static> {
             ValidationApiError::Blob(_) => invalid_params_rpc_err(error.to_string()),
 
             ValidationApiError::Consensus(
-                error @ (ConsensusError::BlockAccessListDecode(_) |
-                ConsensusError::BlockAccessListCostMoreThanGasLimit(_) |
+                error @ (ConsensusError::BlockAccessListCostMoreThanGasLimit(_) |
                 ConsensusError::BlockAccessListHashMismatch(_)),
             ) => invalid_params_rpc_err(error.to_string()),
             ValidationApiError::MissingLatestBlock |


### PR DESCRIPTION
Moves BAL RLP decoding failures out of ConsensusError into a dedicated BlockAccessListDecodeError that is classified as malformed insertion input. The engine preserves malformed-versus-fatal context through on_newPayload, converting only at the response boundary; downloaded and buffered blocks discard malformed input without terminating the engine task.