### PR TITLE
fix(rpc): converge generated access lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+checksum = "e64579d931b3f8eacc7c9ab0b220e87e9c4816e5c724ede1947b55c2f8e92ae5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10109,6 +10109,7 @@ version = "2.5.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-eip2930",
  "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,6 +442,7 @@ alloy-sol-types = { version = "1.6.1", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
+alloy-eip2930 = { version = "0.2.4", default-features = false }
 alloy-eip7928 = { version = "0.4.8", default-features = false, features = ["rlp"] }
 alloy-evm = { version = "0.38.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false, features = ["core-net"] }

--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -1,7 +1,12 @@
 use crate::utils::{eth_payload_attributes, eth_payload_attributes_amsterdam};
-use alloy_eips::{eip2718::Encodable2718, eip7910::EthConfig, BlockNumberOrTag};
+use alloy_eips::{
+    eip2718::Encodable2718,
+    eip2930::{AccessList, AccessListItem, AccessListResult},
+    eip7910::EthConfig,
+    BlockNumberOrTag,
+};
 use alloy_genesis::Genesis;
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{bytes, Address, Bytes, B256, U256};
 use alloy_provider::{
     ext::DebugApi, network::EthereumWallet, Provider, ProviderBuilder, SendableTx,
 };
@@ -14,7 +19,10 @@ use alloy_rpc_types_engine::{
     BlobsBundleV1, CancunPayloadFields, ExecutionPayload, ExecutionPayloadSidecar,
     ExecutionPayloadV3, PraguePayloadFields,
 };
-use alloy_rpc_types_eth::TransactionRequest;
+use alloy_rpc_types_eth::{
+    state::{AccountOverride, StateOverride},
+    TransactionRequest,
+};
 use alloy_rpc_types_trace::geth::{ChainBlockTraceResult, GethDebugTracingOptions};
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -50,6 +58,70 @@ alloy_sol_types::sol! {
             }
         }
     }
+}
+
+#[tokio::test]
+async fn test_create_access_list_converges() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .build(),
+    );
+
+    let (mut nodes, wallet) = setup_engine::<EthereumNode>(
+        1,
+        chain_spec,
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+    let node = nodes.pop().unwrap();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(wallet.wallet_gen().swap_remove(0)))
+        .connect_http(node.rpc_url());
+
+    let contract = Address::with_last_byte(0xc0);
+    let first = Address::with_last_byte(0xa1);
+    let second = Address::with_last_byte(0xa2);
+    let third = Address::with_last_byte(0xa3);
+    let mut state_overrides = StateOverride::default();
+    // Adding `second` changes the intrinsic gas enough for the next trace to take the branch that
+    // touches `third`, so the access list needs multiple passes to converge.
+    state_overrides.insert(
+        contract,
+        AccountOverride::default().with_code(bytes!(
+            "7300000000000000000000000000000000000000a131505a620125c0106038577300000000000000000000000000000000000000a33150005b7300000000000000000000000000000000000000a2315000"
+        )),
+    );
+
+    let result: AccessListResult = provider
+        .raw_request(
+            "eth_createAccessList".into(),
+            (
+                TransactionRequest::default().to(contract).gas_limit(100_000),
+                BlockNumberOrTag::Latest,
+                state_overrides,
+            ),
+        )
+        .await?;
+
+    assert!(result.error.is_none(), "{:?}", result.error);
+    assert_eq!(result.gas_used, U256::from(28_431u64));
+    assert_eq!(
+        result.access_list,
+        AccessList(vec![
+            AccessListItem { address: first, storage_keys: vec![] },
+            AccessListItem { address: second, storage_keys: vec![] },
+            AccessListItem { address: third, storage_keys: vec![] },
+        ])
+    );
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -37,6 +37,7 @@ alloy-evm = { workspace = true, features = ["overrides", "call-util"] }
 alloy-rlp.workspace = true
 alloy-serde.workspace = true
 alloy-eips.workspace = true
