### PR TITLE
fix(rpc): return amsterdam payload for testing rpc

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -2,7 +2,7 @@ use crate::{network::NetworkTestContext, payload::PayloadTestContext, rpc::RpcTe
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_eips::BlockId;
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, Sealable, B256};
-use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV5, ForkchoiceState};
+use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV6, ForkchoiceState};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use eyre::Ok;
 use futures_util::Future;
@@ -353,11 +353,11 @@ where
     pub async fn testing_build_block_v1(
         &self,
         request: TestingBuildBlockRequestV1,
-    ) -> eyre::Result<ExecutionPayloadEnvelopeV5> {
+    ) -> eyre::Result<ExecutionPayloadEnvelopeV6> {
         let client =
             self.rpc_client().ok_or_else(|| eyre::eyre!("HTTP RPC client not available"))?;
 
-        let res: ExecutionPayloadEnvelopeV5 =
+        let res: ExecutionPayloadEnvelopeV6 =
             client.request("testing_buildBlockV1", request.into_params()).await?;
         eyre::Ok(res)
     }

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -2,7 +2,9 @@ use crate::{network::NetworkTestContext, payload::PayloadTestContext, rpc::RpcTe
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_eips::BlockId;
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, Sealable, B256};
-use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV6, ForkchoiceState};
+use alloy_rpc_types_engine::{
+    ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6, ForkchoiceState,
+};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use eyre::Ok;
 use futures_util::Future;
@@ -17,7 +19,7 @@ use reth_provider::{
     BlockReader, BlockReaderIdExt, CanonStateNotificationStream, CanonStateSubscriptions,
     HeaderProvider, StageCheckpointReader,
 };
-use reth_rpc_api::TestingBuildBlockRequestV1;
+use reth_rpc_api::{TestingBuildBlockRequestV1, TestingBuildBlockResponse};
 use reth_rpc_builder::auth::AuthServerHandle;
 use reth_rpc_eth_api::helpers::{EthApiSpec, EthTransactions, TraceExt};
 use reth_stages_types::StageId;
@@ -353,12 +355,35 @@ where
     pub async fn testing_build_block_v1(
         &self,
         request: TestingBuildBlockRequestV1,
+    ) -> eyre::Result<ExecutionPayloadEnvelopeV5> {
+        let client =
+            self.rpc_client().ok_or_else(|| eyre::eyre!("HTTP RPC client not available"))?;
+
+        let res: TestingBuildBlockResponse =
+            client.request("testing_buildBlockV1", request.into_params()).await?;
+        match res {
+            TestingBuildBlockResponse::V5(envelope) => eyre::Ok(envelope),
+            TestingBuildBlockResponse::V6(_) => {
+                Err(eyre::eyre!("testing_buildBlockV1 returned an Amsterdam payload"))
+            }
+        }
+    }
+
+    /// Calls `testing_buildBlockV1` and retains the Amsterdam payload fields.
+    pub async fn testing_build_block_v1_amsterdam(
+        &self,
+        request: TestingBuildBlockRequestV1,
     ) -> eyre::Result<ExecutionPayloadEnvelopeV6> {
         let client =
             self.rpc_client().ok_or_else(|| eyre::eyre!("HTTP RPC client not available"))?;
 
-        let res: ExecutionPayloadEnvelopeV6 =
+        let res: TestingBuildBlockResponse =
             client.request("testing_buildBlockV1", request.into_params()).await?;
-        eyre::Ok(res)
+        match res {
+            TestingBuildBlockResponse::V6(envelope) => eyre::Ok(envelope),
+            TestingBuildBlockResponse::V5(_) => {
+                Err(eyre::eyre!("testing_buildBlockV1 returned a pre-Amsterdam payload"))
+            }
+        }
     }
 }

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,4 +1,6 @@
-use crate::utils::{advance_with_random_transactions, eth_payload_attributes};
+use crate::utils::{
+    advance_with_random_transactions, eth_payload_attributes, eth_payload_attributes_amsterdam,
+};
 use alloy_eips::{eip4844::BlobAndProofV1, eip7685::RequestsOrHash};
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
@@ -32,7 +34,7 @@ use ssz::{Decode, Encode};
 use std::sync::Arc;
 
 const ENGINE_EXECUTION_VERSION_HEADER: &str = "Eth-Execution-Version";
-const ENGINE_PRAGUE_FORK_HEADER: &str = "prague";
+const ENGINE_AMSTERDAM_FORK_HEADER: &str = "amsterdam";
 const ENGINE_PAYLOADS_ROUTE: &str = "/engine/v1/payloads";
 const ENGINE_FORKCHOICE_ROUTE: &str = "/engine/v1/forkchoice";
 const ENGINE_V1_BLOBS_ROUTE: &str = "/engine/v1/blobs/v1";
