### PR TITLE
fix(rpc): guard block access list replay

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/bal.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/bal.rs
@@ -40,6 +40,8 @@ pub trait GetBlockAccessList: Trace + Call + LoadBlock + RpcNodeCoreExt {
                 return Ok(Some(Vec::from(bal)))
             }
 
+            let _permit = self.acquire_owned_blocking_io().await;
+
             self.spawn_blocking_io(move |eth_api| {
                 let state = eth_api
                     .provider()


### PR DESCRIPTION
Acquires a blocking-I/O permit when `eth_getBlockAccessList*` must reconstruct a BAL by replaying the block. Cached BAL reads remain unaffected, while repeated cache misses can no longer bypass the configured RPC concurrency limit.