### PR TITLE
chore(logging): reduce noisy overlay and static file logs

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -1046,7 +1046,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         segment: StaticFileSegment,
         segment_max_block: Option<BlockNumber>,
     ) -> ProviderResult<()> {
-        debug!(
+        trace!(
             target: "providers::static_file",
             ?segment,
             ?segment_max_block,
@@ -1159,11 +1159,11 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 }
 
                 // Update the cached provider.
-                debug!(target: "providers::static_file", ?segment, "Inserting updated jar into cache");
+                trace!(target: "providers::static_file", ?segment, "Inserting updated jar into cache");
                 self.map.insert((fixed_range.end(), segment), LoadedJar::new(jar)?);
 
                 // Delete any cached provider that no longer has an associated jar.
-                debug!(target: "providers::static_file", ?segment, "Cleaning up jar map");
+                trace!(target: "providers::static_file", ?segment, "Cleaning up jar map");
                 self.map.retain(|(end, seg), _| !(*seg == segment && *end > fixed_range.end()));
             }
             None => {
@@ -1172,7 +1172,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
             }
         };
 
-        debug!(target: "providers::static_file", ?segment, "Updated provider index");
+        trace!(target: "providers::static_file", ?segment, "Updated provider index");
         Ok(())
     }
 

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -464,15 +464,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     state_trie_tip_block.hash,
                     finish_tip_block.hash,
                 ) {
-                    debug!(
-                        target: "storage::overlay",
-                        parent_hash = %self.parent_hash,
-                        state_trie_tip_hash = %state_trie_tip_block.hash,
-                        finish_tip_hash = %finish_tip_block.hash,
-                        sparse_trie_anchor_hash = ?self.reused_sparse_trie_anchor_hash,
-                        "Skipping overlay construction because reused sparse trie covers durable frontiers to parent"
-                    );
-
                     self.metrics.sparse_trie_overlay_skips.increment(1);
 
                     return Ok(StateTrieOverlay::empty())


### PR DESCRIPTION
* remove noisy storage::overlay debug log
* change providers::static_file index  to trace