### PR TITLE
fix(engine): classify invalid BAL input as malformed

### DIFF
--- a/crates/consensus/consensus/src/lib.rs
+++ b/crates/consensus/consensus/src/lib.rs
@@ -498,9 +498,6 @@ pub enum ConsensusError {
     /// EIP-7928: Error when the block access list hash doesn't match the expected value.
     #[error("block access list hash mismatch: {0}")]
     BlockAccessListHashMismatch(GotExpectedBoxed<B256>),
-    /// EIP-7928: Error when the block access list cannot be decoded or converted.
-    #[error("invalid block access list: {0}")]
-    BlockAccessListInvalid(String),
     /// Any additional consensus error, for example L2-specific errors.
     #[error(transparent)]
     Other(#[from] Arc<dyn Error + Send + Sync>),

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -112,8 +112,8 @@ impl From<BalExecutionError> for InsertBlockErrorKind {
     fn from(e: BalExecutionError) -> Self {
         match e {
             BalExecutionError::Consensus(inner) => Self::Consensus(inner),
-            inner @ BalExecutionError::BlockAccessListInvalid(_) => {
-                Self::Consensus(ConsensusError::other(inner))
+            BalExecutionError::BlockAccessListInvalid(inner) => {
+                Self::BlockAccessListDecode(BlockAccessListDecodeError::new(inner))
             }
             BalExecutionError::Execution(inner) => Self::Execution(inner),
             BalExecutionError::Provider(inner) => Self::Provider(inner),

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -112,6 +112,9 @@ impl From<BalExecutionError> for InsertBlockErrorKind {
     fn from(e: BalExecutionError) -> Self {
         match e {
             BalExecutionError::Consensus(inner) => Self::Consensus(inner),
+            inner @ BalExecutionError::BlockAccessListInvalid(_) => {
+                Self::Consensus(ConsensusError::other(inner))
+            }
             BalExecutionError::Execution(inner) => Self::Execution(inner),
             BalExecutionError::Provider(inner) => Self::Provider(inner),
             BalExecutionError::Other(inner) => Self::Other(inner),

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -112,9 +112,7 @@ impl From<BalExecutionError> for InsertBlockErrorKind {
     fn from(e: BalExecutionError) -> Self {
         match e {
             BalExecutionError::Consensus(inner) => Self::Consensus(inner),
-            BalExecutionError::BlockAccessListInvalid(inner) => {
-                Self::BlockAccessListDecode(BlockAccessListDecodeError::new(inner))
-            }
+            BalExecutionError::BlockAccessListDecode(inner) => Self::BlockAccessListDecode(inner),
             BalExecutionError::Execution(inner) => Self::Execution(inner),
             BalExecutionError::Provider(inner) => Self::Provider(inner),
             BalExecutionError::Other(inner) => Self::Other(inner),

--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -1,7 +1,7 @@
 //! Errors for the BAL execution path.
 
+use reth_engine_primitives::BlockAccessListDecodeError;
 use reth_errors::{BlockExecutionError, ConsensusError, ProviderError};
-use revm::bytecode::BytecodeDecodeError;
 
 /// Errors surfaced by `execute_block`.
 #[derive(Debug, thiserror::Error)]
@@ -9,9 +9,9 @@ pub enum BalExecutionError {
     /// Block violated consensus rules while running the BAL path.
     #[error(transparent)]
     Consensus(#[from] ConsensusError),
-    /// The block access list contains bytecode that cannot result from valid execution.
-    #[error("invalid block access list: {0}")]
-    BlockAccessListInvalid(#[from] BytecodeDecodeError),
+    /// The block access list could not be decoded for execution.
+    #[error(transparent)]
+    BlockAccessListDecode(#[from] BlockAccessListDecodeError),
     /// Worker or canonical EVM failure.
     #[error("evm execution failed: {0}")]
     Execution(#[from] BlockExecutionError),

--- a/crates/engine/tree/src/tree/payload_processor/bal/error.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/error.rs
@@ -1,6 +1,7 @@
 //! Errors for the BAL execution path.
 
 use reth_errors::{BlockExecutionError, ConsensusError, ProviderError};
+use revm::bytecode::BytecodeDecodeError;
 
 /// Errors surfaced by `execute_block`.
 #[derive(Debug, thiserror::Error)]
@@ -8,6 +9,9 @@ pub enum BalExecutionError {
     /// Block violated consensus rules while running the BAL path.
     #[error(transparent)]
     Consensus(#[from] ConsensusError),
+    /// The block access list contains bytecode that cannot result from valid execution.
+    #[error("invalid block access list: {0}")]
+    BlockAccessListInvalid(#[from] BytecodeDecodeError),
     /// Worker or canonical EVM failure.
     #[error("evm execution failed: {0}")]
     Execution(#[from] BlockExecutionError),

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -193,11 +193,7 @@ fn convert_alloy_to_revm_bal(alloy_bal: &AlloyBal) -> Result<Arc<RevmBal>, BalEx
     // is triggered then the execution is reverted, and as such no actual code change event takes
     // place. Therefore, if we do observe such a bytecode in a BAL then that means the BAL is
     // invalid as no legal execution should've led to this bytecode deployment.
-    let received_bal_revm = RevmBal::clone_from_alloy(alloy_bal.as_vec()).map_err(|e| {
-        BalExecutionError::Consensus(reth_consensus::ConsensusError::BlockAccessListInvalid(
-            format!("{e:?}"),
-        ))
-    })?;
+    let received_bal_revm = RevmBal::clone_from_alloy(alloy_bal.as_vec())?;
     Ok(Arc::new(received_bal_revm))
 }
 
@@ -328,8 +324,11 @@ impl BlockGasTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tree::error::InsertBlockErrorKind;
     use alloy_consensus::{BlockHeader, Header};
-    use alloy_eip7928::{bal::Bal as AlloyBal, BlockAccessList};
+    use alloy_eip7928::{
+        bal::Bal as AlloyBal, AccountChanges, BlockAccessIndex, BlockAccessList, CodeChange,
+    };
     use alloy_eips::{
         eip2935::{HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_CODE},
         eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE},
@@ -447,6 +446,26 @@ mod tests {
             executor.apply_post_execution_changes().expect("post-exec");
         }
         state.take_built_alloy_bal().expect("with_bal_builder was set")
+    }
+
+    #[test]
+    fn invalid_bal_bytecode_is_a_consensus_error() {
+        let alloy_bal = vec![AccountChanges {
+            address: Address::ZERO,
+            code_changes: vec![CodeChange::new(
+                BlockAccessIndex::new(1),
+                vec![0xef, 0x01, 0xde].into(),
+            )],
+            ..Default::default()
+        }]
+        .into();
+
+        let error = convert_alloy_to_revm_bal(&alloy_bal).unwrap_err();
+        assert!(matches!(&error, BalExecutionError::BlockAccessListInvalid(_)));
+        assert!(matches!(
+            InsertBlockErrorKind::from(error),
+            InsertBlockErrorKind::Consensus(reth_consensus::ConsensusError::Other(_))
+        ));
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -25,6 +25,7 @@ use alloy_evm::{
 };
 use alloy_primitives::Address;
 use crossbeam_channel::{Receiver, Sender};
+use reth_engine_primitives::BlockAccessListDecodeError;
 use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Database, EvmEnvFor, ExecutionCtxFor};
 use reth_primitives_traits::ReceiptTy;
 use reth_provider::BlockExecutionOutput;
@@ -193,7 +194,8 @@ fn convert_alloy_to_revm_bal(alloy_bal: &AlloyBal) -> Result<Arc<RevmBal>, BalEx
     // is triggered then the execution is reverted, and as such no actual code change event takes
     // place. Therefore, if we do observe such a bytecode in a BAL then that means the BAL is
     // invalid as no legal execution should've led to this bytecode deployment.
-    let received_bal_revm = RevmBal::clone_from_alloy(alloy_bal.as_vec())?;
+    let received_bal_revm =
+        RevmBal::clone_from_alloy(alloy_bal.as_vec()).map_err(BlockAccessListDecodeError::new)?;
     Ok(Arc::new(received_bal_revm))
 }
 
@@ -461,7 +463,7 @@ mod tests {
         .into();
 
         let error = convert_alloy_to_revm_bal(&alloy_bal).unwrap_err();
-        assert!(matches!(&error, BalExecutionError::BlockAccessListInvalid(_)));
+        assert!(matches!(&error, BalExecutionError::BlockAccessListDecode(_)));
         let error = InsertBlockErrorKind::from(error);
         assert!(matches!(&error, InsertBlockErrorKind::BlockAccessListDecode(_)));
         assert!(matches!(

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -324,7 +324,7 @@ impl BlockGasTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree::error::InsertBlockErrorKind;
+    use crate::tree::error::{InsertBlockErrorKind, InsertBlockProcessingError};
     use alloy_consensus::{BlockHeader, Header};
     use alloy_eip7928::{
         bal::Bal as AlloyBal, AccountChanges, BlockAccessIndex, BlockAccessList, CodeChange,
@@ -449,7 +449,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_bal_bytecode_is_a_consensus_error() {
+    fn invalid_bal_bytecode_is_malformed_input() {
         let alloy_bal = vec![AccountChanges {
             address: Address::ZERO,
             code_changes: vec![CodeChange::new(
@@ -462,9 +462,11 @@ mod tests {
 
         let error = convert_alloy_to_revm_bal(&alloy_bal).unwrap_err();
         assert!(matches!(&error, BalExecutionError::BlockAccessListInvalid(_)));
+        let error = InsertBlockErrorKind::from(error);
+        assert!(matches!(&error, InsertBlockErrorKind::BlockAccessListDecode(_)));
         assert!(matches!(
-            InsertBlockErrorKind::from(error),
-            InsertBlockErrorKind::Consensus(reth_consensus::ConsensusError::Other(_))
+            error.ensure_validation_error(),
+            Err(InsertBlockProcessingError::MalformedInput(_))
         ));
     }
 


### PR DESCRIPTION
Follow-up to #26829.

Moves decoded BAL conversion failures out of `ConsensusError` and into `BalExecutionError::BlockAccessListDecode` using the shared `BlockAccessListDecodeError` wrapper. The wrapped error passes directly into `InsertBlockErrorKind`, so `newPayload` returns invalid params without marking the block invalid.