### PR TITLE
fix(bench): suppress storage overlay OTLP logs

### DIFF
--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -298,7 +298,7 @@ if [ "${BENCH_OTLP_DISABLED:-false}" != "true" ]; then
     RETH_ARGS+=(--tracing-otlp="${BENCH_OTLP_TRACES_ENDPOINT}" --tracing-otlp.service-name=reth-bench --tracing-otlp.service-version="${LABEL}")
   fi
   if [ -n "${BENCH_OTLP_LOGS_ENDPOINT:-}" ]; then
-    RETH_ARGS+=(--logs-otlp="${BENCH_OTLP_LOGS_ENDPOINT}" --logs-otlp.filter=debug)
+    RETH_ARGS+=(--logs-otlp="${BENCH_OTLP_LOGS_ENDPOINT}" --logs-otlp.filter=debug,storage::overlay=off)
   fi
 fi
 

--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -217,6 +217,8 @@ where
                     self.increment_by_one_precompile_cache_misses();
                 }
             }
+            // Oversized successful inputs execute normally but are not cacheable.
+            Ok(output) if output.is_success() => {}
             _ => {
                 self.increment_by_one_precompile_errors();
             }
@@ -255,6 +257,7 @@ impl CachedPrecompileMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
     use reth_evm::{EthEvmFactory, Evm, EvmEnv, EvmFactory};
     use reth_revm::db::EmptyDB;
     use revm::{
@@ -411,5 +414,55 @@ mod tests {
             .into_output()
             .unwrap();
         assert_eq!(result3.as_ref(), b"output_from_precompile_1");
+    }
+
+    #[test]
+    fn test_oversized_successful_input_is_not_an_error() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let cache = PrecompileCache::default();
+        let input_data = Bytes::from(vec![0; MAX_PRECOMPILE_CACHE_INPUT_SIZE + 1]);
+        let address = Address::with_last_byte(1);
+
+        metrics::with_local_recorder(&recorder, || {
+            let precompile: DynPrecompile = (|_input: PrecompileInput<'_>| {
+                Ok(PrecompileOutput {
+                    status: PrecompileStatus::Success,
+                    gas_used: 0,
+                    state_gas_used: 0,
+                    state_gas_spilled: 0,
+                    reservoir: 0,
+                    gas_refunded: 0,
+                    bytes: Bytes::default(),
+                })
+            })
+            .into();
+            let wrapped = CachedPrecompile::wrap(
+                precompile,
+                cache.clone(),
+                SpecId::PRAGUE,
+                Some(CachedPrecompileMetrics::new_with_address(address)),
+            );
+            let mut evm =
+                EthEvmFactory::default().create_evm(EmptyDB::default(), EvmEnv::default());
+            evm.precompiles_mut().apply_precompile(&address, |_| Some(wrapped));
+
+            evm.transact_raw(TxEnv {
+                caller: Address::ZERO,
+                gas_limit: 100_000,
+                data: input_data.clone(),
+                kind: address.into(),
+                ..Default::default()
+            })
+            .unwrap();
+        });
+
+        assert!(cache.get(&input_data, SpecId::PRAGUE).is_none());
+        let error_count = snapshotter.snapshot().into_vec().into_iter().find_map(
+            |(key, _unit, _description, value)| {
+                (key.key().name() == "sync.caching.precompile_errors").then_some(value)
+            },
+        );
+        assert_eq!(error_count, Some(DebugValue::Counter(0)));
     }
 }


### PR DESCRIPTION
Excludes storage::overlay from scheduled benchmark OTLP logs while retaining every other debug target. This target emitted 2.46 GB in six hours, 76% of the scheduled reth-bench stream.

Also avoids counting successful precompile calls with oversized calldata as errors while keeping them uncached.