### PR TITLE
fix(net): bound block access list response decoding

### DIFF
--- a/crates/net/eth-wire-types/src/block_access_lists.rs
+++ b/crates/net/eth-wire-types/src/block_access_lists.rs
@@ -8,6 +8,9 @@ use alloy_rlp::{
 };
 use reth_codecs_derive::add_arbitrary_tests;
 
+/// Maximum number of BAL response entries Reth serves or accepts from peers.
+pub const MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES: usize = 1024;
+
 /// A request for block access lists from the given block hashes.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -48,6 +51,39 @@ impl Encodable for BlockAccessLists {
         let payload_length =
             self.0.iter().map(|entry| entry.as_ref().map_or(1, |bytes| bytes.len())).sum();
         Header { list: true, payload_length }.length_with_payload()
+    }
+}
+
+impl BlockAccessLists {
+    /// Decodes a response after validating its entry count without allocating.
+    pub(crate) fn decode_with_max_entries(
+        buf: &mut &[u8],
+        max_entries: usize,
+    ) -> alloy_rlp::Result<Self> {
+        let input = *buf;
+        let mut rest = input;
+        let mut payload = Header::decode_bytes(&mut rest, true)?;
+        let raw_length = input.len() - rest.len();
+        let mut entries = 0usize;
+
+        while !payload.is_empty() {
+            if entries >= max_entries {
+                return Err(alloy_rlp::Error::Custom(
+                    "block access lists response exceeds maximum entry count",
+                ))
+            }
+            let item_header = Header::decode(&mut payload)?;
+            payload = &payload[item_header.payload_length..];
+            entries += 1;
+        }
+
+        let mut raw = &input[..raw_length];
+        let decoded = <Self as Decodable>::decode(&mut raw)?;
+        if !raw.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength)
+        }
+        *buf = rest;
+        Ok(decoded)
     }
 }
 
