### PR TITLE
feat(overlay): cache execution overlays in manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10473,6 +10473,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "revm",
  "tracing",
 ]
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -18,7 +18,7 @@ use reth_storage_api::{
     StorageSettingsCache,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{Overlay, OverlayManager};
+use reth_storage_overlay::{OverlayManager, StateTrieOverlay};
 use reth_trie::{
     hashed_cursor::{zero_destroyed_account_storage, HashedPostStateCursorFactory},
     proof::{Proof, StorageProof},
@@ -302,8 +302,8 @@ where
             .overlay_manager
             .overlay_builder(anchor_hash)
             .with_immediate_state_trie_overlay(state, nodes);
-        let Overlay { trie_updates, hashed_post_state } =
-            overlay_builder.build_overlay(self.provider)?;
+        let StateTrieOverlay { trie_updates, hashed_post_state } =
+            overlay_builder.build_state_trie_overlay(self.provider)?;
 
         Ok(TrieInputSorted::new(trie_updates, hashed_post_state, prefix_sets))
     }

--- a/crates/storage/storage-overlay/Cargo.toml
+++ b/crates/storage/storage-overlay/Cargo.toml
@@ -39,6 +39,7 @@ metrics.workspace = true
 parking_lot.workspace = true
 rayon = { workspace = true, optional = true }
 tracing.workspace = true
+revm.workspace = true
 
 [dev-dependencies]
 reth-chain-state = { workspace = true, features = ["test-utils"] }

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -1,6 +1,9 @@
 use crate::OverlayManager;
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{BlockHash, B256};
+use alloy_primitives::{
+    map::{AddressMap, B256Map, U256Map},
+    BlockHash, B256, U256,
+};
 use metrics::{Counter, Histogram};
 use reth_chain_state::ExecutedBlock;
 use reth_errors::{ProviderError, ProviderResult};
@@ -15,6 +18,7 @@ use reth_storage_api::{
 };
 use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted};
 use reth_trie_db::DatabaseHashedPostState;
+use revm::{bytecode::Bytecode, state::AccountInfo};
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -23,20 +27,36 @@ use tracing::{debug, debug_span, instrument};
 
 /// Contains the trie and hashed-state data required to initialize an overlay state provider.
 #[derive(Debug, Clone)]
-pub struct Overlay {
+pub struct StateTrieOverlay {
     /// Trie updates overlay.
     pub trie_updates: Arc<TrieUpdatesSorted>,
     /// Hashed state overlay.
     pub hashed_post_state: Arc<HashedPostStateSorted>,
 }
 
-impl Overlay {
+impl StateTrieOverlay {
     fn empty() -> Self {
         Self {
             trie_updates: Arc::new(TrieUpdatesSorted::default()),
             hashed_post_state: Arc::new(HashedPostStateSorted::default()),
         }
     }
+}
+
+/// Execution state required to initialize an overlay state provider.
+///
+/// Account entries preserve known non-existence, while storage and code entries contain only data
+/// explicitly observed during execution.
+#[derive(Clone, Debug, Default)]
+pub struct ExecutionOverlay {
+    /// In-memory block hashes in ascending block-number order.
+    pub block_hashes: Vec<BlockNumHash>,
+    /// Account state by address.
+    pub accounts: AddressMap<Option<AccountInfo>>,
+    /// Storage values by address and slot.
+    pub storage: AddressMap<U256Map<U256>>,
+    /// Bytecode by code hash.
+    pub code_hashes: B256Map<Bytecode>,
 }
 
 /// Source of data to apply on top of the durable database state.
@@ -160,9 +180,12 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         }
     }
 
-    /// Builds the effective overlay for the given provider.
+    /// Builds the effective state trie overlay for the given provider.
     #[instrument(level = "debug", target = "storage::overlay", skip_all)]
-    pub fn build_overlay<Provider>(&self, provider: &Provider) -> ProviderResult<Overlay>
+    pub fn build_state_trie_overlay<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<StateTrieOverlay>
     where
         Provider: StageCheckpointReader
             + PruneCheckpointReader
@@ -173,10 +196,10 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             + StorageSettingsCache,
     {
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(provider)?;
-        self.build_overlay_at_frontiers(provider, state_trie_tip_block, finish_tip_block)
+        self.build_state_trie_overlay_at_frontiers(provider, state_trie_tip_block, finish_tip_block)
     }
 
-    /// Builds the effective overlay using frontiers already read from the provider.
+    /// Builds the effective state trie overlay using frontiers already read from the provider.
     ///
     /// This is useful for callers that key an overlay cache by the durable frontiers.
     #[instrument(
@@ -185,12 +208,12 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         skip_all,
         fields(?state_trie_tip_block, ?finish_tip_block, parent_hash = ?self.parent_hash)
     )]
-    pub fn build_overlay_at_frontiers<Provider>(
+    pub fn build_state_trie_overlay_at_frontiers<Provider>(
         &self,
         provider: &Provider,
         state_trie_tip_block: BlockNumHash,
         finish_tip_block: BlockNumHash,
-    ) -> ProviderResult<Overlay>
+    ) -> ProviderResult<StateTrieOverlay>
     where
         Provider: ChangeSetReader
             + StorageChangeSetReader
@@ -253,7 +276,8 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
                 // Resolve overlays and extend reverts with them. If reverts are empty, use overlays
                 // directly to avoid cloning.
-                let (overlay_trie, overlay_state) = self.resolve_overlays(anchor.hash)?;
+                let (overlay_trie, overlay_state) =
+                    self.resolve_state_trie_overlays(anchor.hash)?;
 
                 let trie_updates = if trie_reverts.is_empty() {
                     overlay_trie
@@ -306,10 +330,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
                     self.metrics.sparse_trie_overlay_skips.increment(1);
 
-                    return Ok(Overlay::empty())
+                    return Ok(StateTrieOverlay::empty())
                 }
 
-                let (trie_updates, hashed_post_state) = self.resolve_overlays(anchor.hash)?;
+                let (trie_updates, hashed_post_state) =
+                    self.resolve_state_trie_overlays(anchor.hash)?;
 
                 retrieve_trie_reverts_duration = Duration::ZERO;
                 retrieve_hashed_state_reverts_duration = Duration::ZERO;
@@ -337,11 +362,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         self.metrics.trie_updates_size.record(trie_updates_total_len as f64);
         self.metrics.hashed_state_size.record(hashed_state_updates_total_len as f64);
 
-        Ok(Overlay { trie_updates, hashed_post_state })
+        Ok(StateTrieOverlay { trie_updates, hashed_post_state })
     }
 
