### PR TITLE
feat(engine): add inclusion list metrics

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -503,7 +503,7 @@ where
         let result = Self::get_inclusion_list_v1(self);
         self.inner.metrics.latency.get_inclusion_list_v1.record(start.elapsed());
         if let Ok(inclusion_list) = &result {
-            let encoded_size = alloy_rlp::list_length::<Bytes, [u8]>(inclusion_list);
+            let encoded_size = inclusion_list.iter().map(|tx| tx.len()).sum::<usize>();
             self.inner.metrics.inclusion_list.transaction_count.record(inclusion_list.len() as f64);
             self.inner.metrics.inclusion_list.encoded_size_bytes.record(encoded_size as f64);
         }

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -502,6 +502,11 @@ where
         let start = Instant::now();
         let result = Self::get_inclusion_list_v1(self);
         self.inner.metrics.latency.get_inclusion_list_v1.record(start.elapsed());
+        if let Ok(inclusion_list) = &result {
+            let encoded_size = alloy_rlp::list_length::<Bytes, [u8]>(inclusion_list);
+            self.inner.metrics.inclusion_list.transaction_count.record(inclusion_list.len() as f64);
+            self.inner.metrics.inclusion_list.encoded_size_bytes.record(encoded_size as f64);
+        }
         result
     }
 

--- a/crates/rpc/rpc-engine-api/src/metrics.rs
+++ b/crates/rpc/rpc-engine-api/src/metrics.rs
@@ -6,6 +6,8 @@ use reth_metrics::Metrics;
 pub(crate) struct EngineApiMetrics {
     /// Engine API latency metrics
     pub(crate) latency: EngineApiLatencyMetrics,
+    /// Inclusion list metrics
+    pub(crate) inclusion_list: InclusionListMetrics,
     /// Blob-related metrics
     pub(crate) blob_metrics: BlobMetrics,
 }
@@ -68,6 +70,16 @@ pub(crate) struct EngineApiLatencyMetrics {
     pub(crate) get_blobs_v4: Histogram,
     /// Latency for `engine_hasBlobs`
     pub(crate) has_blobs: Histogram,
+}
+
+/// Inclusion list metrics.
+#[derive(Metrics)]
+#[metrics(scope = "engine.rpc.inclusion_list")]
+pub(crate) struct InclusionListMetrics {
+    /// Number of transactions returned by `engine_getInclusionListV1`
+    pub(crate) transaction_count: Histogram,
+    /// RLP-encoded size of inclusion lists returned by `engine_getInclusionListV1`
+    pub(crate) encoded_size_bytes: Histogram,
 }
 
 #[derive(Metrics)]

--- a/crates/rpc/rpc-engine-api/src/metrics.rs
+++ b/crates/rpc/rpc-engine-api/src/metrics.rs
@@ -78,7 +78,7 @@ pub(crate) struct EngineApiLatencyMetrics {
 pub(crate) struct InclusionListMetrics {
     /// Number of transactions returned by `engine_getInclusionListV1`
     pub(crate) transaction_count: Histogram,
-    /// RLP-encoded size of inclusion lists returned by `engine_getInclusionListV1`
+    /// Total EIP-2718 transaction bytes returned by `engine_getInclusionListV1`
     pub(crate) encoded_size_bytes: Histogram,
 }
 


### PR DESCRIPTION
Part of #26683

Records the transaction count and total EIP-2718 transaction byte size of each successful `engine_getInclusionListV1` response, complementing the existing latency metric.