@@ -208,13 +210,17 @@ async fn test_engine_graceful_shutdown() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
+async fn test_testing_build_block_v1_amsterdam() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     let runtime = Runtime::test();
 
     let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
     let chain_spec = Arc::new(
-        ChainSpecBuilder::default().chain(MAINNET.chain).genesis(genesis).osaka_activated().build(),
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(genesis)
+            .amsterdam_activated()
+            .build(),
     );
     let genesis_hash = chain_spec.genesis_hash();
 
@@ -232,20 +238,12 @@ async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let node = NodeTestContext::new(node, eth_payload_attributes).await?;
+    let node = NodeTestContext::new(node, eth_payload_attributes_amsterdam).await?;
 
     let wallet = Wallet::default();
     let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
 
-    let payload_attributes = PayloadAttributes {
-        timestamp: chain_spec.genesis().timestamp + 1,
-        prev_randao: B256::ZERO,
-        suggested_fee_recipient: Address::ZERO,
-        withdrawals: Some(vec![]),
-        parent_beacon_block_root: Some(B256::ZERO),
-        slot_number: None,
-        ..Default::default()
-    };
+    let payload_attributes = eth_payload_attributes_amsterdam(chain_spec.genesis().timestamp + 1);
 
     let request = TestingBuildBlockRequestV1 {
         parent_block_hash: genesis_hash,
@@ -258,7 +256,7 @@ async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
 
     let engine_client = node.auth_server_handle().http_client();
     let payload = envelope.execution_payload.clone();
-    let block_hash = payload.payload_inner.payload_inner.block_hash;
+    let block_hash = payload.payload_inner.payload_inner.payload_inner.block_hash;
 
     let versioned_hashes: Vec<B256> = Vec::new();
     let parent_beacon_block_root = B256::ZERO;
@@ -289,7 +287,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         ChainSpecBuilder::default()
             .chain(MAINNET.chain)
             .genesis(genesis)
-            .prague_activated()
+            .amsterdam_activated()
             .build(),
     );
     let genesis_hash = chain_spec.genesis_hash();
@@ -321,20 +319,12 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let node = NodeTestContext::new(node, eth_payload_attributes).await?;
+    let node = NodeTestContext::new(node, eth_payload_attributes_amsterdam).await?;
 
     let wallets = Wallet::new(2).wallet_gen();
     let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallets[0].clone()).await;
 
-    let payload_attributes = PayloadAttributes {
-        timestamp: chain_spec.genesis().timestamp + 1,
-        prev_randao: B256::ZERO,
-        suggested_fee_recipient: Address::ZERO,
-        withdrawals: Some(vec![]),
-        parent_beacon_block_root: Some(B256::ZERO),
-        slot_number: None,
-        ..Default::default()
-    };
+    let payload_attributes = eth_payload_attributes_amsterdam(chain_spec.genesis().timestamp + 1);
 
     let envelope = node
         .testing_build_block_v1(TestingBuildBlockRequestV1 {
@@ -346,7 +336,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .await?;
 
     let payload = envelope.execution_payload;
-    let block_hash = payload.payload_inner.payload_inner.block_hash;
+    let block_hash = payload.payload_inner.payload_inner.payload_inner.block_hash;
     let client = reqwest::Client::new();
     let auth_server = node.auth_server_handle();
     let auth_url = auth_server.http_url();
@@ -414,7 +404,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
     let new_payload_response = client
         .post(format!("{auth_url}{ENGINE_PAYLOADS_ROUTE}"))
         .header(reqwest::header::AUTHORIZATION, auth_header.to_str()?)
-        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_PRAGUE_FORK_HEADER)
+        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_AMSTERDAM_FORK_HEADER)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
         .header(reqwest::header::ACCEPT, "application/octet-stream")
         .body((payload, B256::ZERO, envelope.execution_requests.take()).as_ssz_bytes())
@@ -428,7 +418,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
     let fcu_response = client
         .post(format!("{auth_url}{ENGINE_FORKCHOICE_ROUTE}"))
         .header(reqwest::header::AUTHORIZATION, auth_header.to_str()?)
