### PR TITLE
chore(rpc): fix unused ChainBlockTraceResult import warning

### DIFF
--- a/crates/rpc/rpc-api/src/debug.rs
+++ b/crates/rpc/rpc-api/src/debug.rs
@@ -5,8 +5,7 @@ use alloy_primitives::{Address, Bytes, B256, U64};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_eth::{Account, AccountInfo, Bundle, Index, StateContext};
 use alloy_rpc_types_trace::geth::{
-    ChainBlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
-    TraceResult,
+    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
@@ -54,7 +53,7 @@ pub trait DebugApi<TxReq: RpcObject> {
     #[subscription(
         name = "subscribe" => "subscription",
         unsubscribe = "unsubscribe",
-        item = ChainBlockTraceResult
+        item = alloy_rpc_types_trace::geth::ChainBlockTraceResult
     )]
     async fn debug_subscribe(
         &self,


### PR DESCRIPTION
`ChainBlockTraceResult` is only referenced by jsonrpsee's generated client code, so building `reth-rpc-api` without the `client` feature (e.g. `cargo clippy -p reth-rpc-builder --lib`) warned about an unused import. Reference the type by its full path in the `debug_subscribe` subscription attribute instead, matching the other subscriptions.