### PR TITLE
fix(txpool): enforce minimum priority fee for local transactions

### DIFF
--- a/crates/ethereum/node/tests/e2e/pool.rs
+++ b/crates/ethereum/node/tests/e2e/pool.rs
@@ -2,13 +2,18 @@ use crate::utils::eth_payload_attributes;
 use alloy_consensus::{EthereumTxEnvelope, TxEip4844};
 use alloy_eips::{eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M, Encodable2718};
 use alloy_genesis::Genesis;
-use alloy_primitives::B256;
+use alloy_primitives::{Address, TxKind, B256, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types_eth::TransactionRequest;
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{
-    node::NodeTestContext, transaction::TransactionTestContext, wallet::Wallet,
+    node::NodeTestContext, transaction::TransactionTestContext, wallet::Wallet, E2ETestSetupBuilder,
 };
 use reth_node_builder::{NodeBuilder, NodeHandle};
-use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
+use reth_node_core::{
+    args::{RpcServerArgs, TxPoolArgs},
+    node_config::NodeConfig,
+};
 use reth_node_ethereum::EthereumNode;
 use reth_primitives_traits::Recovered;
 use reth_provider::CanonStateSubscriptions;
@@ -19,6 +24,61 @@ use reth_transaction_pool::{
     TransactionPoolExt,
 };
 use std::{sync::Arc, time::Duration};
+
+#[tokio::test]
+async fn rpc_enforces_minimum_priority_fee() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    const MINIMUM_PRIORITY_FEE: u128 = 1;
+
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json"))?;
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(genesis)
+            .cancun_activated()
+            .build(),
+    );
+    let (mut nodes, wallet) =
+        E2ETestSetupBuilder::<EthereumNode, _>::new(1, chain_spec, eth_payload_attributes)
+            .with_node_config_modifier(|config| {
+                config.with_txpool(TxPoolArgs {
+                    minimum_priority_fee: Some(MINIMUM_PRIORITY_FEE),
+                    ..Default::default()
+                })
+            })
+            .build()
+            .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new().connect_http(node.rpc_url());
+
+    let transaction = |max_priority_fee_per_gas| TransactionRequest {
+        nonce: Some(0),
+        value: Some(U256::from(100)),
+        to: Some(TxKind::Call(Address::ZERO)),
+        gas: Some(21_000),
+        max_fee_per_gas: Some(20_000_000_000),
+        max_priority_fee_per_gas: Some(max_priority_fee_per_gas),
+        chain_id: Some(1),
+        ..Default::default()
+    };
+
+    let below_minimum = TransactionTestContext::sign_tx(wallet.inner.clone(), transaction(0)).await;
+    let err = provider.send_raw_transaction(&below_minimum.encoded_2718()).await.unwrap_err();
+    assert!(
+        err.to_string().contains("transaction priority fee below minimum required priority fee 1"),
+        "{err}"
+    );
+    assert!(node.inner.pool.is_empty());
+
+    let at_minimum =
+        TransactionTestContext::sign_tx(wallet.inner, transaction(MINIMUM_PRIORITY_FEE)).await;
+    let pending = provider.send_raw_transaction(&at_minimum.encoded_2718()).await?;
+    assert_eq!(node.inner.pool.len(), 1);
+    assert!(node.inner.pool.contains(pending.tx_hash()));
+
+    Ok(())
+}
 
 // Test that stale transactions could be correctly evicted.
 #[tokio::test]

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -71,7 +71,7 @@
 //!   activation)
 //! - **Size**: Input data ≤ 128KB (default)
 //! - **Gas**: Limit ≤ block gas limit
-//! - **Fees**: Priority fee ≤ max fee; local tx fee cap; external minimum priority fee
+//! - **Fees**: Priority fee ≤ max fee; local tx fee cap; minimum priority fee
 //! - **Chain ID**: Must match current chain
 //! - **Intrinsic Gas**: Sufficient for data and access lists
 //! - **Blobs** (EIP-4844): Valid count, KZG proofs

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -573,10 +573,9 @@ where
             }
         }
 
-        // Drop non-local transactions with a fee lower than the configured fee for acceptance into
-        // the pool.
-        if !is_local &&
-            transaction.is_dynamic_fee() &&
+        // Drop dynamic fee transactions with a fee lower than the configured fee for acceptance
+        // into the pool.
+        if transaction.is_dynamic_fee() &&
             transaction.max_priority_fee_per_gas() < self.minimum_priority_fee
         {
             return Err(InvalidPoolTransactionError::PriorityFeeBelowMinimum {
@@ -1951,24 +1950,27 @@ mod tests {
         let validator =
             create_validator_with_minimum_fee(provider, Some(minimum_priority_fee), None);
 
-        // External transaction should be rejected due to low priority fee
-        let outcome = validator.validate_one(TransactionOrigin::External, transaction.clone());
-        assert!(outcome.is_invalid());
-
-        if let TransactionValidationOutcome::Invalid(_, err) = outcome {
+        for origin in
+            [TransactionOrigin::External, TransactionOrigin::Local, TransactionOrigin::Private]
+        {
+            let outcome = validator.validate_one(origin, transaction.clone());
             assert!(matches!(
-                err,
-                InvalidPoolTransactionError::PriorityFeeBelowMinimum { minimum_priority_fee: min_fee }
-                if min_fee == minimum_priority_fee
+                outcome,
+                TransactionValidationOutcome::Invalid(
+                    _,
+                    InvalidPoolTransactionError::PriorityFeeBelowMinimum {
+                        minimum_priority_fee: min_fee
+                    }
+                ) if min_fee == minimum_priority_fee
             ));
         }
 
-        // Test pool integration
+        // Local submission is the path used by `eth_sendRawTransaction`.
         let blob_store = InMemoryBlobStore::default();
         let pool =
             Pool::new(validator, CoinbaseTipOrdering::default(), blob_store, Default::default());
 
-        let res = pool.add_external_transaction(transaction.clone()).await;
+        let res = pool.add_transaction(TransactionOrigin::Local, transaction.clone()).await;
         assert!(res.is_err());
         assert!(matches!(
             res.unwrap_err().kind,
@@ -1978,14 +1980,6 @@ mod tests {
         ));
         let tx = pool.get(transaction.hash());
         assert!(tx.is_none());
-
-        // Local transactions should still be accepted regardless of minimum priority fee
-        let (_, local_provider) = setup_priority_fee_test();
-        let validator_local =
-            create_validator_with_minimum_fee(local_provider, Some(minimum_priority_fee), None);
-
-        let local_outcome = validator_local.validate_one(TransactionOrigin::Local, transaction);
-        assert!(local_outcome.is_valid());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #26803

Applies `--txpool.minimum-priority-fee` to dynamic-fee transactions regardless of origin, so RPC submissions follow Geth's origin-independent price floor while retaining local eviction and slot exemptions. Adds validator coverage for every origin and a launched-node `eth_sendRawTransaction` regression test for below-minimum rejection and exact-threshold acceptance.