### PR TITLE
fix(rpc): serve retained fork payloads by hash

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -61,6 +61,8 @@ pub(crate) struct InMemoryState<N: NodePrimitives = EthPrimitives> {
     numbers: RwLock<BTreeMap<u64, B256>>,
     /// The pending block that has not yet been made canonical.
     pending: watch::Sender<Option<BlockState<N>>>,
+    /// Valid non-canonical blocks retained by the engine tree.
+    fork_blocks: RwLock<B256Map<Arc<RecoveredBlock<N::Block>>>>,
     /// Metrics for the in-memory state.
     metrics: InMemoryStateMetrics,
 }
@@ -76,6 +78,7 @@ impl<N: NodePrimitives> InMemoryState<N> {
             blocks: RwLock::new(blocks),
             numbers: RwLock::new(numbers),
             pending,
+            fork_blocks: Default::default(),
             metrics: Default::default(),
         };
         this.update_metrics();
@@ -132,6 +135,11 @@ impl<N: NodePrimitives> InMemoryState<N> {
         self.pending.borrow().clone()
     }
 
+    /// Returns a valid non-canonical block retained by the engine tree.
+    pub(crate) fn fork_block(&self, hash: B256) -> Option<Arc<RecoveredBlock<N::Block>>> {
+        self.fork_blocks.read().get(&hash).cloned()
+    }
+
     #[cfg(test)]
     fn block_count(&self) -> usize {
         self.blocks.read().len()
@@ -163,6 +171,7 @@ impl<N: NodePrimitives> CanonicalInMemoryStateInner<N> {
             self.in_memory_state.pending.send_modify(|p| {
                 p.take();
             });
+            self.in_memory_state.fork_blocks.write().clear();
         }
         self.in_memory_state.update_metrics();
     }
@@ -260,6 +269,24 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
         self.inner.in_memory_state.update_metrics();
     }
 
+    /// Makes a valid block retained by the engine tree available for hash-based lookups.
+    pub fn insert_fork_block(&self, block: Arc<RecoveredBlock<N::Block>>) {
+        self.inner.in_memory_state.fork_blocks.write().insert(block.hash(), block);
+    }
+
+    /// Removes blocks that have been evicted from the engine tree.
+    pub fn remove_fork_blocks(&self, hashes: impl IntoIterator<Item = B256>) {
+        let mut fork_blocks = self.inner.in_memory_state.fork_blocks.write();
+        for hash in hashes {
+            fork_blocks.remove(&hash);
+        }
+    }
+
+    /// Returns a valid non-canonical block retained by the engine tree.
+    pub fn fork_block(&self, hash: B256) -> Option<Arc<RecoveredBlock<N::Block>>> {
+        self.inner.in_memory_state.fork_block(hash)
+    }
+
     /// Append new blocks to the in memory state.
     ///
     /// This removes all reorged blocks and appends the new blocks to the tracked chain and connects
@@ -273,6 +300,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
             // acquire locks, starting with the numbers lock
             let mut numbers = self.inner.in_memory_state.numbers.write();
             let mut blocks = self.inner.in_memory_state.blocks.write();
+            let mut fork_blocks = self.inner.in_memory_state.fork_blocks.write();
 
             // we first remove the blocks from the reorged chain
             for block in reorged {
@@ -280,6 +308,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
                 let number = block.recovered_block().number();
                 blocks.remove(&hash);
                 numbers.remove(&number);
+                fork_blocks.insert(hash, Arc::clone(&block.recovered_block));
             }
 
             // insert the new blocks
@@ -292,6 +321,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
                 // append new blocks
                 blocks.insert(hash, Arc::new(block_state));
                 numbers.insert(number, hash);
+                fork_blocks.remove(&hash);
             }
 
             // remove the pending state

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1773,6 +1773,8 @@ where
                             self.canonical_in_memory_state.set_pending_block(block.clone());
                         }
 
+                        self.canonical_in_memory_state
+                            .insert_fork_block(Arc::clone(&block.recovered_block));
                         self.state.tree_state.insert_executed(block.clone());
                         self.metrics.engine.inserted_already_executed_blocks.increment(1);
                         self.emit_event(EngineApiEvent::BeaconConsensus(
@@ -2005,7 +2007,7 @@ where
             return Ok(())
         };
 
-        if ctrl.is_unwind() {
+        let removed_hashes = if ctrl.is_unwind() {
             // the node reset so we need to clear everything above that height so that backfill
             // height is the new canonical block.
             self.state.set_pending_sparse_trie_prune(false);
@@ -2015,8 +2017,9 @@ where
                 backfill_num_hash,
                 self.persistence_state.last_persisted_block.hash,
                 Some(backfill_num_hash),
-            );
-        }
+            )
+        };
+        self.canonical_in_memory_state.remove_fork_blocks(removed_hashes);
 
         self.metrics.engine.executed_blocks.set(self.state.tree_state.block_count() as f64);
         self.metrics.tree.canonical_chain_height.set(backfill_height as f64);
@@ -3270,6 +3273,7 @@ where
             self.canonical_in_memory_state.set_pending_block(executed.clone());
         }
 