-        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_PRAGUE_FORK_HEADER)
+        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_AMSTERDAM_FORK_HEADER)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
         .header(reqwest::header::ACCEPT, "application/octet-stream")
         .body(

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,13 +1,10 @@
-use crate::utils::{
-    advance_with_random_transactions, eth_payload_attributes, eth_payload_attributes_amsterdam,
-};
-use alloy_eips::{
-    eip4844::BlobAndProofV2,
-    eip7685::{Requests, RequestsOrHash},
-};
+use crate::utils::{advance_with_random_transactions, eth_payload_attributes};
+use alloy_eips::{eip4844::BlobAndProofV1, eip7685::RequestsOrHash};
 use alloy_genesis::Genesis;
-use alloy_primitives::B256;
-use alloy_rpc_types_engine::{ClientVersionV1, ForkchoiceState, PayloadStatusEnum};
+use alloy_primitives::{Address, B256};
+use alloy_rpc_types_engine::{
+    ClientVersionV1, ForkchoiceState, PayloadAttributes, PayloadStatusEnum,
+};
 use jsonrpsee_core::client::ClientT;
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
 use reth_e2e_test_utils::{
@@ -22,9 +19,7 @@ use reth_node_core::{
 };
 use reth_node_ethereum::{
     engine_ssz_containers::{
-        ExecutionPayloadEnvelopeAmsterdam, ForkchoiceUpdateAmsterdam,
-        ForkchoiceUpdateResponse as SszForkchoiceUpdateResponse, Optional,
-        PayloadStatus as SszPayloadStatus,
+        ForkchoiceUpdateResponse as SszForkchoiceUpdateResponse, PayloadStatus as SszPayloadStatus,
     },
     engine_ssz_proxy::EngineSszProxyLayer,
     EthereumAddOns, EthereumEngineValidatorBuilder, EthereumNode,
@@ -37,10 +32,10 @@ use ssz::{Decode, Encode};
 use std::sync::Arc;
 
 const ENGINE_EXECUTION_VERSION_HEADER: &str = "Eth-Execution-Version";
-const ENGINE_AMSTERDAM_FORK_HEADER: &str = "amsterdam";
+const ENGINE_PRAGUE_FORK_HEADER: &str = "prague";
 const ENGINE_PAYLOADS_ROUTE: &str = "/engine/v1/payloads";
 const ENGINE_FORKCHOICE_ROUTE: &str = "/engine/v1/forkchoice";
-const ENGINE_V2_BLOBS_ROUTE: &str = "/engine/v1/blobs/v2";
+const ENGINE_V1_BLOBS_ROUTE: &str = "/engine/v1/blobs/v1";
 const ENGINE_CAPABILITIES_ROUTE: &str = "/engine/v1/capabilities";
 const ENGINE_IDENTITY_ROUTE: &str = "/engine/v1/identity";
 
@@ -213,17 +208,13 @@ async fn test_engine_graceful_shutdown() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_testing_build_block_v1_amsterdam() -> eyre::Result<()> {
+async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     let runtime = Runtime::test();
 
     let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
     let chain_spec = Arc::new(
-        ChainSpecBuilder::default()
-            .chain(MAINNET.chain)
-            .genesis(genesis)
-            .amsterdam_activated()
-            .build(),
+        ChainSpecBuilder::default().chain(MAINNET.chain).genesis(genesis).osaka_activated().build(),
     );
     let genesis_hash = chain_spec.genesis_hash();
 
@@ -241,12 +232,20 @@ async fn test_testing_build_block_v1_amsterdam() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let node = NodeTestContext::new(node, eth_payload_attributes_amsterdam).await?;
+    let node = NodeTestContext::new(node, eth_payload_attributes).await?;
 
     let wallet = Wallet::default();
     let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
 
-    let payload_attributes = eth_payload_attributes_amsterdam(chain_spec.genesis().timestamp + 1);
+    let payload_attributes = PayloadAttributes {
+        timestamp: chain_spec.genesis().timestamp + 1,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Address::ZERO,
+        withdrawals: Some(vec![]),
+        parent_beacon_block_root: Some(B256::ZERO),
+        slot_number: None,
+        ..Default::default()
+    };
 
     let request = TestingBuildBlockRequestV1 {
         parent_block_hash: genesis_hash,
@@ -259,7 +258,7 @@ async fn test_testing_build_block_v1_amsterdam() -> eyre::Result<()> {
 
     let engine_client = node.auth_server_handle().http_client();
     let payload = envelope.execution_payload.clone();
-    let block_hash = payload.payload_inner.payload_inner.payload_inner.block_hash;
+    let block_hash = payload.payload_inner.payload_inner.block_hash;
 
     let versioned_hashes: Vec<B256> = Vec::new();
     let parent_beacon_block_root = B256::ZERO;
@@ -267,7 +266,7 @@ async fn test_testing_build_block_v1_amsterdam() -> eyre::Result<()> {
 
     let status: alloy_rpc_types_engine::PayloadStatus = engine_client
         .request(
-            "engine_newPayloadV5",
+            "engine_newPayloadV4",
             (payload, versioned_hashes, parent_beacon_block_root, execution_requests),
         )
         .await?;
@@ -290,7 +289,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         ChainSpecBuilder::default()
             .chain(MAINNET.chain)
             .genesis(genesis)
-            .amsterdam_activated()
+            .prague_activated()
             .build(),
     );
     let genesis_hash = chain_spec.genesis_hash();
@@ -299,7 +298,6 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
             RpcServerArgs::default()
                 .with_unused_ports()
                 .with_http()
-                .with_force_blob_sidecar_upcasting()
                 .with_http_api(reth_rpc_server_types::RpcModuleSelection::All),
         );
 
@@ -323,12 +321,20 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .launch()
         .await?;
 
-    let node = NodeTestContext::new(node, eth_payload_attributes_amsterdam).await?;
+    let node = NodeTestContext::new(node, eth_payload_attributes).await?;
 
     let wallets = Wallet::new(2).wallet_gen();
     let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallets[0].clone()).await;
 
-    let payload_attributes = eth_payload_attributes_amsterdam(chain_spec.genesis().timestamp + 1);
+    let payload_attributes = PayloadAttributes {
+        timestamp: chain_spec.genesis().timestamp + 1,
+        prev_randao: B256::ZERO,
+        suggested_fee_recipient: Address::ZERO,
+        withdrawals: Some(vec![]),
+        parent_beacon_block_root: Some(B256::ZERO),
+        slot_number: None,
+        ..Default::default()
+    };
 
     let envelope = node
         .testing_build_block_v1(TestingBuildBlockRequestV1 {
@@ -340,7 +346,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .await?;
 
     let payload = envelope.execution_payload;
-    let block_hash = payload.payload_inner.payload_inner.payload_inner.block_hash;
+    let block_hash = payload.payload_inner.payload_inner.block_hash;
     let client = reqwest::Client::new();
     let auth_server = node.auth_server_handle();
     let auth_url = auth_server.http_url();
@@ -408,17 +414,10 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
     let new_payload_response = client
         .post(format!("{auth_url}{ENGINE_PAYLOADS_ROUTE}"))
         .header(reqwest::header::AUTHORIZATION, auth_header.to_str()?)
-        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_AMSTERDAM_FORK_HEADER)
+        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_PRAGUE_FORK_HEADER)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
         .header(reqwest::header::ACCEPT, "application/octet-stream")
-        .body(
-            ExecutionPayloadEnvelopeAmsterdam {
-                payload,
-                parent_beacon_block_root: B256::ZERO,
-                execution_requests: Requests::from_requests(envelope.execution_requests.take()),
-            }
-            .as_ssz_bytes(),
-        )
+        .body((payload, B256::ZERO, envelope.execution_requests.take()).as_ssz_bytes())
         .send()
         .await?;
     assert_eq!(new_payload_response.status(), reqwest::StatusCode::OK);
@@ -429,20 +428,19 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
     let fcu_response = client
         .post(format!("{auth_url}{ENGINE_FORKCHOICE_ROUTE}"))
         .header(reqwest::header::AUTHORIZATION, auth_header.to_str()?)
-        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_AMSTERDAM_FORK_HEADER)
+        .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_PRAGUE_FORK_HEADER)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
         .header(reqwest::header::ACCEPT, "application/octet-stream")
         .body(
-            ForkchoiceUpdateAmsterdam {
-                forkchoice_state: ForkchoiceState {
+            (
+                ForkchoiceState {
                     head_block_hash: block_hash,
                     safe_block_hash: genesis_hash,
                     finalized_block_hash: genesis_hash,
                 },
-                payload_attributes: Optional::none(),
-                custody_columns: Optional::none(),
-            }
-            .as_ssz_bytes(),
+                Vec::<PayloadAttributes>::new(),
+            )
+                .as_ssz_bytes(),
         )
         .send()
         .await?;
@@ -454,7 +452,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
     let versioned_hashes = TransactionTestContext::validate_sidecar(envelope);
 
     let blobs_response = client
-        .post(format!("{auth_url}{ENGINE_V2_BLOBS_ROUTE}"))
+        .post(format!("{auth_url}{ENGINE_V1_BLOBS_ROUTE}"))
         .header(reqwest::header::AUTHORIZATION, auth_header.to_str()?)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
         .header(reqwest::header::ACCEPT, "application/octet-stream")
@@ -463,8 +461,10 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .await?;
     assert_eq!(blobs_response.status(), reqwest::StatusCode::OK);
 
-    let blobs = Vec::<BlobAndProofV2>::from_ssz_bytes(&blobs_response.bytes().await?).unwrap();
+    let blobs =
+        Vec::<Option<BlobAndProofV1>>::from_ssz_bytes(&blobs_response.bytes().await?).unwrap();
     assert_eq!(blobs.len(), versioned_hashes.len());
+    assert!(blobs.iter().all(Option::is_some));
 
     let fcu = SszForkchoiceUpdateResponse::from_ssz_bytes(&fcu_response.bytes().await?).unwrap();
     assert_eq!(fcu.payload_status.status, PayloadStatusEnum::Valid);

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,7 +1,10 @@
 use crate::utils::{
     advance_with_random_transactions, eth_payload_attributes, eth_payload_attributes_amsterdam,
 };
-use alloy_eips::eip7685::{Requests, RequestsOrHash};
+use alloy_eips::{
+    eip4844::BlobAndProofV2,
+    eip7685::{Requests, RequestsOrHash},
+};
 use alloy_genesis::Genesis;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ClientVersionV1, ForkchoiceState, PayloadStatusEnum};
@@ -37,6 +40,7 @@ const ENGINE_EXECUTION_VERSION_HEADER: &str = "Eth-Execution-Version";
 const ENGINE_AMSTERDAM_FORK_HEADER: &str = "amsterdam";
 const ENGINE_PAYLOADS_ROUTE: &str = "/engine/v1/payloads";
 const ENGINE_FORKCHOICE_ROUTE: &str = "/engine/v1/forkchoice";
+const ENGINE_V2_BLOBS_ROUTE: &str = "/engine/v1/blobs/v2";
 const ENGINE_CAPABILITIES_ROUTE: &str = "/engine/v1/capabilities";
 const ENGINE_IDENTITY_ROUTE: &str = "/engine/v1/identity";
 
@@ -295,6 +299,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
             RpcServerArgs::default()
                 .with_unused_ports()
                 .with_http()
+                .with_force_blob_sidecar_upcasting()
                 .with_http_api(reth_rpc_server_types::RpcModuleSelection::All),
         );
 
@@ -320,7 +325,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
 
     let node = NodeTestContext::new(node, eth_payload_attributes_amsterdam).await?;
 
-    let wallets = Wallet::new(1).wallet_gen();
+    let wallets = Wallet::new(2).wallet_gen();
     let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallets[0].clone()).await;
 
     let payload_attributes = eth_payload_attributes_amsterdam(chain_spec.genesis().timestamp + 1);
