### PR TITLE
fix(overlay): run computations on dedicated workers

### DIFF
--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -573,7 +573,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
             if let Some(worker_pool) = &self.worker_pool {
                 let compute_span = _span;
                 let metrics = self.metrics.clone();
-                return worker_pool.install_fn(move || {
+                return worker_pool.spawn_and_wait(move || {
                     let _guard = compute_span.enter();
                     compute_overlay(compute_input, anchor_hash, &metrics)
                 })
@@ -594,7 +594,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
             if let Some(worker_pool) = &self.worker_pool {
                 let compute_span = _span;
                 let metrics = self.execution_metrics.clone();
-                return worker_pool.install_fn(move || {
+                return worker_pool.spawn_and_wait(move || {
                     let _guard = compute_span.enter();
                     compute_execution_overlay_inner(compute_input, anchor_hash, &metrics)
                 })

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -301,6 +301,28 @@ impl WorkerPool {
         })
     }
 
+    /// Runs a closure on this pool, waiting for its result.
+    ///
+    /// Unlike [`install_fn`](Self::install_fn), this always queues the closure onto this pool
+    /// when called from another rayon pool. This avoids Rayon running the closure on the caller's
+    /// worker through its cross-pool install path.
+    pub fn spawn_and_wait<R: Send + 'static>(&self, f: impl FnOnce() -> R + Send + 'static) -> R {
+        let pool = self.pool();
+        if pool.current_thread_index().is_some() {
+            return f()
+        }
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        self.spawn(move || {
+            let _ = tx.send(catch_unwind(AssertUnwindSafe(f)));
+        });
+
+        match rx.recv().expect("worker pool exited before completing task") {
+            Ok(result) => result,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
     /// Spawns a closure on the pool.
     pub fn spawn(&self, f: impl FnOnce() + Send + 'static) {
         let pool = self.pool();
@@ -548,5 +570,22 @@ mod tests {
         assert_eq!(results, vec![10, 11, 12, 13]);
 
         pool.clear();
+    }
+
+    #[test]
+    fn worker_pool_spawn_and_wait_runs_on_target_pool() {
+        let caller_pool = WorkerPool::new(1, "caller");
+        let target_pool = Arc::new(WorkerPool::new(1, "target"));
+
+        let thread_name = caller_pool.install_fn({
+            let target_pool = Arc::clone(&target_pool);
+            move || {
+                WorkerPool::with_worker_mut(|_| {
+                    target_pool.spawn_and_wait(|| thread::current().name().unwrap().to_owned())
+                })
+            }
+        });
+
+        assert_eq!(thread_name, "target-00");
     }
 }


### PR DESCRIPTION
Queues state and execution overlay computation onto the dedicated state-overlay pool instead of using Rayon's cross-pool install path.

This prevents lazy overlay construction during prewarming from re-entering a prewarm worker while its thread-local state is mutably borrowed. The precise broken sequence was:

prewarm transaction → WorkerPool::with_worker_mut → lazy ExecutionOverlay resolution → OverlayManager::compute_execution_overlay → prewarming_pool.install_fn(...) → Rayon runs another prewarm task on that same worker → second with_worker_mut panics.