+        self.canonical_in_memory_state.insert_fork_block(Arc::clone(&executed.recovered_block));
         self.state.tree_state.insert_executed(executed.clone());
         self.metrics.engine.executed_blocks.set(self.state.tree_state.block_count() as f64);
 
@@ -3575,11 +3579,12 @@ where
             None
         };
 
-        self.state.tree_state.remove_until(
+        let removed_hashes = self.state.tree_state.remove_until(
             upper_bound,
             self.persistence_state.last_persisted_block.hash,
             num,
         );
+        self.canonical_in_memory_state.remove_fork_blocks(removed_hashes);
         Ok(())
     }
 

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -61,17 +61,18 @@ impl<N: NodePrimitives> TreeState<N> {
     }
 
     /// Resets the state and points to the given canonical head.
-    pub fn reset(&mut self, current_canonical_head: BlockNumHash) {
+    pub fn reset(&mut self, current_canonical_head: BlockNumHash) -> Vec<B256> {
         let engine_kind = self.engine_kind;
         let removed_hashes = self.blocks_by_hash.keys().copied().collect::<Vec<_>>();
         if !removed_hashes.is_empty() {
-            self.overlay_manager.remove_blocks(removed_hashes);
+            self.overlay_manager.remove_blocks(removed_hashes.clone());
         }
         self.blocks_by_hash.clear();
         self.blocks_by_number.clear();
         self.parent_to_child.clear();
         self.current_canonical_head = current_canonical_head;
         self.engine_kind = engine_kind;
+        removed_hashes
     }
 
     /// Returns the number of executed blocks stored.
@@ -292,7 +293,7 @@ impl<N: NodePrimitives> TreeState<N> {
         upper_bound: BlockNumHash,
         last_persisted_hash: B256,
         finalized_num_hash: Option<BlockNumHash>,
-    ) {
+    ) -> Vec<B256> {
         debug!(target: "engine::tree", ?upper_bound, ?finalized_num_hash, "Removing blocks from the tree");
 
         // If the finalized num is ahead of the upper bound, and exists, we need to instead ensure
@@ -322,8 +323,9 @@ impl<N: NodePrimitives> TreeState<N> {
         }
 
         if !removed_hashes.is_empty() {
-            self.overlay_manager.remove_blocks(removed_hashes);
+            self.overlay_manager.remove_blocks(removed_hashes.clone());
         }
+        removed_hashes
     }
 
     /// Updates the canonical head to the given block.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -1051,6 +1051,7 @@ fn test_validated_payload_bal_is_inserted_into_store() {
 
     assert_eq!(outcome, InsertPayloadOk::Inserted(BlockStatus::Valid));
     assert_eq!(bal_store.get_by_hash(child_num_hash.hash).unwrap(), Some(raw_bal));
+    assert!(test_harness.tree.canonical_in_memory_state.fork_block(child_num_hash.hash).is_some());
 }
 
 #[tokio::test]

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -73,6 +73,12 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         Ok(Self { storage_provider, head_block, canonical_in_memory_state: state })
     }
 
+    /// Returns a valid non-canonical block retained by the engine tree for a hash lookup.
+    fn fork_block(&self, id: BlockHashOrNumber) -> Option<Arc<RecoveredBlock<BlockTy<N>>>> {
+        let BlockHashOrNumber::Hash(hash) = id else { return None };
+        self.canonical_in_memory_state.fork_block(hash)
+    }
+
     // Helper function to convert range bounds
     fn convert_range_bounds<T>(
         &self,
@@ -465,11 +471,12 @@ impl<N: ProviderNodeTypes> HeaderProvider for ConsistentProvider<N> {
     type Header = HeaderTy<N>;
 
     fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
-        self.get_in_memory_or_storage_by_block(
+        let header = self.get_in_memory_or_storage_by_block(
             block_hash.into(),
             |db_provider| db_provider.header(block_hash),
             |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_header())),
-        )
+        )?;
+        Ok(header.or_else(|| self.fork_block(block_hash.into()).map(|b| b.clone_header())))
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
@@ -573,11 +580,12 @@ impl<N: ProviderNodeTypes> BlockNumReader for ConsistentProvider<N> {
     }
 
     fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
-        self.get_in_memory_or_storage_by_block(
+        let number = self.get_in_memory_or_storage_by_block(
             hash.into(),
             |db_provider| db_provider.block_number(hash),
             |block_state| Ok(Some(block_state.number())),
-        )
+        )?;
+        Ok(number.or_else(|| self.fork_block(hash.into()).map(|b| b.number())))
     }
 }
 
@@ -614,11 +622,18 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
         }
 
         if matches!(source, BlockSource::Pending | BlockSource::Any) {
-            return Ok(self
+            let pending = self
                 .canonical_in_memory_state
                 .pending_block()
                 .filter(|b| b.hash() == hash)
-                .map(|b| b.into_block()))
+                .map(|b| b.into_block());
+            if pending.is_some() {
+                return Ok(pending)
+            }
+        }
+
+        if matches!(source, BlockSource::Any) {
+            return Ok(self.fork_block(hash.into()).map(|b| b.clone_block()))
         }
 
         Ok(None)
