### PR TITLE
fix(rpc): track batch entries in a dedicated call counter

### DIFF
--- a/crates/rpc/rpc-builder/src/metrics.rs
+++ b/crates/rpc/rpc-builder/src/metrics.rs
@@ -132,7 +132,7 @@ where
         for batch_entry in req.iter().flatten() {
             let method_name = batch_entry.method_name();
             if let Some(call_metrics) = self.metrics.inner.call_metrics.get(method_name) {
-                call_metrics.started_total.increment(1);
+                call_metrics.batched_total.increment(1);
             }
         }
 
@@ -299,6 +299,12 @@ struct RpcServerCallMetrics {
     successful_total: Counter,
     /// The number of failed calls
     failed_total: Counter,
+    /// The number of calls received as batch entries.
+    ///
+    /// jsonrpsee dispatches batch entries internally without invoking this middleware's `call`,
+    /// so only their per-method volume can be tracked; batched calls are excluded from
+    /// `started_total`, `successful_total`, `failed_total` and `time_seconds`.
+    batched_total: Counter,
     /// Response for a single call
     time_seconds: Histogram,
 }


### PR DESCRIPTION
Closes #26833

`batch()` incremented `rpc_server.calls.started_total` for every batch entry, but the matching `successful_total`/`failed_total`/`time_seconds` are never recorded for batched calls: jsonrpsee dispatches batch entries internally, so the middleware's `call()` never runs for them and the batch response doesn't expose per-entry outcomes. As a result `started_total == successful_total + failed_total` breaks on any node receiving batch traffic, diluting per-method error rates and inflating in-flight gauges derived from these counters.

Batch entries are now counted in a dedicated `rpc_server.calls.batched_total`, which restores the invariant while keeping the per-method batch volume added in #19779. Attributing real per-method outcomes for batches would require decomposing the batch and routing every entry through `call()`, which would hide `batch()` from downstream middleware and add per-entry overhead, so this sticks with volume-only tracking.