### PR TITLE
feat(downloader): select accounts with storage for snap storage requests

### DIFF
--- a/crates/net/downloaders/src/snap/mod.rs
+++ b/crates/net/downloaders/src/snap/mod.rs
@@ -119,30 +119,40 @@ impl VerifiedAccountRange {
 
     /// Borrows the accounts together with the root that authenticated them.
     pub fn batch(&self) -> VerifiedAccountBatch<'_> {
-        VerifiedAccountBatch { state_root: self.state_root, accounts: &self.accounts }
+        VerifiedAccountBatch {
+            state_root: self.state_root,
+            accounts: self.accounts.iter().map(|(hash, account)| (*hash, account)).collect(),
+        }
     }
 
-    /// Borrows a positional subrange of the accounts, so a caller can request storage in bounded
-    /// chunks without losing the root that authenticated them.
+    /// Borrows only the accounts that have storage, together with the root that authenticated
+    /// them.
     ///
-    /// `None` when the range falls outside the response.
-    pub fn batch_range(&self, range: Range<usize>) -> Option<VerifiedAccountBatch<'_>> {
-        self.accounts
-            .get(range)
-            .map(|accounts| VerifiedAccountBatch { state_root: self.state_root, accounts })
+    /// Accounts without storage are omitted because snap storage responses do not preserve an
+    /// outer-list position for them. Empty when no account in the range has storage.
+    pub fn storage_batch(&self) -> VerifiedAccountBatch<'_> {
+        VerifiedAccountBatch {
+            state_root: self.state_root,
+            accounts: self
+                .accounts
+                .iter()
+                .filter(|(_, account)| account.storage_root != EMPTY_ROOT_HASH)
+                .map(|(hash, account)| (*hash, account))
+                .collect(),
+        }
     }
 }
 
 /// Accounts and the state root they were authenticated against.
 ///
-/// Only obtainable from [`VerifiedAccountRange::batch`], so requests built from it can always be
-/// checked against the root the accounts came from.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Only obtainable from [`VerifiedAccountRange`], so requests built from it can always be checked
+/// against the root the accounts came from.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VerifiedAccountBatch<'a> {
     // Root and accounts travel together, so neither can be swapped for another generation's.
     state_root: B256,
     // Accounts the root authenticated, in response order.
-    accounts: &'a [(B256, TrieAccount)],
+    accounts: Vec<(B256, &'a TrieAccount)>,
 }
 
 impl<'a> VerifiedAccountBatch<'a> {
@@ -152,8 +162,18 @@ impl<'a> VerifiedAccountBatch<'a> {
     }
 
     /// Accounts in the order the range returned them.
-    pub const fn accounts(&self) -> &'a [(B256, TrieAccount)] {
+    pub fn accounts(&self) -> &[(B256, &'a TrieAccount)] {
+        &self.accounts
+    }
+
+    /// Borrows a positional subrange of the batch, so storage can be requested in bounded chunks
+    /// without losing the root that authenticated the accounts.
+    ///
+    /// `None` when the range falls outside the batch.
+    pub fn range(&self, range: Range<usize>) -> Option<Self> {
         self.accounts
+            .get(range)
+            .map(|accounts| Self { state_root: self.state_root, accounts: accounts.to_vec() })
     }
 
     // Confirms the batch is the one `request` was built from, so every returned range is checked
@@ -175,7 +195,7 @@ impl<'a> VerifiedAccountBatch<'a> {
             })
         }
         for (index, (requested, (supplied, _))) in