+alloy-eip2930.workspace = true
 alloy-eip7928 = { workspace = true, features = ["rlp"] }
 alloy-dyn-abi = { workspace = true, features = ["eip712"] }
 alloy-json-rpc.workspace = true

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -8,7 +8,7 @@ use crate::{
     helpers::estimate::EstimateCall, FromEvmError, FullEthApiTypes, RpcBlock, RpcNodeCore,
 };
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
-use alloy_eips::eip2930::AccessListResult;
+use alloy_eip2930::AccessListResult;
 use alloy_evm::overrides::{apply_block_overrides, apply_state_overrides, OverrideBlockHashes};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{Bytes, B256, U256};
@@ -460,41 +460,57 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     where
         Self: Trace,
     {
-        self.spawn_with_state_at_block(at, |this, mut db| {
-            let initial = request.as_ref().access_list().cloned().unwrap_or_default();
-            let (evm_env, mut tx_env) = this.prepare_call_env(
-                evm_env,
-                request,
-                &mut db,
-                EvmOverrides::state(state_override),
-            )?;
+        async move {
+            let guard = CancelOnDrop::default();
+            let cancel = guard.clone();
+            let result = self
+                .spawn_with_state_at_block(at, move |this, mut db| {
+                    let mut access_list =
+                        request.as_ref().access_list().cloned().unwrap_or_default().normalized();
+                    let (evm_env, mut tx_env) = this.prepare_call_env(
+                        evm_env,
+                        request,
+                        &mut db,
+                        EvmOverrides::state(state_override),
+                    )?;
+                    tx_env.set_access_list(access_list.clone());
 
-            let mut evm = this.evm_config().evm_with_env_and_inspector(
-                &mut db,
-                evm_env,
-                AccessListInspector::new(initial),
-            );
+                    let mut evm = this.evm_config().evm_with_env_and_inspector(
+                        &mut db,
+                        evm_env,
+                        AccessListInspector::new(access_list.clone()),
+                    );
 
-            let result = evm.transact(tx_env.clone())?;
-            let access_list = core::mem::take(evm.inspector_mut()).into_access_list();
-            let gas_used = result.result.tx_gas_used();
-            tx_env.set_access_list(access_list.clone());
-            if let Err(err) = Self::Error::ensure_success(result.result) {
-                return Ok(AccessListResult {
-                    access_list,
-                    gas_used: U256::from(gas_used),
-                    error: Some(err.to_string()),
-                });
-            }
+                    loop {
+                        if cancel.is_cancelled() {
+                            return Err(EthApiError::InternalEthError.into())
+                        }
 
-            // transact again to get the exact gas used
-            evm.disable_inspector();
-            let result = evm.transact(tx_env)?;
-            let gas_used = result.result.tx_gas_used();
-            let error = Self::Error::ensure_success(result.result).err().map(|e| e.to_string());
+                        let result = evm.transact(tx_env.clone())?;
+                        let next_access_list =
+                            core::mem::take(evm.inspector_mut()).into_access_list().normalized();
 
-            Ok(AccessListResult { access_list, gas_used: U256::from(gas_used), error })
-        })
+                        if next_access_list == access_list {
+                            let gas_used = result.result.tx_gas_used();
+                            let error = Self::Error::ensure_success(result.result)
+                                .err()
+                                .map(|e| e.to_string());
+                            return Ok(AccessListResult {
+                                access_list,
+                                gas_used: U256::from(gas_used),
+                                error,
+                            })
+                        }
+
+                        access_list = next_access_list;
+                        tx_env.set_access_list(access_list.clone());
+                        *evm.inspector_mut() = AccessListInspector::new(access_list.clone());
+                    }
+                })
+                .await;
+            drop(guard);
+            result
+        }
     }
 }
 


### PR DESCRIPTION
Runs eth_createAccessList until its normalized access list reaches a fixed point, matching geth, and reports gas/error from that stable execution. Pins alloy-eip2930 0.2.4 for native normalization.

Companion inspector cleanup: paradigmxyz/revm-inspectors#479.