### PR TITLE
feat(overlay): add overlay state providers

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1,4 +1,3 @@
-use super::state::latest::LatestStateProvider;
 use crate::{
     providers::{
         ConsistentProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider,
@@ -18,12 +17,12 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, TxHash, TxNumber,
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
-    MemoryOverlayStateProvider, PersistedBlockNotifications, PersistedBlockSubscriptions,
+    PersistedBlockNotifications, PersistedBlockSubscriptions,
 };
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::ExecutionOutcome;
-use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
+use reth_node_types::{BlockTy, HeaderTy, NodeTypes, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{
     Account, RecoveredBlock, SealedHeader, SealedOrRecoveredBlock, StorageEntry,
 };
@@ -33,12 +32,10 @@ use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
     BlockBodyIndicesProvider, NodePrimitivesProvider, RangeEnd, RangeResponse, RangeResult,
     StateRangeProvider, StateRangeProviderFactory, StateRangeView, StorageChangeSetReader,
-    StorageRangeResult, TryIntoHistoricalStateProvider,
+    StorageRangeResult,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{
-    anchor_for_parent, AnchorForParent, OverlayStateProvider, OverlayStateProviderFactory,
-};
+use reth_storage_overlay::{OverlayStateProvider, OverlayStateProviderFactory, OwnedProvider};
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,
@@ -57,7 +54,8 @@ use tracing::trace;
 pub const SNAPSHOT_STATE_RETENTION: u64 = 128;
 
 type StateRangeDbProvider<N> = <ProviderFactory<N> as DatabaseProviderFactory>::Provider;
-type HistoricalStateRangeProvider<N> = OverlayStateProvider<StateRangeDbProvider<N>>;
+type HistoricalStateRangeProvider<N> =
+    OverlayStateProvider<OwnedProvider<StateRangeDbProvider<N>>, <N as NodeTypes>::Primitives>;
 
 /// The main type for interacting with the blockchain.
 ///
@@ -155,21 +153,14 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     fn block_state_provider(
         &self,
         state: &BlockState<N::Primitives>,
-    ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
-        let provider = self.database.provider()?;
-        let anchor =
-            anchor_for_parent(state.hash(), state.chain().map(|state| state.block()), &provider)?;
-
-        let (historical, overlay): (StateProviderBox, _) = match anchor {
-            AnchorForParent::NoReverts { overlay, .. } => {
-                (Box::new(LatestStateProvider::new(provider)), overlay)
-            }
-            AnchorForParent::RevertsRequired { anchor, overlay, .. } => {
-                (provider.try_into_history_at_block(anchor.number)?, overlay)
-            }
-        };
-
-        Ok(MemoryOverlayStateProvider::new(historical, overlay))
+    ) -> ProviderResult<StateProviderBox> {
+        let overlay_factory = OverlayStateProviderFactory::new(
+            self.database.clone(),
+            self.database.overlay_manager().overlay_builder(state.hash()),
+        );
+        Ok(Box::new(reth_storage_api::DatabaseProviderROFactory::database_provider_ro(
+            &overlay_factory,
+        )?))
     }
 
     /// Returns a cursor-backed state view for a state root still only in canonical in-memory
@@ -748,7 +739,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
         // use latest state provider if the head state exists
         if let Some(state) = self.canonical_in_memory_state.head_state() {
             trace!(target: "providers::blockchain", "Using head state for latest state provider");
-            Ok(self.block_state_provider(&state)?.boxed())
+            self.block_state_provider(&state)
         } else {
             trace!(target: "providers::blockchain", "Using database state for latest state provider");
             self.database.latest()
@@ -805,7 +796,9 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
     fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?hash, "Getting state by block hash");
-        if let Ok(state) = self.history_by_block_hash(hash) {
+        if let Some(state) = self.canonical_in_memory_state.state_by_hash(hash) {
+            self.block_state_provider(&state)
+        } else if let Ok(state) = self.history_by_block_hash(hash) {
             // This could be tracked by a historical block
             Ok(state)
         } else if let Ok(Some(pending)) = self.pending_state_by_hash(hash) {
@@ -826,7 +819,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
         if let Some(pending) = self.canonical_in_memory_state.pending_state() {
             // we have a pending block
-            return Ok(Box::new(self.block_state_provider(&pending)?));
+            return self.block_state_provider(&pending);
         }
 
         // fallback to latest state if the pending block is not available
@@ -837,14 +830,14 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
         if let Some(pending) = self.canonical_in_memory_state.pending_state() &&
             pending.hash() == block_hash
         {
-            return Ok(Some(Box::new(self.block_state_provider(&pending)?)));
+            return self.block_state_provider(&pending).map(Some);
         }
         Ok(None)
     }
 
     fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>> {
         if let Some(pending) = self.canonical_in_memory_state.pending_state() {
-            return Ok(Some(Box::new(self.block_state_provider(&pending)?)))
+            return self.block_state_provider(&pending).map(Some)
         }
 
         Ok(None)
@@ -1179,6 +1172,9 @@ mod tests {
                 .collect(),
         };
         provider.canonical_in_memory_state.update_chain(chain);
+        for state in provider.canonical_in_memory_state.canonical_chain() {
+            provider.database.overlay_manager().insert_block(state.block());
+        }
 
         // Get canonical, safe, and finalized blocks
         let blocks = database_blocks.iter().chain(in_memory_blocks.iter()).collect::<Vec<_>>();

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1,3 +1,4 @@
+use super::state::latest::LatestStateProvider;
 use crate::{
     providers::{
         ConsistentProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider,
@@ -17,12 +18,12 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, TxHash, TxNumber,
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
-    PersistedBlockNotifications, PersistedBlockSubscriptions,
+    MemoryOverlayStateProvider, PersistedBlockNotifications, PersistedBlockSubscriptions,
 };
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::ExecutionOutcome;
-use reth_node_types::{BlockTy, HeaderTy, NodeTypes, NodeTypesWithDB, ReceiptTy, TxTy};
+use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{
     Account, RecoveredBlock, SealedHeader, SealedOrRecoveredBlock, StorageEntry,
 };
@@ -32,10 +33,12 @@ use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
     BlockBodyIndicesProvider, NodePrimitivesProvider, RangeEnd, RangeResponse, RangeResult,
     StateRangeProvider, StateRangeProviderFactory, StateRangeView, StorageChangeSetReader,
-    StorageRangeResult,
+    StorageRangeResult, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{OverlayStateProvider, OverlayStateProviderFactory, OwnedProvider};
+use reth_storage_overlay::{
+    anchor_for_parent, AnchorForParent, OverlayStateProvider, OverlayStateProviderFactory,
+};
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,
@@ -54,8 +57,7 @@ use tracing::trace;
 pub const SNAPSHOT_STATE_RETENTION: u64 = 128;
 
 type StateRangeDbProvider<N> = <ProviderFactory<N> as DatabaseProviderFactory>::Provider;
-type HistoricalStateRangeProvider<N> =
-    OverlayStateProvider<OwnedProvider<StateRangeDbProvider<N>>, <N as NodeTypes>::Primitives>;
+type HistoricalStateRangeProvider<N> = OverlayStateProvider<StateRangeDbProvider<N>>;
 
 /// The main type for interacting with the blockchain.
 ///
@@ -153,14 +155,21 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     fn block_state_provider(
         &self,
         state: &BlockState<N::Primitives>,
-    ) -> ProviderResult<StateProviderBox> {
-        let overlay_factory = OverlayStateProviderFactory::new(
-            self.database.clone(),
-            self.database.overlay_manager().overlay_builder(state.hash()),
-        );
-        Ok(Box::new(reth_storage_api::DatabaseProviderROFactory::database_provider_ro(
-            &overlay_factory,
-        )?))
+    ) -> ProviderResult<MemoryOverlayStateProvider<N::Primitives>> {
+        let provider = self.database.provider()?;
+        let anchor =
+            anchor_for_parent(state.hash(), state.chain().map(|state| state.block()), &provider)?;
+
+        let (historical, overlay): (StateProviderBox, _) = match anchor {
+            AnchorForParent::NoReverts { overlay, .. } => {
+                (Box::new(LatestStateProvider::new(provider)), overlay)
+            }
+            AnchorForParent::RevertsRequired { anchor, overlay, .. } => {
+                (provider.try_into_history_at_block(anchor.number)?, overlay)
+            }
+        };
+
+        Ok(MemoryOverlayStateProvider::new(historical, overlay))
     }
 
     /// Returns a cursor-backed state view for a state root still only in canonical in-memory
@@ -739,7 +748,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
         // use latest state provider if the head state exists
         if let Some(state) = self.canonical_in_memory_state.head_state() {
             trace!(target: "providers::blockchain", "Using head state for latest state provider");
-            self.block_state_provider(&state)
+            Ok(self.block_state_provider(&state)?.boxed())
         } else {
             trace!(target: "providers::blockchain", "Using database state for latest state provider");
             self.database.latest()
@@ -796,9 +805,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
     fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?hash, "Getting state by block hash");
-        if let Some(state) = self.canonical_in_memory_state.state_by_hash(hash) {
-            self.block_state_provider(&state)
-        } else if let Ok(state) = self.history_by_block_hash(hash) {
+        if let Ok(state) = self.history_by_block_hash(hash) {
             // This could be tracked by a historical block
             Ok(state)
         } else if let Ok(Some(pending)) = self.pending_state_by_hash(hash) {
@@ -819,7 +826,7 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
         if let Some(pending) = self.canonical_in_memory_state.pending_state() {
             // we have a pending block
-            return self.block_state_provider(&pending);
+            return Ok(Box::new(self.block_state_provider(&pending)?));
         }
 
         // fallback to latest state if the pending block is not available
@@ -830,14 +837,14 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
         if let Some(pending) = self.canonical_in_memory_state.pending_state() &&
             pending.hash() == block_hash
         {
-            return self.block_state_provider(&pending).map(Some);
+            return Ok(Some(Box::new(self.block_state_provider(&pending)?)));
         }
         Ok(None)
     }
 
     fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>> {
         if let Some(pending) = self.canonical_in_memory_state.pending_state() {
-            return self.block_state_provider(&pending).map(Some)
+            return Ok(Some(Box::new(self.block_state_provider(&pending)?)))
         }
 
         Ok(None)
@@ -1172,9 +1179,6 @@ mod tests {
                 .collect(),
         };
         provider.canonical_in_memory_state.update_chain(chain);
-        for state in provider.canonical_in_memory_state.canonical_chain() {
-            provider.database.overlay_manager().insert_block(state.block());
-        }
 
         // Get canonical, safe, and finalized blocks
         let blocks = database_blocks.iter().chain(in_memory_blocks.iter()).collect::<Vec<_>>();

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -23,7 +23,7 @@ use reth_chain_state::{
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::ExecutionOutcome;
-use reth_node_types::{BlockTy, HeaderTy, NodeTypesWithDB, ReceiptTy, TxTy};
+use reth_node_types::{BlockTy, HeaderTy, NodeTypes, NodeTypesWithDB, ReceiptTy, TxTy};
 use reth_primitives_traits::{
     Account, RecoveredBlock, SealedHeader, SealedOrRecoveredBlock, StorageEntry,
 };
@@ -38,6 +38,7 @@ use reth_storage_api::{
 use reth_storage_errors::provider::ProviderResult;
 use reth_storage_overlay::{
     anchor_for_parent, AnchorForParent, OverlayStateProvider, OverlayStateProviderFactory,
+    OwnedProvider,
 };
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
@@ -57,7 +58,8 @@ use tracing::trace;
 pub const SNAPSHOT_STATE_RETENTION: u64 = 128;
 
 type StateRangeDbProvider<N> = <ProviderFactory<N> as DatabaseProviderFactory>::Provider;
-type HistoricalStateRangeProvider<N> = OverlayStateProvider<StateRangeDbProvider<N>>;
+type HistoricalStateRangeProvider<N> =
+    OverlayStateProvider<OwnedProvider<StateRangeDbProvider<N>>, <N as NodeTypes>::Primitives>;
 
 /// The main type for interacting with the blockchain.
 ///

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -302,7 +302,7 @@ where
             .overlay_manager
             .overlay_builder(anchor_hash)
             .with_immediate_state_trie_overlay(state, nodes);
-        let StateTrieOverlay { trie_updates, hashed_post_state } =
+        let StateTrieOverlay { trie_updates, hashed_post_state, .. } =
             overlay_builder.build_state_trie_overlay(self.provider)?;
 
         Ok(TrieInputSorted::new(trie_updates, hashed_post_state, prefix_sets))

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -35,10 +35,17 @@ pub struct StateTrieOverlay {
     /// Hashed state overlay.
     pub hashed_post_state: Arc<HashedPostStateSorted>,
     /// Whether construction was skipped because a reused sparse trie covers this range.
-    pub(crate) skipped_for_reused_sparse_trie: bool,
+    skipped_for_reused_sparse_trie: bool,
 }
 
 impl StateTrieOverlay {
+    pub(crate) const fn new(
+        trie_updates: Arc<TrieUpdatesSorted>,
+        hashed_post_state: Arc<HashedPostStateSorted>,
+    ) -> Self {
+        Self { trie_updates, hashed_post_state, skipped_for_reused_sparse_trie: false }
+    }
+
     fn empty() -> Self {
         Self {
             trie_updates: Arc::new(TrieUpdatesSorted::default()),
@@ -486,11 +493,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         self.metrics.trie_updates_size.record(trie_updates_total_len as f64);
         self.metrics.hashed_state_size.record(hashed_state_updates_total_len as f64);
 
-        Ok(StateTrieOverlay {
-            trie_updates,
-            hashed_post_state,
-            skipped_for_reused_sparse_trie: false,
-        })
+        Ok(StateTrieOverlay::new(trie_updates, hashed_post_state))
     }
 
     /// Builds the effective execution overlay for the given provider.

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -102,22 +102,22 @@ impl ExecutionOverlay {
     }
 
     #[cfg(test)]
-    pub(crate) fn block_hashes_mut(&mut self) -> &mut Vec<BlockNumHash> {
+    pub(crate) const fn block_hashes_mut(&mut self) -> &mut Vec<BlockNumHash> {
         &mut self.block_hashes
     }
 
     #[cfg(test)]
-    pub(crate) fn accounts_mut(&mut self) -> &mut AddressMap<Option<AccountInfo>> {
+    pub(crate) const fn accounts_mut(&mut self) -> &mut AddressMap<Option<AccountInfo>> {
         &mut self.accounts
     }
 
     #[cfg(test)]
-    pub(crate) fn storage_mut(&mut self) -> &mut AddressMap<U256Map<U256>> {
+    pub(crate) const fn storage_mut(&mut self) -> &mut AddressMap<U256Map<U256>> {
         &mut self.storage
     }
 
     #[cfg(test)]
-    pub(crate) fn code_hashes_mut(&mut self) -> &mut B256Map<Bytecode> {
+    pub(crate) const fn code_hashes_mut(&mut self) -> &mut B256Map<Bytecode> {
         &mut self.code_hashes
     }
 

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -321,6 +321,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             + StorageChangeSetReader
             + DBProvider
             + BlockNumReader
+            + StageCheckpointReader
             + PruneCheckpointReader
             + StorageSettingsCache,
     {

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -34,6 +34,8 @@ pub struct StateTrieOverlay {
     pub trie_updates: Arc<TrieUpdatesSorted>,
     /// Hashed state overlay.
     pub hashed_post_state: Arc<HashedPostStateSorted>,
+    /// Whether construction was skipped because a reused sparse trie covers this range.
+    pub(crate) skipped_for_reused_sparse_trie: bool,
 }
 
 impl StateTrieOverlay {
@@ -41,7 +43,12 @@ impl StateTrieOverlay {
         Self {
             trie_updates: Arc::new(TrieUpdatesSorted::default()),
             hashed_post_state: Arc::new(HashedPostStateSorted::default()),
+            skipped_for_reused_sparse_trie: true,
         }
+    }
+
+    pub(crate) const fn skipped_for_reused_sparse_trie(&self) -> bool {
+        self.skipped_for_reused_sparse_trie
     }
 }
 
@@ -85,6 +92,26 @@ impl ExecutionOverlay {
     /// Returns the bytecode by code hash.
     pub const fn code_hashes(&self) -> &B256Map<Bytecode> {
         &self.code_hashes
+    }
+
+    #[cfg(test)]
+    pub(crate) fn block_hashes_mut(&mut self) -> &mut Vec<BlockNumHash> {
+        &mut self.block_hashes
+    }
+
+    #[cfg(test)]
+    pub(crate) fn accounts_mut(&mut self) -> &mut AddressMap<Option<AccountInfo>> {
+        &mut self.accounts
+    }
+
+    #[cfg(test)]
+    pub(crate) fn storage_mut(&mut self) -> &mut AddressMap<U256Map<U256>> {
+        &mut self.storage
+    }
+
+    #[cfg(test)]
+    pub(crate) fn code_hashes_mut(&mut self) -> &mut B256Map<Bytecode> {
+        &mut self.code_hashes
     }
 
     /// Extends this overlay with the execution state of a later block.
@@ -459,7 +486,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         self.metrics.trie_updates_size.record(trie_updates_total_len as f64);
         self.metrics.hashed_state_size.record(hashed_state_updates_total_len as f64);
 
-        Ok(StateTrieOverlay { trie_updates, hashed_post_state })
+        Ok(StateTrieOverlay {
+            trie_updates,
+            hashed_post_state,
+            skipped_for_reused_sparse_trie: false,
+        })
     }
 
     /// Builds the effective execution overlay for the given provider.

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -644,11 +644,7 @@ mod tests {
     }
 
     fn empty_overlay() -> StateTrieOverlay {
-        StateTrieOverlay {
-            trie_updates: Arc::default(),
-            hashed_post_state: Arc::default(),
-            skipped_for_reused_sparse_trie: false,
-        }
+        StateTrieOverlay::new(Arc::default(), Arc::default())
     }
 
     fn insert_test_changesets(

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -224,6 +224,7 @@ impl ChangesetCache {
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
+            + StageCheckpointReader
             + PruneCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,
@@ -276,6 +277,7 @@ impl ChangesetCache {
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
+            + StageCheckpointReader
             + PruneCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,
@@ -402,7 +404,7 @@ impl ChangesetCache {
             .overlay_builder(finish.hash)
             .with_no_reverts()
             .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish)?;
-        let state_trie_provider = OverlayStateProvider::new(
+        let state_trie_provider = OverlayStateProvider::<&P, N>::new_with_state_trie(
             provider,
             overlay,
             provider.cached_storage_settings().is_v2(),
@@ -904,11 +906,12 @@ mod tests {
         reth_trie_db::with_adapter!(provider, |A| seed_tip_trie_tables::<_, A>(&*provider));
 
         let overlay = empty_overlay();
-        let state_trie_provider = OverlayStateProvider::new(
-            &*provider,
-            overlay,
-            provider.cached_storage_settings().is_v2(),
-        );
+        let state_trie_provider =
+            OverlayStateProvider::<&_, reth_ethereum_primitives::EthPrimitives>::new_with_state_trie(
+                &*provider,
+                overlay,
+                provider.cached_storage_settings().is_v2(),
+            );
         let actual =
             reth_trie_db::compute_range_trie_changesets(&*provider, &state_trie_provider, 1..=3, 3)
                 .unwrap();
@@ -990,11 +993,12 @@ mod tests {
 
         let expected = legacy_compute_range_trie_changesets(&*provider, 2..=3);
         let overlay = empty_overlay();
-        let state_trie_provider = OverlayStateProvider::new(
-            &*provider,
-            overlay,
-            provider.cached_storage_settings().is_v2(),
-        );
+        let state_trie_provider =
+            OverlayStateProvider::<&_, reth_ethereum_primitives::EthPrimitives>::new_with_state_trie(
+                &*provider,
+                overlay,
+                provider.cached_storage_settings().is_v2(),
+            );
         let actual =
             reth_trie_db::compute_range_trie_changesets(&*provider, &state_trie_provider, 2..=3, 3)
                 .unwrap();

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -644,7 +644,11 @@ mod tests {
     }
 
     fn empty_overlay() -> StateTrieOverlay {
-        StateTrieOverlay { trie_updates: Arc::default(), hashed_post_state: Arc::default() }
+        StateTrieOverlay {
+            trie_updates: Arc::default(),
+            hashed_post_state: Arc::default(),
+            skipped_for_reused_sparse_trie: false,
+        }
     }
 
     fn insert_test_changesets(

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -113,8 +113,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
-            + PruneCheckpointReader
             + StageCheckpointReader
+            + PruneCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,
     {
@@ -138,6 +138,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         P: DBProvider
             + ChangeSetReader
             + StorageChangeSetReader
+            + StageCheckpointReader
             + PruneCheckpointReader
             + BlockNumReader
             + StorageSettingsCache,

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -219,25 +219,24 @@ where
         }
 
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
-        let overlay = match self
-            .state_trie_overlay_cache
-            .entry((state_trie_tip_block.hash, finish_tip_block.hash))
-        {
-            dashmap::Entry::Occupied(entry) => entry.get().clone(),
-            dashmap::Entry::Vacant(entry) => {
-                self.metrics.state_trie_overlay_cache_misses.increment(1);
-                let overlay = self
-                    .overlay_builder
-                    .as_ref()
-                    .expect("state trie overlay must be initialized or lazily resolvable")
-                    .build_state_trie_overlay_at_frontiers(
-                        self.provider(),
-                        state_trie_tip_block,
-                        finish_tip_block,
-                    )?;
-                entry.insert(overlay.clone());
-                overlay
+        let cache_key = (state_trie_tip_block.hash, finish_tip_block.hash);
+        let overlay = if let Some(overlay) = self.state_trie_overlay_cache.get(&cache_key) {
+            overlay.clone()
+        } else {
+            self.metrics.state_trie_overlay_cache_misses.increment(1);
+            let overlay = self
+                .overlay_builder
+                .as_ref()
+                .expect("state trie overlay must be initialized or lazily resolvable")
+                .build_state_trie_overlay_at_frontiers(
+                    self.provider(),
+                    state_trie_tip_block,
+                    finish_tip_block,
+                )?;
+            if !overlay.skipped_for_reused_sparse_trie() {
+                self.state_trie_overlay_cache.insert(cache_key, overlay.clone());
             }
+            overlay
         };
         let _ = self.state_trie_overlay.set(overlay);
         Ok(self.state_trie_overlay.get().expect("state trie overlay was just initialized"))
@@ -254,6 +253,9 @@ where
             + StorageSettingsCache,
     {
         let overlay = self.state_trie_overlay()?;
+        if overlay.skipped_for_reused_sparse_trie() {
+            return Err(ProviderError::UnsupportedProvider)
+        }
         let TrieInputSorted { nodes: input_nodes, state: input_state, prefix_sets } = input;
         let mut nodes = Arc::clone(&overlay.trie_updates);
         let mut state = Arc::clone(&overlay.hashed_post_state);
@@ -666,6 +668,9 @@ where
         &self,
         bundle_state: &revm::database::BundleState,
     ) -> ProviderResult<HashedPostState> {
+        if self.state_trie_overlay()?.skipped_for_reused_sparse_trie() {
+            return Err(ProviderError::UnsupportedProvider)
+        }
         let mut hashed_state =
             HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state());
         if !bundle_state
@@ -1043,6 +1048,32 @@ mod tests {
     }
 
     #[test]
+    fn skipped_state_trie_overlay_is_not_cached_or_used_for_state_roots() {
+        let (factory, blocks) = setup_frontiers(3, 3);
+        let manager = OverlayManager::default();
+        manager.insert_block(blocks[4].clone());
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            factory,
+            manager
+                .overlay_builder(blocks[4].recovered_block().hash())
+                .with_skip_overlay_for_reused_sparse_trie(blocks[3].recovered_block().hash()),
+        );
+
+        let provider = state_provider_factory.database_provider_ro().unwrap();
+        assert!(provider.state_trie_overlay().unwrap().skipped_for_reused_sparse_trie());
+        assert!(state_provider_factory.state_trie_overlay_cache.is_empty());
+        assert!(matches!(
+            provider.state_root(HashedPostState::default()),
+            Err(ProviderError::UnsupportedProvider)
+        ));
+        assert!(matches!(
+            provider.hashed_post_state(&revm::database::BundleState::default()),
+            Err(ProviderError::UnsupportedProvider)
+        ));
+        assert!(state_provider_factory.state_trie_overlay_cache.is_empty());
+    }
+
+    #[test]
     fn execution_overlay_readers_use_overlay_first() {
         let (factory, _) = setup_frontiers(1, 3);
         let address = Address::with_last_byte(1);
@@ -1053,14 +1084,14 @@ mod tests {
         let code_hash = B256::with_last_byte(6);
         let bytecode = RevmBytecode::new_raw([0x60, 0x01].into());
         let mut execution_overlay = ExecutionOverlay::default();
-        execution_overlay.accounts.insert(address, Some(account_info.clone()));
-        execution_overlay.block_hashes.push(BlockNumHash::new(1, block_hash));
+        execution_overlay.accounts_mut().insert(address, Some(account_info.clone()));
+        execution_overlay.block_hashes_mut().push(BlockNumHash::new(1, block_hash));
         execution_overlay
-            .storage
+            .storage_mut()
             .entry(address)
             .or_default()
             .insert(U256::from_be_bytes(storage_key.0), storage_value);
-        execution_overlay.code_hashes.insert(code_hash, bytecode.clone());
+        execution_overlay.code_hashes_mut().insert(code_hash, bytecode.clone());
         let provider = OverlayStateProvider::<_, EthPrimitives>::new_with_execution(
             factory.provider().unwrap(),
             Arc::new(execution_overlay),

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -1,42 +1,43 @@
-use crate::{database_state_frontiers, OverlayBuilder, StateTrieOverlay};
-use alloy_primitives::{BlockHash, B256};
+use crate::{database_state_frontiers, ExecutionOverlay, OverlayBuilder, StateTrieOverlay};
+use alloy_primitives::{Address, BlockHash, BlockNumber, B256, U256};
 use metrics::{Counter, Histogram};
-use reth_db_api::{tables, transaction::DbTx, DatabaseError};
-use reth_errors::ProviderResult;
+use reth_db_api::{cursor::DbDupCursorRO, tables, transaction::DbTx, DatabaseError};
+use reth_errors::{ProviderError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_metrics::Metrics;
 use reth_primitives_traits::{
     dashmap::{self, DashMap},
-    NodePrimitives,
+    Account, NodePrimitives,
 };
 use reth_storage_api::{
-    BlockNumReader, ChangeSetReader, DBProvider, DatabaseProviderFactory,
-    DatabaseProviderROFactory, DbTxProvider, PruneCheckpointReader, StageCheckpointReader,
-    StorageChangeSetReader, StorageSettingsCache,
+    AccountReader, BlockHashReader, BlockNumReader, BytecodeReader, ChangeSetReader, DBProvider,
+    DatabaseProviderFactory, DatabaseProviderROFactory, DbTxProvider, HashedPostStateProvider,
+    PruneCheckpointReader, StageCheckpointReader, StateProofProvider, StateProvider,
+    StateRootProvider, StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
 };
 use reth_trie::{
-    hashed_cursor::{HashedCursorFactory, HashedPostStateCursorFactory},
-    trie_cursor::{InMemoryTrieCursor, TrieCursor, TrieCursorFactory, TrieStorageCursor},
-    HashedPostStateSorted,
+    hashed_cursor::{
+        zero_destroyed_account_storage, HashedCursorFactory, HashedPostStateCursorFactory,
+    },
+    proof::{Proof, StorageProof as TrieStorageProof},
+    trie_cursor::{
+        InMemoryTrieCursor, InMemoryTrieCursorFactory, TrieCursor, TrieCursorFactory,
+        TrieStorageCursor,
+    },
+    updates::TrieUpdates,
+    witness::TrieWitness,
+    AccountProof, ExecutionWitnessMode, HashedPostState, HashedPostStateSorted, HashedStorage,
+    KeccakKeyHasher, MultiProof, MultiProofTargets, StateRoot, StorageMultiProof, StorageProof,
+    StorageRoot, TrieInput, TrieInputSorted,
 };
 use reth_trie_db::{
-    DatabaseAccountTrieCursor, DatabaseHashedCursorFactory, DatabaseStorageTrieCursor,
-    LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter, PackedStoragesTrie,
+    DatabaseAccountTrieCursor, DatabaseHashedCursorFactory, DatabaseProof, DatabaseStateRoot,
+    DatabaseStorageProof, DatabaseStorageRoot, DatabaseStorageTrieCursor,
+    DatabaseTrieCursorFactory, LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter,
+    PackedStoragesTrie,
 };
-use std::{sync::Arc, time::Instant};
+use std::{cell::OnceCell, fmt, ops::Deref, sync::Arc, time::Instant};
 use tracing::instrument;
-
-/// Metrics for overlay state provider factory operations.
-#[derive(Clone, Metrics)]
-#[metrics(scope = "storage.providers.overlay")]
-pub(crate) struct OverlayStateProviderFactoryMetrics {
-    /// Duration of creating the database provider transaction.
-    create_provider_duration: Histogram,
-    /// Overall duration of the [`OverlayStateProviderFactory::database_provider_ro`] call.
-    database_provider_ro_duration: Histogram,
-    /// Number of cache misses when fetching state trie overlays from the overlay cache.
-    overlay_cache_misses: Counter,
-}
 
 /// Factory for creating overlay state providers with optional reverts and overlays.
 ///
@@ -52,18 +53,21 @@ pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
     ///
     /// Under partial persistence the overlay depends on both durable frontiers, so both hashes are
     /// part of the cache key.
-    overlay_cache: Arc<DashMap<(BlockHash, BlockHash), StateTrieOverlay>>,
+    state_trie_overlay_cache: StateTrieOverlayCache,
+    /// A cache which maps durable frontier pairs to [`ExecutionOverlay`]s.
+    execution_overlay_cache: ExecutionOverlayCache,
     /// Metrics for provider factory operations.
     metrics: OverlayStateProviderFactoryMetrics,
 }
 
 impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
-    /// Create a new overlay state provider factory
+    /// Create a new overlay state provider factory.
     pub fn new(factory: F, overlay_builder: OverlayBuilder<N>) -> Self {
         Self {
             factory,
             overlay_builder,
-            overlay_cache: Default::default(),
+            state_trie_overlay_cache: Default::default(),
+            execution_overlay_cache: Default::default(),
             metrics: Default::default(),
         }
     }
@@ -73,45 +77,9 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
     pub fn with_skip_overlay_for_reused_sparse_trie(mut self, anchor_hash: B256) -> Self {
         self.overlay_builder =
             self.overlay_builder.with_skip_overlay_for_reused_sparse_trie(anchor_hash);
-        self.overlay_cache = Default::default();
+        self.state_trie_overlay_cache = Default::default();
+        self.execution_overlay_cache = Default::default();
         self
-    }
-
-    /// Fetches a [`StateTrieOverlay`] from the cache based on the current durable frontiers. If
-    /// there is no cached value then this calculates the [`StateTrieOverlay`] and populates the
-    /// cache.
-    #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
-    fn get_state_trie_overlay<Provider>(
-        &self,
-        provider: &Provider,
-    ) -> ProviderResult<StateTrieOverlay>
-    where
-        Provider: StageCheckpointReader
-            + PruneCheckpointReader
-            + ChangeSetReader
-            + StorageChangeSetReader
-            + DBProvider
-            + BlockNumReader
-            + StorageSettingsCache,
-    {
-        let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(provider)?;
-
-        let overlay =
-            match self.overlay_cache.entry((state_trie_tip_block.hash, finish_tip_block.hash)) {
-                dashmap::Entry::Occupied(entry) => entry.get().clone(),
-                dashmap::Entry::Vacant(entry) => {
-                    self.metrics.overlay_cache_misses.increment(1);
-                    let overlay = self.overlay_builder.build_state_trie_overlay_at_frontiers(
-                        provider,
-                        state_trie_tip_block,
-                        finish_tip_block,
-                    )?;
-                    entry.insert(overlay.clone());
-                    overlay
-                }
-            };
-
-        Ok(overlay)
     }
 }
 
@@ -126,11 +94,13 @@ where
         + StorageChangeSetReader
         + StorageSettingsCache,
 {
-    type Provider = OverlayStateProvider<F::Provider>;
+    type Provider = OverlayStateProvider<OwnedProvider<F::Provider>, N>;
 
     /// Create a read-only [`OverlayStateProvider`].
     #[instrument(level = "debug", target = "providers::state::overlay", skip_all)]
-    fn database_provider_ro(&self) -> ProviderResult<OverlayStateProvider<F::Provider>> {
+    fn database_provider_ro(
+        &self,
+    ) -> ProviderResult<OverlayStateProvider<OwnedProvider<F::Provider>, N>> {
         let overall_start = Instant::now();
 
         // Get a read-only provider
@@ -141,36 +111,637 @@ where
             res
         };
 
-        let overlay = self.get_state_trie_overlay(&provider)?;
-
         let is_v2 = provider.cached_storage_settings().is_v2();
         self.metrics.database_provider_ro_duration.record(overall_start.elapsed());
-        Ok(OverlayStateProvider::new(provider, overlay, is_v2))
+        Ok(OverlayStateProvider::new(
+            provider,
+            self.overlay_builder.clone(),
+            Arc::clone(&self.state_trie_overlay_cache),
+            Arc::clone(&self.execution_overlay_cache),
+            self.metrics.clone(),
+            is_v2,
+        ))
     }
 }
 
-/// State provider with in-memory overlay from trie updates and hashed post state.
-///
-/// This provider uses in-memory trie updates and hashed post state as an overlay
-/// on top of a database provider, implementing [`TrieCursorFactory`] and [`HashedCursorFactory`]
-/// using the in-memory overlay factories.
-#[derive(Debug)]
-pub struct OverlayStateProvider<Provider> {
+/// State provider with lazily resolved state trie and execution overlays.
+pub struct OverlayStateProvider<Provider, N: NodePrimitives = EthPrimitives> {
     provider: Provider,
-    overlay: StateTrieOverlay,
+    overlay_builder: Option<OverlayBuilder<N>>,
+    state_trie_overlay_cache: StateTrieOverlayCache,
+    execution_overlay_cache: ExecutionOverlayCache,
+    metrics: OverlayStateProviderFactoryMetrics,
+    state_trie_overlay: OnceCell<StateTrieOverlay>,
+    execution_overlay: OnceCell<Arc<ExecutionOverlay>>,
     is_v2: bool,
 }
 
-impl<Provider> OverlayStateProvider<Provider> {
-    /// Creates a new overlay state provider.
-    pub const fn new(provider: Provider, overlay: StateTrieOverlay, is_v2: bool) -> Self {
-        Self { provider, overlay, is_v2 }
+impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, N> {
+    const fn new(
+        provider: Provider,
+        overlay_builder: OverlayBuilder<N>,
+        state_trie_overlay_cache: StateTrieOverlayCache,
+        execution_overlay_cache: ExecutionOverlayCache,
+        metrics: OverlayStateProviderFactoryMetrics,
+        is_v2: bool,
+    ) -> Self {
+        Self {
+            provider: OwnedProvider(provider),
+            overlay_builder: Some(overlay_builder),
+            state_trie_overlay_cache,
+            execution_overlay_cache,
+            metrics,
+            state_trie_overlay: OnceCell::new(),
+            execution_overlay: OnceCell::new(),
+            is_v2,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_execution(
+        provider: Provider,
+        execution_overlay: Arc<ExecutionOverlay>,
+        is_v2: bool,
+    ) -> Self {
+        Self {
+            provider: OwnedProvider(provider),
+            overlay_builder: None,
+            state_trie_overlay_cache: Default::default(),
+            execution_overlay_cache: Default::default(),
+            metrics: Default::default(),
+            state_trie_overlay: OnceCell::new(),
+            execution_overlay: OnceCell::from(execution_overlay),
+            is_v2,
+        }
     }
 }
 
-impl<Provider> TrieCursorFactory for OverlayStateProvider<Provider>
+impl<'a, Provider, N: NodePrimitives> OverlayStateProvider<&'a Provider, N> {
+    pub(crate) fn new_with_state_trie(
+        provider: &'a Provider,
+        state_trie_overlay: StateTrieOverlay,
+        is_v2: bool,
+    ) -> Self {
+        Self {
+            provider,
+            overlay_builder: None,
+            state_trie_overlay_cache: Default::default(),
+            execution_overlay_cache: Default::default(),
+            metrics: Default::default(),
+            state_trie_overlay: OnceCell::from(state_trie_overlay),
+            execution_overlay: OnceCell::new(),
+            is_v2,
+        }
+    }
+}
+
+impl<Provider, N: NodePrimitives> OverlayStateProvider<Provider, N>
 where
-    Provider: DbTxProvider,
+    Provider: Deref,
+    Provider::Target: Sized,
+{
+    fn provider(&self) -> &Provider::Target {
+        &self.provider
+    }
+
+    fn state_trie_overlay(&self) -> ProviderResult<&StateTrieOverlay>
+    where
+        Provider::Target: StageCheckpointReader
+            + PruneCheckpointReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + DBProvider
+            + BlockNumReader
+            + StorageSettingsCache,
+    {
+        if let Some(overlay) = self.state_trie_overlay.get() {
+            return Ok(overlay)
+        }
+
+        let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
+        let overlay = match self
+            .state_trie_overlay_cache
+            .entry((state_trie_tip_block.hash, finish_tip_block.hash))
+        {
+            dashmap::Entry::Occupied(entry) => entry.get().clone(),
+            dashmap::Entry::Vacant(entry) => {
+                self.metrics.state_trie_overlay_cache_misses.increment(1);
+                let overlay = self
+                    .overlay_builder
+                    .as_ref()
+                    .expect("state trie overlay must be initialized or lazily resolvable")
+                    .build_state_trie_overlay_at_frontiers(
+                        self.provider(),
+                        state_trie_tip_block,
+                        finish_tip_block,
+                    )?;
+                entry.insert(overlay.clone());
+                overlay
+            }
+        };
+        let _ = self.state_trie_overlay.set(overlay);
+        Ok(self.state_trie_overlay.get().expect("state trie overlay was just initialized"))
+    }
+
+    fn build_overlay(&self, input: TrieInputSorted) -> ProviderResult<TrieInputSorted>
+    where
+        Provider::Target: StageCheckpointReader
+            + PruneCheckpointReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + DBProvider
+            + BlockNumReader
+            + StorageSettingsCache,
+    {
+        let overlay = self.state_trie_overlay()?;
+        let TrieInputSorted { nodes: input_nodes, state: input_state, prefix_sets } = input;
+        let mut nodes = Arc::clone(&overlay.trie_updates);
+        let mut state = Arc::clone(&overlay.hashed_post_state);
+
+        if !input_nodes.is_empty() {
+            Arc::make_mut(&mut nodes).extend_ref_and_sort(&input_nodes);
+        }
+        if !input_state.is_empty() {
+            Arc::make_mut(&mut state).extend_ref_and_sort(&input_state);
+        }
+
+        Ok(TrieInputSorted::new(nodes, state, prefix_sets))
+    }
+
+    fn execution_overlay(&self) -> ProviderResult<&Arc<ExecutionOverlay>>
+    where
+        Provider::Target: StageCheckpointReader
+            + PruneCheckpointReader
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + BlockNumReader,
+    {
+        if let Some(overlay) = self.execution_overlay.get() {
+            return Ok(overlay)
+        }
+
+        let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
+        let overlay = match self
+            .execution_overlay_cache
+            .entry((state_trie_tip_block.hash, finish_tip_block.hash))
+        {
+            dashmap::Entry::Occupied(entry) => entry.get().clone(),
+            dashmap::Entry::Vacant(entry) => {
+                self.metrics.execution_overlay_cache_misses.increment(1);
+                let overlay = self
+                    .overlay_builder
+                    .as_ref()
+                    .expect("execution overlay must be initialized or lazily resolvable")
+                    .build_execution_overlay_at_frontiers(
+                        self.provider(),
+                        state_trie_tip_block,
+                        finish_tip_block,
+                    )?;
+                entry.insert(overlay.clone());
+                overlay
+            }
+        };
+        let _ = self.execution_overlay.set(overlay);
+        Ok(self.execution_overlay.get().expect("execution overlay was just initialized"))
+    }
+}
+
+impl<Provider, N: NodePrimitives> fmt::Debug for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: fmt::Debug + Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OverlayStateProvider")
+            .field("provider", self.provider())
+            .field("state_trie_overlay", &self.state_trie_overlay.get())
+            .field("execution_overlay", &self.execution_overlay.get())
+            .field("is_v2", &self.is_v2)
+            .finish()
+    }
+}
+
+impl<Provider, N: NodePrimitives> AccountReader for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StorageSettingsCache
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader,
+{
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        let overlay = self.execution_overlay()?;
+        if let Some(account) = overlay.accounts.get(address) {
+            return Ok(account.as_ref().map(Account::from))
+        }
+        if self.provider().cached_storage_settings().use_hashed_state() {
+            let hashed_address = alloy_primitives::keccak256(address);
+            self.provider()
+                .tx()
+                .get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)
+                .map_err(Into::into)
+        } else {
+            self.provider()
+                .tx()
+                .get_by_encoded_key::<tables::PlainAccountState>(address)
+                .map_err(Into::into)
+        }
+    }
+}
+
+impl<Provider, N: NodePrimitives> BlockHashReader for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: BlockHashReader
+        + Sized
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader,
+{
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        let overlay = self.execution_overlay()?;
+        if let Some(block) = overlay.block_hashes.iter().find(|block| block.number == number) {
+            return Ok(Some(block.hash))
+        }
+        self.provider().block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        let overlay = self.execution_overlay()?;
+        let mut block_hashes =
+            overlay.block_hashes.iter().filter(|block| (start..end).contains(&block.number));
+        let Some(first_block) = block_hashes.next() else {
+            return self.provider().canonical_hashes_range(start, end)
+        };
+
+        let mut hashes = self.provider().canonical_hashes_range(start, first_block.number)?;
+        hashes.push(first_block.hash);
+        hashes.extend(block_hashes.map(|block| block.hash));
+        Ok(hashes)
+    }
+}
+
+impl<Provider, N: NodePrimitives> BytecodeReader for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader,
+{
+    fn bytecode_by_hash(
+        &self,
+        code_hash: &B256,
+    ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+        let overlay = self.execution_overlay()?;
+        if let Some(bytecode) = overlay.code_hashes.get(code_hash) {
+            return Ok(Some(reth_primitives_traits::Bytecode(bytecode.clone())));
+        }
+        self.provider().tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
+    }
+}
+
+impl<Provider, N: NodePrimitives> StateRootProvider for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + StorageSettingsCache,
+{
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(hashed_state),
+            ))?;
+            Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.provider().tx(), input)?)
+        })
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            Ok(<DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes(
+                self.provider().tx(),
+                input,
+            )?)
+        })
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(hashed_state),
+            ))?;
+            Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(
+                self.provider().tx(),
+                input,
+            )?)
+        })
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            Ok(
+                <DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes_with_updates(
+                    self.provider().tx(),
+                    input,
+                )?,
+            )
+        })
+    }
+}
+
+impl<Provider, N: NodePrimitives> StorageRootProvider for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + StorageSettingsCache,
+{
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )),
+            ))?;
+            let hashed_storage = input
+                .state
+                .account_storages()
+                .get(&alloy_primitives::keccak256(address))
+                .cloned()
+                .unwrap_or_default()
+                .into();
+            <DbStorageRoot<'_, _, A>>::overlay_root(self.provider().tx(), address, hashed_storage)
+                .map_err(|err| ProviderError::Database(err.into()))
+        })
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )),
+            ))?;
+            let hashed_storage = input
+                .state
+                .account_storages()
+                .get(&alloy_primitives::keccak256(address))
+                .cloned()
+                .unwrap_or_default()
+                .into();
+            <DbStorageProof<'_, _, A>>::overlay_storage_proof(
+                self.provider().tx(),
+                address,
+                slot,
+                hashed_storage,
+            )
+            .map_err(ProviderError::from)
+        })
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )),
+            ))?;
+            let hashed_storage = input
+                .state
+                .account_storages()
+                .get(&alloy_primitives::keccak256(address))
+                .cloned()
+                .unwrap_or_default()
+                .into();
+            <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(
+                self.provider().tx(),
+                address,
+                slots,
+                hashed_storage,
+            )
+            .map_err(ProviderError::from)
+        })
+    }
+}
+
+impl<Provider, N: NodePrimitives> StateProofProvider for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + StorageSettingsCache,
+{
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let TrieInputSorted { nodes, state, prefix_sets } =
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = TrieInput::new(
+                Arc::unwrap_or_clone(nodes).into(),
+                Arc::unwrap_or_clone(state).into(),
+                prefix_sets,
+            );
+            let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.provider().tx());
+            proof.overlay_account_proof(input, address, slots).map_err(ProviderError::from)
+        })
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let TrieInputSorted { nodes, state, prefix_sets } =
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = TrieInput::new(
+                Arc::unwrap_or_clone(nodes).into(),
+                Arc::unwrap_or_clone(state).into(),
+                prefix_sets,
+            );
+            let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.provider().tx());
+            proof.overlay_multiproof(input, targets).map_err(ProviderError::from)
+        })
+    }
+
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+        mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let TrieInputSorted { nodes, state, prefix_sets } =
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let witness = TrieWitness::new(
+                InMemoryTrieCursorFactory::new(
+                    DatabaseTrieCursorFactory::<_, A>::new(self.provider().tx()),
+                    nodes.as_ref(),
+                ),
+                HashedPostStateCursorFactory::new(
+                    DatabaseHashedCursorFactory::new(self.provider().tx()),
+                    state.as_ref(),
+                ),
+            )
+            .with_prefix_sets_mut(prefix_sets)
+            .with_execution_witness_mode(mode);
+            let witness =
+                if mode.is_canonical() { witness } else { witness.always_include_root_node() };
+            let mut values: Vec<_> = witness.compute(target)?.into_values().collect();
+            if mode.is_canonical() {
+                values.sort_unstable();
+            }
+            Ok(values)
+        })
+    }
+}
+
+impl<Provider, N: NodePrimitives> HashedPostStateProvider for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + StorageSettingsCache,
+{
+    fn hashed_post_state(
+        &self,
+        bundle_state: &revm::database::BundleState,
+    ) -> ProviderResult<HashedPostState> {
+        let mut hashed_state =
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state());
+        if !bundle_state
+            .state()
+            .values()
+            .any(|account| account.was_destroyed() && account.original_info.is_some())
+        {
+            return Ok(hashed_state)
+        }
+
+        let overlay_state = self.build_overlay(TrieInputSorted::default())?.state;
+        zero_destroyed_account_storage(
+            &HashedPostStateCursorFactory::new(
+                DatabaseHashedCursorFactory::new(self.provider().tx()),
+                overlay_state.as_ref(),
+            ),
+            bundle_state.state(),
+            &mut hashed_state,
+        )?;
+        Ok(hashed_state)
+    }
+}
+
+impl<Provider, N: NodePrimitives> StateProvider for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + BlockHashReader
+        + StorageSettingsCache
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader,
+{
+    fn storage(
+        &self,
+        address: Address,
+        storage_key: alloy_primitives::StorageKey,
+    ) -> ProviderResult<Option<alloy_primitives::StorageValue>> {
+        let overlay = self.execution_overlay()?;
+        if let Some(value) = overlay
+            .storage
+            .get(&address)
+            .and_then(|storage| storage.get(&U256::from_be_bytes(storage_key.0)))
+        {
+            return Ok(Some(*value));
+        }
+        if self.provider().cached_storage_settings().use_hashed_state() {
+            let hashed_address = alloy_primitives::keccak256(address);
+            let hashed_slot = alloy_primitives::keccak256(storage_key);
+            let mut cursor = self.provider().tx().cursor_dup_read::<tables::HashedStorages>()?;
+            Ok(cursor
+                .seek_by_key_subkey(hashed_address, hashed_slot)?
+                .filter(|entry| entry.key == hashed_slot)
+                .map(|entry| entry.value))
+        } else {
+            let mut cursor = self.provider().tx().cursor_dup_read::<tables::PlainStorageState>()?;
+            if let Some(entry) = cursor.seek_by_key_subkey(address, storage_key)? &&
+                entry.key == storage_key
+            {
+                return Ok(Some(entry.value))
+            }
+            Ok(None)
+        }
+    }
+}
+
+impl<Provider, N: NodePrimitives> TrieCursorFactory for OverlayStateProvider<Provider, N>
+where
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + StorageSettingsCache,
 {
     type AccountTrieCursor<'a>
         = InMemoryTrieCursor<'a, Box<dyn TrieCursor + Send + 'a>>
@@ -183,44 +754,53 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
             Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
-                self.provider.tx().cursor_read::<PackedAccountsTrie>()?,
+                self.provider().tx().cursor_read::<PackedAccountsTrie>()?,
             ))
         } else {
             Box::new(DatabaseAccountTrieCursor::<_, LegacyKeyAdapter>::new(
-                self.provider.tx().cursor_read::<tables::AccountsTrie>()?,
+                self.provider().tx().cursor_read::<tables::AccountsTrie>()?,
             ))
         };
