### PR TITLE
fix(rpc): avoid warming moved precompiles 

### DIFF
--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -293,7 +293,16 @@ pub fn apply_precompile_overrides(
         }
     }
 
-    let mut moved_precompiles = HashMap::with_capacity(moves.len());
+    // Validate every source before mutating the map, matching `move_precompiles`.
+    for (source, _) in &moves {
+        if precompiles.get(source).is_none() {
+            return Err(EthSimulateError::NotAPrecompile(*source))
+        }
+    }
+
+    // Extract all sources before handling destinations so swaps and chained moves retain the
+    // original precompiles.
+    let mut extracted = Vec::with_capacity(moves.len());
     for (source, dest) in moves {
         let mut moved_precompile = None;
         precompiles.apply_precompile(&source, |existing| {
@@ -301,13 +310,19 @@ pub fn apply_precompile_overrides(
             None
         });
 
-        let Some(precompile) = moved_precompile else {
-            return Err(EthSimulateError::NotAPrecompile(source))
-        };
-        moved_precompiles.insert(dest, precompile);
+        if let Some(precompile) = moved_precompile {
+            extracted.push((dest, precompile));
+        }
     }
 
-    if !moved_precompiles.is_empty() {
+    if !extracted.is_empty() {
+        let mut moved_precompiles = HashMap::with_capacity(extracted.len());
+        for (dest, precompile) in extracted {
+            // Dynamic lookups are only consulted for addresses absent from the main map.
+            precompiles.apply_precompile(&dest, |_| None);
+            moved_precompiles.insert(dest, precompile);
+        }
+
         precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
             moved_precompiles.get(address).cloned()
         });
@@ -609,7 +624,7 @@ mod tests {
     use crate::{error::ToRpcError, EthApiError};
     use alloy_chains::Chain;
     use alloy_consensus::Header;
-    use alloy_evm::precompiles::PrecompilesMap;
+    use alloy_evm::precompiles::{Precompile, PrecompilesMap};
     use alloy_primitives::{address, U256};
     use alloy_rpc_types_eth::{
         simulate::SimBlock,
@@ -694,6 +709,49 @@ mod tests {
 
         assert!(precompiles.get(&source).is_none());
         assert!(precompiles.get(&dest).is_some());
+        assert!(!precompiles.addresses().any(|address| address == &dest));
+    }
+
+    #[test]
+    fn invalid_precompile_move_does_not_apply_valid_moves() {
+        let source = address!("0000000000000000000000000000000000000001");
+        let dest = address!("0000000000000000000000000000000000123456");
+        let invalid_source = address!("c100000000000000000000000000000000000000");
+        let invalid_dest = address!("c200000000000000000000000000000000000000");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            source,
+            AccountOverride { move_precompile_to: Some(dest), ..Default::default() },
+        );
+        state_overrides.insert(
+            invalid_source,
+            AccountOverride { move_precompile_to: Some(invalid_dest), ..Default::default() },
+        );
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::prague());
+
+        let err = apply_precompile_overrides(&state_overrides, &mut precompiles).unwrap_err();
+
+        assert!(matches!(err, EthSimulateError::NotAPrecompile(addr) if addr == invalid_source));
+        assert!(precompiles.get(&source).is_some());
+        assert!(precompiles.get(&dest).is_none());
+    }
+
+    #[test]
+    fn moved_precompile_replaces_existing_destination() {
+        let source = address!("0000000000000000000000000000000000000001");
+        let dest = address!("0000000000000000000000000000000000000004");
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            source,
+            AccountOverride { move_precompile_to: Some(dest), ..Default::default() },
+        );
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::prague());
+        let source_id = precompiles.get(&source).unwrap().precompile_id().clone();
+
+        apply_precompile_overrides(&state_overrides, &mut precompiles).unwrap();
+
+        assert!(precompiles.get(&source).is_none());
+        assert_eq!(precompiles.get(&dest).unwrap().precompile_id(), &source_id);
         assert!(!precompiles.addresses().any(|address| address == &dest));
     }
 

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -324,22 +324,19 @@ pub fn apply_precompile_overrides(
         }
 
         precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
-            moved_precompiles
-                .get(address)
-                .map(|precompile| shared_precompile(Rc::clone(precompile)))
+            moved_precompiles.get(address).map(|precompile| {
+                let precompile = Rc::clone(precompile);
+                let id = precompile.precompile_id().clone();
+                if precompile.supports_caching() {
+                    DynPrecompile::new(id, move |input| precompile.call(input))
+                } else {
+                    DynPrecompile::new_stateful(id, move |input| precompile.call(input))
+                }
+            })
         });
     }
 
     Ok(())
