### PR TITLE
fix(net): bound block bodies decode memory

### DIFF
--- a/crates/net/eth-wire-types/src/blocks.rs
+++ b/crates/net/eth-wire-types/src/blocks.rs
@@ -1,13 +1,14 @@
 //! Implements the `GetBlockHeaders`, `GetBlockBodies`, `BlockHeaders`, and `BlockBodies` message
 //! types.
 
-use crate::HeadersDirection;
+use crate::{broadcast::decode_list_with_memory_budget, HeadersDirection};
 use alloc::vec::Vec;
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::B256;
-use alloy_rlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
+use alloy_rlp::{Decodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 use derive_more::{Deref, IntoIterator};
 use reth_codecs_derive::{add_arbitrary_tests, generate_tests};
+use reth_primitives_traits::InMemorySize;
 
 /// A request for a peer to return block headers starting at the requested block.
 /// The peer must return at most [`limit`](#structfield.limit) headers.
@@ -113,6 +114,17 @@ pub struct BlockBodies<B = reth_ethereum_primitives::BlockBody>(
 );
 
 generate_tests!(#[rlp, 16] BlockBodies<reth_ethereum_primitives::BlockBody>, EthBlockBodiesTests);
+
+impl<B: Decodable + InMemorySize> BlockBodies<B> {
+    /// Decodes block bodies until their cumulative in-memory size exceeds `memory_budget` bytes.
+    /// Any remaining bodies in the payload are skipped.
+    pub fn decode_with_memory_budget(
+        buf: &mut &[u8],
+        memory_budget: usize,
+    ) -> alloy_rlp::Result<Self> {
+        decode_list_with_memory_budget(buf, memory_budget).map(Self)
+    }
+}
 
 impl<B> From<Vec<B>> for BlockBodies<B> {
     fn from(bodies: Vec<B>) -> Self {
@@ -541,5 +553,21 @@ mod tests {
         body.encode(&mut buf);
         let decoded = BlockBodies::<BlockBody>::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(body, decoded);
+    }
+
+    #[test]
+    fn decode_block_bodies_with_memory_budget() {
+        let bodies = BlockBodies(vec![BlockBody::default(); 3]);
+        let encoded = alloy_rlp::encode(&bodies);
+        let mut buf = encoded.as_slice();
+
+        let decoded = BlockBodies::<BlockBody>::decode_with_memory_budget(
+            &mut buf,
+            core::mem::size_of::<BlockBody>(),
+        )
+        .unwrap();
+
+        assert_eq!(decoded.len(), 1);
+        assert!(buf.is_empty());
     }
 }

--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -168,7 +168,8 @@ impl<T: Decodable + InMemorySize> Transactions<T> {
 }
 
 /// Decodes an RLP list, stopping once the cumulative [`InMemorySize`] of decoded items exceeds
-/// `memory_budget` bytes. Any remaining items in the payload are skipped.
+/// `memory_budget` bytes. [`core::mem::size_of`] is used as a lower bound for each item to account
+/// for its inline storage. Any remaining items in the payload are skipped.
 pub fn decode_list_with_memory_budget<T: Decodable + InMemorySize>(
     buf: &mut &[u8],
     memory_budget: usize,
@@ -184,36 +185,41 @@ pub fn decode_list_with_memory_budget<T: Decodable + InMemorySize>(
     let (payload, rest) = buf.split_at(header.payload_length);
     let mut payload = payload;
 
-    let mut txs = Vec::with_capacity(estimated_transaction_list_capacity(header.payload_length));
+    let mut items = Vec::with_capacity(estimated_list_capacity(header.payload_length));
     let mut total_size = 0usize;
 
     while !payload.is_empty() {
+        let minimum_item_size = core::mem::size_of::<T>();
+        if total_size.saturating_add(minimum_item_size) > memory_budget {
+            break;
+        }
+
         let item = T::decode(&mut payload)?;
-        total_size = total_size.saturating_add(item.size());
+        total_size = total_size.saturating_add(item.size().max(minimum_item_size));
 
         if total_size > memory_budget {
             break;
         }
 
-        txs.push(item);
+        items.push(item);
     }
 
     *buf = rest;
-    Ok(txs)
+    Ok(items)
 }
 
 // Keep this as a conservative hint: small lists stay allocation-free until the first push, while
 // large untrusted payloads cannot force an outsized preallocation.
-const MIN_TRANSACTION_RLP_SIZE_ESTIMATE: usize = 128;
-const MIN_PREALLOCATED_TRANSACTIONS: usize = 4;
-const MAX_PREALLOCATED_TRANSACTIONS: usize = 1024;
+const MIN_RLP_ITEM_SIZE_ESTIMATE: usize = 128;
+const MIN_PREALLOCATED_ITEMS: usize = 4;
+const MAX_PREALLOCATED_ITEMS: usize = 1024;
 
-const fn estimated_transaction_list_capacity(payload_length: usize) -> usize {
-    let estimate = payload_length / MIN_TRANSACTION_RLP_SIZE_ESTIMATE;
-    if estimate < MIN_PREALLOCATED_TRANSACTIONS {
+const fn estimated_list_capacity(payload_length: usize) -> usize {
+    let estimate = payload_length / MIN_RLP_ITEM_SIZE_ESTIMATE;
+    if estimate < MIN_PREALLOCATED_ITEMS {
         0
-    } else if estimate > MAX_PREALLOCATED_TRANSACTIONS {
-        MAX_PREALLOCATED_TRANSACTIONS
+    } else if estimate > MAX_PREALLOCATED_ITEMS {
+        MAX_PREALLOCATED_ITEMS
     } else {
         estimate
     }

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -29,6 +29,10 @@ use core::fmt::Debug;
 // https://github.com/ethereum/go-ethereum/blob/30602163d5d8321fbc68afdcbbaf2362b2641bde/eth/protocols/eth/protocol.go#L50
 pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
 
+/// Multiplier applied to `max_message_size` to derive the in-memory budget for decoding messages
+/// whose RLP representation can expand substantially in memory.
+pub const MESSAGE_MEMORY_BUDGET_MULTIPLIER: usize = 2;
+
 /// Multiplier applied to `max_message_size` to derive the in-memory budget for decoding
 /// `Transactions` and `PooledTransactions` messages.
 ///
@@ -36,7 +40,7 @@ pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
 /// allocations. With many peers in flight this can cause significant memory pressure, so we
 /// stop decoding once the cumulative in-memory size of decoded transactions exceeds
 /// `max_message_size * TX_MEMORY_BUDGET_MULTIPLIER`. Remaining transactions are silently dropped.
-pub const TX_MEMORY_BUDGET_MULTIPLIER: usize = 2;
+pub const TX_MEMORY_BUDGET_MULTIPLIER: usize = MESSAGE_MEMORY_BUDGET_MULTIPLIER;
 
 /// Error when sending/receiving a message
 #[derive(thiserror::Error, Debug)]
@@ -97,7 +101,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
     ///
     /// This will enforce decoding according to the given [`EthVersion`] of the connection.
     pub fn decode_message(version: EthVersion, buf: &mut &[u8]) -> Result<Self, MessageError> {
-        Self::decode_message_with_tx_memory_budget(version, buf, usize::MAX)
+        Self::decode_message_with_memory_budgets(version, buf, usize::MAX, usize::MAX)
     }
 
     /// Like [`Self::decode_message`], but caps the cumulative in-memory size of decoded
@@ -109,6 +113,27 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         version: EthVersion,
         buf: &mut &[u8],
         tx_memory_budget: usize,
+    ) -> Result<Self, MessageError> {
+        Self::decode_message_with_memory_budgets(version, buf, tx_memory_budget, usize::MAX)
+    }
+
+    /// Like [`Self::decode_message`], but caps the cumulative in-memory size of decoded
+    /// transactions and block bodies. Once exceeded, remaining list items are silently dropped.
+    ///
+    /// Use [`MESSAGE_MEMORY_BUDGET_MULTIPLIER`] to derive a reasonable default.
+    pub fn decode_message_with_memory_budget(
+        version: EthVersion,
+        buf: &mut &[u8],
+        memory_budget: usize,
+    ) -> Result<Self, MessageError> {
+        Self::decode_message_with_memory_budgets(version, buf, memory_budget, memory_budget)
+    }
+
+    fn decode_message_with_memory_budgets(
+        version: EthVersion,
+        buf: &mut &[u8],
+        tx_memory_budget: usize,
+        block_bodies_memory_budget: usize,
     ) -> Result<Self, MessageError> {
         let message_type = EthMessageID::decode(buf)?;
 
@@ -147,7 +172,11 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
             EthMessageID::GetBlockHeaders => EthMessage::GetBlockHeaders(RequestPair::decode(buf)?),
             EthMessageID::BlockHeaders => EthMessage::BlockHeaders(RequestPair::decode(buf)?),
             EthMessageID::GetBlockBodies => EthMessage::GetBlockBodies(RequestPair::decode(buf)?),
-            EthMessageID::BlockBodies => EthMessage::BlockBodies(RequestPair::decode(buf)?),
+            EthMessageID::BlockBodies => {
+                EthMessage::BlockBodies(RequestPair::decode_with(buf, |buf| {
+                    BlockBodies::decode_with_memory_budget(buf, block_bodies_memory_budget)
+                })?)
+            }
             EthMessageID::GetPooledTransactions => {
                 EthMessage::GetPooledTransactions(RequestPair::decode(buf)?)
             }
@@ -1062,6 +1091,29 @@ mod tests {
         let decoded =
             ProtocolMessage::decode_message(EthVersion::Eth68, &mut buf.as_slice()).unwrap();
         assert_eq!(empty_block_bodies, decoded);
+    }
+
+    #[test]
+    fn block_bodies_protocol_memory_budget() {
+        let block_bodies =
+            ProtocolMessage::from(EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
+                request_id: 0,
+                message: vec![BlockBody::default(); 3].into(),
+            }));
+        let mut buf = Vec::new();
+        block_bodies.encode(&mut buf);
+
+        let decoded = ProtocolMessage::<EthNetworkPrimitives>::decode_message_with_memory_budget(
+            EthVersion::Eth68,
+            &mut buf.as_slice(),
+            core::mem::size_of::<BlockBody>(),
+        )
+        .unwrap();
+        let EthMessage::BlockBodies(decoded) = decoded.message else {
+            panic!("expected block bodies response")
+        };
+
+        assert_eq!(decoded.message.len(), 1);
     }
 
     #[test]

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -7,7 +7,7 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
-    message::{EthBroadcastMessage, MAX_MESSAGE_SIZE, TX_MEMORY_BUDGET_MULTIPLIER},
+    message::{EthBroadcastMessage, MAX_MESSAGE_SIZE, MESSAGE_MEMORY_BUDGET_MULTIPLIER},
     p2pstream::HANDSHAKE_TIMEOUT,
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     UnifiedStatus,
@@ -157,10 +157,10 @@ where
             return Err(EthStreamError::UnsupportedMessage { message_id: id });
         }
 
-        let msg = match ProtocolMessage::decode_message_with_tx_memory_budget(
+        let msg = match ProtocolMessage::decode_message_with_memory_budget(
             self.version,
             &mut bytes.as_ref(),
-            self.max_message_size * TX_MEMORY_BUDGET_MULTIPLIER,
+            self.max_message_size.saturating_mul(MESSAGE_MEMORY_BUDGET_MULTIPLIER),
         ) {
             Ok(m) => m,
             Err(err) => {
@@ -355,28 +355,56 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::UnauthedEthStream;
+    use super::{EthStreamInner, UnauthedEthStream};
     use crate::{
+        blocks::BlockBodies,
         broadcast::BlockHashNumber,
         errors::{EthHandshakeError, EthStreamError},
         ethstream::RawCapabilityMessage,
         hello::DEFAULT_TCP_PORT,
+        message::{RequestPair, MESSAGE_MEMORY_BUDGET_MULTIPLIER},
         p2pstream::UnauthedP2PStream,
         EthMessage, EthStream, EthVersion, HelloMessageWithProtocols, PassthroughCodec,
-        ProtocolVersion, Status, StatusMessage,
+        ProtocolMessage, ProtocolVersion, Status, StatusMessage,
     };
     use alloy_chains::NamedChain;
     use alloy_primitives::{bytes::Bytes, B256, U256};
-    use alloy_rlp::Decodable;
+    use alloy_rlp::{Decodable, Encodable};
     use futures::{SinkExt, StreamExt};
     use reth_ecies::stream::ECIESStream;
-    use reth_eth_wire_types::{EthNetworkPrimitives, UnifiedStatus};
+    use reth_eth_wire_types::{EthNetworkPrimitives, NetworkPrimitives, UnifiedStatus};
     use reth_ethereum_forks::{ForkFilter, Head};
     use reth_network_peers::pk2id;
     use secp256k1::{SecretKey, SECP256K1};
     use std::time::Duration;
     use tokio::net::{TcpListener, TcpStream};
     use tokio_util::codec::Decoder;
+
+    #[test]
+    fn block_bodies_decode_respects_memory_budget() {
+        let message = EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
+            request_id: 0,
+            message: BlockBodies(vec![Default::default(); 3]),
+        });
+        let mut encoded = Vec::new();
+        ProtocolMessage::from(message).encode(&mut encoded);
+
+        type Body = <EthNetworkPrimitives as NetworkPrimitives>::BlockBody;
+        let max_message_size = core::mem::size_of::<Body>() / MESSAGE_MEMORY_BUDGET_MULTIPLIER;
+        assert!(encoded.len() <= max_message_size);
+
+        let decoded = EthStreamInner::<EthNetworkPrimitives>::with_max_message_size(
+            EthVersion::Eth68,
+            max_message_size,
+        )
+        .decode_message(encoded.as_slice().into())
+        .unwrap();
+        let EthMessage::BlockBodies(decoded) = decoded else {
+            panic!("expected block bodies response")
+        };
+
+        assert_eq!(decoded.message.len(), 1);
+    }
 
     #[tokio::test]
     async fn can_handshake() {


### PR DESCRIPTION
Caps decoded `BlockBodies` at twice the configured ETH message size, matching the existing transaction response budget. Each body is charged at least its inline size so compact empty-body responses cannot expand unchecked before request correlation.