### PR TITLE
refactor(provider): remove historical state factory methods

### DIFF
--- a/crates/cli/commands/src/db/state.rs
+++ b/crates/cli/commands/src/db/state.rs
@@ -9,8 +9,11 @@ use reth_db_api::{
 };
 use reth_db_common::DbTool;
 use reth_node_builder::NodeTypesWithDB;
-use reth_provider::{providers::ProviderNodeTypes, StaticFileProviderFactory};
-use reth_storage_api::{BlockNumReader, StateProvider, StorageSettingsCache};
+use reth_provider::{
+    providers::{BlockchainProvider, ProviderNodeTypes},
+    StaticFileProviderFactory,
+};
+use reth_storage_api::{BlockNumReader, StateProvider, StateProviderFactory, StorageSettingsCache};
 use reth_tasks::spawn_scoped_os_thread;
 use std::{
     collections::BTreeSet,
@@ -138,7 +141,8 @@ impl Command {
         block: BlockNumber,
         limit: usize,
     ) -> eyre::Result<()> {
-        let provider = tool.provider_factory.history_by_block_number(block)?;
+        let provider = BlockchainProvider::new(tool.provider_factory.clone())?
+            .history_by_block_number(block)?;
 
         // Get account info at that block
         let account = provider.basic_account(&address)?;

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -701,14 +701,16 @@ mod tests {
 
         // Check the primary can read its own historical state.
         {
-            let primary_state_at_1 = provider_factory.history_by_block_number(1).unwrap();
+            let provider = provider_factory.provider().unwrap();
+            let primary_state_at_1 = provider.history_by_block_number(1).unwrap();
             let primary_account = primary_state_at_1.basic_account(&signer).unwrap();
             assert!(primary_account.is_some(), "primary: signer must exist at block 1");
         }
 
         // Verify historical state at block 1 is accessible via changesets on the secondary.
         {
-            let state_at_1 = secondary.history_by_block_number(1).unwrap();
+            let provider = secondary.provider().unwrap();
+            let state_at_1 = provider.history_by_block_number(1).unwrap();
             let account_at_1 = state_at_1.basic_account(&signer).unwrap();
             assert!(account_at_1.is_some(), "signer account must exist at block 1");
             let account_at_1 = account_at_1.unwrap();
@@ -803,7 +805,8 @@ mod tests {
         );
 
         // Verify historical state at block 1 is still accessible after the reorg.
-        let state_at_1 = secondary.history_by_block_number(1).unwrap();
+        let provider = secondary.provider().unwrap();
+        let state_at_1 = provider.history_by_block_number(1).unwrap();
         let account_at_1 = state_at_1.basic_account(&signer).unwrap();
         assert!(account_at_1.is_some(), "signer account must exist at block 1 after reorg");
         let account_at_1 = account_at_1.unwrap();
@@ -817,7 +820,8 @@ mod tests {
         );
 
         // Verify the latest state (at block 2) reflects the reorged execution.
-        let state_at_2 = secondary.history_by_block_number(2).unwrap();
+        let provider = secondary.provider().unwrap();
+        let state_at_2 = provider.history_by_block_number(2).unwrap();
         let account_at_2 = state_at_2.basic_account(&signer).unwrap();
         assert!(account_at_2.is_some(), "signer account must exist at block 2 after reorg");
         let account_at_2 = account_at_2.unwrap();

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -30,7 +30,7 @@ use reth_stages_types::{PipelineTarget, StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
     BlockBodyIndicesProvider, ChainStateBlockReader, ChainStateBlockWriter, DBProvider,
-    NodePrimitivesProvider, StorageSettings, StorageSettingsCache, TryIntoHistoricalStateProvider,
+    NodePrimitivesProvider, StorageSettings, StorageSettingsCache,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_storage_overlay::OverlayManager;
@@ -461,29 +461,6 @@ impl<N: ProviderNodeTypes> ProviderFactory<N> {
     pub fn latest(&self) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::db", "Returning latest state provider");
         Ok(Box::new(LatestStateProvider::new(self.database_provider_ro()?)))
-    }
-
-    /// Storage provider for state at that given block
-    pub fn history_by_block_number(
-        &self,
-        block_number: BlockNumber,
-    ) -> ProviderResult<StateProviderBox> {
-        let state_provider = self.provider()?.try_into_history_at_block(block_number)?;
-        trace!(target: "providers::db", ?block_number, "Returning historical state provider for block number");
-        Ok(state_provider)
-    }
-
-    /// Storage provider for state at that given block hash
-    pub fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox> {
-        let provider = self.provider()?;
-
-        let block_number = provider
-            .block_number(block_hash)?
-            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
-
-        let state_provider = provider.try_into_history_at_block(block_number)?;
-        trace!(target: "providers::db", ?block_number, %block_hash, "Returning historical state provider for block hash");
-        Ok(state_provider)
     }
 
     /// Asserts that the static files and database are consistent. If not,

--- a/examples/db-access/src/main.rs
+++ b/examples/db-access/src/main.rs
@@ -6,8 +6,9 @@ use reth_ethereum::{
     node::EthereumNode,
     primitives::{AlloyBlockHeader, SealedBlock, SealedHeader},
     provider::{
-        providers::ReadOnlyConfig, AccountReader, BlockNumReader, BlockReader, BlockSource,
-        HeaderProvider, ReceiptProvider, StateProvider, TransactionVariant, TransactionsProvider,
+        providers::{BlockchainProvider, ReadOnlyConfig},
+        AccountReader, BlockNumReader, BlockReader, BlockSource, HeaderProvider, ReceiptProvider,
+        StateProvider, StateProviderFactory, TransactionVariant, TransactionsProvider,
     },
     rpc::eth::primitives::Filter,
     TransactionSigned,
@@ -44,7 +45,11 @@ fn main() -> eyre::Result<()> {
     receipts_provider_example(&provider)?;
 
     state_provider_example(factory.latest()?, &provider, provider.best_block_number()?)?;
-    state_provider_example(factory.history_by_block_number(block_num)?, &provider, block_num)?;
+    state_provider_example(
+        BlockchainProvider::new(factory.clone())?.history_by_block_number(block_num)?,
+        &provider,
+        block_num,
+    )?;
 
     // Closes the RO transaction opened in the `factory.provider()` call. This is optional and
     // would happen anyway at the end of the function scope.


### PR DESCRIPTION
Removes `ProviderFactory` historical-state methods. The database state CLI and db-access example now resolve historical state through `BlockchainProvider`.

After this PR the BlockchainProvider will be the only type which materializes StateProviders for specific historical or in-memory blocks.