### PR TITLE
feat(provider): implement multiproof_v2 on OverlayStateProvider

### DIFF
--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_primitives_traits::Account;
-use reth_storage_errors::provider::{ProviderError, ProviderResult};
+use reth_storage_errors::provider::ProviderResult;
 use reth_trie_common::{
     updates::{StorageTrieUpdatesSorted, TrieUpdates, TrieUpdatesSorted},
     AccountProof, DecodedMultiProofV2, ExecutionWitnessMode, HashedPostState, HashedStorage,
@@ -165,11 +165,9 @@ pub trait StateProofProvider {
     /// Generate a V2 decoded multiproof for target hashed accounts and storage slots.
     fn multiproof_v2(
         &self,
-        _input: TrieInput,
-        _targets: MultiProofTargetsV2,
-    ) -> ProviderResult<DecodedMultiProofV2> {
-        Err(ProviderError::UnsupportedProvider)
-    }
+        input: TrieInput,
+        targets: MultiProofTargetsV2,
+    ) -> ProviderResult<DecodedMultiProofV2>;
 
     /// Get trie witness for provided state using the given witness generation mode.
     fn witness(

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -26,9 +26,10 @@ use reth_trie::{
     },
     updates::TrieUpdates,
     witness::TrieWitness,
-    AccountProof, ExecutionWitnessMode, HashedPostState, HashedPostStateSorted, HashedStorage,
-    KeccakKeyHasher, MultiProof, MultiProofTargets, StateRoot, StorageMultiProof, StorageProof,
-    StorageRoot, TrieInput, TrieInputSorted,
+    AccountProof, DecodedMultiProofV2, ExecutionWitnessMode, HashedPostState,
+    HashedPostStateSorted, HashedStorage, KeccakKeyHasher, MultiProof, MultiProofTargets,
+    MultiProofTargetsV2, StateRoot, StorageMultiProof, StorageProof, StorageRoot, TrieInput,
+    TrieInputSorted,
 };
 use reth_trie_db::{
     DatabaseAccountTrieCursor, DatabaseHashedCursorFactory, DatabaseProof, DatabaseStateRoot,
@@ -621,6 +622,24 @@ where
             );
             let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.provider().tx());
             proof.overlay_multiproof(input, targets).map_err(ProviderError::from)
+        })
+    }
+
+    fn multiproof_v2(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargetsV2,
+    ) -> ProviderResult<DecodedMultiProofV2> {
+        reth_trie_db::with_adapter!(self.provider(), |A| {
+            let TrieInputSorted { nodes, state, prefix_sets } =
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = TrieInput::new(
+                Arc::unwrap_or_clone(nodes).into(),
+                Arc::unwrap_or_clone(state).into(),
+                prefix_sets,
+            );
+            let proof = <DbProof<'_, _, A> as DatabaseProof>::from_tx(self.provider().tx());
+            proof.overlay_multiproof_v2(input, targets).map_err(ProviderError::from)
         })
     }
 


### PR DESCRIPTION
Adds V2 multiproof generation to OverlayStateProvider. The method builds the managed trie overlay before delegating to the database proof implementation.