### PR TITLE
fix(rpc): return used gas from the basic transfer estimate shortcut

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -3,7 +3,9 @@ use alloy_eips::{eip2718::Encodable2718, eip7910::EthConfig, BlockNumberOrTag};
 use alloy_genesis::Genesis;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_provider::{
-    ext::DebugApi, network::EthereumWallet, Provider, ProviderBuilder, SendableTx,
+    ext::DebugApi,
+    network::{EthereumWallet, TransactionBuilder},
+    Provider, ProviderBuilder, SendableTx,
 };
 use alloy_rpc_types_beacon::relay::{
     BidTrace, BuilderBlockValidationRequestV3, BuilderBlockValidationRequestV4,
@@ -14,12 +16,16 @@ use alloy_rpc_types_engine::{
     BlobsBundleV1, CancunPayloadFields, ExecutionPayload, ExecutionPayloadSidecar,
     ExecutionPayloadV3, PraguePayloadFields,
 };
-use alloy_rpc_types_eth::{error::EthRpcErrorCode, TransactionRequest};
+use alloy_rpc_types_eth::{
+    error::EthRpcErrorCode,
+    state::{AccountOverride, StateOverride},
+    TransactionRequest,
+};
 use alloy_rpc_types_trace::geth::{ChainBlockTraceResult, GethDebugTracingOptions};
 use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, EthChainSpec, MAINNET};
-use reth_e2e_test_utils::{setup_engine, E2ETestSetupBuilder};
+use reth_e2e_test_utils::{setup_engine, wallet::Wallet, E2ETestSetupBuilder};
 use reth_network::{types::NatResolver, PeersInfo};
 use reth_node_builder::{NodeBuilder, NodeHandle};
 use reth_node_core::{
@@ -536,6 +542,92 @@ async fn test_flashbots_validate_v6() -> eyre::Result<()> {
         .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV6".into(), (&request,))
         .await
         .is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_estimate_gas_basic_transfers_post_amsterdam() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .amsterdam_activated()
+            .build(),
+    );
+
+    let (mut nodes, _) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes_amsterdam,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new().connect_http(node.rpc_url());
+
+    let mut signers = Wallet::new(2).wallet_gen();
+    let from = signers.remove(0).address();
+    let existing_recipient = signers.remove(0).address();
+
+    let self_send_gas = provider
+        .estimate_gas(
+            TransactionRequest::default().with_from(from).with_to(from).with_value(U256::from(1)),
+        )
+        .await?;
+    assert_eq!(self_send_gas, 12_000);
+
+    let zero_value_existing_gas = provider
+        .estimate_gas(TransactionRequest::default().with_from(from).with_to(existing_recipient))
+        .await?;
+    assert_eq!(zero_value_existing_gas, 15_000);
+
+    let value_existing_gas = provider
+        .estimate_gas(
+            TransactionRequest::default()
+                .with_from(from)
+                .with_to(existing_recipient)
+                .with_value(U256::from(1)),
+        )
+        .await?;
+    assert_eq!(value_existing_gas, 21_000);
+
+    let fresh_recipient = Address::repeat_byte(0xfe);
+    let zero_value_fresh_gas = provider
+        .estimate_gas(TransactionRequest::default().with_from(from).with_to(fresh_recipient))
+        .await?;
+    assert_eq!(zero_value_fresh_gas, 15_000);
+
+    // Account creation costs state gas beyond 21_000, so this must miss the shortcut and fall
+    // through to the binary search.
+    let value_fresh_gas = provider
+        .estimate_gas(
+            TransactionRequest::default()
+                .with_from(from)
+                .with_to(fresh_recipient)
+                .with_value(U256::from(1)),
+        )
+        .await?;
+    assert!(value_fresh_gas > 21_000);
+
+    // GAS PUSH2 4000 LT PUSH1 9 JUMPI INVALID JUMPDEST STOP: succeeds only with more than
+    // 4_000 gas left at entry. The 21_000 probe satisfies that while its used gas does not,
+    // so a shortcut that misses override-installed code returns an inexecutable estimate.
+    let gas_gate = Address::repeat_byte(0xaa);
+    let mut overrides = StateOverride::default();
+    overrides.insert(
+        gas_gate,
+        AccountOverride {
+            code: Some("0x5a610fa010600957fe5b00".parse::<Bytes>()?),
+            ..Default::default()
+        },
+    );
+    let gated_tx = TransactionRequest::default().with_from(from).with_to(gas_gate);
+    let gated_gas = provider.estimate_gas(gated_tx.clone()).overrides(overrides.clone()).await?;
+    provider.call(gated_tx.with_gas_limit(gated_gas)).overrides(overrides).await?;
 
     Ok(())
 }

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -601,8 +601,8 @@ async fn test_estimate_gas_basic_transfers_post_amsterdam() -> eyre::Result<()> 
         .await?;
     assert_eq!(zero_value_fresh_gas, 15_000);
 
