### PR TITLE
fix(engine): validate BALs for downloaded blocks

### DIFF
--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -106,7 +106,10 @@ use crate::tree::{
     PayloadHandle, StateProviderBuilder, StateProviderDatabase, TreeConfig, WaitForCaches,
 };
 use alloy_consensus::transaction::{Either, TxHashRef};
-use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash_with_buf, BlockAccessList};
+use alloy_eip7928::{
+    bal::{Bal, DecodedBal},
+    BlockAccessList,
+};
 use alloy_eips::{eip1898::BlockWithParent, eip4895::Withdrawal, NumHash};
 use alloy_evm::Evm;
 use alloy_primitives::{
@@ -1010,7 +1013,7 @@ where
     {
         debug!(target: "engine::tree::payload_validator", "Executing block");
 
-        let has_bal = env.decoded_bal.is_some();
+        let has_bal = input.has_block_access_list();
         let mut db = debug_span!(target: "engine::tree", "build_state_db").in_scope(|| {
             State::builder()
                 .with_database(StateProviderDatabase::new(state_provider))
@@ -1326,16 +1329,24 @@ where
         let _enter =
             debug_span!(target: "engine::tree::payload_validator", "validate_block_post_execution")
                 .entered();
-        let block_access_list_hash = built_bal
-            .as_ref()
-            .map(|bal| compute_block_access_list_hash_with_buf(bal, &mut self.bal_hash_buf));
+        let built_bal = built_bal.map(Bal::from);
+        let block_access_list_hash =
+            built_bal.as_ref().map(|bal| bal.compute_hash_with_buf(&mut self.bal_hash_buf));
 
-        if let Err(err) = self.consensus.validate_block_post_execution(
-            block,
-            output,
-            receipt_root_bloom,
-            block_access_list_hash,
-        ) {
+        let validation_result = built_bal
+            .as_ref()
+            .map(|bal| bal.validate_gas_limit(block.gas_limit()).map_err(ConsensusError::from))
+            .transpose()
+            .and_then(|_| {
+                self.consensus.validate_block_post_execution(
+                    block,
+                    output,
+                    receipt_root_bloom,
+                    block_access_list_hash,
+                )
+            });
+
+        if let Err(err) = validation_result {
             // call post-block hook
             self.on_invalid_block(parent_block, block, output, None, ctx.state_mut());
             return Err(err.into())
@@ -2027,6 +2038,14 @@ impl<T: PayloadTypes> BlockOrPayload<T> {
                 .map(|block_access_list| DecodedBal::from_rlp_bytes(block_access_list.clone()))
                 .transpose(),
             Self::Block(_) => Ok(None),
+        }
+    }
+
+    /// Returns whether execution must build a block access list.
+    pub fn has_block_access_list(&self) -> bool {
+        match self {
+            Self::Payload(payload) => payload.block_access_list().is_some(),
+            Self::Block(block) => block.block_access_list_hash().is_some(),
         }
     }
 

--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -542,4 +542,20 @@ mod tests {
             .validate_header(&SealedHeader::seal_slow(header,))
             .is_ok());
     }
+
+    #[test]
+    fn amsterdam_post_execution_requires_computed_block_access_list_hash() {
+        let chain_spec = Arc::new(ChainSpecBuilder::mainnet().amsterdam_activated().build());
+        let block = prague_recovered_block_with_bal_hash(B256::ZERO);
+        let result = BlockExecutionResult::<Receipt>::default();
+        let consensus = EthBeaconConsensus::new(chain_spec);
+
+        assert!(matches!(
+            FullConsensus::<EthPrimitives>::validate_block_post_execution(
+                &consensus, &block, &result, None, None,
+            )
+            .unwrap_err(),
+            ConsensusError::BlockAccessListHashMissing
+        ));
+    }
 }

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -110,8 +110,12 @@ where
         !chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) &&
         block.header().block_access_list_hash().is_some();
 
-    if (chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp()) ||
-        is_allowed_pre_amsterdam_bal_hash) &&
+    let is_amsterdam = chain_spec.is_amsterdam_active_at_timestamp(block.header().timestamp());
+    if is_amsterdam && block_access_list_hash.is_none() {
+        return Err(ConsensusError::BlockAccessListHashMissing)
+    }
+
+    if (is_amsterdam || is_allowed_pre_amsterdam_bal_hash) &&
         let Some(block_access_list_hash) = block_access_list_hash
     {
         let block_bal_hash = block.header().block_access_list_hash().unwrap_or_default();

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -1,19 +1,27 @@
-use crate::utils::{advance_with_random_transactions, eth_payload_attributes};
+use crate::utils::{
+    advance_with_random_transactions, eth_payload_attributes, eth_payload_attributes_amsterdam,
+};
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
 use alloy_eips::Encodable2718;
 use alloy_network::TxSignerSync;
+use alloy_primitives::B256;
 use alloy_provider::{Provider, ProviderBuilder};
-use futures::future::JoinAll;
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use futures::{future::JoinAll, StreamExt};
 use rand::{rngs::StdRng, seq::IndexedRandom, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{
     setup, setup_engine, setup_engine_with_connection, transaction::TransactionTestContext,
     wallet::Wallet,
 };
-use reth_network::{NetworkInfo, PeersInfo};
+use reth_engine_primitives::ConsensusEngineEvent;
+use reth_ethereum_primitives::EthPrimitives;
+use reth_network::{test_utils::Testnet, NetworkInfo, Peers, PeersInfo};
 use reth_node_builder::{NodeBuilder, NodeHandle};
 use reth_node_core::{args::NetworkArgs, node_config::NodeConfig};
 use reth_node_ethereum::EthereumNode;
+use reth_primitives_traits::SealedBlock;
+use reth_provider::test_utils::MockEthProvider;
 use reth_rpc_api::EthApiServer;
 use reth_tasks::Runtime;
 use std::{net::UdpSocket, sync::Arc, time::Duration};
@@ -130,6 +138,97 @@ async fn can_sync() -> eyre::Result<()> {
 
     // expect second node advanced via p2p gossip
     second_node.assert_new_block(tx_hash, block_hash, 1).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejects_downloaded_block_with_invalid_bal_hash() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .amsterdam_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec.clone(),
+        false,
+        Default::default(),
+        eth_payload_attributes_amsterdam,
+    )
+    .await?;
+    let mut node = nodes.pop().unwrap();
+
+    // Build a valid Amsterdam block without submitting it to the engine, then change only its BAL
+    // commitment so all other execution-derived header fields remain valid.
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
+    node.rpc.inject_tx(raw_tx).await?;
+    let payload = node.new_payload().await?;
+    let mut invalid_block = payload.block().clone().into_block();
+    let valid_bal_hash = invalid_block.header.block_access_list_hash.unwrap();
+    invalid_block.header.block_access_list_hash = Some(B256::ZERO);
+    assert_ne!(valid_bal_hash, B256::ZERO);
+
+    let invalid_block = SealedBlock::seal_slow(invalid_block);
+    let invalid_hash = invalid_block.hash();
+    let genesis_hash = node.block_hash(0);
+
+    // Serve the malformed block from a real eth protocol peer so the node must fetch it after the
+    // forkchoice update instead of receiving it through `newPayload`.
+    let peer_provider = Arc::new(
+        MockEthProvider::<EthPrimitives>::new()
+            .with_chain_spec((*chain_spec).clone())
+            .with_genesis_block(),
+    );
+    peer_provider.add_block(invalid_hash, invalid_block.into_block());
+
+    let mut testnet = Testnet::create_with(1, peer_provider).await;
+    testnet.for_each_mut(|peer| peer.install_request_handler());
+    let peer = testnet.peers()[0].handle();
+    let peer_id = *peer.peer_id();
+    let peer_addr = peer.local_addr();
+    let _testnet = testnet.spawn();
+
+    node.inner.network.add_peer(peer_id, peer_addr);
+    assert_eq!(node.network.next_session_established().await, Some(peer_id));
+
+    let mut engine_events = node.inner.add_ons_handle.consensus_engine_events().new_listener();
+    let state = ForkchoiceState {
+        head_block_hash: invalid_hash,
+        safe_block_hash: genesis_hash,
+        finalized_block_hash: genesis_hash,
+    };
+    let response =
+        node.inner.add_ons_handle.beacon_engine_handle.fork_choice_updated(state, None).await?;
+    assert_eq!(response.payload_status.status, PayloadStatusEnum::Syncing);
+
+    let error = tokio::time::timeout(Duration::from_secs(20), async {
+        while let Some(event) = engine_events.next().await {
+            match event {
+                ConsensusEngineEvent::InvalidBlock { block, error }
+                    if block.hash() == invalid_hash =>
+                {
+                    return error
+                }
+                ConsensusEngineEvent::CanonicalBlockAdded(block, _)
+                    if block.recovered_block().hash() == invalid_hash =>
+                {
+                    panic!("block with invalid BAL hash became canonical")
+                }
+                _ => {}
+            }
+        }
+        panic!("consensus engine event stream ended")
+    })
+    .await?;
+
+    assert!(error.contains("block access list hash mismatch"), "{error}");
+    assert_eq!(node.current_forkchoice_state()?.head_block_hash, genesis_hash);
 
     Ok(())
 }


### PR DESCRIPTION
Builds and validates BALs during serial engine-tree execution whenever a payload or downloaded block commits to one, and fails closed if Amsterdam post-execution validation has no computed BAL hash.

Adds an e2e covering FCU-triggered P2P download and rejection of a block with an invalid BAL commitment.