@@ -442,6 +447,24 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .send()
         .await?;
     assert_eq!(fcu_response.status(), reqwest::StatusCode::OK);
+
+    let blob_tx = TransactionTestContext::tx_with_blobs_bytes(1, wallets[1].clone()).await?;
+    let blob_tx_hash = node.rpc.inject_tx(blob_tx).await?;
+    let envelope = node.rpc.envelope_by_hash(blob_tx_hash).await?;
+    let versioned_hashes = TransactionTestContext::validate_sidecar(envelope);
+
+    let blobs_response = client
+        .post(format!("{auth_url}{ENGINE_V2_BLOBS_ROUTE}"))
+        .header(reqwest::header::AUTHORIZATION, auth_header.to_str()?)
+        .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+        .header(reqwest::header::ACCEPT, "application/octet-stream")
+        .body(versioned_hashes.as_ssz_bytes())
+        .send()
+        .await?;
+    assert_eq!(blobs_response.status(), reqwest::StatusCode::OK);
+
+    let blobs = Vec::<BlobAndProofV2>::from_ssz_bytes(&blobs_response.bytes().await?).unwrap();
+    assert_eq!(blobs.len(), versioned_hashes.len());
 
     let fcu = SszForkchoiceUpdateResponse::from_ssz_bytes(&fcu_response.bytes().await?).unwrap();
     assert_eq!(fcu.payload_status.status, PayloadStatusEnum::Valid);

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,7 +1,10 @@
 use crate::utils::{
     advance_with_random_transactions, eth_payload_attributes, eth_payload_attributes_amsterdam,
 };