-    /// Resolves the effective overlay (trie updates, hashed state).
-    fn resolve_overlays(
+    /// Resolves the effective state trie overlay (trie updates, hashed state).
+    fn resolve_state_trie_overlays(
         &self,
         anchor_hash: BlockHash,
     ) -> ProviderResult<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>)> {
@@ -678,11 +703,11 @@ mod tests {
         (factory, blocks)
     }
 
-    fn account_keys(overlay: &Overlay) -> Vec<B256> {
+    fn account_keys(overlay: &StateTrieOverlay) -> Vec<B256> {
         overlay.hashed_post_state.accounts.iter().map(|(key, _)| *key).collect()
     }
 
-    fn account_node_paths(overlay: &Overlay) -> Vec<Nibbles> {
+    fn account_node_paths(overlay: &StateTrieOverlay) -> Vec<Nibbles> {
         overlay.trie_updates.account_nodes_ref().iter().map(|(path, _)| *path).collect()
     }
 
@@ -698,7 +723,7 @@ mod tests {
         for (parent_index, expected_ids) in [(3, vec![3, 4]), (4, vec![3, 4, 5])] {
             let overlay = manager
                 .overlay_builder(blocks[parent_index].recovered_block().hash())
-                .build_overlay(&provider)
+                .build_state_trie_overlay(&provider)
                 .unwrap();
 
             assert_eq!(
@@ -726,7 +751,7 @@ mod tests {
         let overlay = manager
             .overlay_builder(blocks[4].recovered_block().hash())
             .with_skip_overlay_for_reused_sparse_trie(blocks[3].recovered_block().hash())
-            .build_overlay(&provider)
+            .build_state_trie_overlay(&provider)
             .unwrap();
 
         assert!(overlay.hashed_post_state.is_empty());
@@ -741,7 +766,7 @@ mod tests {
         let error = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(blocks[1].recovered_block().hash())
             .with_no_reverts()
-            .build_overlay(&provider)
+            .build_state_trie_overlay(&provider)
             .unwrap_err();
 
         assert!(error.to_string().contains("reverts are disabled"));
@@ -773,7 +798,7 @@ mod tests {
         let error = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(blocks[3].recovered_block().hash())
             .with_overlay_source(None)
-            .build_overlay(&provider)
+            .build_state_trie_overlay(&provider)
             .unwrap_err();
 
         assert!(
@@ -789,7 +814,7 @@ mod tests {
         let parent_hash = blocks[3].recovered_block().hash();
         let error = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(parent_hash)
-            .build_overlay(&provider)
+            .build_state_trie_overlay(&provider)
             .unwrap_err();
 
         assert!(error.to_string().contains("is after partial state trie frontier"));
@@ -800,7 +825,7 @@ mod tests {
         let parent_hash = B256::with_last_byte(1);
         let builder = OverlayManager::<EthPrimitives>::default().overlay_builder(parent_hash);
 
-        let (trie, state) = builder.resolve_overlays(parent_hash).unwrap();
+        let (trie, state) = builder.resolve_state_trie_overlays(parent_hash).unwrap();
         assert!(trie.is_empty());
         assert!(state.is_empty());
     }
@@ -811,7 +836,7 @@ mod tests {
         let anchor_hash = B256::with_last_byte(2);
         let builder = OverlayManager::<EthPrimitives>::default().overlay_builder(parent_hash);
 
-        let err = builder.resolve_overlays(anchor_hash).unwrap_err();
+        let err = builder.resolve_state_trie_overlays(anchor_hash).unwrap_err();
 
         assert!(err.to_string().contains("cannot be anchored"));
     }

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -46,7 +46,11 @@ impl StateTrieOverlay {
 /// Execution state required to initialize an overlay state provider.
 ///
 /// Account entries preserve known non-existence, while storage and code entries contain only data
-/// explicitly observed during execution.
+/// explicitly observed during execution. This intentionally does not retain account status or
+/// known-storage wipes, so it cannot represent pre-Dencun `SELFDESTRUCT` of existing accounts.
+/// The execution overlay is used only for post-Dencun engine execution, where that operation does
+/// not clear existing storage; pipeline sync does not use it. Extend this representation before
+/// using it for pre-Dencun execution.
 #[derive(Clone, Debug, Default)]
 pub struct ExecutionOverlay {
     /// In-memory block hashes in ascending block-number order.
@@ -57,6 +61,39 @@ pub struct ExecutionOverlay {
     pub storage: AddressMap<U256Map<U256>>,
     /// Bytecode by code hash.
     pub code_hashes: B256Map<Bytecode>,
+}
+
+impl ExecutionOverlay {
+    pub(crate) fn extend<N: NodePrimitives>(&mut self, block: &ExecutedBlock<N>) {
+        self.block_hashes.push(block.recovered_block().num_hash());
+        let state = &block.execution_output.state;
+        let (accounts, storage, code_hashes) =
+            (&mut self.accounts, &mut self.storage, &mut self.code_hashes);
+
+        #[allow(unused_mut)]
+        let mut extend_state = || {
+            for (address, account) in state.state() {
+                accounts.insert(*address, account.info.clone());
+                let account_storage = storage.entry(*address).or_default();
+                for (slot, value) in &account.storage {
+                    account_storage.insert(*slot, value.present_value);
+                }
+            }
+        };
+        #[allow(unused_mut)]
+        let mut extend_code_hashes = || {
+            code_hashes.extend(state.contracts.iter().map(|(hash, code)| (*hash, code.clone())));
+        };
+
+        #[cfg(feature = "rayon")]
+        rayon::join(extend_state, extend_code_hashes);
+
+        #[cfg(not(feature = "rayon"))]
+        {
+            extend_state();
+            extend_code_hashes();
+        }
+    }
 }
 
 /// Source of data to apply on top of the durable database state.

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -401,7 +401,7 @@ impl ChangesetCache {
         let overlay = overlay_manager
             .overlay_builder(finish.hash)
             .with_no_reverts()
-            .build_overlay_at_frontiers(provider, partial_state_trie, finish)?;
+            .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish)?;
         let state_trie_provider = OverlayStateProvider::new(
             provider,
             overlay,
@@ -615,7 +615,7 @@ impl ChangesetCacheInner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Overlay;
+    use crate::StateTrieOverlay;
     use alloy_consensus::Header;
     use alloy_primitives::{
         keccak256,
@@ -641,8 +641,8 @@ mod tests {
         Arc::new(TrieUpdatesSorted::new(vec![], B256Map::default()))
     }
 
-    fn empty_overlay() -> Overlay {
-        Overlay { trie_updates: Arc::default(), hashed_post_state: Arc::default() }
+    fn empty_overlay() -> StateTrieOverlay {
+        StateTrieOverlay { trie_updates: Arc::default(), hashed_post_state: Arc::default() }
     }
 
     fn insert_test_changesets(

--- a/crates/storage/storage-overlay/src/lib.rs
+++ b/crates/storage/storage-overlay/src/lib.rs
@@ -11,5 +11,7 @@ pub(crate) use changeset_cache::ChangesetCache;
 mod manager;
 pub use manager::*;
 
+mod manager_metrics;
+
 mod provider;
 pub use provider::*;

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -846,7 +846,8 @@ fn extend_execution_overlay<N: NodePrimitives>(
     let (accounts, storage, code_hashes) =
         (&mut overlay.accounts, &mut overlay.storage, &mut overlay.code_hashes);
 
-    let extend_state = || {
+    #[allow(unused_mut)]
+    let mut extend_state = || {
         for (address, account) in state.state() {
             accounts.insert(*address, account.info.clone());
             let account_storage = storage.entry(*address).or_default();
@@ -855,7 +856,8 @@ fn extend_execution_overlay<N: NodePrimitives>(
             }
         }
     };
-    let extend_code_hashes = || {
+    #[allow(unused_mut)]
+    let mut extend_code_hashes = || {
         code_hashes.extend(state.contracts.iter().map(|(hash, code)| (*hash, code.clone())));
     };
 

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -8,13 +8,10 @@ use crate::{
     changeset_cache::compute_block_trie_updates,
     database_state_frontiers,
     manager_metrics::{ExecutionOverlayMetrics, OverlayCacheMetrics, StateTrieOverlayMetrics},
-    ChangesetCache, OverlayBuilder,
+    ChangesetCache, ExecutionOverlay, OverlayBuilder,
 };
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{
-    map::{AddressMap, B256Map, U256Map},
-    BlockNumber, B256, U256,
-};
+use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
 use reth_errors::ProviderResult;
@@ -30,7 +27,6 @@ use reth_storage_api::{
 #[cfg(feature = "rayon")]
 use reth_tasks::WorkerPool;
 use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted, TrieInputSorted};
-use revm::{bytecode::Bytecode, state::AccountInfo};
 use std::{
     fmt,
     ops::RangeInclusive,
@@ -573,20 +569,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
         compute_execution_overlay_inner(compute_input, anchor_hash, &self.execution_metrics)
     }
-}
-
-/// Execution state accumulated from in-memory blocks.
-///
-/// Account entries preserve known non-existence, while storage and code entries contain only data
-/// explicitly observed during execution.
-#[derive(Clone, Debug, Default)]
-pub struct ExecutionOverlay {
-    /// Account state by address.
-    pub accounts: AddressMap<Option<AccountInfo>>,
-    /// Storage values by address and slot.
-    pub storage: AddressMap<U256Map<U256>>,
-    /// Bytecode by code hash.
-    pub code_hashes: B256Map<Bytecode>,
 }
 
 /// Error returned when a state trie overlay cannot be built from the manager's current block set.

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -1,23 +1,24 @@
-//! Flattened state trie overlays for in-memory blocks.
+//! State trie and execution overlays for in-memory blocks.
 //!
 //! Payload validation needs a view of the state trie as of an in-memory parent block even when that
-//! parent has not been persisted yet. [`OverlayManager`] tracks those in-memory blocks and
-//! builds reusable flattened state trie overlays on demand.
+//! parent has not been persisted yet. [`OverlayManager`] tracks those in-memory blocks and builds
+//! reusable state trie and execution overlays on demand.
 
 use crate::{
-    changeset_cache::compute_block_trie_updates, database_state_frontiers, ChangesetCache,
-    OverlayBuilder,
+    changeset_cache::compute_block_trie_updates,
+    database_state_frontiers,
+    manager_metrics::{ExecutionOverlayMetrics, OverlayCacheMetrics, StateTrieOverlayMetrics},
+    ChangesetCache, OverlayBuilder,
 };
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{BlockNumber, B256};
+use alloy_primitives::{
+    map::{AddressMap, B256Map, U256Map},
+    BlockNumber, B256, U256,
+};
 use parking_lot::Mutex;
 use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
 use reth_errors::ProviderResult;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_metrics::{
-    metrics::{Counter, Histogram},
-    Metrics,
-};
 use reth_primitives_traits::{
     dashmap::{mapref::entry::Entry, DashMap},
     AlloyBlockHeader, FastInstant, NodePrimitives,
@@ -29,6 +30,7 @@ use reth_storage_api::{
 #[cfg(feature = "rayon")]
 use reth_tasks::WorkerPool;
 use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted, TrieInputSorted};
+use revm::{bytecode::Bytecode, state::AccountInfo};
 use std::{
     fmt,
     ops::RangeInclusive,
@@ -37,43 +39,35 @@ use std::{
 };
 use tracing::{debug, trace};
 
-/// Manages flattened state trie overlays for in-memory blocks.
+/// Manages state trie and execution overlays for in-memory blocks.
 ///
-/// The manager owns the in-memory block graph, changeset cache, and a cache of flattened state trie
-/// overlays keyed by `(anchor_hash, tip_hash)`.
+/// The manager owns the in-memory block graph, changeset cache, and caches keyed by
+/// `(anchor_hash, tip_hash)`.
 #[derive(Clone)]
 pub struct OverlayManager<N: NodePrimitives = EthPrimitives> {
     blocks: Arc<DashMap<B256, ExecutedBlock<N>>>,
-    overlays: Arc<DashMap<OverlayCacheKey, OverlayCacheEntry>>,
+    state_trie_overlays: OverlayCache<TrieInputSorted>,
+    execution_overlays: OverlayCache<ExecutionOverlay>,
     changeset_cache: ChangesetCache,
     preserved_sparse_trie: Arc<Mutex<Option<PreservedSparseTrie>>>,
     #[cfg(feature = "rayon")]
     worker_pool: Option<Arc<WorkerPool>>,
     metrics: StateTrieOverlayMetrics,
-}
-
-/// Metrics for state trie overlay management.
-#[derive(Clone, Metrics)]
-#[metrics(scope = "sync.block_validation.state_trie_overlay")]
-struct StateTrieOverlayMetrics {
-    /// Duration of overlay computation in seconds.
-    overlay_computation_duration_seconds: Histogram,
-    /// Number of requests satisfied by an existing overlay cache entry.
-    overlay_cache_reuses: Counter,
-    /// Number of overlay cache entries populated by computing an overlay.
-    overlay_cache_fills: Counter,
+    execution_metrics: ExecutionOverlayMetrics,
 }
 
 impl<N: NodePrimitives> Default for OverlayManager<N> {
     fn default() -> Self {
         Self {
             blocks: Default::default(),
-            overlays: Default::default(),
+            state_trie_overlays: Default::default(),
+            execution_overlays: Default::default(),
             changeset_cache: Default::default(),
             preserved_sparse_trie: Default::default(),
             #[cfg(feature = "rayon")]
             worker_pool: None,
             metrics: Default::default(),
+            execution_metrics: Default::default(),
         }
     }
 }
@@ -82,7 +76,8 @@ impl<N: NodePrimitives> std::fmt::Debug for OverlayManager<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OverlayManager")
             .field("blocks", &self.blocks.len())
-            .field("overlays", &self.overlays.len())
+            .field("state_trie_overlays", &self.state_trie_overlays.len())
+            .field("execution_overlays", &self.execution_overlays.len())
             .finish()
     }
 }
@@ -93,11 +88,13 @@ impl<N: NodePrimitives> OverlayManager<N> {
     pub fn new(worker_pool: Arc<WorkerPool>) -> Self {
         Self {
             blocks: Default::default(),
-            overlays: Default::default(),
+            state_trie_overlays: Default::default(),
+            execution_overlays: Default::default(),
             changeset_cache: Default::default(),
             preserved_sparse_trie: Default::default(),
             worker_pool: Some(worker_pool),
             metrics: Default::default(),
+            execution_metrics: Default::default(),
         }
     }
 
@@ -276,11 +273,15 @@ impl<N: NodePrimitives> OverlayManager<N> {
         span.record("removed_blocks", removed_blocks);
 
         if removed_blocks > 0 {
-            let overlays_before = self.overlays.len();
-            self.overlays.retain(|key, _| {
+            let overlays_before = self.state_trie_overlays.len() + self.execution_overlays.len();
+            self.state_trie_overlays.retain(|key, _| {
                 self.contains_hash(key.tip_hash, key.anchor_hash, key.anchor_hash)
             });
-            pruned_overlays = overlays_before.saturating_sub(self.overlays.len());
+            self.execution_overlays.retain(|key, _| {
+                self.contains_hash(key.tip_hash, key.anchor_hash, key.anchor_hash)
+            });
+            pruned_overlays = overlays_before
+                .saturating_sub(self.state_trie_overlays.len() + self.execution_overlays.len());
             span.record("pruned_overlays", pruned_overlays);
         }
         debug!(
@@ -310,8 +311,35 @@ impl<N: NodePrimitives> OverlayManager<N> {
             %anchor_hash,
             "loading state trie overlay for parent"
         );
-        let input = self.get_overlay(parent_hash, anchor_hash)?;
+        let input = self.get_or_compute_overlay(
+            &self.state_trie_overlays,
+            &self.metrics,
+            parent_hash,
+            anchor_hash,
+            |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
+        )?;
         Ok((Arc::clone(&input.nodes), Arc::clone(&input.state)))
+    }
+
+    /// Returns execution data for the in-memory chain from `anchor_hash` to `parent_hash`.
+    #[tracing::instrument(
+        level = "trace",
+        target = "storage::overlay::manager",
+        skip_all,
+        fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
+    )]
+    pub fn execution_overlay_for_parent(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+    ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
+        self.get_or_compute_overlay(
+            &self.execution_overlays,
+            &self.execution_metrics,
+            parent_hash,
+            anchor_hash,
+            |input, span| self.compute_execution_overlay(input, anchor_hash, span),
+        )
     }
 
     #[tracing::instrument(
@@ -326,16 +354,23 @@ impl<N: NodePrimitives> OverlayManager<N> {
             parent_overlay_reused = tracing::field::Empty,
         )
     )]
-    fn get_overlay(
+    fn get_or_compute_overlay<T, M>(
         &self,
+        cache: &OverlayCache<T>,
+        metrics: &M,
         tip_hash: B256,
         anchor_hash: B256,
-    ) -> Result<Arc<TrieInputSorted>, StateTrieOverlayError> {
+        compute: impl FnOnce(ComputeOverlayInput<N, T>, tracing::Span) -> T,
+    ) -> Result<Arc<T>, StateTrieOverlayError>
+    where
+        M: OverlayCacheMetrics,
+    {
         let key = OverlayCacheKey { anchor_hash, tip_hash };
         let span = tracing::Span::current();
 
-        if let Some(entry) = self.overlays.get(&key).map(|entry| entry.value().clone()) {
-            self.record_overlay_cache_reuse(&span);
+        if let Some(entry) = cache.entries.get(&key).map(|entry| entry.value().clone()) {
+            metrics.record_cache_reuse();
+            span.record("cache_reused", true);
             return Ok(match entry {
                 OverlayCacheEntry::Ready(input) => input,
                 OverlayCacheEntry::Computing(waiter) => waiter.wait(),
@@ -362,7 +397,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
             let parent_hash = block.recovered_block().parent_hash();
             (parent_hash != anchor_hash)
                 .then(|| {
-                    self.overlays
+                    cache
+                        .entries
                         .get(&OverlayCacheKey { anchor_hash, tip_hash: parent_hash })
                         .and_then(|entry| entry.value().ready())
                 })
@@ -376,23 +412,24 @@ impl<N: NodePrimitives> OverlayManager<N> {
             None => ComputeOverlayInput::MergeBlocks(blocks),
         };
 
-        enum CacheAction {
-            Ready(Arc<TrieInputSorted>),
-            Wait(Arc<OverlayWaiter>),
-            Compute(Arc<OverlayWaiter>),
+        enum CacheAction<T> {
+            Ready(Arc<T>),
+            Wait(Arc<OverlayWaiter<T>>),
+            Compute(Arc<OverlayWaiter<T>>),
         }
 
-        let action = match self.overlays.entry(key) {
+        let action = match cache.entries.entry(key) {
             Entry::Occupied(entry) => {
                 let entry = entry.get().clone();
-                self.record_overlay_cache_reuse(&span);
+                metrics.record_cache_reuse();
+                span.record("cache_reused", true);
                 match entry {
                     OverlayCacheEntry::Ready(input) => CacheAction::Ready(input),
                     OverlayCacheEntry::Computing(waiter) => CacheAction::Wait(waiter),
                 }
             }
             Entry::Vacant(entry) => {
-                self.metrics.overlay_cache_fills.increment(1);
+                metrics.record_cache_fill();
                 let waiter = Arc::new(OverlayWaiter::new());
                 entry.insert(OverlayCacheEntry::Computing(Arc::clone(&waiter)));
                 CacheAction::Compute(waiter)
@@ -403,10 +440,10 @@ impl<N: NodePrimitives> OverlayManager<N> {
             CacheAction::Ready(input) => Ok(input),
             CacheAction::Wait(waiter) => Ok(waiter.wait()),
             CacheAction::Compute(waiter) => {
-                let input = self.compute_overlay(compute_input, anchor_hash, span);
+                let input = Arc::new(compute(compute_input, span));
                 waiter.finish(Arc::clone(&input));
 
-                if let Entry::Occupied(mut entry) = self.overlays.entry(key) {
+                if let Entry::Occupied(mut entry) = cache.entries.entry(key) {
                     // The entry may have been pruned while the overlay was computing. Only cache
                     // the result if the map still points at the waiter installed by this task.
                     let should_publish = match entry.get() {
@@ -421,11 +458,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 Ok(input)
             }
         }
-    }
-
-    fn record_overlay_cache_reuse(&self, span: &tracing::Span) {
-        self.metrics.overlay_cache_reuses.increment(1);
-        span.record("cache_reused", true);
     }
 
     /// Returns every in-memory block in the chain whose tip is `parent_hash`.
@@ -459,26 +491,61 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
     }
 
-    fn compute_overlay(
+    fn compute_state_trie_overlay(
         &self,
-        compute_input: ComputeOverlayInput<N>,
+        compute_input: ComputeOverlayInput<N, TrieInputSorted>,
         anchor_hash: B256,
         _span: tracing::Span,
-    ) -> Arc<TrieInputSorted> {
+    ) -> TrieInputSorted {
         #[cfg(feature = "rayon")]
         {
             if let Some(worker_pool) = &self.worker_pool {
                 let compute_span = _span;
                 let metrics = self.metrics.clone();
-                return Arc::new(worker_pool.install_fn(move || {
+                return worker_pool.install_fn(move || {
                     let _guard = compute_span.enter();
                     compute_overlay(compute_input, anchor_hash, &metrics)
-                }))
+                })
             }
         }
 
-        Arc::new(compute_overlay(compute_input, anchor_hash, &self.metrics))
+        compute_overlay(compute_input, anchor_hash, &self.metrics)
     }
+
+    fn compute_execution_overlay(
+        &self,
+        compute_input: ComputeOverlayInput<N, ExecutionOverlay>,
+        anchor_hash: B256,
+        _span: tracing::Span,
+    ) -> ExecutionOverlay {
+        #[cfg(feature = "rayon")]
+        {
+            if let Some(worker_pool) = &self.worker_pool {
+                let compute_span = _span;
+                let metrics = self.execution_metrics.clone();
+                return worker_pool.install_fn(move || {
+                    let _guard = compute_span.enter();
+                    compute_execution_overlay_inner(compute_input, anchor_hash, &metrics)
+                })
+            }
+        }
+
+        compute_execution_overlay_inner(compute_input, anchor_hash, &self.execution_metrics)
+    }
+}
+
+/// Execution state accumulated from in-memory blocks.
+///
+/// Account entries preserve known non-existence, while storage and code entries contain only data
+/// explicitly observed during execution.
+#[derive(Clone, Debug, Default)]
+pub struct ExecutionOverlay {
+    /// Account state by address.
+    pub accounts: AddressMap<Option<AccountInfo>>,
+    /// Storage values by address and slot.
+    pub storage: AddressMap<U256Map<U256>>,
+    /// Bytecode by code hash.
+    pub code_hashes: B256Map<Bytecode>,
 }
 
 /// Error returned when a state trie overlay cannot be built from the manager's current block set.
@@ -508,14 +575,48 @@ struct OverlayCacheKey {
     tip_hash: B256,
 }
 
-#[derive(Clone)]
-enum OverlayCacheEntry {
-    Ready(Arc<TrieInputSorted>),
-    Computing(Arc<OverlayWaiter>),
+struct OverlayCache<T> {
+    entries: Arc<DashMap<OverlayCacheKey, OverlayCacheEntry<T>>>,
 }
 
-impl OverlayCacheEntry {
-    fn ready(&self) -> Option<Arc<TrieInputSorted>> {
+impl<T> Default for OverlayCache<T> {
+    fn default() -> Self {
+        Self { entries: Default::default() }
+    }
+}
+
+impl<T> Clone for OverlayCache<T> {
+    fn clone(&self) -> Self {
+        Self { entries: Arc::clone(&self.entries) }
+    }
+}
+
+impl<T> OverlayCache<T> {
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn retain(&self, mut keep: impl FnMut(&OverlayCacheKey, &OverlayCacheEntry<T>) -> bool) {
+        self.entries.retain(|key, entry| keep(key, entry))
+    }
+}
+
+enum OverlayCacheEntry<T> {
+    Ready(Arc<T>),
+    Computing(Arc<OverlayWaiter<T>>),
+}
+
+impl<T> Clone for OverlayCacheEntry<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Ready(input) => Self::Ready(Arc::clone(input)),
+            Self::Computing(waiter) => Self::Computing(Arc::clone(waiter)),
+        }
+    }
+}
+
+impl<T> OverlayCacheEntry<T> {
+    fn ready(&self) -> Option<Arc<T>> {
         match self {
             Self::Ready(input) => Some(Arc::clone(input)),
             Self::Computing(_) => None,
@@ -523,26 +624,26 @@ impl OverlayCacheEntry {
     }
 }
 
-struct OverlayWaiter {
-    input: OnceLock<Arc<TrieInputSorted>>,
+struct OverlayWaiter<T> {
+    input: OnceLock<Arc<T>>,
 }
 
-impl OverlayWaiter {
+impl<T> OverlayWaiter<T> {
     const fn new() -> Self {
         Self { input: OnceLock::new() }
     }
 
-    fn wait(&self) -> Arc<TrieInputSorted> {
+    fn wait(&self) -> Arc<T> {
         Arc::clone(self.input.wait())
     }
 
-    fn finish(&self, computed: Arc<TrieInputSorted>) {
+    fn finish(&self, computed: Arc<T>) {
         let _ = self.input.set(computed);
     }
 }
 
-enum ComputeOverlayInput<N: NodePrimitives> {
-    ExtendCached { block: ExecutedBlock<N>, parent_input: Arc<TrieInputSorted> },
+enum ComputeOverlayInput<N: NodePrimitives, T> {
+    ExtendCached { block: ExecutedBlock<N>, parent_input: Arc<T> },
     MergeBlocks(Vec<ExecutedBlock<N>>),
 }
 
@@ -558,7 +659,7 @@ enum ComputeOverlayInput<N: NodePrimitives> {
     )
 )]
 fn compute_overlay<N: NodePrimitives>(
-    input: ComputeOverlayInput<N>,
+    input: ComputeOverlayInput<N, TrieInputSorted>,
     anchor_hash: B256,
     metrics: &StateTrieOverlayMetrics,
 ) -> TrieInputSorted {
@@ -670,14 +771,90 @@ fn extend_overlay(
     }
 }
 
+fn compute_execution_overlay_inner<N: NodePrimitives>(
+    input: ComputeOverlayInput<N, ExecutionOverlay>,
+    anchor_hash: B256,
+    metrics: &ExecutionOverlayMetrics,
+) -> ExecutionOverlay {
+    let started_at = Instant::now();
+    let block_count = match &input {
+        ComputeOverlayInput::ExtendCached { .. } => 1,
+        ComputeOverlayInput::MergeBlocks(blocks) => blocks.len(),
+    };
+    let parent_overlay = matches!(&input, ComputeOverlayInput::ExtendCached { .. });
+    tracing::Span::current().record("block_count", block_count);
+    tracing::Span::current().record("parent_overlay", parent_overlay);
+
+    let overlay = match input {
+        ComputeOverlayInput::ExtendCached { block, parent_input } => {
+            let mut overlay = parent_input.as_ref().clone();
+            extend_execution_overlay(&mut overlay, &block);
+            overlay
+        }
+        ComputeOverlayInput::MergeBlocks(blocks) => {
+            let mut overlay = ExecutionOverlay::default();
+            for block in blocks.iter().rev() {
+                extend_execution_overlay(&mut overlay, block);
+            }
+            overlay
+        }
+    };
+
+    let elapsed = started_at.elapsed();
+    metrics.overlay_computation_duration_seconds.record(elapsed.as_secs_f64());
+    tracing::Span::current().record("elapsed_us", elapsed.as_micros() as u64);
+    debug!(
+        target: "storage::overlay::manager",
+        %anchor_hash,
+        block_count,
+        parent_overlay,
+        ?elapsed,
+        "computed execution overlay"
+    );
+
+    overlay
+}
+
+fn extend_execution_overlay<N: NodePrimitives>(
+    overlay: &mut ExecutionOverlay,
+    block: &ExecutedBlock<N>,
+) {
+    let state = &block.execution_output.state;
+    let (accounts, storage, code_hashes) =
+        (&mut overlay.accounts, &mut overlay.storage, &mut overlay.code_hashes);
+
+    let extend_state = || {
+        for (address, account) in state.state() {
+            accounts.insert(*address, account.info.clone());
+            let account_storage = storage.entry(*address).or_default();
+            for (slot, value) in &account.storage {
+                account_storage.insert(*slot, value.present_value);
+            }
+        }
+    };
+    let extend_code_hashes = || {
+        code_hashes.extend(state.contracts.iter().map(|(hash, code)| (*hash, code.clone())));
+    };
+
+    #[cfg(feature = "rayon")]
+    rayon::join(extend_state, extend_code_hashes);
+
+    #[cfg(not(feature = "rayon"))]
+    {
+        extend_state();
+        extend_code_hashes();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::U256;
+    use alloy_primitives::{map::HashMap, Address, U256};
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock, SparseTrie};
     use reth_ethereum_primitives::EthPrimitives;
     use reth_primitives_traits::Account;
     use reth_trie::{updates::TrieUpdatesSorted, ComputedTrieData, HashedPostState, HashedStorage};
+    use revm::{bytecode::Bytecode, database::BundleState, state::AccountInfo};
     use std::{
         sync::{mpsc, Arc},
         thread,
@@ -697,10 +874,23 @@ mod tests {
                 HashedStorage::from_iter([(hashed_slot, U256::from(id))]),
             )])
             .into_sorted();
+        let address = Address::with_last_byte(id);
+        let slot = U256::from(id);
+        let code_hash = B256::with_last_byte(id.saturating_add(64));
+        let state = BundleState::builder(block.block_number()..=block.block_number())
+            .state_present_account_info(
+                address,
+                AccountInfo { nonce: id as u64, balance: U256::from(id), ..Default::default() },
+            )
+            .state_storage(address, HashMap::from_iter([(slot, (U256::ZERO, U256::from(id)))]))
+            .contract(code_hash, Bytecode::new_raw(vec![id].into()))
+            .build();
+        let mut execution_output = (*block.execution_output).clone();
+        execution_output.state = state;
 
         ExecutedBlock::new(
             Arc::clone(&block.recovered_block),
-            Arc::clone(&block.execution_output),
+            Arc::new(execution_output),
             ComputedTrieData::new(Arc::new(hashed_state), Arc::new(TrieUpdatesSorted::default())),
         )
     }
@@ -746,6 +936,39 @@ mod tests {
         let (_, cached_short) =
             manager.overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor).unwrap();
         assert!(Arc::ptr_eq(&short, &cached_short));
+    }
+
+    #[test]
+    fn builds_execution_overlay_for_inserted_blocks() {
+        let manager = OverlayManager::default();
+        let blocks = test_blocks();
+        for block in &blocks {
+            manager.insert_block(block.clone());
+        }
+
+        let anchor_hash = blocks[0].recovered_block().parent_hash();
+        let overlay = manager
+            .execution_overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash)
+            .unwrap();
+
+        for id in 1..=3 {
+            let address = Address::with_last_byte(id);
+            let code_hash = B256::with_last_byte(id + 64);
+            assert_eq!(overlay.accounts[&address].as_ref().unwrap().nonce, id as u64);
+            assert_eq!(overlay.storage[&address][&U256::from(id)], U256::from(id));
+            assert_eq!(overlay.code_hashes[&code_hash], Bytecode::new_raw(vec![id].into()));
+        }
+
+        let cached = manager
+            .execution_overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash)
+            .unwrap();
+        assert!(Arc::ptr_eq(&overlay, &cached));
+
+        let short_anchor = blocks[1].recovered_block().hash();
+        let short = manager
+            .execution_overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor)
+            .unwrap();
+        assert_eq!(short.accounts.len(), 1);
     }
 
     #[test]
@@ -829,7 +1052,10 @@ mod tests {
             tip_hash: B256::with_last_byte(2),
         };
         let waiter = Arc::new(OverlayWaiter::new());
-        manager.overlays.insert(key, OverlayCacheEntry::Computing(Arc::clone(&waiter)));
+        manager
+            .state_trie_overlays
+            .entries
+            .insert(key, OverlayCacheEntry::Computing(Arc::clone(&waiter)));
 
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
@@ -859,6 +1085,9 @@ mod tests {
 
         let original_anchor = blocks[0].recovered_block().parent_hash();
         manager.overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor).unwrap();
+        manager
+            .execution_overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
+            .unwrap();
 
         manager.remove_blocks([
             blocks[0].recovered_block().hash(),
@@ -869,9 +1098,16 @@ mod tests {
         assert!(manager
             .overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
             .is_err());
+        assert!(manager
+            .execution_overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
+            .is_err());
 
         let (_, state) =
             manager.overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash).unwrap();
         assert_eq!(state.accounts.len(), 1);
+        let execution = manager
+            .execution_overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash)
+            .unwrap();
+        assert_eq!(execution.accounts.len(), 1);
     }
 }

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -264,6 +264,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         #[cfg(not(feature = "rayon"))]
         let _ = cached_parent_overlays;
 
+        // When a new block is inserted we optimistically and asynchronously flatten an execution overlay for it
         #[cfg(feature = "rayon")]
         {
             let parent_span = span;

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -281,7 +281,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                         anchor_hash = %anchor_hash,
                     )
                     .entered();
-                    let _ = manager.execution_overlay_for_parent(hash, anchor_hash);
+                    let _ = manager.precompute_execution_overlay_for_parent(hash, anchor_hash);
                 });
             }
         }
@@ -352,13 +352,16 @@ impl<N: NodePrimitives> OverlayManager<N> {
             %anchor_hash,
             "loading state trie overlay for parent"
         );
-        let input = self.get_or_compute_overlay(
-            &self.state_trie_overlays,
-            &self.metrics,
-            parent_hash,
-            anchor_hash,
-            |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
-        )?;
+        let input = self
+            .get_or_compute_overlay(
+                &self.state_trie_overlays,
+                &self.metrics,
+                parent_hash,
+                anchor_hash,
+                true,
+                |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
+            )?
+            .expect("required overlay lookup cannot skip an in-progress computation");
         Ok((Arc::clone(&input.nodes), Arc::clone(&input.state)))
     }
 
@@ -374,11 +377,32 @@ impl<N: NodePrimitives> OverlayManager<N> {
         parent_hash: B256,
         anchor_hash: B256,
     ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
+        Ok(self
+            .execution_overlay_for_parent_inner(parent_hash, anchor_hash, true)?
+            .expect("required overlay lookup cannot skip an in-progress computation"))
+    }
+
+    #[cfg(feature = "rayon")]
+    fn precompute_execution_overlay_for_parent(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+    ) -> Result<(), StateTrieOverlayError> {
+        self.execution_overlay_for_parent_inner(parent_hash, anchor_hash, false).map(drop)
+    }
+
+    fn execution_overlay_for_parent_inner(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+        wait_for_pending: bool,
+    ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
         self.get_or_compute_overlay(
             &self.execution_overlays,
             &self.execution_metrics,
             parent_hash,
             anchor_hash,
+            wait_for_pending,
             |input, span| self.compute_execution_overlay(input, anchor_hash, span),
         )
     }
@@ -401,8 +425,9 @@ impl<N: NodePrimitives> OverlayManager<N> {
         metrics: &M,
         tip_hash: B256,
         anchor_hash: B256,
+        wait_for_pending: bool,
         compute: impl FnOnce(ComputeOverlayInput<N, T>, tracing::Span) -> T,
-    ) -> Result<Arc<T>, StateTrieOverlayError>
+    ) -> Result<Option<Arc<T>>, StateTrieOverlayError>
     where
         M: OverlayCacheMetrics,
     {
@@ -412,10 +437,11 @@ impl<N: NodePrimitives> OverlayManager<N> {
         if let Some(entry) = cache.entries.get(&key).map(|entry| entry.value().clone()) {
             metrics.record_cache_reuse();
             span.record("cache_reused", true);
-            return Ok(match entry {
-                OverlayCacheEntry::Ready(input) => input,
-                OverlayCacheEntry::Computing(waiter) => waiter.wait(),
-            })
+            return match entry {
+                OverlayCacheEntry::Ready(input) => Ok(Some(input)),
+                OverlayCacheEntry::Computing(waiter) if wait_for_pending => Ok(Some(waiter.wait())),
+                OverlayCacheEntry::Computing(_) => Ok(None),
+            }
         }
         span.record("cache_reused", false);
 
@@ -447,6 +473,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 span.record("cache_reused", true);
                 match entry {
                     OverlayCacheEntry::Ready(input) => CacheAction::Ready(input),
+                    OverlayCacheEntry::Computing(_) if !wait_for_pending => return Ok(None),
                     OverlayCacheEntry::Computing(waiter) => CacheAction::Wait(waiter),
                 }
             }
@@ -459,8 +486,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
         };
 
         match action {
-            CacheAction::Ready(input) => Ok(input),
-            CacheAction::Wait(waiter) => Ok(waiter.wait()),
+            CacheAction::Ready(input) => Ok(Some(input)),
+            CacheAction::Wait(waiter) => Ok(Some(waiter.wait())),
             CacheAction::Compute(waiter) => {
                 let parent_input = blocks.first().and_then(|block| {
                     let parent_hash = block.recovered_block().parent_hash();
@@ -494,7 +521,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                     }
                 }
 
-                Ok(input)
+                Ok(Some(input))
             }
         }
     }
@@ -1096,6 +1123,36 @@ mod tests {
             anchor_hash,
             tip_hash: blocks[0].recovered_block().hash(),
         }));
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn execution_overlay_precompute_does_not_wait_for_pending_entry() {
+        let worker_pool = Arc::new(WorkerPool::new(1, "execution-overlay-pending-test"));
+        let manager = OverlayManager::new(Arc::clone(&worker_pool));
+        let block = test_blocks().remove(0);
+        let anchor_hash = block.recovered_block().parent_hash();
+        let tip_hash = block.recovered_block().hash();
+        manager.insert_block(block);
+
+        let waiter = Arc::new(OverlayWaiter::new());
+        manager.execution_overlays.entries.insert(
+            OverlayCacheKey { anchor_hash, tip_hash },
+            OverlayCacheEntry::Computing(Arc::clone(&waiter)),
+        );
+
+        let precompute_manager = manager.clone();
+        let (tx, rx) = mpsc::channel();
+        worker_pool.spawn(move || {
+            precompute_manager
+                .precompute_execution_overlay_for_parent(tip_hash, anchor_hash)
+                .unwrap();
+            tx.send(()).unwrap();
+        });
+
+        let completed = rx.recv_timeout(Duration::from_millis(100));
+        waiter.finish(Arc::new(ExecutionOverlay::default()));
+        assert!(completed.is_ok(), "execution overlay precompute waited for pending entry");
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -846,13 +846,13 @@ fn compute_execution_overlay_inner<N: NodePrimitives>(
     let overlay = match input {
         ComputeOverlayInput::ExtendCached { block, parent_input } => {
             let mut parent_input = parent_input;
-            extend_execution_overlay(Arc::make_mut(&mut parent_input), &block);
+            Arc::make_mut(&mut parent_input).extend(&block);
             Arc::try_unwrap(parent_input).expect("Arc::make_mut leaves the child overlay unique")
         }
         ComputeOverlayInput::MergeBlocks(blocks) => {
             let mut overlay = ExecutionOverlay::default();
             for block in blocks.iter().rev() {
-                extend_execution_overlay(&mut overlay, block);
+                overlay.extend(block);
             }
             overlay
         }
@@ -871,40 +871,6 @@ fn compute_execution_overlay_inner<N: NodePrimitives>(
     );
 
     overlay
-}
-
-fn extend_execution_overlay<N: NodePrimitives>(
-    overlay: &mut ExecutionOverlay,
-    block: &ExecutedBlock<N>,
-) {
-    overlay.block_hashes.push(block.recovered_block().num_hash());
-    let state = &block.execution_output.state;
-    let (accounts, storage, code_hashes) =
-        (&mut overlay.accounts, &mut overlay.storage, &mut overlay.code_hashes);
-
-    #[allow(unused_mut)]
-    let mut extend_state = || {
-        for (address, account) in state.state() {
-            accounts.insert(*address, account.info.clone());
-            let account_storage = storage.entry(*address).or_default();
-            for (slot, value) in &account.storage {
-                account_storage.insert(*slot, value.present_value);
-            }
-        }
-    };
-    #[allow(unused_mut)]
-    let mut extend_code_hashes = || {
-        code_hashes.extend(state.contracts.iter().map(|(hash, code)| (*hash, code.clone())));
-    };
-
-    #[cfg(feature = "rayon")]
-    rayon::join(extend_state, extend_code_hashes);
-
-    #[cfg(not(feature = "rayon"))]
-    {
-        extend_state();
-        extend_code_hashes();
-    }
 }
 
 #[cfg(test)]
@@ -1161,12 +1127,9 @@ mod tests {
             OverlayCacheEntry::Computing(Arc::clone(&waiter)),
         );
 
-        let precompute_manager = manager.clone();
         let (tx, rx) = mpsc::channel();
         worker_pool.spawn(move || {
-            precompute_manager
-                .precompute_execution_overlay_for_parent(tip_hash, anchor_hash)
-                .unwrap();
+            manager.precompute_execution_overlay_for_parent(tip_hash, anchor_hash).unwrap();
             tx.send(()).unwrap();
         });
 

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -859,6 +859,7 @@ fn extend_execution_overlay<N: NodePrimitives>(
     overlay: &mut ExecutionOverlay,
     block: &ExecutedBlock<N>,
 ) {
+    overlay.block_hashes.push(block.recovered_block().num_hash());
     let state = &block.execution_output.state;
     let (accounts, storage, code_hashes) =
         (&mut overlay.accounts, &mut overlay.storage, &mut overlay.code_hashes);
@@ -1000,6 +1001,10 @@ mod tests {
             assert_eq!(overlay.storage[&address][&U256::from(id)], U256::from(id));
             assert_eq!(overlay.code_hashes[&code_hash], Bytecode::new_raw(vec![id].into()));
         }
+        assert_eq!(
+            overlay.block_hashes,
+            blocks[..=2].iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(),
+        );
 
         let cached = manager
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash)

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -238,12 +238,55 @@ impl<N: NodePrimitives> OverlayManager<N> {
             }
         }
 
+        // Snapshot matching parent overlays before spawning so DashMap iteration guards are
+        // dropped.
+        let cached_parent_overlays = self
+            .execution_overlays
+            .entries
+            .iter()
+            .filter_map(|entry| {
+                let key = *entry.key();
+                (key.tip_hash == parent_hash).then_some(key.anchor_hash)
+            })
+            .collect::<Vec<_>>();
+
         debug!(
             target: "storage::overlay::manager",
             %hash,
             %parent_hash,
             "inserted block into state trie overlay manager"
         );
+        if cached_parent_overlays.is_empty() {
+            return
+        }
+
+        #[cfg(feature = "rayon")]
+        let Some(worker_pool) = self.worker_pool.clone() else {
+            return
+        };
+
+        #[cfg(not(feature = "rayon"))]
+        let _ = cached_parent_overlays;
+
+        #[cfg(feature = "rayon")]
+        {
+            let parent_span = span;
+            for anchor_hash in cached_parent_overlays {
+                let manager = self.clone();
+                let parent_span = parent_span.clone();
+                worker_pool.spawn(move || {
+                    let _span = tracing::trace_span!(
+                        target: "storage::overlay::manager",
+                        parent: parent_span,
+                        "precompute_execution_overlay",
+                        tip_hash = %hash,
+                        anchor_hash = %anchor_hash,
+                    )
+                    .entered();
+                    let _ = manager.execution_overlay_for_parent(hash, anchor_hash);
+                });
+            }
+        }
     }
 
     /// Removes blocks from the live block graph and prunes cached overlays that can no longer be
@@ -853,6 +896,8 @@ mod tests {
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock, SparseTrie};
     use reth_ethereum_primitives::EthPrimitives;
     use reth_primitives_traits::Account;
+    #[cfg(feature = "rayon")]
+    use reth_tasks::WorkerPool;
     use reth_trie::{updates::TrieUpdatesSorted, ComputedTrieData, HashedPostState, HashedStorage};
     use revm::{bytecode::Bytecode, database::BundleState, state::AccountInfo};
     use std::{
@@ -969,6 +1014,32 @@ mod tests {
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor)
             .unwrap();
         assert_eq!(short.accounts.len(), 1);
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn precomputes_execution_overlay_for_cached_parent() {
+        let manager = OverlayManager::new(Arc::new(WorkerPool::new(1, "execution-overlay-test")));
+        let blocks = test_blocks();
+        let anchor_hash = blocks[0].recovered_block().parent_hash();
+
+        manager.insert_block(blocks[0].clone());
+        manager
+            .execution_overlay_for_parent(blocks[0].recovered_block().hash(), anchor_hash)
+            .unwrap();
+
+        manager.insert_block(blocks[1].clone());
+        let key = OverlayCacheKey { anchor_hash, tip_hash: blocks[1].recovered_block().hash() };
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while !manager
+            .execution_overlays
+            .entries
+            .get(&key)
+            .is_some_and(|entry| matches!(entry.value(), OverlayCacheEntry::Ready(_)))
+        {
+            assert!(std::time::Instant::now() < deadline, "execution overlay was not precomputed");
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -653,6 +653,9 @@ impl<T> OverlayCache<T> {
     }
 
     /// Removes and returns a ready entry.
+    ///
+    /// Transferring a parent entry lets `Arc::make_mut` extend it in place when no caller retains
+    /// it. Keeping the cache entry would otherwise guarantee a clone.
     fn take_ready(&self, key: &OverlayCacheKey) -> Option<Arc<T>> {
         let (_, entry) =
             self.entries.remove_if(key, |_, entry| matches!(entry, OverlayCacheEntry::Ready(_)))?;

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -397,6 +397,10 @@ impl<N: NodePrimitives> OverlayManager<N> {
         anchor_hash: B256,
         wait_for_pending: bool,
     ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
+        if parent_hash == anchor_hash {
+            return Ok(Some(Arc::new(ExecutionOverlay::default())))
+        }
+
         self.get_or_compute_overlay(
             &self.execution_overlays,
             &self.execution_metrics,
@@ -1032,6 +1036,19 @@ mod tests {
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor)
             .unwrap();
         assert_eq!(short.accounts.len(), 1);
+    }
+
+    #[test]
+    fn execution_overlay_for_parent_at_anchor_is_empty() {
+        let manager = OverlayManager::<EthPrimitives>::default();
+        let anchor_hash = B256::with_last_byte(1);
+
+        let overlay = manager.execution_overlay_for_parent(anchor_hash, anchor_hash).unwrap();
+
+        assert!(overlay.accounts.is_empty());
+        assert!(overlay.storage.is_empty());
+        assert!(overlay.code_hashes.is_empty());
+        assert!(overlay.block_hashes.is_empty());
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -436,25 +436,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
             hash = parent_hash;
         }
         span.record("block_count", blocks.len());
-        let parent_input = blocks.first().and_then(|block| {
-            let parent_hash = block.recovered_block().parent_hash();
-            (parent_hash != anchor_hash)
-                .then(|| {
-                    cache
-                        .entries
-                        .get(&OverlayCacheKey { anchor_hash, tip_hash: parent_hash })
-                        .and_then(|entry| entry.value().ready())
-                })
-                .flatten()
-        });
-        span.record("parent_overlay_reused", parent_input.is_some());
-        let compute_input = match parent_input {
-            Some(parent_input) => {
-                ComputeOverlayInput::ExtendCached { block: blocks.swap_remove(0), parent_input }
-            }
-            None => ComputeOverlayInput::MergeBlocks(blocks),
-        };
-
         enum CacheAction<T> {
             Ready(Arc<T>),
             Wait(Arc<OverlayWaiter<T>>),
@@ -483,6 +464,23 @@ impl<N: NodePrimitives> OverlayManager<N> {
             CacheAction::Ready(input) => Ok(input),
             CacheAction::Wait(waiter) => Ok(waiter.wait()),
             CacheAction::Compute(waiter) => {
+                let parent_input = blocks.first().and_then(|block| {
+                    let parent_hash = block.recovered_block().parent_hash();
+                    (parent_hash != anchor_hash)
+                        .then(|| {
+                            cache
+                                .take_ready(&OverlayCacheKey { anchor_hash, tip_hash: parent_hash })
+                        })
+                        .flatten()
+                });
+                span.record("parent_overlay_reused", parent_input.is_some());
+                let compute_input = match parent_input {
+                    Some(parent_input) => ComputeOverlayInput::ExtendCached {
+                        block: blocks.swap_remove(0),
+                        parent_input,
+                    },
+                    None => ComputeOverlayInput::MergeBlocks(blocks),
+                };
                 let input = Arc::new(compute(compute_input, span));
                 waiter.finish(Arc::clone(&input));
 
@@ -642,6 +640,14 @@ impl<T> OverlayCache<T> {
     fn retain(&self, mut keep: impl FnMut(&OverlayCacheKey, &OverlayCacheEntry<T>) -> bool) {
         self.entries.retain(|key, entry| keep(key, entry))
     }
+
+    /// Removes and returns a ready entry.
+    fn take_ready(&self, key: &OverlayCacheKey) -> Option<Arc<T>> {
+        let (_, entry) =
+            self.entries.remove_if(key, |_, entry| matches!(entry, OverlayCacheEntry::Ready(_)))?;
+        let OverlayCacheEntry::Ready(input) = entry else { unreachable!() };
+        Some(input)
+    }
 }
 
 enum OverlayCacheEntry<T> {
@@ -654,15 +660,6 @@ impl<T> Clone for OverlayCacheEntry<T> {
         match self {
             Self::Ready(input) => Self::Ready(Arc::clone(input)),
             Self::Computing(waiter) => Self::Computing(Arc::clone(waiter)),
-        }
-    }
-}
-
-impl<T> OverlayCacheEntry<T> {
-    fn ready(&self) -> Option<Arc<T>> {
-        match self {
-            Self::Ready(input) => Some(Arc::clone(input)),
-            Self::Computing(_) => None,
         }
     }
 }
@@ -726,13 +723,13 @@ fn compute_overlay<N: NodePrimitives>(
                 "extending cached parent state trie overlay"
             );
 
-            let mut overlay = parent_input.as_ref().clone();
+            let mut parent_input = parent_input;
             extend_overlay(
-                &mut overlay,
+                Arc::make_mut(&mut parent_input),
                 &trie_data.sorted.hashed_state,
                 &trie_data.sorted.trie_updates,
             );
-            overlay
+            Arc::try_unwrap(parent_input).expect("Arc::make_mut leaves the child overlay unique")
         }
         ComputeOverlayInput::MergeBlocks(blocks) => merge_blocks(blocks),
     };
@@ -830,9 +827,9 @@ fn compute_execution_overlay_inner<N: NodePrimitives>(
 
     let overlay = match input {
         ComputeOverlayInput::ExtendCached { block, parent_input } => {
-            let mut overlay = parent_input.as_ref().clone();
-            extend_execution_overlay(&mut overlay, &block);
-            overlay
+            let mut parent_input = parent_input;
+            extend_execution_overlay(Arc::make_mut(&mut parent_input), &block);
+            Arc::try_unwrap(parent_input).expect("Arc::make_mut leaves the child overlay unique")
         }
         ComputeOverlayInput::MergeBlocks(blocks) => {
             let mut overlay = ExecutionOverlay::default();
@@ -1016,6 +1013,70 @@ mod tests {
         assert_eq!(short.accounts.len(), 1);
     }
 
+    #[test]
+    fn promotes_ready_parent_overlays_to_the_child() {
+        let manager = OverlayManager::default();
+        let blocks = test_blocks();
+        for block in &blocks {
+            manager.insert_block(block.clone());
+        }
+
+        let anchor_hash = blocks[0].recovered_block().parent_hash();
+        let parent_hash = blocks[1].recovered_block().hash();
+        let child_hash = blocks[2].recovered_block().hash();
+        let parent_key = OverlayCacheKey { anchor_hash, tip_hash: parent_hash };
+        let child_key = OverlayCacheKey { anchor_hash, tip_hash: child_hash };
+
+        manager.overlay_for_parent(parent_hash, anchor_hash).unwrap();
+        manager.execution_overlay_for_parent(parent_hash, anchor_hash).unwrap();
+
+        manager.overlay_for_parent(child_hash, anchor_hash).unwrap();
+        manager.execution_overlay_for_parent(child_hash, anchor_hash).unwrap();
+
+        assert!(!manager.state_trie_overlays.entries.contains_key(&parent_key));
+        assert!(manager.state_trie_overlays.entries.contains_key(&child_key));
+        assert!(!manager.execution_overlays.entries.contains_key(&parent_key));
+        assert!(manager.execution_overlays.entries.contains_key(&child_key));
+    }
+
+    #[test]
+    fn promotes_parent_overlays_held_by_callers() {
+        let manager = OverlayManager::default();
+        let blocks = test_blocks();
+        for block in &blocks {
+            manager.insert_block(block.clone());
+        }
+
+        let anchor_hash = blocks[0].recovered_block().parent_hash();
+        let parent_hash = blocks[1].recovered_block().hash();
+        let child_hash = blocks[2].recovered_block().hash();
+        let parent_key = OverlayCacheKey { anchor_hash, tip_hash: parent_hash };
+
+        manager.overlay_for_parent(parent_hash, anchor_hash).unwrap();
+        let state_parent = manager
+            .state_trie_overlays
+            .entries
+            .get(&parent_key)
+            .and_then(|entry| match entry.value() {
+                OverlayCacheEntry::Ready(input) => Some(Arc::clone(input)),
+                OverlayCacheEntry::Computing(_) => None,
+            })
+            .unwrap();
+        let execution_parent =
+            manager.execution_overlay_for_parent(parent_hash, anchor_hash).unwrap();
+
+        let (_, child_state) = manager.overlay_for_parent(child_hash, anchor_hash).unwrap();
+        let child_execution =
+            manager.execution_overlay_for_parent(child_hash, anchor_hash).unwrap();
+
+        assert!(!manager.state_trie_overlays.entries.contains_key(&parent_key));
+        assert!(!manager.execution_overlays.entries.contains_key(&parent_key));
+        assert_eq!(state_parent.state.accounts.len(), 2);
+        assert_eq!(execution_parent.accounts.len(), 2);
+        assert_eq!(child_state.accounts.len(), 3);
+        assert_eq!(child_execution.accounts.len(), 3);
+    }
+
     #[cfg(feature = "rayon")]
     #[test]
     fn precomputes_execution_overlay_for_cached_parent() {
@@ -1040,6 +1101,10 @@ mod tests {
             assert!(std::time::Instant::now() < deadline, "execution overlay was not precomputed");
             thread::sleep(Duration::from_millis(10));
         }
+        assert!(!manager.execution_overlays.entries.contains_key(&OverlayCacheKey {
+            anchor_hash,
+            tip_hash: blocks[0].recovered_block().hash(),
+        }));
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -264,7 +264,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
         #[cfg(not(feature = "rayon"))]
         let _ = cached_parent_overlays;
 
-        // When a new block is inserted we optimistically and asynchronously flatten an execution overlay for it
+        // When a new block is inserted we optimistically and asynchronously flatten an execution
+        // overlay for it
         #[cfg(feature = "rayon")]
         {
             let parent_span = span;

--- a/crates/storage/storage-overlay/src/manager_metrics.rs
+++ b/crates/storage/storage-overlay/src/manager_metrics.rs
@@ -1,0 +1,54 @@
+use reth_metrics::{
+    metrics::{Counter, Histogram},
+    Metrics,
+};
+
+/// Metrics for state trie overlay management.
+#[derive(Clone, Metrics)]
+#[metrics(scope = "sync.block_validation.state_trie_overlay")]
+pub(crate) struct StateTrieOverlayMetrics {
+    /// Duration of overlay computation in seconds.
+    pub(crate) overlay_computation_duration_seconds: Histogram,
+    /// Number of requests satisfied by an existing overlay cache entry.
+    pub(crate) overlay_cache_reuses: Counter,
+    /// Number of overlay cache entries populated by computing an overlay.
+    pub(crate) overlay_cache_fills: Counter,
+}
+
+/// Metrics for execution overlay management.
+#[derive(Clone, Metrics)]
+#[metrics(scope = "sync.block_validation.execution_overlay")]
+pub(crate) struct ExecutionOverlayMetrics {
+    /// Duration of overlay computation in seconds.
+    pub(crate) overlay_computation_duration_seconds: Histogram,
+    /// Number of requests satisfied by an existing overlay cache entry.
+    pub(crate) overlay_cache_reuses: Counter,
+    /// Number of overlay cache entries populated by computing an overlay.
+    pub(crate) overlay_cache_fills: Counter,
+}
+
+pub(crate) trait OverlayCacheMetrics {
+    fn record_cache_reuse(&self);
+
+    fn record_cache_fill(&self);
+}
+
+impl OverlayCacheMetrics for StateTrieOverlayMetrics {
+    fn record_cache_reuse(&self) {
+        self.overlay_cache_reuses.increment(1);
+    }
+
+    fn record_cache_fill(&self) {
+        self.overlay_cache_fills.increment(1);
+    }
+}
+
+impl OverlayCacheMetrics for ExecutionOverlayMetrics {
+    fn record_cache_reuse(&self) {
+        self.overlay_cache_reuses.increment(1);
+    }
+
+    fn record_cache_fill(&self) {
+        self.overlay_cache_fills.increment(1);
+    }
+}

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -353,7 +353,7 @@ mod tests {
         );
 
         let provider = factory.provider().unwrap();
-        let first = overlay_factory.get_overlay(&provider).unwrap();
+        let first = overlay_factory.get_state_trie_overlay(&provider).unwrap();
         assert_eq!(account_keys(&first), vec![B256::with_last_byte(3), B256::with_last_byte(4)]);
         drop(provider);
 
@@ -369,7 +369,7 @@ mod tests {
         provider_rw.commit().unwrap();
 
         let provider = factory.provider().unwrap();
-        let second = overlay_factory.get_overlay(&provider).unwrap();
+        let second = overlay_factory.get_state_trie_overlay(&provider).unwrap();
         assert_eq!(account_keys(&second), vec![B256::with_last_byte(4)]);
         assert_eq!(account_node_paths(&second), vec![Nibbles::from_nibbles([4])]);
         assert_eq!(overlay_factory.overlay_cache.len(), 2);

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -1,4 +1,4 @@
-use crate::{database_state_frontiers, Overlay, OverlayBuilder};
+use crate::{database_state_frontiers, OverlayBuilder, StateTrieOverlay};
 use alloy_primitives::{BlockHash, B256};
 use metrics::{Counter, Histogram};
 use reth_db_api::{tables, transaction::DbTx, DatabaseError};
@@ -34,7 +34,7 @@ pub(crate) struct OverlayStateProviderFactoryMetrics {
     create_provider_duration: Histogram,
     /// Overall duration of the [`OverlayStateProviderFactory::database_provider_ro`] call.
     database_provider_ro_duration: Histogram,
-    /// Number of cache misses when fetching [`Overlay`]s from the overlay cache.
+    /// Number of cache misses when fetching state trie overlays from the overlay cache.
     overlay_cache_misses: Counter,
 }
 
@@ -48,11 +48,11 @@ pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
     factory: F,
     /// Overlay builder containing the configuration and overlay calculation logic.
     overlay_builder: OverlayBuilder<N>,
-    /// A cache which maps `(state_trie_tip, finish_tip) -> Overlay`.
+    /// A cache which maps `(state_trie_tip, finish_tip) -> [`StateTrieOverlay`].
     ///
     /// Under partial persistence the overlay depends on both durable frontiers, so both hashes are
     /// part of the cache key.
-    overlay_cache: Arc<DashMap<(BlockHash, BlockHash), Overlay>>,
+    overlay_cache: Arc<DashMap<(BlockHash, BlockHash), StateTrieOverlay>>,
     /// Metrics for provider factory operations.
     metrics: OverlayStateProviderFactoryMetrics,
 }
@@ -77,10 +77,14 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
         self
     }
 
-    /// Fetches an [`Overlay`] from the cache based on the current durable frontiers. If there is no
-    /// cached value then this calculates the [`Overlay`] and populates the cache.
+    /// Fetches a [`StateTrieOverlay`] from the cache based on the current durable frontiers. If
+    /// there is no cached value then this calculates the [`StateTrieOverlay`] and populates the
+    /// cache.
     #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
-    fn get_overlay<Provider>(&self, provider: &Provider) -> ProviderResult<Overlay>
+    fn get_state_trie_overlay<Provider>(
+        &self,
+        provider: &Provider,
+    ) -> ProviderResult<StateTrieOverlay>
     where
         Provider: StageCheckpointReader
             + PruneCheckpointReader
@@ -97,7 +101,7 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
                 dashmap::Entry::Occupied(entry) => entry.get().clone(),
                 dashmap::Entry::Vacant(entry) => {
                     self.metrics.overlay_cache_misses.increment(1);
-                    let overlay = self.overlay_builder.build_overlay_at_frontiers(
+                    let overlay = self.overlay_builder.build_state_trie_overlay_at_frontiers(
                         provider,
                         state_trie_tip_block,
                         finish_tip_block,
@@ -137,7 +141,7 @@ where
             res
         };
 
-        let overlay = self.get_overlay(&provider)?;
+        let overlay = self.get_state_trie_overlay(&provider)?;
 
         let is_v2 = provider.cached_storage_settings().is_v2();
         self.metrics.database_provider_ro_duration.record(overall_start.elapsed());
@@ -153,13 +157,13 @@ where
 #[derive(Debug)]
 pub struct OverlayStateProvider<Provider> {
     provider: Provider,
-    overlay: Overlay,
+    overlay: StateTrieOverlay,
     is_v2: bool,
 }
 
 impl<Provider> OverlayStateProvider<Provider> {
     /// Creates a new overlay state provider.
-    pub const fn new(provider: Provider, overlay: Overlay, is_v2: bool) -> Self {
+    pub const fn new(provider: Provider, overlay: StateTrieOverlay, is_v2: bool) -> Self {
         Self { provider, overlay, is_v2 }
     }
 }
@@ -328,11 +332,11 @@ mod tests {
         (factory, blocks)
     }
 
-    fn account_keys(overlay: &Overlay) -> Vec<B256> {
+    fn account_keys(overlay: &StateTrieOverlay) -> Vec<B256> {
         overlay.hashed_post_state.accounts.iter().map(|(key, _)| *key).collect()
     }
 
-    fn account_node_paths(overlay: &Overlay) -> Vec<Nibbles> {
+    fn account_node_paths(overlay: &StateTrieOverlay) -> Vec<Nibbles> {
         overlay.trie_updates.account_nodes_ref().iter().map(|(path, _)| *path).collect()
     }
 

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -48,7 +48,7 @@ pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
     factory: F,
     /// Overlay builder containing the configuration and overlay calculation logic.
     overlay_builder: OverlayBuilder<N>,
-    /// A cache which maps `(state_trie_tip, finish_tip) -> [`StateTrieOverlay`].
+    /// A cache mapping `(state_trie_tip, finish_tip)` to [`StateTrieOverlay`].
     ///
     /// Under partial persistence the overlay depends on both durable frontiers, so both hashes are
     /// part of the cache key.


### PR DESCRIPTION
Adds an execution-overlay cache to `OverlayManager`, sharing its cache, promotion, and precomputation machinery with state-trie overlays. The execution overlay of a block is optimistically and asynchronously computed when it is inserted into the OverlayManager (ie immediately after it is validated).

Renames the state-trie overlay APIs to distinguish them from execution overlays.

The new overlay cache is not yet used.