### PR TITLE
fix(engine): keep tree alive on invalid downloads

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2722,9 +2722,10 @@ where
                 Err(err) => {
                     if let InsertPayloadError::Block(err) = err {
                         debug!(target: "engine::tree", ?err, "failed to connect buffered block to tree");
-                        if let Err(fatal) = self.on_internal_insert_block_error(err) {
+                        if let Err(InsertBlockProcessingError::Fatal(fatal)) =
+                            self.on_insert_block_error(err)
+                        {
                             warn!(target: "engine::tree", %fatal, "fatal error occurred while connecting buffered blocks");
-                            return Err(fatal)
                         }
                     }
                 }
@@ -3097,9 +3098,10 @@ where
             Err(err) => {
                 if let InsertPayloadError::Block(err) = err {
                     debug!(target: "engine::tree", err=%err.kind(), "failed to insert downloaded block");
-                    if let Err(fatal) = self.on_internal_insert_block_error(err) {
+                    if let Err(InsertBlockProcessingError::Fatal(fatal)) =
+                        self.on_insert_block_error(err)
+                    {
                         warn!(target: "engine::tree", %fatal, "fatal error occurred while inserting downloaded block");
-                        return Err(fatal)
                     }
                 }
             }
@@ -3343,17 +3345,6 @@ where
             PayloadStatusEnum::Invalid { validation_error: validation_err.to_string() },
             latest_valid_hash,
         ))
-    }
-
-    /// Handles an insertion error from a non-RPC source, where malformed input can be discarded.
-    fn on_internal_insert_block_error(
-        &mut self,
-        error: InsertBlockError<N::Block>,
-    ) -> Result<(), InsertBlockFatalError> {
-        match self.on_insert_block_error(error) {
-            Ok(_) | Err(InsertBlockProcessingError::MalformedInput(_)) => Ok(()),
-            Err(InsertBlockProcessingError::Fatal(error)) => Err(error),
-        }
     }
 
     /// Handles a [`NewPayloadError`] by converting it to a [`PayloadStatus`].

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -1159,9 +1159,9 @@ mod tests {
     }
 
     #[test]
-    fn worker_tx_recovery_error_becomes_other_error() {
+    fn worker_tx_recovery_error_becomes_validation_error() {
         // A tx recovery failure fed into the worker channel must surface as
-        // BalExecutionError::Other. Uses execute_block directly since tx_stream hardcodes
+        // a block validation error. Uses execute_block directly since tx_stream hardcodes
         // Infallible and cannot inject errors.
         let evm_config = EthEvmConfig::mainnet();
         let block = empty_amsterdam_block(B256::ZERO);
@@ -1192,8 +1192,8 @@ mod tests {
         );
 
         assert!(
-            matches!(result, Err(BalExecutionError::Other(_))),
-            "expected Other error from tx recovery failure, got {result:?}",
+            matches!(result, Err(BalExecutionError::Execution(BlockExecutionError::Validation(_)))),
+            "expected validation error from tx recovery failure, got {result:?}",
         );
     }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -2,7 +2,7 @@ use super::BalExecutionError;
 use alloy_consensus::Transaction;
 use alloy_eip7928::BlockAccessIndex;
 use alloy_evm::{
-    block::{BlockExecutionError, BlockExecutor, BlockExecutorFactory},
+    block::{BlockExecutionError, BlockExecutor, BlockExecutorFactory, BlockValidationError},
     Evm,
 };
 use alloy_primitives::Address;
@@ -28,7 +28,9 @@ impl From<BalWorkerError> for BalExecutionError {
     fn from(err: BalWorkerError) -> Self {
         match err {
             BalWorkerError::Setup(err) => err,
-            BalWorkerError::Transaction(err) => Self::Other(err),
+            BalWorkerError::Transaction(err) => {
+                Self::Execution(BlockValidationError::Other(err).into())
+            }
             BalWorkerError::Execution(err) => Self::Execution(err),
         }
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -135,7 +135,7 @@ use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
     ConfigureEngineEvm, ExecutableTxIterator, ExecutionPayload, InvalidBlockHook, PayloadValidator,
 };
-use reth_errors::{BlockExecutionError, ProviderResult};
+use reth_errors::{BlockExecutionError, BlockValidationError, ProviderResult};
 use reth_evm::{
     block::BlockExecutor, execute::ExecutableTxFor, ConfigureEvm, EvmEnvFor, ExecutionCtxFor,
     OnStateHook, SpecFor,
@@ -1262,7 +1262,7 @@ where
             let Some(tx_result) = transactions.next() else { break };
             self.metrics.record_transaction_wait(wait_start.elapsed());
 
-            let tx = tx_result.map_err(BlockExecutionError::other)?;
+            let tx = tx_result.map_err(BlockValidationError::other)?;
             let tx_signer = *<Tx as alloy_evm::RecoveredTx<InnerTx>>::signer(&tx);
 
             senders.push(tx_signer);


### PR DESCRIPTION
Classifies transaction recovery failures as block validation errors in both sequential and BAL execution. Downloaded and buffered insertion failures are handled locally so a malformed peer-served block cannot stop the engine tree task.