-use alloy_eips::{eip4844::BlobAndProofV1, eip7685::RequestsOrHash};
+use alloy_eips::{
+    eip4844::BlobAndProofV1,
+    eip7685::{Requests, RequestsOrHash},
+};
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{
@@ -21,7 +24,9 @@ use reth_node_core::{
 };
 use reth_node_ethereum::{
     engine_ssz_containers::{
-        ForkchoiceUpdateResponse as SszForkchoiceUpdateResponse, PayloadStatus as SszPayloadStatus,
+        ExecutionPayloadEnvelopeAmsterdam, ForkchoiceUpdateAmsterdam,
+        ForkchoiceUpdateResponse as SszForkchoiceUpdateResponse, Optional,
+        PayloadStatus as SszPayloadStatus,
     },
     engine_ssz_proxy::EngineSszProxyLayer,
     EthereumAddOns, EthereumEngineValidatorBuilder, EthereumNode,
@@ -264,7 +269,7 @@ async fn test_testing_build_block_v1_amsterdam() -> eyre::Result<()> {
 
     let status: alloy_rpc_types_engine::PayloadStatus = engine_client
         .request(
-            "engine_newPayloadV4",
+            "engine_newPayloadV5",
             (payload, versioned_hashes, parent_beacon_block_root, execution_requests),
         )
         .await?;
@@ -407,7 +412,14 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .header(ENGINE_EXECUTION_VERSION_HEADER, ENGINE_AMSTERDAM_FORK_HEADER)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
         .header(reqwest::header::ACCEPT, "application/octet-stream")
-        .body((payload, B256::ZERO, envelope.execution_requests.take()).as_ssz_bytes())
+        .body(
+            ExecutionPayloadEnvelopeAmsterdam {
+                payload,
+                parent_beacon_block_root: B256::ZERO,
+                execution_requests: Requests::from_requests(envelope.execution_requests.take()),
+            }
+            .as_ssz_bytes(),
+        )
         .send()
         .await?;
     assert_eq!(new_payload_response.status(), reqwest::StatusCode::OK);
@@ -422,15 +434,16 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
         .header(reqwest::header::ACCEPT, "application/octet-stream")
         .body(
-            (
-                ForkchoiceState {
+            ForkchoiceUpdateAmsterdam {
+                forkchoice_state: ForkchoiceState {
                     head_block_hash: block_hash,
                     safe_block_hash: genesis_hash,
                     finalized_block_hash: genesis_hash,
                 },
-                Vec::<PayloadAttributes>::new(),
-            )
-                .as_ssz_bytes(),
+                payload_attributes: Optional::none(),
+                custody_columns: Optional::none(),
+            }
+            .as_ssz_bytes(),
         )
         .send()
         .await?;

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -1,15 +1,10 @@
 use crate::utils::{
     advance_with_random_transactions, eth_payload_attributes, eth_payload_attributes_amsterdam,
 };
-use alloy_eips::{
-    eip4844::BlobAndProofV1,
-    eip7685::{Requests, RequestsOrHash},
-};
+use alloy_eips::eip7685::{Requests, RequestsOrHash};
 use alloy_genesis::Genesis;
-use alloy_primitives::{Address, B256};
-use alloy_rpc_types_engine::{
-    ClientVersionV1, ForkchoiceState, PayloadAttributes, PayloadStatusEnum,
-};
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{ClientVersionV1, ForkchoiceState, PayloadStatusEnum};
 use jsonrpsee_core::client::ClientT;
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
 use reth_e2e_test_utils::{
@@ -42,7 +37,6 @@ const ENGINE_EXECUTION_VERSION_HEADER: &str = "Eth-Execution-Version";
 const ENGINE_AMSTERDAM_FORK_HEADER: &str = "amsterdam";
 const ENGINE_PAYLOADS_ROUTE: &str = "/engine/v1/payloads";
 const ENGINE_FORKCHOICE_ROUTE: &str = "/engine/v1/forkchoice";
-const ENGINE_V1_BLOBS_ROUTE: &str = "/engine/v1/blobs/v1";
 const ENGINE_CAPABILITIES_ROUTE: &str = "/engine/v1/capabilities";
 const ENGINE_IDENTITY_ROUTE: &str = "/engine/v1/identity";
 
@@ -326,7 +320,7 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
 
     let node = NodeTestContext::new(node, eth_payload_attributes_amsterdam).await?;
 
-    let wallets = Wallet::new(2).wallet_gen();
+    let wallets = Wallet::new(1).wallet_gen();
     let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallets[0].clone()).await;
 
     let payload_attributes = eth_payload_attributes_amsterdam(chain_spec.genesis().timestamp + 1);
@@ -448,26 +442,6 @@ async fn test_engine_ssz_proxy_can_mine_block() -> eyre::Result<()> {
         .send()
         .await?;
     assert_eq!(fcu_response.status(), reqwest::StatusCode::OK);
-
-    let blob_tx = TransactionTestContext::tx_with_blobs_bytes(1, wallets[1].clone()).await?;
-    let blob_tx_hash = node.rpc.inject_tx(blob_tx).await?;
-    let envelope = node.rpc.envelope_by_hash(blob_tx_hash).await?;
-    let versioned_hashes = TransactionTestContext::validate_sidecar(envelope);
-
-    let blobs_response = client
-        .post(format!("{auth_url}{ENGINE_V1_BLOBS_ROUTE}"))
-        .header(reqwest::header::AUTHORIZATION, auth_header.to_str()?)
-        .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
-        .header(reqwest::header::ACCEPT, "application/octet-stream")
-        .body(versioned_hashes.as_ssz_bytes())
-        .send()
-        .await?;
-    assert_eq!(blobs_response.status(), reqwest::StatusCode::OK);
-
-    let blobs =
-        Vec::<Option<BlobAndProofV1>>::from_ssz_bytes(&blobs_response.bytes().await?).unwrap();
-    assert_eq!(blobs.len(), versioned_hashes.len());
-    assert!(blobs.iter().all(Option::is_some));
 
     let fcu = SszForkchoiceUpdateResponse::from_ssz_bytes(&fcu_response.bytes().await?).unwrap();
     assert_eq!(fcu.payload_status.status, PayloadStatusEnum::Valid);

--- a/crates/rpc/rpc-api/src/lib.rs
+++ b/crates/rpc/rpc-api/src/lib.rs
@@ -33,7 +33,10 @@ mod validation;
 mod web3;
 
 pub use reth::RethJitAction;
-pub use testing::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1, TESTING_COMMIT_BLOCK_V1};
+pub use testing::{
+    TestingBuildBlockRequestV1, TestingBuildBlockResponse, TESTING_BUILD_BLOCK_V1,
+    TESTING_COMMIT_BLOCK_V1,
+};
 
 /// re-export of all server traits
 pub use servers::*;

--- a/crates/rpc/rpc-api/src/testing.rs
+++ b/crates/rpc/rpc-api/src/testing.rs
@@ -6,7 +6,7 @@
 //! explicit operator flag.
 
 use alloy_primitives::{Bytes, B256};
-use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV5, PayloadAttributes};
+use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV6, PayloadAttributes};
 use jsonrpsee::proc_macros::rpc;
 
 pub use alloy_rpc_types_engine::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1};
@@ -40,7 +40,7 @@ pub trait TestingApi {
         payload_attributes: PayloadAttributes,
         transactions: Option<Vec<Bytes>>,
         extra_data: Option<Bytes>,
-    ) -> jsonrpsee::core::RpcResult<ExecutionPayloadEnvelopeV5>;
+    ) -> jsonrpsee::core::RpcResult<ExecutionPayloadEnvelopeV6>;
 
     /// Builds a block on top of the current canonical head, inserts it, and makes it canonical.
     ///