-        Ok(InMemoryTrieCursor::new_account(cursor, &self.overlay.trie_updates))
+        Ok(InMemoryTrieCursor::new_account(cursor, &overlay.trie_updates))
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
             Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
-                self.provider.tx().cursor_dup_read::<PackedStoragesTrie>()?,
+                self.provider().tx().cursor_dup_read::<PackedStoragesTrie>()?,
                 hashed_address,
             ))
         } else {
             Box::new(DatabaseStorageTrieCursor::<_, LegacyKeyAdapter>::new(
-                self.provider.tx().cursor_dup_read::<tables::StoragesTrie>()?,
+                self.provider().tx().cursor_dup_read::<tables::StoragesTrie>()?,
                 hashed_address,
             ))
         };
-        Ok(InMemoryTrieCursor::new_storage(cursor, &self.overlay.trie_updates, hashed_address))
+        Ok(InMemoryTrieCursor::new_storage(cursor, &overlay.trie_updates, hashed_address))
     }
 }
 
-impl<Provider> HashedCursorFactory for OverlayStateProvider<Provider>
+impl<Provider, N: NodePrimitives> HashedCursorFactory for OverlayStateProvider<Provider, N>
 where
-    Provider: DbTxProvider,
+    Provider: Deref,
+    Provider::Target: DBProvider
+        + StageCheckpointReader
+        + PruneCheckpointReader
+        + ChangeSetReader
+        + StorageChangeSetReader
+        + BlockNumReader
+        + StorageSettingsCache,
 {
     type AccountCursor<'a>
         = <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        DatabaseHashedCursorFactory<&'a <Provider::Target as DbTxProvider>::Tx>,
         &'a Arc<HashedPostStateSorted>,
     > as HashedCursorFactory>::AccountCursor<'a>
     where
@@ -228,16 +808,17 @@ where
 
     type StorageCursor<'a>
         = <HashedPostStateCursorFactory<
-        DatabaseHashedCursorFactory<&'a Provider::Tx>,
+        DatabaseHashedCursorFactory<&'a <Provider::Target as DbTxProvider>::Tx>,
         &'a Arc<HashedPostStateSorted>,
     > as HashedCursorFactory>::StorageCursor<'a>
     where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         HashedPostStateCursorFactory::new(
-            DatabaseHashedCursorFactory::new(self.provider.tx()),
-            &self.overlay.hashed_post_state,
+            DatabaseHashedCursorFactory::new(self.provider().tx()),
+            &overlay.hashed_post_state,
         )
         .hashed_account_cursor()
     }