-            request.account_hashes.iter().zip(self.accounts).enumerate()
+            request.account_hashes.iter().zip(&self.accounts).enumerate()
         {
             if requested != supplied {
                 return Err(InvalidStorageRangeRequest::AccountMismatch {
@@ -189,8 +209,11 @@ impl<'a> VerifiedAccountBatch<'a> {
     }
 
     // The accounts from `from` onwards under the same state root, or none if the batch is shorter.
-    pub(super) fn slice(&self, from: usize) -> Option<Self> {
-        self.accounts.get(from..).map(|accounts| Self { state_root: self.state_root, accounts })
+    pub(super) fn slice(mut self, from: usize) -> Option<Self> {
+        (from <= self.accounts.len()).then(|| {
+            self.accounts.drain(..from);
+            self
+        })
     }
 }
 
@@ -430,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn batch_range_narrows_the_accounts_and_keeps_their_root() {
+    fn a_subrange_narrows_the_accounts_and_keeps_their_root() {
         let accounts = vec![(key(1), account(7)), (key(2), account(8)), (key(3), account(9))];
         let root_hash = root(&accounts);
         let range = VerifiedAccountRange {
@@ -440,11 +463,42 @@ mod tests {
             next: None,
         };
 
-        let chunk = range.batch_range(1..3).expect("chunk is inside the range");
-        assert_eq!(chunk.accounts(), &accounts[1..3]);
+        let batch = range.batch();
+        let chunk = batch.range(1..3).expect("chunk is inside the batch");
+        let expected =
+            accounts[1..3].iter().map(|(hash, account)| (*hash, account)).collect::<Vec<_>>();
+        assert_eq!(chunk.accounts(), expected);
         assert_eq!(chunk.state_root(), root_hash);
 
-        assert_eq!(range.batch_range(2..4), None);
+        assert_eq!(batch.range(2..4), None);
+    }
+
+    #[test]
+    fn storage_batch_omits_interleaved_accounts_without_storage() {
+        let mut first = account(1);
+        first.storage_root = B256::repeat_byte(0x11);
+        let empty = account(2);
+        let mut third = account(3);
+        third.storage_root = B256::repeat_byte(0x33);
+        let accounts = vec![(key(1), first), (key(2), empty), (key(3), third)];
+        let root_hash = root(&accounts);
+        let range =
+            VerifiedAccountRange { state_root: root_hash, accounts, has_more: false, next: None };
+
+        let batch = range.storage_batch();
+
+        assert_eq!(batch.state_root(), root_hash);
+        assert_eq!(
+            batch.accounts().iter().map(|(hash, _)| *hash).collect::<Vec<_>>(),
+            vec![key(1), key(3)]
+        );
+
+        let chunk = batch.range(1..2).expect("chunk is inside the batch");
+        assert_eq!(
+            chunk.accounts().iter().map(|(hash, _)| *hash).collect::<Vec<_>>(),
+            vec![key(3)]
+        );
+        assert_eq!(chunk.state_root(), root_hash);
     }
 
     #[test]

--- a/crates/net/downloaders/src/snap/storage.rs
+++ b/crates/net/downloaders/src/snap/storage.rs
@@ -39,13 +39,13 @@ impl<C: SnapClient> StorageRangeDownloader<C> {
     /// root; their storage roots authenticate the returned ranges. Pairing a batch with a request
     /// for another root would penalize a peer that answered honestly.
     ///
-    /// Accounts with empty storage roots must be omitted because Snap responses do not preserve
-    /// an outer-list position for them. Use [`super::VerifiedAccountRange::batch_range`] to select
-    /// the accounts included in the request without losing their state-root provenance.
+    /// Accounts without storage must be omitted, since snap responses do not preserve an
+    /// outer-list position for them. [`super::VerifiedAccountRange::storage_batch`] selects the
+    /// accounts to request, and [`VerifiedAccountBatch::range`] splits them into bounded chunks.
     pub fn new(
         client: C,
         request: GetStorageRangesMessage,
-        batch: VerifiedAccountBatch<'_>,
+        batch: &VerifiedAccountBatch<'_>,
         runtime: Runtime,
     ) -> Result<Self, InvalidStorageRangeRequest> {
         let origin = request.starting_hash.unwrap_or(B256::ZERO);
@@ -506,6 +506,10 @@ mod tests {
         slots.iter().map(|(hash, value)| StorageData::from_value(*hash, *value)).collect()
     }
 
+    fn account_refs(accounts: &[(B256, TrieAccount)]) -> Vec<(B256, &TrieAccount)> {
+        accounts.iter().map(|(hash, account)| (*hash, account)).collect()
+    }
+
     fn request(accounts: &[(B256, TrieAccount)]) -> GetStorageRangesMessage {
         GetStorageRangesMessage {
             request_id: 1,
@@ -542,7 +546,7 @@ mod tests {
         accounts: &[(B256, TrieAccount)],
     ) -> Result<StorageRangeDownloader<C>, InvalidStorageRangeRequest> {
         let range = verified_range(accounts);
-        StorageRangeDownloader::new(client, request, range.batch(), Runtime::test())
+        StorageRangeDownloader::new(client, request, &range.batch(), Runtime::test())
     }
 
     #[tokio::test]
@@ -626,27 +630,28 @@ mod tests {
     }
 
     #[test]
-    fn a_mixed_batch_with_an_empty_storage_root_is_refused_before_submission() {
+    fn empty_storage_roots_must_be_filtered_before_submission() {
         let accounts = vec![
-            (key(100), account(EMPTY_ROOT_HASH)),
-            (key(200), account(B256::repeat_byte(0xbb))),
+            (key(100), account(B256::repeat_byte(0xaa))),
+            (key(200), account(EMPTY_ROOT_HASH)),
+            (key(300), account(B256::repeat_byte(0xbb))),
         ];
         let client = TestSnapClient::new([response(PeerId::random(), 1, Vec::new(), Vec::new())]);
 
         assert_eq!(
             downloader(&client, request(&accounts), &accounts).unwrap_err(),
-            InvalidStorageRangeRequest::EmptyStorageRoot { index: 0, account_hash: key(100) }
+            InvalidStorageRangeRequest::EmptyStorageRoot { index: 1, account_hash: key(200) }
         );
         assert!(client.priorities().is_empty());
 
         let range = verified_range(&accounts);
-        assert!(StorageRangeDownloader::new(
-            &client,
-            request(&accounts[1..]),
-            range.batch_range(1..2).unwrap(),
-            Runtime::test(),
-        )
-        .is_ok());
+        let batch = range.storage_batch();
+        let mut storage_request = request(&accounts);
+        storage_request.account_hashes = batch.accounts().iter().map(|(hash, _)| *hash).collect();
+        assert_eq!(storage_request.account_hashes, vec![key(100), key(300)]);
+        assert!(
+            StorageRangeDownloader::new(&client, storage_request, &batch, Runtime::test()).is_ok()
+        );
         assert_eq!(*client.priorities(), [Priority::Normal]);
     }
 
@@ -820,7 +825,7 @@ mod tests {
         let StorageRangeOutcome::Verified(verified) = outcome else { panic!("verified ranges") };
         let range = verified_range(&accounts);
         let (follow_up, narrowed) = verified.follow_up(2, range.batch()).unwrap().unwrap();
-        assert_eq!(narrowed.accounts(), &accounts[..]);
+        assert_eq!(narrowed.accounts(), account_refs(&accounts));
         assert_eq!(follow_up.request_id, 2);
         assert_eq!(follow_up.root_hash, bounded.root_hash);
         assert_eq!(follow_up.account_hashes, bounded.account_hashes);
@@ -859,7 +864,7 @@ mod tests {
 
         let range = verified_range(&accounts);
         let (follow_up, narrowed) = verified.follow_up(2, range.batch()).unwrap().unwrap();
-        assert_eq!(narrowed.accounts(), &accounts[1..]);
+        assert_eq!(narrowed.accounts(), account_refs(&accounts[1..]));
         assert_eq!(follow_up.account_hashes, vec![key(200)]);
         assert_eq!(follow_up.starting_hash, key(2).into());
         assert_eq!(follow_up.limit_hash, RangeBound::default());
@@ -952,7 +957,7 @@ mod tests {
             let outcome = StorageRangeDownloader::new(
                 Arc::clone(&client),
                 request.clone(),
-                batch,
+                &batch,
                 Runtime::test(),
             )
             .unwrap()
@@ -965,7 +970,7 @@ mod tests {
             let (follow_up, narrowed) =
                 verified.follow_up(request.request_id + 1, batch).unwrap().unwrap();
             assert_eq!(follow_up.account_hashes.len(), remaining);
-            assert_eq!(narrowed.accounts(), &accounts[accounts.len() - remaining..]);
+            assert_eq!(narrowed.accounts(), account_refs(&accounts[accounts.len() - remaining..]));
             request = follow_up;
             batch = narrowed;
         }


### PR DESCRIPTION
Follow up https://github.com/paradigmxyz/reth/pull/26814#discussion_r3870802583

Adds `VerifiedAccountRange::storage_batch`, which drops accounts without storage instead of forcing a separate request around each interleaved EOA. 

Chunking moves from `batch_range` onto `VerifiedAccountBatch::range` so it composes with the filter, and `StorageRangeDownloader::new` borrows the batch.