### PR TITLE
fix(engine): return invalid for undecodable block access lists

### DIFF
--- a/crates/engine/primitives/src/error.rs
+++ b/crates/engine/primitives/src/error.rs
@@ -90,23 +90,28 @@ pub enum InsertBlockErrorKind {
 }
 
 impl InsertBlockErrorKind {
-    /// Returns whether the error was caused by an invalid block.
+    /// Returns whether the error must be reported as an invalid payload.
     pub const fn is_validation_error(&self) -> bool {
-        matches!(self, Self::Consensus(_) | Self::Execution(BlockExecutionError::Validation(_)))
+        matches!(
+            self,
+            Self::Consensus(_) |
+                Self::BlockAccessListDecode(_) |
+                Self::Execution(BlockExecutionError::Validation(_))
+        )
     }
 
-    /// Returns an [`InsertBlockValidationError`] if the failure invalidates the block, or an
-    /// [`InsertBlockProcessingError`] if the failure is not attributable to the block itself.
+    /// Returns an [`InsertBlockValidationError`] if the failure must be reported as an invalid
+    /// payload, or an [`InsertBlockProcessingError`] if block processing itself failed.
     ///
-    /// This distinction controls whether the block may be returned as `INVALID` and its hash cached
-    /// as invalid. Because `INVALID` has consensus meaning, malformed supplemental input and
-    /// internal failures must remain processing errors instead.
+    /// This distinction controls whether the payload may be returned as `INVALID`. Errors
+    /// classified as invalid payloads by the Engine API are validation errors; malformed request
+    /// parameters and internal failures remain processing errors instead.
     pub fn ensure_validation_error(
         self,
     ) -> Result<InsertBlockValidationError, InsertBlockProcessingError> {
         match self {
             Self::BlockAccessListDecode(error) => {
-                Err(InsertBlockProcessingError::MalformedInput(Box::new(error)))
+                Ok(InsertBlockValidationError::BlockAccessListDecode(error))
             }
             Self::Consensus(err) => Ok(InsertBlockValidationError::Consensus(err)),
             Self::Execution(err) => match err {
@@ -176,6 +181,9 @@ pub enum InsertBlockValidationError {
     /// Block violated consensus rules.
     #[error(transparent)]
     Consensus(#[from] ConsensusError),
+    /// Block access list bytes could not be decoded.
+    #[error(transparent)]
+    BlockAccessListDecode(#[from] BlockAccessListDecodeError),
     /// Validation error, transparently wrapping [`BlockValidationError`].
     #[error(transparent)]
     Validation(#[from] BlockValidationError),
@@ -185,16 +193,15 @@ pub enum InsertBlockValidationError {
 mod tests {
     use super::*;
 
-    // Undecodable block access list bytes are malformed request params and must not be treated
-    // as a block validation error.
     #[test]
     fn ensure_insert_block_validation_error() {
         let err = InsertBlockErrorKind::BlockAccessListDecode(BlockAccessListDecodeError::new(
             alloy_rlp::Error::UnexpectedString,
         ));
+        assert!(err.is_validation_error());
         assert!(matches!(
             err.ensure_validation_error(),
-            Err(InsertBlockProcessingError::MalformedInput(_))
+            Ok(InsertBlockValidationError::BlockAccessListDecode(_))
         ));
 
         assert!(matches!(

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3313,9 +3313,15 @@ where
             %validation_err,
             "Invalid block error on new payload",
         );
-        let latest_valid_hash = self
-            .latest_valid_hash_for_invalid_payload(block.parent_hash())
-            .map_err(InsertBlockFatalError::from)?;
+        // The Amsterdam Engine API requires `latestValidHash: null` for an undecodable BAL.
+        // <https://github.com/ethereum/execution-apis/blob/df75e230befef0de56ee8833322ed714bacb479c/src/engine/amsterdam.md?plain=1#L129>
+        let latest_valid_hash =
+            if matches!(&validation_err, InsertBlockValidationError::BlockAccessListDecode(_)) {
+                None
+            } else {
+                self.latest_valid_hash_for_invalid_payload(block.parent_hash())
+                    .map_err(InsertBlockFatalError::from)?
+            };
 
         // keep track of the invalid header unless the consensus impl considers it transient
         let is_transient = match &validation_err {

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -326,7 +326,7 @@ impl BlockGasTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tree::error::{InsertBlockErrorKind, InsertBlockProcessingError};
+    use crate::tree::error::{InsertBlockErrorKind, InsertBlockValidationError};
     use alloy_consensus::{BlockHeader, Header};
     use alloy_eip7928::{
         bal::Bal as AlloyBal, AccountChanges, BlockAccessIndex, BlockAccessList, CodeChange,
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_bal_bytecode_is_malformed_input() {
+    fn invalid_bal_bytecode_is_validation_error() {
         let alloy_bal = vec![AccountChanges {
             address: Address::ZERO,
             code_changes: vec![CodeChange::new(
@@ -468,7 +468,7 @@ mod tests {
         assert!(matches!(&error, InsertBlockErrorKind::BlockAccessListDecode(_)));
         assert!(matches!(
             error.ensure_validation_error(),
-            Err(InsertBlockProcessingError::MalformedInput(_))
+            Ok(InsertBlockValidationError::BlockAccessListDecode(_))
         ));
     }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -570,8 +570,8 @@ where
             .in_scope(|| self.evm_env_for(&input))
             .map_err(NewPayloadError::other)?;
 
-        // Extract the decoded BAL, if present. Undecodable block access list bytes are malformed
-        // request params, not an invalid block.
+        // Extract the decoded BAL, if present. Undecodable block access list bytes invalidate the
+        // payload.
         let decoded_bal =
             ensure_ok!(input.try_decoded_access_list().map_err(BlockAccessListDecodeError::new))
                 .map(Arc::new);

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -565,19 +565,19 @@ fn test_tree_persist_block_batch() {
 }
 
 #[test]
-fn malformed_input_is_non_fatal_insert_outcome() {
+fn block_access_list_decode_returns_invalid_with_null_latest_valid_hash() {
     let mut test_harness = TestHarness::new(MAINNET.clone());
-    let block = test_harness.block_builder.generate_random_block(1, B256::ZERO);
+    let parent_hash = test_harness.tree.state.tree_state.canonical_block_hash();
+    let block = test_harness.block_builder.generate_random_block(1, parent_hash);
     let error = InsertBlockError::new(
         block,
         InsertBlockErrorKind::BlockAccessListDecode(BlockAccessListDecodeError::new(
             alloy_rlp::Error::UnexpectedString,
         )),
     );
-    assert_matches!(
-        test_harness.tree.on_insert_block_error(error),
-        Err(InsertBlockProcessingError::MalformedInput(_))
-    );
+    let status = test_harness.tree.on_insert_block_error(error).unwrap();
+    assert!(status.is_invalid());
+    assert_eq!(status.latest_valid_hash, None);
 }
 
 #[tokio::test]

--- a/crates/ethereum/node/tests/e2e/invalid_payload.rs
+++ b/crates/ethereum/node/tests/e2e/invalid_payload.rs
@@ -7,7 +7,6 @@ use crate::utils::{eth_payload_attributes, eth_payload_attributes_amsterdam};
 use alloy_eips::eip7685::RequestsOrHash;
 use alloy_primitives::{keccak256, Bytes, B256};
 use alloy_rpc_types_engine::{ExecutionPayloadV3, PayloadStatusEnum};
-use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use reth_chainspec::{ChainSpecBuilder, MAINNET};
 use reth_e2e_test_utils::{setup_engine, transaction::TransactionTestContext};
@@ -358,10 +357,10 @@ async fn can_handle_invalid_payload_with_transactions() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Tests that `engine_newPayloadV5` rejects undecodable block access list bytes with an invalid
-/// params error (`-32602`) instead of an `INVALID` payload status.
+/// Tests that `engine_newPayloadV5` returns `INVALID` with no latest valid hash for undecodable
+/// block access list bytes.
 #[tokio::test]
-async fn undecodable_bal_is_rejected_as_invalid_params() -> eyre::Result<()> {
+async fn undecodable_bal_is_invalid_payload() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let chain_spec = Arc::new(
@@ -402,20 +401,16 @@ async fn undecodable_bal_is_rejected_as_invalid_params() -> eyre::Result<()> {
 
     let engine = node.auth_server_handle().http_client();
     let parent_beacon_block_root = block.header().parent_beacon_block_root.unwrap();
-    let err = EngineApiClient::<reth_node_ethereum::EthEngineTypes>::new_payload_v5(
+    let invalid_status = EngineApiClient::<reth_node_ethereum::EthEngineTypes>::new_payload_v5(
         &engine,
         corrupted,
         vec![],
         parent_beacon_block_root,
         RequestsOrHash::Requests(envelope.execution_requests.clone()),
     )
-    .await
-    .unwrap_err();
-
-    let jsonrpsee::core::client::Error::Call(err) = err else {
-        panic!("expected an invalid params error object, got {err:?}")
-    };
-    assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    .await?;
+    assert!(matches!(invalid_status.status, PayloadStatusEnum::Invalid { .. }));
+    assert_eq!(invalid_status.latest_valid_hash, None);
 
     // The same block with well-formed block access list bytes is processed normally.
     let status = EngineApiClient::<reth_node_ethereum::EthEngineTypes>::new_payload_v5(

--- a/crates/rpc/rpc-engine-api/src/error.rs
+++ b/crates/rpc/rpc-engine-api/src/error.rs
@@ -302,13 +302,13 @@ mod tests {
             EngineApiError::UnknownPayload,
         );
 
-        // Malformed payload params, e.g. undecodable block access list bytes, are rejected with
-        // an invalid params error instead of an `INVALID` payload status.
+        // Processing errors explicitly classified as malformed request parameters are rejected
+        // with an invalid params error instead of an `INVALID` payload status.
         ensure_engine_rpc_error(
             INVALID_PARAMS_CODE,
             INVALID_PARAMS_MSG,
             EngineApiError::NewPayload(BeaconOnNewPayloadError::InvalidParams(
-                "undecodable block access list".into(),
+                "malformed payload parameters".into(),
             )),
         );
 


### PR DESCRIPTION
Treats undecodable `blockAccessList` values as `INVALID` payloads with `latestValidHash: null` instead of returning `-32602 Invalid params`.

Aligns `engine_newPayloadV5` with https://github.com/ethereum/execution-apis/pull/869.