--- a/crates/rpc/rpc-api/src/testing.rs
+++ b/crates/rpc/rpc-api/src/testing.rs
@@ -6,10 +6,26 @@
 //! explicit operator flag.
 
 use alloy_primitives::{Bytes, B256};
-use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV6, PayloadAttributes};
+use alloy_rpc_types_engine::{
+    ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6, PayloadAttributes,
+};
 use jsonrpsee::proc_macros::rpc;
 
 pub use alloy_rpc_types_engine::{TestingBuildBlockRequestV1, TESTING_BUILD_BLOCK_V1};
+
+/// Versioned response returned by `testing_buildBlockV1`.
+///
+/// The endpoint uses the payload attributes timestamp to select the envelope version. Keeping
+/// both variants on the wire is important: decoding an Amsterdam response as V5 would silently
+/// discard the block access list and other V6 payload fields.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+pub enum TestingBuildBlockResponse {
+    /// Amsterdam payload, including the block access list.
+    V6(ExecutionPayloadEnvelopeV6),
+    /// Pre-Amsterdam payload.
+    V5(ExecutionPayloadEnvelopeV5),
+}
 
 /// Capability string for `testing_commitBlockV1`.
 pub const TESTING_COMMIT_BLOCK_V1: &str = "testing_commitBlockV1";
