### PR TITLE
fix(rpc): return invalid params error for eth_getLogs fromBlock beyond head

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -583,13 +583,6 @@ where
                     });
                 }
 
-                if let Some(f) = from &&
-                    f > info.best_number
-                {
-                    // start block higher than local head, can return empty
-                    return Ok(Vec::new());
-                }
-
                 let (from_block_number, to_block_number) =
                     logs_utils::get_filter_block_range(from, to, start_block, info)?;
 
@@ -1426,6 +1419,20 @@ mod tests {
             EthEvmConfig::new(provider.chain_spec()),
         )
         .build()
+    }
+
+    #[tokio::test]
+    async fn test_logs_for_filter_from_block_beyond_head() {
+        let provider = MockEthProvider::default();
+        provider.add_header(FixedBytes::random(), alloy_consensus::Header::default());
+        let eth_api = build_test_eth_api(provider);
+
+        let eth_filter =
+            super::EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
+
+        let filter = Filter::new().from_block(100u64).to_block(BlockNumberOrTag::Latest);
+        let result = eth_filter.inner.clone().logs_for_filter(filter, QueryLimits::default()).await;
+        assert!(matches!(result, Err(EthFilterError::InvalidBlockRangeParams)), "{result:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
eth_getLogs returns an empty array when fromBlock is above the local head and toBlock resolves to the head. Every other client returns an error for this request: geth, Nethermind, Besu, and Erigon all return -32602. A cross-client survey in hive rpc-compat found reth is the only client that returns a result. ethereum/execution-apis#875 has the survey, the spec clarification, and a new conformance test for this case.

This removes the early return, so `get_filter_block_range` rejects the range with "invalid block range params" (-32602), the same response geth gives. The neighboring toBlock check already errors for the other future-range shapes.

The early return also swallowed reversed ranges when fromBlock was above the head (from > head with to < head returned an empty array). Those now error too.