### PR TITLE
fix(trie): reveal terminal extension nodes

### DIFF
--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -1063,9 +1063,39 @@ pub mod triehash {
 mod tests {
     use super::*;
     use alloy_trie::{
-        nodes::{BranchNode, LeafNode, RlpNode},
+        nodes::{BranchNode, ExtensionNode, LeafNode, RlpNode},
         TrieMask,
     };
+
+    #[test]
+    fn witness_preserves_terminal_extension_node() {
+        fn insert_node(witness: &mut B256Map<Bytes>, node: impl alloy_rlp::Encodable) -> RlpNode {
+            let encoded = alloy_rlp::encode(node);
+            witness.insert(keccak256(&encoded), encoded.clone().into());
+            RlpNode::from_rlp(&encoded)
+        }
+
+        let mut witness = B256Map::default();
+        let extension_path = Nibbles::from_nibbles([0xb]);
+        let extension = ExtensionNode::new(
+            Nibbles::from_nibbles([0x3]),
+            RlpNode::word_rlp(&B256::repeat_byte(0x11)),
+        );
+        let extension_rlp = insert_node(&mut witness, extension.clone());
+        let state_root = insert_node(
+            &mut witness,
+            BranchNode::new(vec![extension_rlp], TrieMask::from(1 << 0xb)),
+        )
+        .as_hash()
+        .expect("state root is hashed");
+
+        let proof = DecodedMultiProofV2::from_witness(state_root, &witness).unwrap();
+
+        assert!(proof.account_proofs.iter().any(|node| {
+            node.path == extension_path &&
+                matches!(&node.node, crate::TrieNodeV2::Extension(actual) if actual == &extension)
+        }));
+    }
 
     #[test]
     fn witness_nodes_are_depth_first_ordered() {

--- a/crates/trie/common/src/trie_node_v2.rs
+++ b/crates/trie/common/src/trie_node_v2.rs
@@ -80,13 +80,13 @@ impl ProofTrieNodeV2 {
                         branch_v2.key = ext.key;
                         branch_v2.branch_rlp_node = Some(ext.child);
                         last.path = path;
+                        continue
                     }
 
-                    // If we reach here, the extension's child is not a branch in the
-                    // result. This happens when the child branch is hashed (not revealed
-                    // in the proof). In V2 format, extension nodes are always combined
-                    // with their child branch, so we skip extension nodes whose child
-                    // isn't revealed.
+                    // An exclusion proof can terminate at an extension whose key diverges from
+                    // the target. In that case the child is intentionally not revealed, but the
+                    // extension itself must be retained to prove non-membership.
+                    result.push(Self { path, node: TrieNodeV2::Extension(ext), masks });
                 }
             }
         }

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -132,7 +132,9 @@ impl ArenaCursor {
         if let Some(parent) = self.stack.last() {
             let child_is_dirty = arena.get(entry.index).is_some_and(|node| match node {
                 ArenaSparseNode::Branch(b) => matches!(b.state, ArenaSparseNodeState::Dirty),
-                ArenaSparseNode::Leaf { state, .. } => matches!(state, ArenaSparseNodeState::Dirty),
+                ArenaSparseNode::Extension { state, .. } | ArenaSparseNode::Leaf { state, .. } => {
+                    matches!(state, ArenaSparseNodeState::Dirty)
+                }
                 ArenaSparseNode::Subtrie(s) => {
                     let root = &s.arena[s.root];
                     matches!(root.state_ref(), Some(ArenaSparseNodeState::Dirty))
@@ -164,10 +166,10 @@ impl ArenaCursor {
         logical_branch_path(arena, self.stack.last().expect("cursor is non-empty"))
     }
 
-    /// Returns the length of the logical path of the branch at the top of the stack.
-    /// Equivalent to `head_logical_branch_path(arena).len()` but avoids constructing the path.
-    pub(super) fn head_logical_branch_path_len(&self, arena: &NodeArena) -> usize {
-        logical_branch_path_len(arena, self.stack.last().expect("cursor is non-empty"))
+    /// Returns the length of the logical path of the branch or extension at the top of the stack.
+    pub(super) fn head_logical_path_len(&self, arena: &NodeArena) -> usize {
+        let head = self.stack.last().expect("cursor is non-empty");
+        head.path.len() + arena[head.index].short_key().expect("head has a short key").len()
     }
 
     /// Returns the absolute path of a child at `child_nibble` under the branch at the top of
@@ -321,6 +323,15 @@ impl ArenaCursor {
                         SeekResult::Diverged
                     };
                 }
+                ArenaSparseNode::Extension { key, .. } => {
+                    let mut child_path = head.path;
+                    child_path.extend(key);
+                    return if full_path == &head.path || full_path.starts_with(&child_path) {
+                        SeekResult::Blinded
+                    } else {
+                        SeekResult::Diverged
+                    };
+                }
                 ArenaSparseNode::Branch(b) => b,
                 ArenaSparseNode::Subtrie(_) => {
                     return SeekResult::RevealedSubtrie;
@@ -364,10 +375,4 @@ fn logical_branch_path(arena: &NodeArena, entry: &ArenaCursorStackEntry) -> Nibb
     let mut path = entry.path;
     path.extend(&arena[entry.index].branch_ref().short_key);
     path
-}
-
-/// Returns the length of the logical path of a branch stack entry.
-/// Equivalent to `logical_branch_path(arena, entry).len()` but avoids constructing the path.
-fn logical_branch_path_len(arena: &NodeArena, entry: &ArenaCursorStackEntry) -> usize {
-    entry.path.len() + arena[entry.index].branch_ref().short_key.len()
 }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -352,7 +352,7 @@ impl ArenaSparseSubtrie {
 
             // If the path hits a blinded node, request a proof regardless of update type.
             if matches!(find_result, SeekResult::Blinded) {
-                let logical_len = self.buffers.cursor.head_logical_branch_path_len(&self.arena);
+                let logical_len = self.buffers.cursor.head_logical_path_len(&self.arena);
                 self.required_proofs.push((
                     idx,
                     ArenaRequiredProof { key, parent: ProofV2TargetParent::new(logical_len) },
@@ -689,6 +689,15 @@ impl ArenaParallelSparseTrie {
                         state: Some(state_to_record(&b.state)),
                     })
                 }
+                ArenaSparseNode::Extension { key, child, state } => Some(ProofTrieNodeRecord {
+                    path,
+                    node: TrieNodeRecord(TrieNode::Extension(
+                        alloy_trie::nodes::ExtensionNode::new(*key, child.clone()),
+                    )),
+                    masks: None,
+                    short_key: None,
+                    state: Some(state_to_record(state)),
+                }),
                 ArenaSparseNode::Leaf { key, value, state, .. } => Some(ProofTrieNodeRecord {
                     path,
                     node: TrieNodeRecord(TrieNode::Leaf(alloy_trie::nodes::LeafNode::new(
@@ -720,7 +729,12 @@ impl ArenaParallelSparseTrie {
 
             loop {
                 match cursor.next(arena, |_, node| {
-                    matches!(node, ArenaSparseNode::Branch(_) | ArenaSparseNode::Leaf { .. })
+                    matches!(
+                        node,
+                        ArenaSparseNode::Branch(_) |
+                            ArenaSparseNode::Extension { .. } |
+                            ArenaSparseNode::Leaf { .. }
+                    )
                 }) {
                     NextResult::Done => break,
                     NextResult::Branch | NextResult::NonBranch => {
@@ -785,10 +799,12 @@ impl ArenaParallelSparseTrie {
             return;
         }
 
-        // Only branch and leaf nodes can become subtrie roots.
+        // Only branch, extension, and leaf nodes can become subtrie roots.
         if !matches!(
             self.upper_arena[child_idx],
-            ArenaSparseNode::Branch(_) | ArenaSparseNode::Leaf { .. }
+            ArenaSparseNode::Branch(_) |
+                ArenaSparseNode::Extension { .. } |
+                ArenaSparseNode::Leaf { .. }
         ) {
             return;
         }
@@ -1138,6 +1154,10 @@ impl ArenaParallelSparseTrie {
                     ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone(), epoch: node_epoch };
                 return rlp_node
             }
+            ArenaSparseNode::Extension { .. } => {
+                Self::encode_extension(arena, root, rlp_buf, rlp_node_buf, new_epoch);
+                return rlp_node_buf.pop().expect("encode_extension must push an RlpNode")
+            }
             ArenaSparseNode::Leaf { .. } => {
                 Self::encode_leaf(arena, root, rlp_buf, rlp_node_buf, new_epoch);
                 return rlp_node_buf.pop().expect("encode_leaf must push an RlpNode");
@@ -1200,6 +1220,15 @@ impl ArenaParallelSparseTrie {
                     ArenaSparseNodeBranchChild::Revealed(child_idx) => {
                         let child_idx = *child_idx;
                         match &arena[child_idx] {
+                            ArenaSparseNode::Extension { .. } => {
+                                Self::encode_extension(
+                                    arena,
+                                    child_idx,
+                                    rlp_buf,
+                                    rlp_node_buf,
+                                    new_epoch,
+                                );
+                            }
                             ArenaSparseNode::Leaf { .. } => {
                                 Self::encode_leaf(
                                     arena,
@@ -1224,13 +1253,21 @@ impl ArenaParallelSparseTrie {
                                         state: ArenaSparseNodeState::Cached { rlp_node, .. },
                                         ..
                                     }) |
+                                    ArenaSparseNode::Extension {
+                                        state: ArenaSparseNodeState::Cached { rlp_node, .. },
+                                        ..
+                                    } |
                                     ArenaSparseNode::Leaf {
                                         state: ArenaSparseNodeState::Cached { rlp_node, .. },
                                         ..
                                     } => {
                                         rlp_node_buf.push(rlp_node.clone());
                                     }
-                                    _ => panic!("subtrie root must be a cached Branch or Leaf"),
+                                    _ => {
+                                        panic!(
+                                            "subtrie root must be a cached Branch, Extension, or Leaf"
+                                        )
+                                    }
                                 }
                             }
                             ArenaSparseNode::TakenSubtrie | ArenaSparseNode::EmptyRoot { .. } => {
@@ -1317,7 +1354,9 @@ impl ArenaParallelSparseTrie {
     ) -> Option<&'a Vec<u8>> {
         loop {
             match &arena[current] {
-                ArenaSparseNode::EmptyRoot { .. } | ArenaSparseNode::TakenSubtrie => return None,
+                ArenaSparseNode::EmptyRoot { .. } |
+                ArenaSparseNode::Extension { .. } |
+                ArenaSparseNode::TakenSubtrie => return None,
                 ArenaSparseNode::Leaf { key, value, .. } => {
                     let remaining = full_path.slice(path_offset..);
                     return (remaining == *key).then_some(value);
@@ -1367,6 +1406,20 @@ impl ArenaParallelSparseTrie {
             match &arena[current] {
                 ArenaSparseNode::EmptyRoot { .. } | ArenaSparseNode::TakenSubtrie => {
                     return Ok(LeafLookup::NonExistent);
+                }
+                ArenaSparseNode::Extension { key, child, .. } => {
+                    let logical_end = path_offset + key.len();
+                    if full_path.len() < logical_end ||
+                        full_path.slice(path_offset..logical_end) != *key
+                    {
+                        return Ok(LeafLookup::NonExistent)
+                    }
+
+                    let hash = child.as_hash().unwrap_or_else(|| keccak256(child.as_slice()));
+                    return Err(LeafLookupError::BlindedNode {
+                        path: full_path.slice(..logical_end),
+                        hash,
+                    })
                 }
                 ArenaSparseNode::Leaf { key, value, .. } => {
                     let remaining = full_path.slice(path_offset..);
@@ -1461,6 +1514,36 @@ impl ArenaParallelSparseTrie {
         rlp_node_buf.push(rlp_node);
     }
 
+    /// Encodes an extension node with a blinded child and pushes its [`RlpNode`] onto
+    /// `rlp_node_buf`. If the extension is already cached, its existing encoding is reused.
+    fn encode_extension(
+        arena: &mut NodeArena,
+        idx: Index,
+        rlp_buf: &mut Vec<u8>,
+        rlp_node_buf: &mut Vec<RlpNode>,
+        new_epoch: TrieNodeEpoch,
+    ) {
+        let (key, child, state) = match &arena[idx] {
+            ArenaSparseNode::Extension { key, child, state } => (key, child, state),
+            _ => unreachable!("encode_extension called on non-Extension node"),
+        };
+
+        let epoch = match state {
+            ArenaSparseNodeState::Cached { rlp_node, .. } => {
+                rlp_node_buf.push(rlp_node.clone());
+                return
+            }
+            ArenaSparseNodeState::Revealed => TrieNodeEpoch::UNMODIFIED,
+            ArenaSparseNodeState::Dirty => new_epoch,
+        };
+
+        rlp_buf.clear();
+        let rlp_node = ExtensionNodeRef::new(key, child).rlp(rlp_buf);
+        *arena[idx].state_mut() =
+            ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone(), epoch };
+        rlp_node_buf.push(rlp_node);
+    }
+
     /// Creates a new leaf and a new branch that splits an existing child from the new leaf at
     /// a divergence point. Returns the index of the new branch.
     ///
@@ -1498,9 +1581,23 @@ impl ArenaParallelSparseTrie {
         let old_child_nibble = old_child_short_key.get_unchecked(diverge_len);
         let old_child_suffix = old_child_short_key.slice(diverge_len + 1..);
 
+        // If an exclusion proof terminates at a one-nibble extension, splitting at that nibble
+        // makes the extension disappear and its blinded child becomes the branch child directly.
+        let collapsed_extension_child = match &arena[old_child_idx] {
+            ArenaSparseNode::Extension { child, .. } if old_child_suffix.is_empty() => {
+                Some(child.clone())
+            }
+            _ => None,
+        };
+
         // Truncate the old child's key/short_key and mark it dirty.
         // Track whether the existing node was not already dirty (a leaf that becomes newly dirty).
         let newly_dirtied_existing = match &mut arena[old_child_idx] {
+            ArenaSparseNode::Extension { key, state, .. } => {
+                *key = old_child_suffix;
+                *state = state.to_dirty();
+                false
+            }
             ArenaSparseNode::Leaf { key, state, .. } => {
                 *key = old_child_suffix;
                 let was_clean = !matches!(state, ArenaSparseNodeState::Dirty);
@@ -1513,7 +1610,14 @@ impl ArenaParallelSparseTrie {
                 // Branches don't contribute to num_dirty_leaves.
                 false
             }
-            _ => unreachable!("split_and_insert_leaf called on non-Leaf/Branch node"),
+            _ => unreachable!("split_and_insert_leaf called on non-Extension/Leaf/Branch node"),
+        };
+
+        let old_child = if let Some(child) = collapsed_extension_child {
+            arena.remove(old_child_idx);
+            ArenaSparseNodeBranchChild::Blinded(child)
+        } else {
+            ArenaSparseNodeBranchChild::Revealed(old_child_idx)
         };
 
         let short_key = new_leaf_path.slice(..diverge_len);
@@ -1526,17 +1630,18 @@ impl ArenaParallelSparseTrie {
             value: value.to_vec(),
         });
 
+        let new_child = ArenaSparseNodeBranchChild::Revealed(new_leaf_idx);
         let (first_nibble, first_child, second_nibble, second_child) =
             if old_child_nibble < new_leaf_nibble {
-                (old_child_nibble, old_child_idx, new_leaf_nibble, new_leaf_idx)
+                (old_child_nibble, old_child, new_leaf_nibble, new_child)
             } else {
-                (new_leaf_nibble, new_leaf_idx, old_child_nibble, old_child_idx)
+                (new_leaf_nibble, new_child, old_child_nibble, old_child)
             };
 
         let state_mask = TrieMask::from(1u16 << first_nibble | 1u16 << second_nibble);
         let mut children = SmallVec::with_capacity(2);
-        children.push(ArenaSparseNodeBranchChild::Revealed(first_child));
-        children.push(ArenaSparseNodeBranchChild::Revealed(second_child));
+        children.push(first_child);
+        children.push(second_child);
 
         let new_branch_idx = arena.insert(ArenaSparseNode::Branch(ArenaSparseNodeBranch {
             state: ArenaSparseNodeState::Dirty,
@@ -1926,6 +2031,13 @@ impl ArenaParallelSparseTrie {
         // Prepend the prefix to the child's key/short_key and mark dirty.
         // Track whether a leaf was newly dirtied by this collapse.
         let newly_dirtied_leaf = match &mut arena[child_idx] {
+            ArenaSparseNode::Extension { key, state, .. } => {
+                let mut new_key = prefix;
+                new_key.extend(key);
+                *key = new_key;
+                *state = state.to_dirty();
+                false
+            }
             ArenaSparseNode::Leaf { key, state, .. } => {
                 let mut new_key = prefix;
                 new_key.extend(key);
@@ -1944,6 +2056,12 @@ impl ArenaParallelSparseTrie {
             ArenaSparseNode::Subtrie(subtrie) => {
                 subtrie.path = branch_entry.path;
                 match &mut subtrie.arena[subtrie.root] {
+                    ArenaSparseNode::Extension { key, state, .. } => {
+                        let mut new_key = prefix;
+                        new_key.extend(key);
+                        *key = new_key;
+                        *state = state.to_dirty();
+                    }
                     ArenaSparseNode::Branch(b) => {
                         let mut new_short_key = prefix;
                         new_short_key.extend(&b.short_key);
@@ -1961,12 +2079,14 @@ impl ArenaParallelSparseTrie {
                         }
                     }
                     _ => {
-                        unreachable!("subtrie root must be a Branch or Leaf during collapse_branch")
+                        unreachable!(
+                            "subtrie root must be an Extension, Branch, or Leaf during collapse_branch"
+                        )
                     }
                 }
                 false
             }
-            _ => unreachable!("remaining child must be Leaf, Branch, or Subtrie"),
+            _ => unreachable!("remaining child must be Extension, Leaf, Branch, or Subtrie"),
         };
 
         // Replace the branch with the remaining child in the grandparent (or root).
@@ -2128,6 +2248,27 @@ impl ArenaParallelSparseTrie {
 
         let head = cursor.head().expect("cursor is non-empty");
         let head_idx = head.index;
+
+        if matches!(arena[head_idx], ArenaSparseNode::Extension { .. }) {
+            if node.path != head.path {
+                return None
+            }
+
+            let cached_rlp = arena[head_idx]
+                .state_ref()
+                .and_then(ArenaSparseNodeState::cached_rlp_node)
+                .cloned()
+                .expect("revealed extension must have cached RLP");
+            let proof_node = mem::replace(node, ProofTrieNodeV2::empty());
+            let mut arena_node = ArenaSparseNode::from_proof_node(proof_node);
+            *arena_node.state_mut() = ArenaSparseNodeState::Cached {
+                rlp_node: cached_rlp,
+                epoch: TrieNodeEpoch::UNMODIFIED,
+            };
+            arena[head_idx] = arena_node;
+            return Some(head_idx)
+        }
+
         let head_branch_logical_path = cursor.head_logical_branch_path(arena);
 
         debug_assert_eq!(
@@ -2305,8 +2446,13 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     branch_masks: masks.unwrap_or_default(),
                 });
             }
-            TrieNodeV2::Extension(_) => {
-                panic!("set_root does not support Extension nodes; extensions are represented as branches with a short_key")
+            TrieNodeV2::Extension(extension) => {
+                trace!(target: TRACE_TARGET, key = ?extension.key, "Setting extension root");
+                self.upper_arena[self.root] = ArenaSparseNode::Extension {
+                    state: ArenaSparseNodeState::Revealed,
+                    key: extension.key,
+                    child: extension.child,
+                };
             }
         }
 
@@ -2512,7 +2658,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         let mut taken: Vec<(Index, Box<ArenaSparseSubtrie>)> = Vec::new();
         for (idx, node) in &mut self.upper_arena {
             let ArenaSparseNode::Subtrie(s) = node else { continue };
-            if s.num_dirty_leaves == 0 {
+            if s.num_dirty_leaves == 0 && s.arena[s.root].is_cached() {
                 continue;
             }
             total_dirty_leaves += s.num_dirty_leaves;
@@ -2662,6 +2808,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 matches!(
                     child,
                     ArenaSparseNode::Branch(_) |
+                        ArenaSparseNode::Extension { .. } |
                         ArenaSparseNode::Subtrie(_) |
                         ArenaSparseNode::Leaf { .. }
                 )
@@ -2676,7 +2823,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
             let head_path = head.path;
 
             match &self.upper_arena[head_idx] {
-                ArenaSparseNode::Branch(_) | ArenaSparseNode::Leaf { .. } => {
+                ArenaSparseNode::Branch(_) |
+                ArenaSparseNode::Extension { .. } |
+                ArenaSparseNode::Leaf { .. } => {
                     // Don't prune the root.
                     if cursor.depth() == 0 {
                         continue;
@@ -2826,7 +2975,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
             match find_result {
                 // Blinded — request a proof regardless of update type.
                 SeekResult::Blinded => {
-                    let logical_len = cursor.head_logical_branch_path_len(&self.upper_arena);
+                    let logical_len = cursor.head_logical_path_len(&self.upper_arena);
                     let parent = ProofV2TargetParent::new(logical_len);
                     trace!(target: TRACE_TARGET, ?key, ?parent, "Update hit blinded node, requesting proof");
                     proof_required_fn(key, parent);

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -173,6 +173,15 @@ pub(super) enum ArenaSparseNode {
     },
     /// A branch node with up to 16 children.
     Branch(ArenaSparseNodeBranch),
+    /// An extension node whose child is blinded.
+    Extension {
+        /// Cached or dirty state of this node.
+        state: ArenaSparseNodeState,
+        /// The path segment compressed by this extension.
+        key: Nibbles,
+        /// The RLP-encoded pointer to the blinded child.
+        child: RlpNode,
+    },
     /// A leaf node containing a value.
     Leaf {
         /// Cached or dirty state of this node.
@@ -189,27 +198,32 @@ pub(super) enum ArenaSparseNode {
 }
 
 impl ArenaSparseNode {
-    /// Returns the state of an `EmptyRoot`, `Branch`, `Leaf`, or `Subtrie` root node, or `None` for
-    /// other types.
+    /// Returns the state of an `EmptyRoot`, `Branch`, `Extension`, `Leaf`, or `Subtrie` root node,
+    /// or `None` for other types.
     pub(super) fn state_ref(&self) -> Option<&ArenaSparseNodeState> {
         match self {
-            Self::EmptyRoot { state } | Self::Leaf { state, .. } => Some(state),
+            Self::EmptyRoot { state } |
+            Self::Extension { state, .. } |
+            Self::Leaf { state, .. } => Some(state),
             Self::Branch(b) => Some(&b.state),
             Self::Subtrie(s) => s.arena[s.root].state_ref(),
             _ => None,
         }
     }
 
-    /// Returns a mutable reference to the state of an `EmptyRoot`, `Branch`, or `Leaf` node.
+    /// Returns a mutable reference to the state of an `EmptyRoot`, `Branch`, `Extension`, or `Leaf`
+    /// node.
     ///
     /// # Panics
     ///
-    /// Panics if called on a non-EmptyRoot/Branch/Leaf node.
+    /// Panics if called on another node type.
     pub(super) fn state_mut(&mut self) -> &mut ArenaSparseNodeState {
         match self {
-            Self::EmptyRoot { state } | Self::Leaf { state, .. } => state,
+            Self::EmptyRoot { state } |
+            Self::Extension { state, .. } |
+            Self::Leaf { state, .. } => state,
             Self::Branch(b) => &mut b.state,
-            _ => panic!("state_mut called on non-EmptyRoot/Branch/Leaf node"),
+            _ => panic!("state_mut called on node without direct state"),
         }
     }
 
@@ -218,11 +232,11 @@ impl ArenaSparseNode {
         self.state_ref().is_some_and(|s| matches!(s, ArenaSparseNodeState::Cached { .. }))
     }
 
-    /// Returns the short key of the branch or leaf, or None.
+    /// Returns the short key of the branch, extension, or leaf, or `None`.
     pub(super) const fn short_key(&self) -> Option<&Nibbles> {
         match self {
             Self::Branch(b) => Some(&b.short_key),
-            Self::Leaf { key, .. } => Some(key),
+            Self::Extension { key, .. } | Self::Leaf { key, .. } => Some(key),
             _ => None,
         }
     }
@@ -295,9 +309,11 @@ impl ArenaSparseNode {
     /// case where a branch's RLP is small enough to be embedded rather than hashed.
     pub(super) fn cached_hash(&self) -> B256 {
         let rlp_node = match self {
-            Self::Branch(ArenaSparseNodeBranch { state, .. }) | Self::Leaf { state, .. } => state
+            Self::Branch(ArenaSparseNodeBranch { state, .. }) |
+            Self::Extension { state, .. } |
+            Self::Leaf { state, .. } => state
                 .cached_rlp_node()
-                .expect("cached_hash called on non-Cached branch or leaf: {self:?}"),
+                .expect("cached_hash called on non-Cached branch, extension, or leaf: {self:?}"),
             Self::Subtrie(s) => return s.arena[s.root].cached_hash(),
             _ => panic!("cached_hash called on {self:?}"),
         };
@@ -307,11 +323,6 @@ impl ArenaSparseNode {
 
 impl ArenaSparseNode {
     /// Converts a [`ProofTrieNodeV2`] into an [`ArenaSparseNode`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the node is an `Extension`, which should have been merged into a branch
-    /// by [`TrieNodeV2`].
     pub(super) fn from_proof_node(proof_node: ProofTrieNodeV2) -> Self {
         let ProofTrieNodeV2 { node, masks, .. } = proof_node;
         match node {
@@ -334,9 +345,11 @@ impl ArenaSparseNode {
                     branch_masks: masks.unwrap_or_default(),
                 })
             }
-            TrieNodeV2::Extension(_) => {
-                panic!("Extension nodes should be merged into branches by TrieNodeV2")
-            }
+            TrieNodeV2::Extension(extension) => Self::Extension {
+                state: ArenaSparseNodeState::Revealed,
+                key: extension.key,
+                child: extension.child,
+            },
         }
     }
 }

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -584,7 +584,7 @@ mod tests {
     use super::*;
     use crate::{ArenaParallelSparseTrie, LeafLookup, LeafUpdate};
     use alloy_primitives::{
-        b256,
+        b256, keccak256,
         map::{HashMap, HashSet},
         U256,
     };
@@ -595,8 +595,8 @@ mod tests {
     use reth_trie::{updates::StorageTrieUpdates, HashBuilder, MultiProof, EMPTY_ROOT_HASH};
     use reth_trie_common::{
         proof::{ProofNodes, ProofRetainer},
-        BranchNodeMasks, BranchNodeMasksMap, BranchNodeV2, LeafNode, RlpNode, StorageMultiProof,
-        TrieAccount, TrieMask, TrieNodeV2,
+        BranchNodeMasks, BranchNodeMasksMap, BranchNodeV2, ExtensionNode, LeafNode, RlpNode,
+        StorageMultiProof, TrieAccount, TrieMask, TrieNodeV2,
     };
 
     const fn epoch(value: u64) -> TrieNodeEpoch {
@@ -615,6 +615,210 @@ mod tests {
         let mut updates = B256Map::from_iter([(address, update)]);
         sparse.trie_mut().update_leaves(&mut updates, |_, _| {}).unwrap();
         assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn terminal_extension_proves_exclusion_and_supports_insert() {
+        let blinded_child = B256::repeat_byte(0x11);
+        let extension = TrieNodeV2::Extension(ExtensionNode::new(
+            Nibbles::from_nibbles([0x3]),
+            RlpNode::word_rlp(&blinded_child),
+        ));
+        let extension_rlp = RlpNode::from_rlp(&alloy_rlp::encode(&extension));
+        let root_node = TrieNodeV2::Branch(BranchNodeV2::new(
+            Nibbles::default(),
+            vec![extension_rlp],
+            TrieMask::from_nibble(0xb),
+            None,
+        ));
+        let root = keccak256(alloy_rlp::encode(&root_node));
+
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
+        sparse
+            .reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
+                account_proofs: vec![
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0xb]),
+                        node: extension,
+                        masks: None,
+                    },
+                    ProofTrieNodeV2 { path: Nibbles::default(), node: root_node, masks: None },
+                ],
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert_eq!(sparse.root(epoch(0)).unwrap(), root);
+
+        let absent_path = leaf_key([0xb, 0x8], 64);
+        assert_eq!(
+            sparse.state_trie_ref().unwrap().find_leaf(&absent_path, None),
+            Ok(LeafLookup::NonExistent)
+        );
+
+        let blinded_path = leaf_key([0xb, 0x3], 64);
+        assert!(matches!(
+            sparse.state_trie_ref().unwrap().find_leaf(&blinded_path, None),
+            Err(crate::LeafLookupError::BlindedNode { path, hash })
+                if path == Nibbles::from_nibbles([0xb, 0x3]) && hash == blinded_child
+        ));
+
+        let value = alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec();
+        let mut updates = B256Map::from_iter([(
+            B256::from_slice(&absent_path.pack()),
+            LeafUpdate::Changed(value.clone()),
+        )]);
+        sparse.trie_mut().update_leaves(&mut updates, |_, _| {}).unwrap();
+        assert!(updates.is_empty());
+        assert_eq!(sparse.state_trie_ref().unwrap().get_leaf_value(&absent_path), Some(&value));
+
+        let new_leaf = RlpNode::from_rlp(&alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
+            leaf_key([], 62),
+            value,
+        ))));
+        let split_branch =
+            RlpNode::from_rlp(&alloy_rlp::encode(TrieNodeV2::Branch(BranchNodeV2::new(
+                Nibbles::default(),
+                vec![RlpNode::word_rlp(&blinded_child), new_leaf],
+                TrieMask::from_nibble(0x3) | TrieMask::from_nibble(0x8),
+                None,
+            ))));
+        let expected_root = keccak256(alloy_rlp::encode(TrieNodeV2::Branch(BranchNodeV2::new(
+            Nibbles::default(),
+            vec![split_branch],
+            TrieMask::from_nibble(0xb),
+            None,
+        ))));
+        assert_eq!(sparse.root(epoch(1)).unwrap(), expected_root);
+    }
+
+    #[test]
+    fn insert_at_extension_divergence_preserves_remaining_key() {
+        let blinded_child = B256::repeat_byte(0x22);
+        let extension = TrieNodeV2::Extension(ExtensionNode::new(
+            Nibbles::from_nibbles([0x3, 0x4]),
+            RlpNode::word_rlp(&blinded_child),
+        ));
+        let initial_root = keccak256(alloy_rlp::encode(&extension));
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
+        sparse
+            .reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
+                account_proofs: vec![ProofTrieNodeV2 {
+                    path: Nibbles::default(),
+                    node: extension,
+                    masks: None,
+                }],
+                ..Default::default()
+            })
+            .unwrap();
+
+        let inserted_path = leaf_key([0x8], 64);
+        let value = alloy_rlp::encode_fixed_size(&U256::from(2)).to_vec();
+        let mut updates = B256Map::from_iter([(
+            B256::from_slice(&inserted_path.pack()),
+            LeafUpdate::Changed(value.clone()),
+        )]);
+        sparse.trie_mut().update_leaves(&mut updates, |_, _| {}).unwrap();
+        assert!(updates.is_empty());
+
+        let remaining_extension = RlpNode::from_rlp(&alloy_rlp::encode(TrieNodeV2::Extension(
+            ExtensionNode::new(Nibbles::from_nibbles([0x4]), RlpNode::word_rlp(&blinded_child)),
+        )));
+        let new_leaf = RlpNode::from_rlp(&alloy_rlp::encode(TrieNodeV2::Leaf(LeafNode::new(
+            leaf_key([], 63),
+            value,
+        ))));
+        let expected_root = keccak256(alloy_rlp::encode(TrieNodeV2::Branch(BranchNodeV2::new(
+            Nibbles::default(),
+            vec![remaining_extension, new_leaf],
+            TrieMask::from_nibble(0x3) | TrieMask::from_nibble(0x8),
+            None,
+        ))));
+        assert_eq!(sparse.root(epoch(1)).unwrap(), expected_root);
+
+        let mut updates = B256Map::from_iter([(
+            B256::from_slice(&inserted_path.pack()),
+            LeafUpdate::Changed(Vec::new()),
+        )]);
+        sparse.trie_mut().update_leaves(&mut updates, |_, _| {}).unwrap();
+        assert!(updates.is_empty());
+        assert_eq!(sparse.root(epoch(2)).unwrap(), initial_root);
+    }
+
+    #[test]
+    fn terminal_extension_can_be_revealed_later() {
+        let value_0 = alloy_rlp::encode_fixed_size(&U256::from(3)).to_vec();
+        let value_1 = alloy_rlp::encode_fixed_size(&U256::from(4)).to_vec();
+        let leaf_0_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 61), value_0.clone()));
+        let leaf_1_node = TrieNodeV2::Leaf(LeafNode::new(leaf_key([], 61), value_1));
+        let leaf_0 = RlpNode::from_rlp(&alloy_rlp::encode(&leaf_0_node));
+        let leaf_1 = RlpNode::from_rlp(&alloy_rlp::encode(&leaf_1_node));
+        let child_branch =
+            RlpNode::from_rlp(&alloy_rlp::encode(TrieNodeV2::Branch(BranchNodeV2::new(
+                Nibbles::default(),
+                vec![leaf_0.clone(), leaf_1.clone()],
+                TrieMask::from_nibble(0x4) | TrieMask::from_nibble(0x5),
+                None,
+            ))));
+        let extension = TrieNodeV2::Extension(ExtensionNode::new(
+            Nibbles::from_nibbles([0x3]),
+            child_branch.clone(),
+        ));
+        let root_node = TrieNodeV2::Branch(BranchNodeV2::new(
+            Nibbles::default(),
+            vec![RlpNode::from_rlp(&alloy_rlp::encode(&extension))],
+            TrieMask::from_nibble(0xb),
+            None,
+        ));
+        let root = keccak256(alloy_rlp::encode(&root_node));
+
+        let mut sparse = SparseStateTrie::<ArenaParallelSparseTrie>::default();
+        sparse
+            .reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
+                account_proofs: vec![
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0xb]),
+                        node: extension,
+                        masks: None,
+                    },
+                    ProofTrieNodeV2 { path: Nibbles::default(), node: root_node, masks: None },
+                ],
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(sparse.root(epoch(0)).unwrap(), root);
+
+        sparse
+            .reveal_decoded_multiproof_v2(reth_trie_common::DecodedMultiProofV2 {
+                account_proofs: vec![
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0xb, 0x3, 0x4]),
+                        node: leaf_0_node,
+                        masks: None,
+                    },
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0xb, 0x3, 0x5]),
+                        node: leaf_1_node,
+                        masks: None,
+                    },
+                    ProofTrieNodeV2 {
+                        path: Nibbles::from_nibbles([0xb]),
+                        node: TrieNodeV2::Branch(BranchNodeV2::new(
+                            Nibbles::from_nibbles([0x3]),
+                            vec![leaf_0, leaf_1],
+                            TrieMask::from_nibble(0x4) | TrieMask::from_nibble(0x5),
+                            Some(child_branch),
+                        )),
+                        masks: None,
+                    },
+                ],
+                ..Default::default()
+            })
+            .unwrap();
+
+        let revealed_path = leaf_key([0xb, 0x3, 0x4], 64);
+        assert_eq!(sparse.state_trie_ref().unwrap().get_leaf_value(&revealed_path), Some(&value_0));
+        assert_eq!(sparse.root(epoch(0)).unwrap(), root);
     }
 
     #[test]


### PR DESCRIPTION
Preserves standalone terminal extensions when converting proof nodes and represents them directly in the arena sparse trie. This authenticates exclusion at a divergent extension while retaining later reveal and update support, so RPC proofs do not need to include the child branch.

Alternative to #26851.

Prompted by: @rkrasiuk