@@ -40,7 +56,7 @@ pub trait TestingApi {
         payload_attributes: PayloadAttributes,
         transactions: Option<Vec<Bytes>>,
         extra_data: Option<Bytes>,
-    ) -> jsonrpsee::core::RpcResult<ExecutionPayloadEnvelopeV6>;
+    ) -> jsonrpsee::core::RpcResult<TestingBuildBlockResponse>;
 
     /// Builds a block on top of the current canonical head, inserts it, and makes it canonical.
     ///

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -23,8 +23,9 @@ use alloy_primitives::{
 };
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{
-    BlobsBundleV2, ExecutionData, ExecutionPayloadEnvelopeV5, ExecutionPayloadSidecar,
-    ExecutionPayloadV3, ForkchoiceState, PayloadAttributes, PraguePayloadFields,
+    BlobsBundleV2, ExecutionData, ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6,
+    ExecutionPayloadSidecar, ExecutionPayloadV3, ExecutionPayloadV4, ForkchoiceState,
+    PayloadAttributes, PraguePayloadFields,
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -290,7 +291,7 @@ where
         &self,
         request: TestingBuildBlockRequestV1,
         use_pool_transactions: bool,
-    ) -> Result<ExecutionPayloadEnvelopeV5, Eth::Error> {
+    ) -> Result<ExecutionPayloadEnvelopeV6, Eth::Error> {
         let payload = self
             .build_payload_v1(request, self.skip_invalid_transactions, use_pool_transactions)
             .await?;
@@ -300,8 +301,12 @@ where
         let block_hash = block.hash();
         let block = block.into_block().into_ethereum_block();
 
-        Ok(ExecutionPayloadEnvelopeV5 {
-            execution_payload: ExecutionPayloadV3::from_block_unchecked(block_hash, &block),
+        Ok(ExecutionPayloadEnvelopeV6 {
+            execution_payload: ExecutionPayloadV4::from_block_unchecked_with_bal(
+                block_hash,
+                &block,
+                *payload.block_access_list().unwrap_or_default(),
+            ),
             block_value: fees,
             blobs_bundle: BlobsBundleV2::empty(),
             should_override_builder: false,
@@ -422,7 +427,7 @@ where
         payload_attributes: PayloadAttributes,
         transactions: Option<Vec<Bytes>>,
         extra_data: Option<Bytes>,
-    ) -> RpcResult<ExecutionPayloadEnvelopeV5> {
+    ) -> RpcResult<ExecutionPayloadEnvelopeV6> {
         let use_pool_transactions = transactions.is_none();
         let request = TestingBuildBlockRequestV1 {
             parent_block_hash,

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -23,9 +23,8 @@ use alloy_primitives::{
 };
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{
-    BlobsBundleV2, ExecutionData, ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6,
-    ExecutionPayloadSidecar, ExecutionPayloadV3, ExecutionPayloadV4, ForkchoiceState,
-    PayloadAttributes, PraguePayloadFields,
+    BlobsBundleV2, ExecutionData, ExecutionPayloadEnvelopeV6, ExecutionPayloadSidecar,
+    ExecutionPayloadV4, ForkchoiceState, PayloadAttributes, PraguePayloadFields,
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -297,6 +296,7 @@ where
             .await?;
         let fees = payload.fees();
         let requests = payload.requests().unwrap_or_default();
+        let block_access_list = payload.block_access_list().cloned().unwrap_or_default();
         let block = Arc::unwrap_or_clone(payload.into_block_arc());
         let block_hash = block.hash();
         let block = block.into_block().into_ethereum_block();
@@ -305,7 +305,7 @@ where
             execution_payload: ExecutionPayloadV4::from_block_unchecked_with_bal(
                 block_hash,
                 &block,
-                *payload.block_access_list().unwrap_or_default(),
+                block_access_list,
             ),
             block_value: fees,
             blobs_bundle: BlobsBundleV2::empty(),

--- a/crates/rpc/rpc/src/testing.rs
+++ b/crates/rpc/rpc/src/testing.rs
@@ -23,8 +23,9 @@ use alloy_primitives::{
 };
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::{
-    BlobsBundleV2, ExecutionData, ExecutionPayloadEnvelopeV6, ExecutionPayloadSidecar,
-    ExecutionPayloadV4, ForkchoiceState, PayloadAttributes, PraguePayloadFields,
+    BlobsBundleV2, ExecutionData, ExecutionPayloadEnvelopeV5, ExecutionPayloadEnvelopeV6,
+    ExecutionPayloadSidecar, ExecutionPayloadV3, ExecutionPayloadV4, ForkchoiceState,
+    PayloadAttributes, PraguePayloadFields,
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -40,7 +41,7 @@ use reth_primitives_traits::{
     AlloyBlockHeader as BlockTrait, Block as _, HeaderTy, TxTy,
 };
 use reth_revm::{database::StateProviderDatabase, db::State};
-use reth_rpc_api::{TestingApiServer, TestingBuildBlockRequestV1};
+use reth_rpc_api::{TestingApiServer, TestingBuildBlockRequestV1, TestingBuildBlockResponse};
 use reth_rpc_eth_api::{helpers::Call, FromEthApiError};
 use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::{BlockReader, BlockReaderIdExt, HeaderProvider};
@@ -290,28 +291,43 @@ where
         &self,
         request: TestingBuildBlockRequestV1,
         use_pool_transactions: bool,
-    ) -> Result<ExecutionPayloadEnvelopeV6, Eth::Error> {
+    ) -> Result<TestingBuildBlockResponse, Eth::Error> {
         let payload = self
             .build_payload_v1(request, self.skip_invalid_transactions, use_pool_transactions)
             .await?;
         let fees = payload.fees();
         let requests = payload.requests().unwrap_or_default();
         let block_access_list = payload.block_access_list().cloned().unwrap_or_default();
+        let is_amsterdam = self
+            .eth_api
+            .provider()
+            .chain_spec()
+            .is_amsterdam_active_at_timestamp(payload.block().timestamp());
         let block = Arc::unwrap_or_clone(payload.into_block_arc());
         let block_hash = block.hash();
         let block = block.into_block().into_ethereum_block();
 
-        Ok(ExecutionPayloadEnvelopeV6 {
-            execution_payload: ExecutionPayloadV4::from_block_unchecked_with_bal(
-                block_hash,
-                &block,
-                block_access_list,
-            ),
-            block_value: fees,
-            blobs_bundle: BlobsBundleV2::empty(),
-            should_override_builder: false,
-            execution_requests: requests,
-        })
+        if is_amsterdam {
+            Ok(TestingBuildBlockResponse::V6(ExecutionPayloadEnvelopeV6 {
+                execution_payload: ExecutionPayloadV4::from_block_unchecked_with_bal(
+                    block_hash,
+                    &block,
+                    block_access_list,
+                ),
+                block_value: fees,
+                blobs_bundle: BlobsBundleV2::empty(),
+                should_override_builder: false,
+                execution_requests: requests,
+            }))
+        } else {
+            Ok(TestingBuildBlockResponse::V5(ExecutionPayloadEnvelopeV5 {
+                execution_payload: ExecutionPayloadV3::from_block_unchecked(block_hash, &block),
+                block_value: fees,
+                blobs_bundle: BlobsBundleV2::empty(),
+                should_override_builder: false,
+                execution_requests: requests,
+            }))
+        }
     }
 
     async fn commit_block_v1(
@@ -427,7 +443,7 @@ where
         payload_attributes: PayloadAttributes,
         transactions: Option<Vec<Bytes>>,
         extra_data: Option<Bytes>,
-    ) -> RpcResult<ExecutionPayloadEnvelopeV6> {
+    ) -> RpcResult<TestingBuildBlockResponse> {
         let use_pool_transactions = transactions.is_none();
         let request = TestingBuildBlockRequestV1 {
             parent_block_hash,


### PR DESCRIPTION
Adds amsterdam support to testing build block rpc. This now builds bal and returns ExecutionPaylaodEnvelopeV6.
TThis rpc now expects BAL in the payload. See [this](https://github.com/ethereum/execution-apis/pull/867/changes#diff-41a07e288bd51d563e9609a54a3dd7ac64a5d0f6bc310065af894ba209263640R3)