@@ -246,19 +827,69 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         HashedPostStateCursorFactory::new(
-            DatabaseHashedCursorFactory::new(self.provider.tx()),
-            &self.overlay.hashed_post_state,
+            DatabaseHashedCursorFactory::new(self.provider().tx()),
+            &overlay.hashed_post_state,
         )
         .hashed_storage_cursor(hashed_address)
+    }
+}
+
+/// Metrics for overlay state provider factory operations.
+#[derive(Clone, Metrics)]
+#[metrics(scope = "storage.providers.overlay")]
+pub(crate) struct OverlayStateProviderFactoryMetrics {
+    /// Duration of creating the database provider transaction.
+    create_provider_duration: Histogram,
+    /// Overall duration of the [`OverlayStateProviderFactory::database_provider_ro`] call.
+    database_provider_ro_duration: Histogram,
+    /// Number of cache misses when fetching state trie overlays.
+    state_trie_overlay_cache_misses: Counter,
+    /// Number of cache misses when fetching execution overlays.
+    execution_overlay_cache_misses: Counter,
+}
+
+type StateTrieOverlayCache = Arc<DashMap<(BlockHash, BlockHash), StateTrieOverlay>>;
+type ExecutionOverlayCache = Arc<DashMap<(BlockHash, BlockHash), Arc<ExecutionOverlay>>>;
+
+type DbStateRoot<'a, TX, A> =
+    StateRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
+type DbStorageRoot<'a, TX, A> =
+    StorageRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
+type DbStorageProof<'a, TX, A> = TrieStorageProof<
+    'static,
+    DatabaseTrieCursorFactory<&'a TX, A>,
+    DatabaseHashedCursorFactory<&'a TX>,
+>;
+type DbProof<'a, TX, A> =
+    Proof<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct OwnedProvider<Provider>(Provider);
+
+impl<Provider> Deref for OwnedProvider<Provider> {
+    type Target = Provider;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+fn into_database_error(error: ProviderError) -> DatabaseError {
+    match error {
+        ProviderError::Database(error) => error,
+        error => DatabaseError::Other(error.to_string()),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::OverlayManager;
-    use alloy_primitives::U256;
+    use crate::{ExecutionOverlay, OverlayManager};
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::{Address, U256};
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
     use reth_primitives_traits::Account;
     use reth_provider::{
@@ -271,6 +902,7 @@ mod tests {
         updates::TrieUpdatesSorted, BranchNodeCompact, ComputedTrieData, HashedPostState,
         HashedStorage, Nibbles,
     };
+    use revm::{bytecode::Bytecode as RevmBytecode, state::AccountInfo};
 
     fn with_unique_trie_data(
         block: &ExecutedBlock<EthPrimitives>,
@@ -352,8 +984,8 @@ mod tests {
             manager.overlay_builder(blocks[3].recovered_block().hash()),
         );
 
-        let provider = factory.provider().unwrap();
-        let first = overlay_factory.get_state_trie_overlay(&provider).unwrap();
+        let provider = overlay_factory.database_provider_ro().unwrap();
+        let first = provider.state_trie_overlay().unwrap().clone();
         assert_eq!(account_keys(&first), vec![B256::with_last_byte(3), B256::with_last_byte(4)]);
         drop(provider);
 
@@ -368,10 +1000,79 @@ mod tests {
             .unwrap();
         provider_rw.commit().unwrap();
 
-        let provider = factory.provider().unwrap();
-        let second = overlay_factory.get_state_trie_overlay(&provider).unwrap();
+        let provider = overlay_factory.database_provider_ro().unwrap();
+        let second = provider.state_trie_overlay().unwrap().clone();
         assert_eq!(account_keys(&second), vec![B256::with_last_byte(4)]);
         assert_eq!(account_node_paths(&second), vec![Nibbles::from_nibbles([4])]);
-        assert_eq!(overlay_factory.overlay_cache.len(), 2);
+        assert_eq!(overlay_factory.state_trie_overlay_cache.len(), 2);
+    }
+
+    #[test]
+    fn overlays_are_computed_lazily() {
+        let (factory, blocks) = setup_frontiers(1, 3);
+        let manager = OverlayManager::default();
+        for block in &blocks[2..=3] {
+            manager.insert_block(block.clone());
+        }
+        let overlay_factory = OverlayStateProviderFactory::new(
+            factory,
+            manager.overlay_builder(blocks[3].recovered_block().hash()),
+        );
+
+        let provider = overlay_factory.database_provider_ro().unwrap();
+
+        assert!(provider.state_trie_overlay.get().is_none());
+        assert!(provider.execution_overlay.get().is_none());
+        assert!(overlay_factory.state_trie_overlay_cache.is_empty());
+        assert!(overlay_factory.execution_overlay_cache.is_empty());
+
+        provider.basic_account(&Address::ZERO).unwrap();
+        let execution_overlay = Arc::clone(provider.execution_overlay.get().unwrap());
+        assert!(provider.state_trie_overlay.get().is_none());
+        assert!(provider.execution_overlay.get().is_some());
+        assert!(overlay_factory.state_trie_overlay_cache.is_empty());
+        assert_eq!(overlay_factory.execution_overlay_cache.len(), 1);
+        let cached_overlay = overlay_factory.execution_overlay_cache.iter().next().unwrap();
+        assert!(Arc::ptr_eq(&execution_overlay, cached_overlay.value()));
+
+        provider.account_trie_cursor().unwrap();
+        assert_eq!(overlay_factory.state_trie_overlay_cache.len(), 1);
+        assert_eq!(overlay_factory.execution_overlay_cache.len(), 1);
+    }
+
+    #[test]
+    fn execution_overlay_readers_use_overlay_first() {
+        let (factory, _) = setup_frontiers(1, 3);
+        let address = Address::with_last_byte(1);
+        let account_info = AccountInfo { nonce: 1, balance: U256::from(2), ..Default::default() };
+        let block_hash = B256::with_last_byte(3);
+        let storage_key = B256::with_last_byte(4);
+        let storage_value = U256::from(5);
+        let code_hash = B256::with_last_byte(6);
+        let bytecode = RevmBytecode::new_raw([0x60, 0x01].into());
+        let mut execution_overlay = ExecutionOverlay::default();
+        execution_overlay.accounts.insert(address, Some(account_info.clone()));
+        execution_overlay.block_hashes.push(BlockNumHash::new(1, block_hash));
+        execution_overlay
+            .storage
+            .entry(address)
+            .or_default()
+            .insert(U256::from_be_bytes(storage_key.0), storage_value);
+        execution_overlay.code_hashes.insert(code_hash, bytecode.clone());
+        let provider = OverlayStateProvider::<_, EthPrimitives>::new_with_execution(
+            factory.provider().unwrap(),
+            Arc::new(execution_overlay),
+            false,
+        );
+
+        assert_eq!(provider.basic_account(&address).unwrap(), Some(Account::from(account_info)));
+        assert!(provider.basic_account(&Address::with_last_byte(2)).unwrap().is_none());
+        assert_eq!(provider.block_hash(1).unwrap(), Some(block_hash));
+        assert_eq!(provider.canonical_hashes_range(1, 2).unwrap(), vec![block_hash]);
+        assert_eq!(provider.storage(address, storage_key).unwrap(), Some(storage_value));
+        assert_eq!(
+            provider.bytecode_by_hash(&code_hash).unwrap(),
+            Some(reth_primitives_traits::Bytecode(bytecode))
+        );
     }
 }

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -671,9 +671,6 @@ where
         &self,
         bundle_state: &revm::database::BundleState,
     ) -> ProviderResult<HashedPostState> {
-        if self.state_trie_overlay()?.skipped_for_reused_sparse_trie() {
-            return Err(ProviderError::UnsupportedProvider)
-        }
         let mut hashed_state =
             HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state());
         if !bundle_state
@@ -1067,10 +1064,6 @@ mod tests {
         assert!(state_provider_factory.state_trie_overlay_cache.is_empty());
         assert!(matches!(
             provider.state_root(HashedPostState::default()),
-            Err(ProviderError::UnsupportedProvider)
-        ));
-        assert!(matches!(
-            provider.hashed_post_state(&revm::database::BundleState::default()),
             Err(ProviderError::UnsupportedProvider)
         ));
         assert!(state_provider_factory.state_trie_overlay_cache.is_empty());

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -219,24 +219,27 @@ where
         }
 
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
-        let cache_key = (state_trie_tip_block.hash, finish_tip_block.hash);
-        let overlay = if let Some(overlay) = self.state_trie_overlay_cache.get(&cache_key) {
-            overlay.clone()
-        } else {
-            self.metrics.state_trie_overlay_cache_misses.increment(1);
-            let overlay = self
-                .overlay_builder
-                .as_ref()
-                .expect("state trie overlay must be initialized or lazily resolvable")
-                .build_state_trie_overlay_at_frontiers(
-                    self.provider(),
-                    state_trie_tip_block,
-                    finish_tip_block,
-                )?;
-            if !overlay.skipped_for_reused_sparse_trie() {
-                self.state_trie_overlay_cache.insert(cache_key, overlay.clone());
+        let overlay = match self
+            .state_trie_overlay_cache
+            .entry((state_trie_tip_block.hash, finish_tip_block.hash))
+        {
+            dashmap::Entry::Occupied(entry) => entry.get().clone(),
+            dashmap::Entry::Vacant(entry) => {
+                self.metrics.state_trie_overlay_cache_misses.increment(1);
+                let overlay = self
+                    .overlay_builder
+                    .as_ref()
+                    .expect("state trie overlay must be initialized or lazily resolvable")
+                    .build_state_trie_overlay_at_frontiers(
+                        self.provider(),
+                        state_trie_tip_block,
+                        finish_tip_block,
+                    )?;
+                if !overlay.skipped_for_reused_sparse_trie() {
+                    entry.insert(overlay.clone());
+                }
+                overlay
             }
-            overlay
         };
         let _ = self.state_trie_overlay.set(overlay);
         Ok(self.state_trie_overlay.get().expect("state trie overlay was just initialized"))

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -274,6 +274,7 @@ where
             + PruneCheckpointReader
             + ChangeSetReader
             + StorageChangeSetReader
+            + DBProvider
             + BlockNumReader,
     {
         if let Some(overlay) = self.execution_overlay.get() {
@@ -334,7 +335,7 @@ where
 {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         let overlay = self.execution_overlay()?;
-        if let Some(account) = overlay.accounts.get(address) {
+        if let Some(account) = overlay.accounts().get(address) {
             return Ok(account.as_ref().map(Account::from))
         }
         if self.provider().cached_storage_settings().use_hashed_state() {
@@ -356,6 +357,7 @@ impl<Provider, N: NodePrimitives> BlockHashReader for OverlayStateProvider<Provi
 where
     Provider: Deref,
     Provider::Target: BlockHashReader
+        + DBProvider
         + Sized
         + StageCheckpointReader
         + PruneCheckpointReader
@@ -365,7 +367,7 @@ where
 {
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
         let overlay = self.execution_overlay()?;
-        if let Some(block) = overlay.block_hashes.iter().find(|block| block.number == number) {
+        if let Some(block) = overlay.block_hashes().iter().find(|block| block.number == number) {
             return Ok(Some(block.hash))
         }
         self.provider().block_hash(number)
@@ -378,7 +380,7 @@ where
     ) -> ProviderResult<Vec<B256>> {
         let overlay = self.execution_overlay()?;
         let mut block_hashes =
-            overlay.block_hashes.iter().filter(|block| (start..end).contains(&block.number));
+            overlay.block_hashes().iter().filter(|block| (start..end).contains(&block.number));
         let Some(first_block) = block_hashes.next() else {
             return self.provider().canonical_hashes_range(start, end)
         };
@@ -405,7 +407,7 @@ where
         code_hash: &B256,
     ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
         let overlay = self.execution_overlay()?;
-        if let Some(bytecode) = overlay.code_hashes.get(code_hash) {
+        if let Some(bytecode) = overlay.code_hashes().get(code_hash) {
             return Ok(Some(reth_primitives_traits::Bytecode(bytecode.clone())));
         }
         self.provider().tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
@@ -706,7 +708,7 @@ where
     ) -> ProviderResult<Option<alloy_primitives::StorageValue>> {
         let overlay = self.execution_overlay()?;
         if let Some(value) = overlay
-            .storage
+            .storage()
             .get(&address)
             .and_then(|storage| storage.get(&U256::from_be_bytes(storage_key.0)))
         {


### PR DESCRIPTION
This PR gives the OverlayStateProvider access to the flattened ExecutionOverlay from the OverlayBuilder (#26838) and uses it to implement StateProvider. It is composed of a number of related changes:

* Move trie/execution caches from OverlayStateProviderFactory to OverlayStateProvider. The caches are now populated lazily as-needed, rather than on provider creation like they were before. This is only relevant for proof workers, which used to calculate the overlay as they initialized asynchronously. They now generally skip the overlay entirely thanks to the sparse trie skip path, so this is not an issue.

* All StateProvider traits are implemented. Nothing yet uses them.

* A new constructor, `OverlayStateProvider::new_with_state_trie`, is introduced for cases where we want to provide our own provider+overlay.

* Some trait/ownership shenanigans have been done to continue allowing OverlayStateProvider to hold either an owned or borrowed Provider.