@@ -226,6 +262,48 @@ mod tests {
         let err =
             alloy_rlp::decode_exact::<BlockAccessLists>(&[0xc2, EMPTY_LIST_CODE]).unwrap_err();
         assert!(matches!(err, alloy_rlp::Error::InputTooShort));
+    }
+
+    #[test]
+    fn bounded_decoder_accepts_maximum_entries() {
+        let original = BlockAccessLists(vec![None; MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES]);
+        let encoded = alloy_rlp::encode(&original);
+        let mut encoded = encoded.as_slice();
+        let decoded = BlockAccessLists::decode_with_max_entries(
+            &mut encoded,
+            MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES,
+        )
+        .unwrap();
+
+        assert_eq!(decoded, original);
+        assert!(encoded.is_empty());
+    }
+
+    #[test]
+    fn bounded_decoder_rejects_too_many_entries_without_advancing() {
+        let encoded = alloy_rlp::encode(BlockAccessLists(vec![
+            None;
+            MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES +
+                1
+        ]));
+        let mut input = encoded.as_slice();
+        let err = BlockAccessLists::decode_with_max_entries(
+            &mut input,
+            MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, alloy_rlp::Error::Custom(_)));
+        assert_eq!(input, encoded.as_slice());
+    }
+
+    #[test]
+    fn canonical_decoder_does_not_apply_response_policy() {
+        let original = BlockAccessLists(vec![None; MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES + 1]);
+        let encoded = alloy_rlp::encode(&original);
+        let decoded = alloy_rlp::decode_exact::<BlockAccessLists>(&encoded).unwrap();
+
+        assert_eq!(decoded, original);
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -11,6 +11,7 @@ use super::{
     GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
     GetReceipts70, NewPooledTransactionHashes66, NewPooledTransactionHashes68, NodeData,
     PooledTransactions, Receipts, Status, StatusEth69, Transactions,
+    MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES,
 };
 use crate::{
     status::StatusMessage, BlockRangeUpdate, BroadcastPoolTransactions, Cells,
@@ -209,7 +210,12 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 if version < EthVersion::Eth71 {
                     return Err(MessageError::Invalid(version, EthMessageID::BlockAccessLists))
                 }
-                EthMessage::BlockAccessLists(RequestPair::decode(buf)?)
+                EthMessage::BlockAccessLists(RequestPair::decode_with(buf, |buf| {
+                    BlockAccessLists::decode_with_max_entries(
+                        buf,
+                        MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES,
+                    )
+                })?)
             }
             EthMessageID::Cells => {
                 if version < EthVersion::Eth72 {
@@ -893,7 +899,7 @@ mod tests {
     use crate::{
         message::RequestPair, BlockAccessLists, EthMessage, EthMessageID, EthNetworkPrimitives,
         EthVersion, GetBlockAccessLists, GetNodeData, NodeData, ProtocolMessage,
-        RawCapabilityMessage,
+        RawCapabilityMessage, MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES,
     };
     use alloy_primitives::hex;
     use alloy_rlp::{Decodable, Encodable, Error};
@@ -986,6 +992,23 @@ mod tests {
         .unwrap();
 
         assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn test_bal_message_eth71_rejects_too_many_response_entries() {
+        let msg = ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockAccessLists(
+            RequestPair {
+                request_id: 42,
+                message: BlockAccessLists(vec![None; MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES + 1]),
+            },
+        ));
+        let encoded = encode(msg);
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+            EthVersion::Eth71,
+            &mut &encoded[..],
+        );
+
+        assert!(matches!(decoded, Err(MessageError::RlpError(Error::Custom(_)))));
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -5,10 +5,10 @@
 //!
 //! This module implements the snap/2 (EIP-8189) message definitions.
 
-use crate::BlockAccessLists;
+use crate::{BlockAccessLists, MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES};
 use alloc::vec::Vec;
 use alloy_primitives::{Bytes, B256, KECCAK256_EMPTY, U256};
-use alloy_rlp::{BufMut, Decodable, Encodable, RlpDecodable, RlpEncodable};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
 use alloy_trie::{TrieAccount, EMPTY_ROOT_HASH};
 use reth_codecs_derive::add_arbitrary_tests;
 
@@ -323,6 +323,19 @@ pub struct BlockAccessListsMessage {
     pub block_access_lists: BlockAccessLists,
 }
 
+impl BlockAccessListsMessage {
+    fn decode_with_max_entries(buf: &mut &[u8], max_entries: usize) -> alloy_rlp::Result<Self> {
+        let mut payload = Header::decode_bytes(buf, true)?;
+        let request_id = u64::decode(&mut payload)?;
+        let block_access_lists =
+            BlockAccessLists::decode_with_max_entries(&mut payload, max_entries)?;
+        if !payload.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength)
+        }
+        Ok(Self { request_id, block_access_lists })
+    }
+}
+
 /// Represents all types of messages in the snap sync protocol.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SnapProtocolMessage {
@@ -498,13 +511,12 @@ impl SnapProtocolMessage {
             GetBlockAccessLists,
             GetBlockAccessListsMessage
         );
-        decode_snap_message_variant!(
-            message_id,
-            buf,
-            SnapMessageId::BlockAccessLists,
-            BlockAccessLists,
-            BlockAccessListsMessage
-        );
+        if message_id == SnapMessageId::BlockAccessLists as u8 {
+            return Ok(Self::BlockAccessLists(BlockAccessListsMessage::decode_with_max_entries(
+                buf,
+                MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES,
+            )?));
+        }
 
         Err(alloy_rlp::Error::Custom("Unknown message ID"))
     }
@@ -843,6 +855,23 @@ mod tests {
         assert!(matches!(
             SnapProtocolMessage::decode_versioned(SnapVersion::V2, &[0x08, 0xff]),
             Err(SnapProtocolError::Rlp(_))
+        ));
+    }
+
+    #[test]
+    fn decode_versioned_rejects_too_many_block_access_list_response_entries() {
+        let msg = SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
+            request_id: 1,
+            block_access_lists: BlockAccessLists(vec![
+                None;
+                crate::MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES +
+                    1
+            ]),
+        });
+
+        assert!(matches!(
+            SnapProtocolMessage::decode_versioned(SnapVersion::V2, &msg.encode()),
+            Err(SnapProtocolError::Rlp(alloy_rlp::Error::Custom(_)))
         ));
     }
 

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -62,7 +62,8 @@ pub const MAX_BODIES_SERVE: usize = 1024;
 /// Maximum number of block access lists to serve.
 ///
 /// Used to limit lookups.
-pub const MAX_BLOCK_ACCESS_LISTS_SERVE: usize = 1024;
+pub const MAX_BLOCK_ACCESS_LISTS_SERVE: usize =
+    reth_eth_wire::MAX_BLOCK_ACCESS_LISTS_RESPONSE_ENTRIES;
 
 /// Maximum number of cell lookups to serve.
 ///


### PR DESCRIPTION
Adds an allocation-free entry-count preflight used by the eth/71 and snap/2 BAL response dispatchers, rejecting more than 1,024 entries before canonical RLP decoding allocates the response vector or raw BAL bytes. Keeps the canonical BlockAccessLists and BlockAccessListsMessage decoders unrestricted because 1,024 is a Reth peer policy rather than part of the RLP format.

Context: https://github.com/tempoxyz/tempo/pull/7314#discussion_r3865692926