### PR TITLE
fix(engine): flush partial state before backfill

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -333,6 +333,8 @@ where
     /// A durable persistence completion whose destructive in-memory handoff is deferred until
     /// payload jobs finish.
     pending_persisted_handoff: Option<PersistenceResult>,
+    /// A backfill action deferred until partially persisted state is fully flushed.
+    pending_backfill_action: Option<BackfillAction>,
     /// Task runtime for spawning blocking work on named, reusable threads.
     runtime: reth_tasks::Runtime,
 }
@@ -362,6 +364,7 @@ where
             .field("execution_timing_stats", &self.execution_timing_stats.len())
             .field("payload_builds_active", &self.payload_builds.is_active())
             .field("pending_persisted_handoff", &self.pending_persisted_handoff)
+            .field("pending_backfill_action", &self.pending_backfill_action)
             .field("runtime", &self.runtime)
             .finish()
     }
@@ -430,6 +433,7 @@ where
             payload_builds,
             payload_build_finished,
             pending_persisted_handoff: None,
+            pending_backfill_action: None,
             runtime,
         }
     }
@@ -1472,12 +1476,36 @@ where
             return Ok(())
         }
 
-        if !self.persistence_state.in_progress() {
-            if let Some(new_tip_num) = self.find_disk_reorg()? {
-                self.remove_blocks(new_tip_num)
-            } else if let Some(input) = self.get_save_blocks_input(PersistTarget::Threshold) {
-                self.persist_blocks(input);
+        if self.persistence_state.in_progress() {
+            return Ok(())
+        }
+
+        if let Some(new_tip_num) = self.find_disk_reorg()? {
+            self.remove_blocks(new_tip_num);
+            return Ok(())
+        }
+
+        if self.pending_backfill_action.is_some() {
+            if self.persistence_state.last_state_trie_persisted_block !=
+                self.persistence_state.last_persisted_block
+            {
+                if let Some(input) = self.get_save_blocks_input(PersistTarget::Head) {
+                    self.persist_blocks(input);
+                }
+                return Ok(())
             }
+
+            if self.payload_builds.is_active() {
+                return Ok(())
+            }
+
+            let action = self.pending_backfill_action.take().expect("checked above");
+            self.emit_event(EngineApiEvent::BackfillAction(action));
+            return Ok(())
+        }
+
+        if let Some(input) = self.get_save_blocks_input(PersistTarget::Threshold) {
+            self.persist_blocks(input);
         }
 
         Ok(())
@@ -2181,6 +2209,23 @@ where
                 // Backfill can remove the same in-memory blocks as an active payload job or a
                 // persisted handoff, so it must not start until the next sync trigger.
                 debug!(target: "engine::tree", "skipping backfill while in-memory overlay is in use");
+                return
+            }
+
+            if self.persistence_state.last_state_trie_persisted_block !=
+                self.persistence_state.last_persisted_block
+            {
+                let EngineApiEvent::BackfillAction(action) = &event else { unreachable!() };
+                debug!(
+                    target: "engine::tree",
+                    last_persisted_block = self.persistence_state.last_persisted_block.number,
+                    last_state_trie_persisted_block = self
+                        .persistence_state
+                        .last_state_trie_persisted_block
+                        .number,
+                    "deferring backfill until partially persisted state is fully flushed"
+                );
+                self.pending_backfill_action = Some(action.clone());
                 return
             }
 

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -862,6 +862,52 @@ fn backfill_action_skips_while_persisted_handoff_is_pending() {
 }
 
 #[test]
+fn backfill_action_flushes_partial_persistence_before_emitting() {
+    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(0..4).collect();
+    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
+    let persisted_tip = blocks[2].recovered_block().num_hash();
+    let state_trie_tip = blocks[1].recovered_block().num_hash();
+    test_harness.tree.persistence_state.last_persisted_block = persisted_tip;
+    test_harness.tree.persistence_state.last_state_trie_persisted_block = state_trie_tip;
+
+    let target = B256::random();
+    test_harness
+        .tree
+        .emit_event(EngineApiEvent::BackfillAction(BackfillAction::Start(target.into())));
+
+    assert!(test_harness.tree.backfill_sync_state.is_idle());
+    assert!(test_harness.tree.pending_backfill_action.is_some());
+    assert!(test_harness.from_tree_rx.try_recv().is_err());
+
+    test_harness.tree.advance_persistence().unwrap();
+    let action = test_harness.action_rx.recv().unwrap();
+    let PersistenceAction::SaveBlocks(input, sender) = action else {
+        panic!("expected save blocks action, got {action:?}")
+    };
+    let canonical_head = blocks[3].recovered_block().num_hash();
+    assert_eq!(input.new_db_tip(), canonical_head.number);
+    assert_eq!(input.new_partial_state_trie(), canonical_head.number);
+
+    sender
+        .send(PersistenceResult {
+            last_block: canonical_head,
+            last_state_trie_block: canonical_head,
+            commit_duration: Some(Duration::ZERO),
+        })
+        .unwrap();
+    assert!(test_harness.tree.try_poll_persistence().unwrap());
+    test_harness.tree.advance_persistence().unwrap();
+
+    assert!(test_harness.tree.pending_backfill_action.is_none());
+    assert!(test_harness.tree.backfill_sync_state.is_pending());
+    assert_matches!(
+        test_harness.from_tree_rx.try_recv(),
+        Ok(EngineApiEvent::BackfillAction(BackfillAction::Start(actual)))
+            if actual == target.into()
+    );
+}
+
+#[test]
 fn configured_persistence_suppression_tracks_payload_job_lifetime() {
     let config = TreeConfig::default()
         .with_has_enough_parallelism(true)


### PR DESCRIPTION
Defers pipeline backfill while hashed-state/trie persistence lags the database tip. Runs a head-targeted flush and emits the queued backfill only after both persistence frontiers match, preventing pipeline execution from reading database state that still requires the in-memory mask.

Prompted by: @mediocregopher