### PR TITLE
refactor(rpc): simplify helper trait composition

### DIFF
--- a/crates/e2e-test-utils/src/rpc.rs
+++ b/crates/e2e-test-utils/src/rpc.rs
@@ -6,7 +6,6 @@ use reth_chainspec::EthereumHardforks;
 use reth_node_api::{BlockTy, FullNodeComponents};
 use reth_node_builder::{rpc::RpcRegistry, NodeTypes};
 use reth_provider::BlockReader;
-use reth_rpc_api::DebugApiServer;
 use reth_rpc_eth_api::{
     helpers::{EthApiSpec, EthTransactions, TraceExt},
     EthApiTypes,
@@ -35,7 +34,7 @@ where
         &self,
         hash: B256,
     ) -> eyre::Result<EthereumTxEnvelope<TxEip4844Variant<BlobTransactionSidecarVariant>>> {
-        let tx = self.inner.debug_api().raw_transaction(hash).await?.unwrap();
+        let tx = self.inner.eth_api().raw_transaction_by_hash(hash).await?.unwrap();
         let tx = tx.to_vec();
         Ok(EthereumTxEnvelope::decode_2718(&mut tx.as_ref()).unwrap())
     }

--- a/crates/rpc/rpc-builder/src/lib.rs
+++ b/crates/rpc/rpc-builder/src/lib.rs
@@ -45,8 +45,8 @@ use reth_rpc_api::servers::*;
 use reth_rpc_engine_api::RethEngineApi;
 use reth_rpc_eth_api::{
     helpers::{
-        pending_block::PendingEnvBuilder, Call, EthApiSpec, EthTransactions, LoadPendingBlock,
-        TraceExt,
+        pending_block::PendingEnvBuilder, Call, EthApiSpec, EthTransactions, GetBlockAccessList,
+        LoadPendingBlock, TraceExt,
     },
     node::RpcNodeCoreAdapter,
     EthApiServer, EthApiTypes, FullEthApiServer, FullEthApiTypes, RpcBlock, RpcConvert,
@@ -710,7 +710,7 @@ where
     /// If called outside of the tokio runtime. See also [`Self::eth_api`]
     pub fn register_debug(&mut self) -> &mut Self
     where
-        EthApi: EthTransactions + TraceExt,
+        EthApi: EthTransactions + TraceExt + GetBlockAccessList,
     {
         let debug_api = self.debug_api();
         self.modules.insert(RethRpcModule::Debug, debug_api.into_rpc().into());

--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -10,12 +10,12 @@ use reth_rpc_eth_types::{error::FromEthApiError, EthApiError};
 use reth_storage_api::StateProviderFactory;
 
 use crate::{
-    helpers::{Call, LoadBlock, Trace},
-    RpcNodeCore, RpcNodeCoreExt,
+    helpers::{LoadBlock, Trace},
+    RpcNodeCore,
 };
 
 /// Helper trait for `eth_blockAccessList` RPC method.
-pub trait GetBlockAccessList: Trace + Call + LoadBlock + RpcNodeCoreExt {
+pub trait GetBlockAccessList: Trace + LoadBlock {
     /// Retrieves the block access list for a block identified by its hash.
     fn get_block_access_list(
         &self,

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -23,7 +23,7 @@ use crate::EthApiTypes;
 /// This provides access to semaphores that permit how many of those are permitted concurrently.
 /// It's expected that tracing related tasks are configured with a lower threshold, because not only
 /// are they CPU heavy but they can also accumulate more memory for the traces.
-pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
+pub trait SpawnBlocking: EthApiTypes + 'static {
     /// Returns a handle for spawning IO heavy blocking tasks.
     ///
     /// Runtime access in default trait method implementations.

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -53,7 +53,7 @@ pub type SimulatedBlocksResult<N, E> = Result<Vec<SimulatedBlock<RpcBlock<N>>>, 
 
 /// Execution related functions for the [`EthApiServer`](crate::EthApiServer) trait in
 /// the `eth_` namespace.
-pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthApiTypes {
+pub trait EthCall: EstimateCall + LoadBlock + FullEthApiTypes {
     /// Estimate gas needed for execution of the `request` at the [`BlockId`].
     fn estimate_gas_at(
         &self,

--- a/crates/rpc/rpc-eth-api/src/helpers/mod.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/mod.rs
@@ -44,44 +44,35 @@ pub use subscriptions::EthSubscriptions;
 pub use trace::Trace;
 pub use transaction::{EthTransactions, LoadTransaction};
 
-use crate::FullEthApiTypes;
-
 /// Extension trait that bundles traits needed for tracing transactions.
-pub trait TraceExt:
-    LoadTransaction + LoadBlock + SpawnBlocking + Trace + Call + GetBlockAccessList
-{
-}
+pub trait TraceExt: LoadTransaction + LoadBlock + Trace {}
 
-impl<T> TraceExt for T where T: LoadTransaction + LoadBlock + Trace + Call + GetBlockAccessList {}
+impl<T> TraceExt for T where T: LoadTransaction + LoadBlock + Trace {}
 
 /// Helper trait to unify all `eth` rpc server building block traits, for simplicity.
 ///
 /// This trait is automatically implemented for any type that implements all the `Eth` traits.
 pub trait FullEthApi:
-    FullEthApiTypes
-    + EthApiSpec
+    EthApiSpec
     + EthTransactions
     + EthBlocks
     + EthState
     + EthCall
     + EthFees
     + EthSubscriptions
-    + Trace
     + LoadReceipt
     + GetBlockAccessList
 {
 }
 
 impl<T> FullEthApi for T where
-    T: FullEthApiTypes
-        + EthApiSpec
+    T: EthApiSpec
         + EthTransactions
         + EthBlocks
         + EthState
         + EthCall
         + EthFees
         + EthSubscriptions
-        + Trace
         + LoadReceipt
         + GetBlockAccessList
 {

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -1,6 +1,6 @@
 //! Loads a pending block from database. Helper trait for `eth_` call and trace RPC methods.
 
-use super::{Call, LoadBlock, LoadState, LoadTransaction};
+use super::{Call, LoadBlock, LoadTransaction};
 use crate::{FromEthApiError, FromEvmError};
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_eip7928::bal::DecodedBal;
@@ -20,7 +20,7 @@ use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use std::sync::Arc;
 
 /// Executes CPU heavy tasks.
-pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
+pub trait Trace: Call {
     /// Executes the [`TxEnvFor`] with [`reth_evm::EvmEnv`] against the given [`StateCacheDb`]
     /// without committing state changes.
     fn inspect<'a>(

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -8,7 +8,7 @@ use reth_node_api::{FullNodeComponents, NodePrimitives, PrimitivesTy};
 use reth_primitives_traits::{BlockTy, HeaderTy, ReceiptTy, TxTy};
 use reth_rpc_eth_types::EthStateCache;
 use reth_storage_api::{
-    BalProvider, BlockReader, BlockReaderIdExt, PruneCheckpointReader, StageCheckpointReader,
+    BalProvider, BlockReaderIdExt, PruneCheckpointReader, StageCheckpointReader,
     StateProviderFactory,
 };
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
@@ -98,7 +98,7 @@ where
 
 /// Additional components, asides the core node components, needed to run `eth_` namespace API
 /// server.
-pub trait RpcNodeCoreExt: RpcNodeCore<Provider: BlockReader> {
+pub trait RpcNodeCoreExt: RpcNodeCore {
     /// Returns handle to RPC cache service.
     fn cache(&self) -> &EthStateCache<Self::Primitives>;
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -28,7 +28,7 @@ use reth_revm::{db::State, witness::ExecutionWitnessRecord};
 use reth_rpc_api::DebugApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
-    helpers::{EthTransactions, TraceExt},
+    helpers::{EthTransactions, GetBlockAccessList, TraceExt},
     FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
@@ -842,7 +842,7 @@ where
 #[async_trait]
 impl<Eth> DebugApiServer<RpcTxReq<Eth::NetworkTypes>> for DebugApi<Eth>
 where
-    Eth: EthTransactions + TraceExt,
+    Eth: EthTransactions + TraceExt + GetBlockAccessList,
 {
     /// Handler for `debug_getRawHeader`
     async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes> {


### PR DESCRIPTION
Collapses redundant RPC helper-trait supertraits so each capability is expressed once through existing implications. Keeps block-access-list access explicit at Debug and routes the e2e raw-transaction lookup through `EthTransactions` instead of an unrelated Debug bound.