### PR TITLE
rpc: drop size from eth_getHeaderBy* responses

### DIFF
--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -4,12 +4,24 @@ use alloy_json_rpc::RpcObject;
 use alloy_network::{primitives::HeaderResponse, Network, ReceiptResponse, TransactionResponse};
 use alloy_rpc_types_eth::TransactionRequest;
 
+/// A header response carrying the non-consensus `size` field.
+pub trait SizedHeader {
+    /// Clears the `size` field so it is omitted from the response.
+    fn clear_size(&mut self);
+}
+
+impl<H> SizedHeader for alloy_rpc_types_eth::Header<H> {
+    fn clear_size(&mut self) {
+        self.size = None;
+    }
+}
+
 /// RPC types used by the `eth_` RPC API.
 ///
 /// This is a subset of [`Network`] trait with only RPC response types kept.
 pub trait RpcTypes: Send + Sync + Clone + Unpin + Debug + 'static {
     /// Header response type.
-    type Header: RpcObject + HeaderResponse;
+    type Header: RpcObject + HeaderResponse + SizedHeader;
     /// Receipt response type.
     type Receipt: RpcObject + ReceiptResponse;
     /// Log response type.
@@ -23,6 +35,7 @@ pub trait RpcTypes: Send + Sync + Clone + Unpin + Debug + 'static {
 impl<T> RpcTypes for T
 where
     T: Network<TransactionRequest: AsRef<TransactionRequest> + AsMut<TransactionRequest>> + Unpin,
+    T::HeaderResponse: SizedHeader,
 {
     type Header = T::HeaderResponse;
     type Receipt = T::ReceiptResponse;

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_eth::{Block, BlockTransactions, Index};
 use futures::Future;
 use reth_node_api::BlockBody;
 use reth_primitives_traits::{AlloyBlockHeader, RecoveredBlock, SealedHeader, TransactionMeta};
-use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert, RpcHeader};
+use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert, RpcHeader, SizedHeader};
 use reth_storage_api::{BlockIdReader, BlockReader, ProviderHeader, ProviderReceipt, ProviderTx};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 use revm::state::bal::Bal as RevmBal;
@@ -43,8 +43,11 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
     {
         async move {
             let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-            let header =
+            let mut header =
                 self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
+            // Header responses carry no size field, unlike block responses that embed the same
+            // type: https://github.com/ethereum/execution-apis/pull/877
+            header.clear_size();
             Ok(Some(header))
         }
     }


### PR DESCRIPTION
`eth_getHeaderByNumber` and `eth_getHeaderByHash` no longer emit `size`. The value was the whole-block RLP length, the same number `eth_getBlockBy*` reports, so it leaked body data into a header-only response. geth, Nethermind, and Erigon's `erigon_getHeaderBy*` all omit it.

Implements the semantics proposed in ethereum/execution-apis#877 (ethereum/execution-apis#874). Block responses keep `size`.

Mechanics: `RpcTypes::Header` gains a `SizedHeader` bound with a `clear_size` implementation for `alloy_rpc_types_eth::Header`, and `rpc_block_header` clears the field after conversion. An alternative is changing `FromConsensusHeader` in reth-core to take an optional size; happy to redo it that way if preferred.

Follow-up candidate: a header-only lookup path, since `rpc_block_header` loads and recovers the full block only to discard the body.