-}
-
-fn shared_precompile(precompile: Rc<DynPrecompile>) -> DynPrecompile {
-    let id = precompile.precompile_id().clone();
-    if precompile.supports_caching() {
-        DynPrecompile::new(id, move |input| precompile.call(input))
-    } else {
-        DynPrecompile::new_stateful(id, move |input| precompile.call(input))
-    }
 }
 
 /// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -9,7 +9,7 @@ use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
 use alloy_evm::{
     block::TxResult,
-    precompiles::{DynPrecompile, PrecompilesMap},
+    precompiles::{DynPrecompile, Precompile, PrecompilesMap},
 };
 use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy_rpc_types_eth::{
@@ -34,7 +34,7 @@ use revm::{
     primitives::{Address, Bytes, TxKind, U256},
     Database,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, rc::Rc};
 
 /// Fallback seconds added between simulated block timestamps when neither the user nor the chain
 /// hint provides a value.
@@ -320,15 +320,26 @@ pub fn apply_precompile_overrides(
         for (dest, precompile) in extracted {
             // Dynamic lookups are only consulted for addresses absent from the main map.
             precompiles.apply_precompile(&dest, |_| None);
-            moved_precompiles.insert(dest, precompile);
+            moved_precompiles.insert(dest, Rc::new(precompile));
         }
 
         precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
-            moved_precompiles.get(address).cloned()
+            moved_precompiles
+                .get(address)
+                .map(|precompile| shared_precompile(Rc::clone(precompile)))
         });
     }
 
     Ok(())
+}
+
+fn shared_precompile(precompile: Rc<DynPrecompile>) -> DynPrecompile {
+    let id = precompile.precompile_id().clone();
+    if precompile.supports_caching() {
+        DynPrecompile::new(id, move |input| precompile.call(input))
+    } else {
+        DynPrecompile::new_stateful(id, move |input| precompile.call(input))
+    }
 }
 
 /// Converts all [`TransactionRequest`]s into [`Recovered`] transactions and applies them to the

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -7,7 +7,10 @@ use crate::{
 use alloy_chains::Chain;
 use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction as _};
 use alloy_eips::eip2718::WithEncoded;
-use alloy_evm::{block::TxResult, precompiles::PrecompilesMap};
+use alloy_evm::{
+    block::TxResult,
+    precompiles::{DynPrecompile, PrecompilesMap},
+};
 use alloy_network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy_rpc_types_eth::{
     simulate::{SimBlock, SimCallResult, SimulateError, SimulatedBlock},
@@ -31,6 +34,7 @@ use revm::{
     primitives::{Address, Bytes, TxKind, U256},
     Database,
 };
+use std::collections::HashMap;
 
 /// Fallback seconds added between simulated block timestamps when neither the user nor the chain
 /// hint provides a value.
@@ -289,11 +293,25 @@ pub fn apply_precompile_overrides(
         }
     }
 
-    precompiles.move_precompiles(moves).map_err(
-        |alloy_evm::precompiles::MovePrecompileError::NotAPrecompile(addr)| {
-            EthSimulateError::NotAPrecompile(addr)
-        },
-    )?;
+    let mut moved_precompiles = HashMap::with_capacity(moves.len());
+    for (source, dest) in moves {
+        let mut moved_precompile = None;
+        precompiles.apply_precompile(&source, |existing| {
+            moved_precompile = existing;
+            None
+        });
+
+        let Some(precompile) = moved_precompile else {
+            return Err(EthSimulateError::NotAPrecompile(source))
+        };
+        moved_precompiles.insert(dest, precompile);
+    }
+
+    if !moved_precompiles.is_empty() {
+        precompiles.set_precompile_lookup(move |address: &Address| -> Option<DynPrecompile> {
+            moved_precompiles.get(address).cloned()
+        });
+    }
 
     Ok(())
 }
@@ -662,7 +680,7 @@ mod tests {
     }
 
     #[test]
-    fn moved_precompile_is_callable() {
+    fn moved_precompile_is_callable_but_not_warm() {
         let source = address!("0000000000000000000000000000000000000001");
         let dest = address!("0000000000000000000000000000000000123456");
         let mut state_overrides = StateOverride::default();
@@ -676,6 +694,7 @@ mod tests {
 
         assert!(precompiles.get(&source).is_none());
         assert!(precompiles.get(&dest).is_some());
+        assert!(!precompiles.addresses().any(|address| address == &dest));
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

Moving a precompile could incorrectly warm the destination address and could produce incorrect behavior for swaps, chained moves, existing destinations, or partially invalid move requests. The moved precompile also had to retain whether it used stateless or stateful caching.

## What was fixed

All move sources are validated before mutation, sources are extracted before destinations are updated, and moved precompiles are resolved dynamically without adding their destinations to the warm/static precompile set. The original caching and stateful-call semantics are preserved.