### PR TITLE
fix(txpool): hold sidecar permit until conversion completes

### DIFF
--- a/crates/transaction-pool/src/blobstore/converter.rs
+++ b/crates/transaction-pool/src/blobstore/converter.rs
@@ -21,10 +21,13 @@ impl BlobSidecarConverter {
         &self,
         sidecar: BlobTransactionSidecar,
     ) -> Option<BlobTransactionSidecarEip7594> {
-        let _permit = SEMAPHORE.acquire().await.ok()?;
-        tokio::task::spawn_blocking(move || sidecar.try_into_7594(EnvKzgSettings::Default.get()))
-            .await
-            .ok()?
-            .ok()
+        let permit = SEMAPHORE.acquire().await.ok()?;
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            sidecar.try_into_7594(EnvKzgSettings::Default.get())
+        })
+        .await
+        .ok()?
+        .ok()
     }
 }


### PR DESCRIPTION
Move the semaphore permit into the blocking conversion task so cancelled callers cannot release capacity while the conversion is still running.