@@ -654,15 +669,20 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
             }
         }
 
+        if matches!(source, BlockSource::Any) {
+            return Ok(self.fork_block(hash.into()).map(SealedOrRecoveredBlock::recovered_arc))
+        }
+
         Ok(None)
     }
 
     fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Self::Block>> {
-        self.get_in_memory_or_storage_by_block(
+        let block = self.get_in_memory_or_storage_by_block(
             id,
             |db_provider| db_provider.block(id),
             |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_block())),
-        )
+        )?;
+        Ok(block.or_else(|| self.fork_block(id).map(|b| b.clone_block())))
     }
 
     fn pending_block(&self) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
@@ -686,11 +706,12 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        self.get_in_memory_or_storage_by_block(
+        let block = self.get_in_memory_or_storage_by_block(
             id,
             |db_provider| db_provider.recovered_block(id, transaction_kind),
             |block_state| Ok(Some(block_state.block().recovered_block().clone())),
-        )
+        )?;
+        Ok(block.or_else(|| self.fork_block(id).map(|b| (*b).clone())))
     }
 
     fn sealed_block_with_senders(
@@ -698,11 +719,12 @@ impl<N: ProviderNodeTypes> BlockReader for ConsistentProvider<N> {
         id: BlockHashOrNumber,
         transaction_kind: TransactionVariant,
     ) -> ProviderResult<Option<RecoveredBlock<Self::Block>>> {
-        self.get_in_memory_or_storage_by_block(
+        let block = self.get_in_memory_or_storage_by_block(
             id,
             |db_provider| db_provider.sealed_block_with_senders(id, transaction_kind),
             |block_state| Ok(Some(block_state.block().recovered_block().clone())),
-        )
+        )?;
+        Ok(block.or_else(|| self.fork_block(id).map(|b| (*b).clone())))
     }
 
     fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Self::Block>> {
@@ -1487,8 +1509,11 @@ mod tests {
     use reth_db_api::models::AccountBeforeTx;
     use reth_ethereum_primitives::Block;
     use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult, ExecutionOutcome};
-    use reth_primitives_traits::{RecoveredBlock, SealedBlock};
-    use reth_storage_api::{BlockReader, BlockSource, ChangeSetReader, StateReader};
+    use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
+    use reth_storage_api::{
+        BlockNumReader, BlockReader, BlockSource, ChangeSetReader, HeaderProvider, StateReader,
+        TransactionVariant,
+    };
     use reth_testing_utils::generators::{
         self, random_block_range, random_changeset_range, random_eoa_accounts, BlockRangeParams,
     };
@@ -1673,6 +1698,56 @@ mod tests {
             .expect("pending block should be found");
         assert_eq!(block.sealed_block(), last_in_mem_block);
         assert!(block.recovered_block().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_reader_finds_engine_tree_fork_by_hash() -> eyre::Result<()> {
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+        let provider = BlockchainProvider::with_latest(factory, SealedHeader::default())?;
+        let block = random_block_range(
+            &mut rng,
+            1..=1,
+            BlockRangeParams { parent: Some(B256::random()), tx_count: 0..1, ..Default::default() },
+        )
+        .pop()
+        .unwrap();
+        let recovered = Arc::new(RecoveredBlock::new_sealed(
+            block.clone(),
+            block.senders().expect("failed to recover senders"),
+        ));
+
+        provider.canonical_in_memory_state.insert_fork_block(recovered.clone());
+        let consistent_provider = provider.consistent_provider()?;
+
+        assert_eq!(
+            consistent_provider.find_block_by_hash(block.hash(), BlockSource::Any)?,
+            Some(block.clone().into_block())
+        );
+        assert_eq!(
+            consistent_provider.find_block_by_hash(block.hash(), BlockSource::Canonical)?,
+            None
+        );
+        assert_eq!(
+            consistent_provider.find_block_by_hash(block.hash(), BlockSource::Pending)?,
+            None
+        );
+        assert_eq!(
+            consistent_provider.block(block.hash().into())?,
+            Some(block.clone().into_block())
+        );
+        assert_eq!(
+            consistent_provider
+                .sealed_block_with_senders(block.hash().into(), TransactionVariant::WithHash)?,
+            Some((*recovered).clone())
+        );
+        assert_eq!(consistent_provider.header(block.hash())?, Some(block.header().clone()));
+        assert_eq!(consistent_provider.block_number(block.hash())?, Some(block.number));
+
+        provider.canonical_in_memory_state.remove_fork_blocks([block.hash()]);
+        assert!(consistent_provider.block(block.hash().into())?.is_none());
 
         Ok(())
     }


### PR DESCRIPTION
Keep valid non-canonical blocks available to hash-based provider lookups while they remain retained by the engine tree. This lets Gloas clients reconstruct full execution payload envelopes through `eth_getBlockByHash` and `engine_getPayloadBodiesByHashV2` instead of receiving null blocks.

Prompted by: @Rjected