-    // Account creation costs state gas beyond 21_000, so this must miss the shortcut and fall
-    // through to the binary search.
+    // Creating the recipient requires additional state gas, so the 21_000-gas run fails and
+    // estimation falls back to binary search.
     let value_fresh_gas = provider
         .estimate_gas(
             TransactionRequest::default()
@@ -613,9 +613,8 @@ async fn test_estimate_gas_basic_transfers_post_amsterdam() -> eyre::Result<()> 
         .await?;
     assert!(value_fresh_gas > 21_000);
 
-    // GAS PUSH2 4000 LT PUSH1 9 JUMPI INVALID JUMPDEST STOP: succeeds only with more than
-    // 4_000 gas left at entry. The 21_000 probe satisfies that while its used gas does not,
-    // so a shortcut that misses override-installed code returns an inexecutable estimate.
+    // The override installs code that needs more than 4_000 gas at entry. If the estimator
+    // mistakes this for a basic transfer, it returns too little gas for the code to run.
     let gas_gate = Address::repeat_byte(0xaa);
     let mut overrides = StateOverride::default();
     overrides.insert(

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -120,7 +120,8 @@ pub trait EstimateCall: Call {
         let is_basic_transfer = if tx_env.input().is_empty() &&
             let TxKind::Call(to) = tx_env.kind()
         {
-            // Check the account after applying state overrides, since an override may add bytecode.
+            // Fetch the account through `Database::basic` so the state overrides applied above
+            // are visible.
             match db.basic(to) {
                 Ok(Some(account)) => account.is_empty_code_hash(),
                 Ok(None) => true,

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -29,7 +29,7 @@ use reth_rpc_server_types::constants::gas_oracle::{CALL_STIPEND_GAS, ESTIMATE_GA
 use revm::{
     context::Block,
     context_interface::{result::ExecutionResult, Cfg, Transaction},
-    primitives::KECCAK_EMPTY,
+    Database as _,
 };
 use tracing::trace;
 
@@ -117,14 +117,15 @@ pub trait EstimateCall: Call {
         let mut tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
 
         // Check if this is a basic transfer (no input data to account with no code)
+        // Read through the `State` so state overrides that install code at `to` are visible;
+        // the probe must never execute code, or its used gas is not a proven gas limit.
         let is_basic_transfer = if tx_env.input().is_empty() &&
             let TxKind::Call(to) = tx_env.kind()
         {
-            match db.database.basic_account(&to) {
-                Ok(Some(account)) => {
-                    account.bytecode_hash.is_none() || account.bytecode_hash == Some(KECCAK_EMPTY)
-                }
-                _ => true,
+            match db.basic(to) {
+                Ok(Some(account)) => account.is_empty_code_hash(),
+                Ok(None) => true,
+                Err(_) => false,
             }
         } else {
             false
@@ -148,10 +149,10 @@ pub trait EstimateCall: Call {
         // For basic transfers, try using minimum gas before running full binary search
         if is_basic_transfer {
             // If the tx is a simple transfer (call to an account with no code) we can
-            // shortcircuit. But simply returning
-            // `MIN_TRANSACTION_GAS` is dangerous because there might be additional
-            // field combos that bump the price up, so we try executing the function
-            // with the minimum gas limit to make sure.
+            // shortcircuit by probing at the minimum gas limit. A transfer runs no code and
+            // gets no refunds, so on success its used gas is the lowest gas limit that
+            // succeeds. EIP-2780 prices some transfers below 21_000, so returning
+            // `MIN_TRANSACTION_GAS` itself would over-estimate post-Amsterdam.
             let mut min_tx_env = tx_env.clone();
             min_tx_env.set_gas_limit(MIN_TRANSACTION_GAS);
 
@@ -159,7 +160,7 @@ pub trait EstimateCall: Call {
             if let Ok(res) = evm.transact(min_tx_env).map_err(Self::Error::from_evm_err) &&
                 res.result.is_success()
             {
-                return Ok(U256::from(MIN_TRANSACTION_GAS))
+                return Ok(U256::from(res.result.tx_gas_used()))
             }
         }
 

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -116,11 +116,11 @@ pub trait EstimateCall: Call {
 
         let mut tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
 
-        // A state override may add bytecode to the recipient, so check the overridden account
-        // before treating an empty-input call as a basic transfer.
+        // Check whether this is a basic transfer: empty input to an account without bytecode.
         let is_basic_transfer = if tx_env.input().is_empty() &&
             let TxKind::Call(to) = tx_env.kind()
         {
+            // Check the account after applying state overrides, since an override may add bytecode.
             match db.basic(to) {
                 Ok(Some(account)) => account.is_empty_code_hash(),
                 Ok(None) => true,

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -116,9 +116,8 @@ pub trait EstimateCall: Call {
 
         let mut tx_env = self.create_txn_env(&evm_env, request, &mut db)?;
 
-        // Check if this is a basic transfer (no input data to account with no code)
-        // Read through the `State` so state overrides that install code at `to` are visible;
-        // the probe must never execute code, or its used gas is not a proven gas limit.
+        // A state override may add bytecode to the recipient, so check the overridden account
+        // before treating an empty-input call as a basic transfer.
         let is_basic_transfer = if tx_env.input().is_empty() &&
             let TxKind::Call(to) = tx_env.kind()
         {
@@ -146,13 +145,10 @@ pub trait EstimateCall: Call {
         // Create EVM instance once and reuse it throughout the entire estimation process
         let mut evm = self.evm_config().evm_with_env(&mut db, evm_env);
 
-        // For basic transfers, try using minimum gas before running full binary search
         if is_basic_transfer {
-            // If the tx is a simple transfer (call to an account with no code) we can
-            // shortcircuit by probing at the minimum gas limit. A transfer runs no code and
-            // gets no refunds, so on success its used gas is the lowest gas limit that
-            // succeeds. EIP-2780 prices some transfers below 21_000, so returning
-            // `MIN_TRANSACTION_GAS` itself would over-estimate post-Amsterdam.
+            // Run the transfer with 21_000 gas. Since it executes no bytecode and receives no
+            // refunds, the amount consumed is the exact gas required. EIP-2780 can make that less
+            // than 21_000.
             let mut min_tx_env = tx_env.clone();
             min_tx_env.set_gas_limit(MIN_TRANSACTION_GAS);
 

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -145,9 +145,10 @@ pub trait EstimateCall: Call {
         // Create EVM instance once and reuse it throughout the entire estimation process
         let mut evm = self.evm_config().evm_with_env(&mut db, evm_env);
 
+        // For basic transfers, try 21_000 gas before running the full binary search.
         if is_basic_transfer {
-            // Run the transfer with 21_000 gas. Since it executes no bytecode and receives no
-            // refunds, the amount consumed is the exact gas required. EIP-2780 can make that less
+            // A basic transfer executes no bytecode and receives no refunds, so the amount
+            // consumed by a successful run is the exact gas required. EIP-2780 can make that less
             // than 21_000.
             let mut min_tx_env = tx_env.clone();
             min_tx_env.set_gas_limit(MIN_TRANSACTION_GAS);


### PR DESCRIPTION
The basic transfer shortcut probes at `MIN_TRANSACTION_GAS` and returns the constant on success. After Amsterdam the constant is wrong: EIP-2780 prices a self-send at 12000 and a zero-value call to an existing account at 15000, so `eth_estimateGas` over-reports those by up to 75%. Return the probe's used gas instead. Before Amsterdam the used gas is exactly 21000, so nothing changes there.

Same fix as ethereum/go-ethereum#35592 and besu-eth/besu#11178. Replaces #26068 without duplicating EIP-2780 constants in RPC code.

Verified in hive rpc-compat against the Amsterdam fixtures from ethereum/execution-apis#867. The commit cherry-picks clean onto `glamsterdam-devnet-8`; built from that, all 7 eth_estimateGas tests pass. The unmodified devnet-8 build fails estimate-simple-transfer with 21000 against the expected 15000. The runs use the devnet-8 base because main does not execute that chain yet.
