### PR TITLE
fix(overlay): snapshot parent blocks for lazy providers

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -330,9 +330,6 @@ where
     payload_builds: PayloadBuildTracker,
     /// Notifies the engine when the final active payload job finishes.
     payload_build_finished: Receiver<()>,
-    /// A durable persistence completion whose destructive in-memory handoff is deferred until
-    /// payload jobs finish.
-    pending_persisted_handoff: Option<PersistenceResult>,
     /// Task runtime for spawning blocking work on named, reusable threads.
     runtime: reth_tasks::Runtime,
 }
@@ -361,7 +358,6 @@ where
             .field("evm_config", &self.evm_config)
             .field("execution_timing_stats", &self.execution_timing_stats.len())
             .field("payload_builds_active", &self.payload_builds.is_active())
-            .field("pending_persisted_handoff", &self.pending_persisted_handoff)
             .field("runtime", &self.runtime)
             .finish()
     }
@@ -429,7 +425,6 @@ where
             execution_timing_stats: B256Map::default(),
             payload_builds,
             payload_build_finished,
-            pending_persisted_handoff: None,
             runtime,
         }
     }
@@ -606,12 +601,7 @@ where
                         return
                     }
                 }
-                LoopEvent::PayloadBuildFinished => {
-                    if let Err(err) = self.on_payload_build_finished() {
-                        error!(target: "engine::tree", %err, "Payload build completion handling failed");
-                        return
-                    }
-                }
+                LoopEvent::PayloadBuildFinished => {}
                 LoopEvent::Disconnected => {
                     error!(target: "engine::tree", "Channel disconnected");
                     return
@@ -647,28 +637,11 @@ where
         }
     }
 
-    /// Blocks until the next event that can safely be processed is ready.
+    /// Blocks until the next event is ready.
     ///
-    /// A pending persisted handoff keeps processing engine messages while prioritizing the
-    /// notification that all active payload builds have finished. This keeps the engine responsive
-    /// without reclaiming the in-memory overlay while a payload job may still access it. Otherwise,
-    /// uses biased selection to prioritize persistence completion to update in-memory state and
-    /// unblock further writes.
+    /// Uses biased selection to prioritize persistence completion so in-memory state is updated and
+    /// further writes are unblocked.
     fn wait_for_event(&mut self) -> LoopEvent<T, N> {
-        if self.pending_persisted_handoff.is_some() {
-            self.metrics.engine.backpressure_active.set(0.0);
-            return crossbeam_channel::select_biased! {
-                recv(self.payload_build_finished) -> result => match result {
-                    Ok(()) => LoopEvent::PayloadBuildFinished,
-                    Err(_) => LoopEvent::Disconnected,
-                },
-                recv(self.incoming) -> msg => match msg {
-                    Ok(m) => LoopEvent::EngineMessage(m),
-                    Err(_) => LoopEvent::Disconnected,
-                },
-            }
-        }
-
         // Take ownership of persistence rx if present
         let maybe_persistence = self.persistence_state.rx.take();
 
@@ -1466,12 +1439,6 @@ where
     /// This checks if we need to remove blocks (disk reorg) or save new blocks to disk.
     /// Persistence completion is handled separately via the `wait_for_event` method.
     fn advance_persistence(&mut self) -> Result<(), AdvancePersistenceError> {
-        // A second persistence completion would overwrite the frontier needed by the deferred
-        // handoff. Wait until the payload jobs using the old overlay have finished.
-        if self.pending_persisted_handoff.is_some() {
-            return Ok(())
-        }
-
         if !self.persistence_state.in_progress() {
             if let Some(new_tip_num) = self.find_disk_reorg()? {
                 self.remove_blocks(new_tip_num)
@@ -1504,7 +1471,7 @@ where
             if let Some((rx, start_time, action)) = self.persistence_state.rx.take() {
                 debug!(target: "engine::tree", ?action, "waiting for in-flight persistence");
                 let result = rx.recv().map_err(|_| AdvancePersistenceError::ChannelClosed)?;
-                self.finish_persistence(result, start_time);
+                self.on_persistence_complete(result, start_time)?;
                 continue
             }
 
@@ -1556,31 +1523,9 @@ where
         result: PersistenceResult,
         start_time: Instant,
     ) -> Result<(), AdvancePersistenceError> {
-        let handoff = self.finish_persistence(result, start_time);
-
-        if self.payload_builds.is_active() {
-            debug_assert!(
-                self.pending_persisted_handoff.is_none(),
-                "a new persistence task must not start while its predecessor handoff is pending"
-            );
-            debug!(target: "engine::tree", "Deferring persisted in-memory handoff until payload jobs finish");
-            self.pending_persisted_handoff = Some(handoff);
-            return Ok(())
-        }
-
-        self.on_persisted_handoff(handoff)
-    }
-
-    /// Records a completed persistence operation and returns its deferred in-memory handoff.
-    fn finish_persistence(
-        &mut self,
-        result: PersistenceResult,
-        start_time: Instant,
-    ) -> PersistenceResult {
         self.metrics.engine.persistence_duration.record(start_time.elapsed());
 
-        let last_block = result.last_block;
-        let last_state_trie_block = result.last_state_trie_block;
+        let PersistenceResult { last_block, last_state_trie_block, commit_duration } = result;
         debug_assert!(
             last_state_trie_block.number <= last_block.number,
             "state/trie frontier cannot exceed the last persisted block"
@@ -1589,28 +1534,6 @@ where
         debug!(target: "engine::tree", ?last_block, ?last_state_trie_block, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
         self.persistence_state.finish(last_block, last_state_trie_block);
 
-        result
-    }
-
-    /// Applies the destructive in-memory portion of a completed persistence operation.
-    fn on_persisted_handoff(
-        &mut self,
-        handoff: PersistenceResult,
-    ) -> Result<(), AdvancePersistenceError> {
-        if handoff.last_block != self.persistence_state.last_persisted_block ||
-            handoff.last_state_trie_block !=
-                self.persistence_state.last_state_trie_persisted_block
-        {
-            debug!(
-                target: "engine::tree",
-                handoff_last_block = ?handoff.last_block,
-                current_last_block = ?self.persistence_state.last_persisted_block,
-                "Discarding stale persisted handoff"
-            );
-            return Ok(())
-        }
-
-        let PersistenceResult { last_block, commit_duration, .. } = handoff;
         let last_block_number = last_block.number;
 
         // Evict cached changesets for blocks below the eviction threshold.
@@ -1637,19 +1560,6 @@ where
         self.on_new_persisted_block()?;
 
         self.purge_timing_stats(last_block_number, commit_duration);
-
-        Ok(())
-    }
-
-    /// Releases work deferred until all payload jobs have finished.
-    fn on_payload_build_finished(&mut self) -> Result<(), AdvancePersistenceError> {
-        if self.payload_builds.is_active() {
-            return Ok(())
-        }
-
-        if let Some(handoff) = self.pending_persisted_handoff.take() {
-            self.on_persisted_handoff(handoff)?;
-        }
 
         Ok(())
     }
@@ -2174,12 +2084,9 @@ where
                 "backfill action should only be emitted when backfill is idle"
             );
 
-            if self.payload_builds.is_active() ||
-                self.persistence_state.in_progress() ||
-                self.pending_persisted_handoff.is_some()
-            {
-                // Backfill can remove the same in-memory blocks as an active payload job or a
-                // persisted handoff, so it must not start until the next sync trigger.
+            if self.payload_builds.is_active() || self.persistence_state.in_progress() {
+                // Backfill can remove the same in-memory blocks as an active payload job or
+                // persistence task, so it must not start until the next sync trigger.
                 debug!(target: "engine::tree", "skipping backfill while in-memory overlay is in use");
                 return
             }
@@ -3559,7 +3466,7 @@ where
         /// When the persistence operation started.
         start_time: Instant,
     },
-    /// The last active payload job has finished, so deferred in-memory work may proceed.
+    /// The last active payload job has finished, so suppressed persistence may resume.
     PayloadBuildFinished,
     /// A channel was disconnected.
     Disconnected,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1614,16 +1614,15 @@ where
                             }
                         };
 
-                        // if the parent is the canonical head, we can insert the block as the
-                        // pending block
-                        if self.state.tree_state.canonical_block_hash() ==
-                            block.recovered_block().parent_hash()
-                        {
+                        let is_pending = self.state.tree_state.canonical_block_hash() ==
+                            block.recovered_block().parent_hash();
+                        self.state.tree_state.insert_executed(block.clone());
+
+                        if is_pending {
                             debug!(target: "engine::tree", pending=?block_num_hash, "updating pending block");
                             self.canonical_in_memory_state.set_pending_block(block.clone());
                         }
 
-                        self.state.tree_state.insert_executed(block.clone());
                         self.metrics.engine.inserted_already_executed_blocks.increment(1);
                         self.emit_event(EngineApiEvent::BeaconConsensus(
                             ConsensusEngineEvent::CanonicalBlockAdded(block, now.elapsed()),
@@ -3134,14 +3133,15 @@ where
             self.execution_timing_stats.insert(executed.recovered_block().hash(), stats);
         }
 
-        // if the parent is the canonical head, we can insert the block as the pending block
-        if self.state.tree_state.canonical_block_hash() == executed.recovered_block().parent_hash()
-        {
+        let is_pending = self.state.tree_state.canonical_block_hash() ==
+            executed.recovered_block().parent_hash();
+        self.state.tree_state.insert_executed(executed.clone());
+
+        if is_pending {
             debug!(target: "engine::tree", pending=?block_num_hash, "updating pending block");
             self.canonical_in_memory_state.set_pending_block(executed.clone());
         }
 
-        self.state.tree_state.insert_executed(executed.clone());
         self.metrics.engine.executed_blocks.set(self.state.tree_state.block_count() as f64);
 
         // emit insert event

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -683,7 +683,7 @@ fn payload_build_tracker_notifies_after_last_lease_drops() {
 }
 
 #[test]
-fn persistence_handoff_waits_for_active_payload_jobs() {
+fn persistence_completion_does_not_wait_for_active_payload_jobs() {
     let config = TreeConfig::default()
         .with_has_enough_parallelism(true)
         .with_persistence_threshold(0)
@@ -693,8 +693,7 @@ fn persistence_handoff_waits_for_active_payload_jobs() {
         TestHarness::with_config(MAINNET.clone(), config).with_blocks(blocks.clone());
     let persisted = blocks[0].recovered_block().num_hash();
     let persisted_hash = persisted.hash;
-    let first = test_harness.tree.payload_builds.acquire();
-    let second = test_harness.tree.payload_builds.acquire();
+    let _payload_build = test_harness.tree.payload_builds.acquire();
 
     test_harness
         .tree
@@ -708,102 +707,11 @@ fn persistence_handoff_waits_for_active_payload_jobs() {
         )
         .unwrap();
 
-    // Durability advances immediately, but the in-memory overlay remains available to jobs.
+    // Payload jobs own an overlay snapshot, so persistence can immediately reclaim the manager's
+    // copy.
     assert_eq!(test_harness.tree.persistence_state.last_persisted_block, persisted);
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-    assert!(test_harness.tree.state.tree_state.contains_hash(&persisted_hash));
-    assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(persisted_hash).is_some());
-
-    // Do not let another persistence action overwrite the deferred handoff's frontier.
-    test_harness.tree.advance_persistence().unwrap();
-    assert!(!test_harness.tree.persistence_state.in_progress());
-
-    drop(first);
-    assert!(test_harness.tree.payload_build_finished.try_recv().is_err());
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-
-    drop(second);
-    assert!(matches!(test_harness.tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished));
-    test_harness.tree.on_payload_build_finished().unwrap();
-
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
     assert!(!test_harness.tree.state.tree_state.contains_hash(&persisted_hash));
     assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(persisted_hash).is_none());
-}
-
-#[test]
-fn pending_persisted_handoff_keeps_engine_messages_responsive() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
-    let mut test_harness = TestHarness::with_config(
-        MAINNET.clone(),
-        TreeConfig::default().with_has_enough_parallelism(true),
-    )
-    .with_blocks(blocks.clone());
-    let persisted = blocks[0].recovered_block().num_hash();
-    let payload_build = test_harness.tree.payload_builds.acquire();
-
-    test_harness
-        .tree
-        .on_persistence_complete(
-            PersistenceResult {
-                last_block: persisted,
-                last_state_trie_block: persisted,
-                commit_duration: Some(Duration::ZERO),
-            },
-            Instant::now(),
-        )
-        .unwrap();
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-
-    // Engine messages remain processable while the handoff waits for the active payload build.
-    test_harness.to_tree_tx.send(FromEngine::Event(FromOrchestrator::BackfillSyncStarted)).unwrap();
-    assert_matches!(
-        test_harness.tree.wait_for_event(),
-        super::LoopEvent::EngineMessage(FromEngine::Event(FromOrchestrator::BackfillSyncStarted))
-    );
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-    assert!(test_harness.tree.state.tree_state.contains_hash(&persisted.hash));
-
-    // Once the final lease drops, its completion is prioritized over queued engine messages so the
-    // handoff gets the first opportunity to reclaim the overlay.
-    test_harness.to_tree_tx.send(FromEngine::Event(FromOrchestrator::BackfillSyncStarted)).unwrap();
-    drop(payload_build);
-    assert_matches!(test_harness.tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished);
-    test_harness.tree.on_payload_build_finished().unwrap();
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
-    assert!(!test_harness.tree.state.tree_state.contains_hash(&persisted.hash));
-    assert_matches!(
-        test_harness.tree.wait_for_event(),
-        super::LoopEvent::EngineMessage(FromEngine::Event(FromOrchestrator::BackfillSyncStarted))
-    );
-}
-
-#[test]
-fn persist_until_complete_updates_frontiers_without_in_memory_handoff() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
-    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
-    let persisted = blocks.last().unwrap().recovered_block().num_hash();
-    let persisted_hash = persisted.hash;
-    let (tx, rx) = crossbeam_channel::bounded(1);
-
-    tx.send(PersistenceResult {
-        last_block: persisted,
-        last_state_trie_block: persisted,
-        commit_duration: Some(Duration::ZERO),
-    })
-    .unwrap();
-    test_harness.tree.persistence_state.start_save(persisted, rx);
-
-    test_harness.tree.persist_until_complete().unwrap();
-
-    // Shutdown waits for the durable write, but process teardown does not need the destructive
-    // in-memory handoff that normally follows a completed persistence task.
-    assert_eq!(test_harness.tree.persistence_state.last_persisted_block, persisted);
-    assert_eq!(test_harness.tree.persistence_state.last_state_trie_persisted_block, persisted);
-    assert!(!test_harness.tree.persistence_state.in_progress());
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
-    assert!(test_harness.tree.state.tree_state.contains_hash(&persisted_hash));
-    assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(persisted_hash).is_some());
 }
 
 #[test]
@@ -813,50 +721,13 @@ fn backfill_action_skips_while_payload_build_is_active() {
     let action = BackfillAction::Start(B256::random().into());
 
     test_harness.tree.emit_event(EngineApiEvent::BackfillAction(action));
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
     assert!(test_harness.tree.backfill_sync_state.is_idle());
     assert!(test_harness.from_tree_rx.try_recv().is_err());
 
     drop(payload_build);
     assert!(matches!(test_harness.tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished));
-    test_harness.tree.on_payload_build_finished().unwrap();
 
     // The skipped action is not queued for a later replay.
-    assert!(test_harness.tree.backfill_sync_state.is_idle());
-    assert!(test_harness.from_tree_rx.try_recv().is_err());
-}
-
-#[test]
-fn backfill_action_skips_while_persisted_handoff_is_pending() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
-    let mut test_harness = TestHarness::with_config(
-        MAINNET.clone(),
-        TreeConfig::default().with_has_enough_parallelism(true),
-    )
-    .with_blocks(blocks.clone());
-    let persisted = blocks[0].recovered_block().num_hash();
-    let payload_build = test_harness.tree.payload_builds.acquire();
-
-    test_harness
-        .tree
-        .on_persistence_complete(
-            PersistenceResult {
-                last_block: persisted,
-                last_state_trie_block: persisted,
-                commit_duration: Some(Duration::ZERO),
-            },
-            Instant::now(),
-        )
-        .unwrap();
-
-    drop(payload_build);
-    assert!(!test_harness.tree.payload_builds.is_active());
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-
-    test_harness
-        .tree
-        .emit_event(EngineApiEvent::BackfillAction(BackfillAction::Start(B256::random().into())));
-
     assert!(test_harness.tree.backfill_sync_state.is_idle());
     assert!(test_harness.from_tree_rx.try_recv().is_err());
 }

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -387,7 +387,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
         // Collect any reverts which are required to bring the DB view back to the anchor hash.
         let (trie_updates, hashed_post_state) = match &anchor_for_parent {
-            AnchorForParent::RevertsRequired { anchor, finish } => {
+            AnchorForParent::RevertsRequired { anchor, .. } => {
                 let revert_blocks =
                     self.revert_blocks(&anchor_for_parent)?.expect("reverts are required");
 
@@ -403,8 +403,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         .entered();
                     let start = Instant::now();
                     let accumulated_reverts =
-                        self.overlay_manager.changeset_cache().get_or_compute_range(
-                            self.clone().with_parent_state_at(*finish),
+                        self.overlay_manager.get_or_compute_cached_changesets_range_at_frontiers(
                             provider,
                             revert_blocks.clone(),
                             state_trie_tip_block,
@@ -633,19 +632,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                 Ok(Some(anchor.number + 1..=finish.number))
             }
         }
-    }
-
-    /// Reuses this builder's snapshot at `parent`, discarding any newer blocks.
-    fn with_parent_state_at(mut self, parent: BlockNumHash) -> Self {
-        self.parent_hash = parent.hash;
-        self.parent_state = self.parent_state.as_ref().and_then(|state| {
-            state
-                .chain()
-                .find(|state| state.block_ref().recovered_block().num_hash() == parent)
-                .cloned()
-        });
-        self.reused_sparse_trie_anchor_hash = None;
-        self
     }
 
     /// Returns true if managed overlay resolution can be skipped for this builder.
@@ -1361,30 +1347,6 @@ mod tests {
                 panic!("persisted parent below Finish must require reverts")
             }
         }
-    }
-
-    #[test]
-    fn builder_trims_parent_state_to_checkpoint() {
-        let manager = OverlayManager::default();
-        let blocks = test_blocks();
-        for block in &blocks {
-            manager.insert_block(block.clone());
-        }
-
-        let builder = manager
-            .overlay_builder(blocks[4].recovered_block().hash())
-            .with_parent_state_at(blocks[2].recovered_block().num_hash());
-        let hashes =
-            builder.parent_state.unwrap().chain().map(BlockState::hash).collect::<Vec<_>>();
-
-        assert_eq!(
-            hashes,
-            blocks[..=2]
-                .iter()
-                .rev()
-                .map(|block| block.recovered_block().hash())
-                .collect::<Vec<_>>()
-        );
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
     Address, BlockHash, BlockNumber, B256, U256,
 };
 use metrics::{Counter, Histogram};
-use reth_chain_state::ExecutedBlock;
+use reth_chain_state::{BlockState, ExecutedBlock};
 use reth_errors::{ProviderError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_metrics::Metrics;
@@ -236,8 +236,10 @@ pub struct OverlayBuilder<N: NodePrimitives = EthPrimitives> {
     parent_hash: B256,
     /// Optional overlay source.
     overlay_source: Option<OverlaySource>,
-    /// Manager used for cached changesets and in-memory parent state.
+    /// Manager used for cached changesets and overlays.
     overlay_manager: OverlayManager<N>,
+    /// Snapshot of the in-memory chain ending at the requested parent.
+    parent_state: Option<Arc<BlockState<N>>>,
     /// Anchor hash of the reused sparse trie, if this task reused one.
     reused_sparse_trie_anchor_hash: Option<B256>,
     /// Whether building the overlay may query revert changesets.
@@ -248,11 +250,16 @@ pub struct OverlayBuilder<N: NodePrimitives = EthPrimitives> {
 
 impl<N: NodePrimitives> OverlayBuilder<N> {
     /// Create a new manager-backed overlay builder.
-    pub(crate) fn new(parent_hash: B256, overlay_manager: OverlayManager<N>) -> Self {
+    pub(crate) fn new(
+        parent_hash: B256,
+        parent_state: Option<Arc<BlockState<N>>>,
+        overlay_manager: OverlayManager<N>,
+    ) -> Self {
         Self {
             parent_hash,
             overlay_source: Some(OverlaySource::Managed),
             overlay_manager,
+            parent_state,
             reused_sparse_trie_anchor_hash: None,
             no_reverts: false,
             metrics: OverlayBuilderMetrics::default(),
@@ -315,7 +322,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         match &self.overlay_source {
             Some(OverlaySource::Managed) => anchor_for_parent_with_frontiers(
                 self.parent_hash,
-                self.overlay_manager.parent_chain(self.parent_hash),
+                self.parent_state.iter().flat_map(|state| state.chain()).map(BlockState::block),
                 partial_state_trie,
                 finish,
                 provider,
@@ -383,7 +390,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
         // Collect any reverts which are required to bring the DB view back to the anchor hash.
         let (trie_updates, hashed_post_state) = match &anchor_for_parent {
-            AnchorForParent::RevertsRequired { anchor, .. } => {
+            AnchorForParent::RevertsRequired { anchor, overlay, .. } => {
                 let revert_blocks =
                     self.revert_blocks(&anchor_for_parent)?.expect("reverts are required");
 
@@ -422,7 +429,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                 // Resolve overlays and extend reverts with them. If reverts are empty, use overlays
                 // directly to avoid cloning.
                 let (overlay_trie, overlay_state) =
-                    self.resolve_state_trie_overlays(anchor.hash)?;
+                    self.resolve_state_trie_overlays(anchor.hash, overlay)?;
 
                 let trie_updates = if trie_reverts.is_empty() {
                     overlay_trie
@@ -456,7 +463,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
                 (trie_updates, hashed_state_updates)
             }
-            AnchorForParent::NoReverts { anchor, .. } => {
+            AnchorForParent::NoReverts { anchor, overlay } => {
                 // If no reverts are needed, use the manager overlay directly unless the reused
                 // sparse trie already covers both durable frontiers through the
                 // requested parent.
@@ -470,7 +477,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                 }
 
                 let (trie_updates, hashed_post_state) =
-                    self.resolve_state_trie_overlays(anchor.hash)?;
+                    self.resolve_state_trie_overlays(anchor.hash, overlay)?;
 
                 retrieve_trie_reverts_duration = Duration::ZERO;
                 retrieve_hashed_state_reverts_duration = Duration::ZERO;
@@ -546,7 +553,10 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             AnchorForParent::NoReverts { .. } => None,
         };
         Ok((
-            self.resolve_execution_overlay(anchor_for_parent.anchor().hash)?,
+            self.resolve_execution_overlay(
+                anchor_for_parent.anchor().hash,
+                anchor_for_parent.overlay(),
+            )?,
             fallback_block_number,
         ))
     }
@@ -555,6 +565,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     fn resolve_state_trie_overlays(
         &self,
         anchor_hash: BlockHash,
+        blocks: &[ExecutedBlock<N>],
     ) -> ProviderResult<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>)> {
         match &self.overlay_source {
             Some(OverlaySource::Managed) => {
@@ -565,7 +576,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     ))
                 } else {
                     self.overlay_manager
-                        .overlay_for_parent(self.parent_hash, anchor_hash)
+                        .overlay_for_parent_with_blocks(self.parent_hash, anchor_hash, blocks)
                         .map_err(ProviderError::other)
                 }
             }
@@ -589,11 +600,12 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     fn resolve_execution_overlay(
         &self,
         anchor_hash: BlockHash,
+        blocks: &[ExecutedBlock<N>],
     ) -> ProviderResult<Arc<ExecutionOverlay>> {
         match &self.overlay_source {
             Some(OverlaySource::Managed) if anchor_hash != self.parent_hash => self
                 .overlay_manager
-                .execution_overlay_for_parent(self.parent_hash, anchor_hash)
+                .execution_overlay_for_parent_with_blocks(self.parent_hash, anchor_hash, blocks)
                 .map_err(ProviderError::other),
             Some(OverlaySource::Managed) | None => Ok(Arc::new(ExecutionOverlay::default())),
             Some(OverlaySource::Immediate { .. }) => Err(ProviderError::other(
@@ -631,17 +643,27 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
         match &self.overlay_source {
             Some(OverlaySource::Managed) => {
-                self.overlay_manager.contains_hash(
-                    self.parent_hash,
-                    anchor_hash,
-                    state_trie_tip_hash,
-                ) && self.overlay_manager.contains_hash(
-                    self.parent_hash,
-                    anchor_hash,
-                    finish_tip_hash,
-                )
+                self.contains_hash(anchor_hash, state_trie_tip_hash) &&
+                    self.contains_hash(anchor_hash, finish_tip_hash)
             }
             _ => false,
+        }
+    }
+
+    fn contains_hash(&self, anchor_hash: B256, hash: B256) -> bool {
+        let mut current_hash = self.parent_hash;
+        let mut blocks = self.parent_state.iter().flat_map(|state| state.chain());
+
+        loop {
+            if current_hash == hash {
+                return true
+            }
+            if current_hash == anchor_hash {
+                return false
+            }
+
+            let Some(block) = blocks.next() else { return false };
+            current_hash = block.block_ref().recovered_block().parent_hash();
         }
     }
 }
@@ -740,6 +762,12 @@ impl<N: NodePrimitives> AnchorForParent<N> {
     pub const fn anchor(&self) -> BlockNumHash {
         match self {
             Self::NoReverts { anchor, .. } | Self::RevertsRequired { anchor, .. } => *anchor,
+        }
+    }
+
+    fn overlay(&self) -> &[ExecutedBlock<N>] {
+        match self {
+            Self::NoReverts { overlay, .. } | Self::RevertsRequired { overlay, .. } => overlay,
         }
     }
 }
@@ -1368,7 +1396,7 @@ mod tests {
         let parent_hash = B256::with_last_byte(1);
         let builder = OverlayManager::<EthPrimitives>::default().overlay_builder(parent_hash);
 
-        let (trie, state) = builder.resolve_state_trie_overlays(parent_hash).unwrap();
+        let (trie, state) = builder.resolve_state_trie_overlays(parent_hash, &[]).unwrap();
         assert!(trie.is_empty());
         assert!(state.is_empty());
     }
@@ -1379,7 +1407,7 @@ mod tests {
         let anchor_hash = B256::with_last_byte(2);
         let builder = OverlayManager::<EthPrimitives>::default().overlay_builder(parent_hash);
 
-        let err = builder.resolve_state_trie_overlays(anchor_hash).unwrap_err();
+        let err = builder.resolve_state_trie_overlays(anchor_hash, &[]).unwrap_err();
 
         assert!(err.to_string().contains("cannot be anchored"));
     }

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -298,10 +298,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Returns the durable anchor to use for this builder's parent.
-    pub fn anchor_at_parent<Provider>(
-        &self,
-        provider: &Provider,
-    ) -> ProviderResult<AnchorForParent<N>>
+    pub fn anchor_at_parent<Provider>(&self, provider: &Provider) -> ProviderResult<AnchorForParent>
     where
         Provider: StageCheckpointReader + BlockNumReader + PruneCheckpointReader,
     {
@@ -315,7 +312,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         provider: &Provider,
         partial_state_trie: BlockNumHash,
         finish: BlockNumHash,
-    ) -> ProviderResult<AnchorForParent<N>>
+    ) -> ProviderResult<AnchorForParent>
     where
         Provider: BlockNumReader + PruneCheckpointReader,
     {
@@ -329,7 +326,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             ),
             _ => anchor_for_parent_with_frontiers(
                 self.parent_hash,
-                std::iter::empty(),
+                std::iter::empty::<ExecutedBlock<N>>(),
                 partial_state_trie,
                 finish,
                 provider,
@@ -390,7 +387,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
         // Collect any reverts which are required to bring the DB view back to the anchor hash.
         let (trie_updates, hashed_post_state) = match &anchor_for_parent {
-            AnchorForParent::RevertsRequired { anchor, overlay, .. } => {
+            AnchorForParent::RevertsRequired { anchor, .. } => {
                 let revert_blocks =
                     self.revert_blocks(&anchor_for_parent)?.expect("reverts are required");
 
@@ -429,7 +426,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                 // Resolve overlays and extend reverts with them. If reverts are empty, use overlays
                 // directly to avoid cloning.
                 let (overlay_trie, overlay_state) =
-                    self.resolve_state_trie_overlays(anchor.hash, overlay)?;
+                    self.resolve_state_trie_overlays(anchor.hash)?;
 
                 let trie_updates = if trie_reverts.is_empty() {
                     overlay_trie
@@ -463,7 +460,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
                 (trie_updates, hashed_state_updates)
             }
-            AnchorForParent::NoReverts { anchor, overlay } => {
+            AnchorForParent::NoReverts { anchor } => {
                 // If no reverts are needed, use the manager overlay directly unless the reused
                 // sparse trie already covers both durable frontiers through the
                 // requested parent.
@@ -477,7 +474,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                 }
 
                 let (trie_updates, hashed_post_state) =
-                    self.resolve_state_trie_overlays(anchor.hash, overlay)?;
+                    self.resolve_state_trie_overlays(anchor.hash)?;
 
                 retrieve_trie_reverts_duration = Duration::ZERO;
                 retrieve_hashed_state_reverts_duration = Duration::ZERO;
@@ -553,10 +550,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             AnchorForParent::NoReverts { .. } => None,
         };
         Ok((
-            self.resolve_execution_overlay(
-                anchor_for_parent.anchor().hash,
-                anchor_for_parent.overlay(),
-            )?,
+            self.resolve_execution_overlay(anchor_for_parent.anchor().hash)?,
             fallback_block_number,
         ))
     }
@@ -565,7 +559,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     fn resolve_state_trie_overlays(
         &self,
         anchor_hash: BlockHash,
-        blocks: &[ExecutedBlock<N>],
     ) -> ProviderResult<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>)> {
         match &self.overlay_source {
             Some(OverlaySource::Managed) => {
@@ -575,8 +568,13 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         Arc::new(HashedPostStateSorted::default()),
                     ))
                 } else {
+                    let parent_state = self.parent_state.as_ref().ok_or_else(|| {
+                        ProviderError::other(std::io::Error::other(
+                            "state trie overlay cannot be anchored without in-memory parent state",
+                        ))
+                    })?;
                     self.overlay_manager
-                        .overlay_for_blocks(self.parent_hash, anchor_hash, blocks)
+                        .overlay_for_parent(parent_state, anchor_hash)
                         .map_err(ProviderError::other)
                 }
             }
@@ -600,13 +598,16 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     fn resolve_execution_overlay(
         &self,
         anchor_hash: BlockHash,
-        blocks: &[ExecutedBlock<N>],
     ) -> ProviderResult<Arc<ExecutionOverlay>> {
         match &self.overlay_source {
-            Some(OverlaySource::Managed) if anchor_hash != self.parent_hash => self
-                .overlay_manager
-                .execution_overlay_for_blocks(self.parent_hash, anchor_hash, blocks)
-                .map_err(ProviderError::other),
+            Some(OverlaySource::Managed) if anchor_hash != self.parent_hash => {
+                let parent_state = self.parent_state.as_ref().ok_or_else(|| {
+                    ProviderError::other(std::io::Error::other("missing in-memory parent state"))
+                })?;
+                self.overlay_manager
+                    .execution_overlay_for_block_state(parent_state, anchor_hash)
+                    .map_err(ProviderError::other)
+            }
             Some(OverlaySource::Managed) | None => Ok(Arc::new(ExecutionOverlay::default())),
             Some(OverlaySource::Immediate { .. }) => Err(ProviderError::other(
                 std::io::Error::other("immediate state trie overlay has no execution state"),
@@ -617,7 +618,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     /// Returns the blocks to revert from Finish to the selected anchor, if any.
     fn revert_blocks(
         &self,
-        anchor_for_parent: &AnchorForParent<N>,
+        anchor_for_parent: &AnchorForParent,
     ) -> ProviderResult<Option<RangeInclusive<BlockNumber>>> {
         match anchor_for_parent {
             AnchorForParent::NoReverts { .. } => Ok(None),
@@ -738,13 +739,11 @@ fn anchor_for_parent_in<N: NodePrimitives>(
 
 /// Describes whether an overlay must revert the database before using its anchor.
 #[derive(Debug)]
-pub enum AnchorForParent<N: NodePrimitives> {
+pub enum AnchorForParent {
     /// The in-memory chain covers the durable frontiers through this anchor.
     NoReverts {
         /// Block to anchor the overlay to.
         anchor: BlockNumHash,
-        /// In-memory blocks from `parent_hash` through, but excluding, `anchor`.
-        overlay: Vec<ExecutedBlock<N>>,
     },
     /// The database must be reverted from `finish` to `anchor` first.
     RevertsRequired {
@@ -752,22 +751,14 @@ pub enum AnchorForParent<N: NodePrimitives> {
         anchor: BlockNumHash,
         /// Current Finish frontier.
         finish: BlockNumHash,
-        /// In-memory blocks from `parent_hash` through, but excluding, `anchor`.
-        overlay: Vec<ExecutedBlock<N>>,
     },
 }
 
-impl<N: NodePrimitives> AnchorForParent<N> {
+impl AnchorForParent {
     /// Returns the durable block anchoring this overlay.
     pub const fn anchor(&self) -> BlockNumHash {
         match self {
             Self::NoReverts { anchor, .. } | Self::RevertsRequired { anchor, .. } => *anchor,
-        }
-    }
-
-    fn overlay(&self) -> &[ExecutedBlock<N>] {
-        match self {
-            Self::NoReverts { overlay, .. } | Self::RevertsRequired { overlay, .. } => overlay,
         }
     }
 }
@@ -782,7 +773,7 @@ pub fn anchor_for_parent<N, Provider>(
     parent_hash: B256,
     in_mem_chain: impl Iterator<Item = ExecutedBlock<N>>,
     provider: &Provider,
-) -> ProviderResult<AnchorForParent<N>>
+) -> ProviderResult<AnchorForParent>
 where
     N: NodePrimitives,
     Provider: StageCheckpointReader + BlockNumReader + PruneCheckpointReader,
@@ -812,7 +803,7 @@ pub fn anchor_for_parent_with_frontiers<N, Provider>(
     partial_state_trie: BlockNumHash,
     finish: BlockNumHash,
     provider: &Provider,
-) -> ProviderResult<AnchorForParent<N>>
+) -> ProviderResult<AnchorForParent>
 where
     N: NodePrimitives,
     Provider: BlockNumReader + PruneCheckpointReader,
@@ -824,26 +815,23 @@ where
         .filter(|&parent_number| parent_number <= partial_state_trie.number);
 
     let mut finish_seen = parent_hash == finish.hash;
-    let (anchor, overlay) = if let Some(parent_number) = persisted_parent {
-        (BlockNumHash::new(parent_number, parent_hash), Vec::new())
+    let anchor = if let Some(parent_number) = persisted_parent {
+        BlockNumHash::new(parent_number, parent_hash)
     } else {
-        let mut overlay = Vec::new();
         let mut in_mem_chain = in_mem_chain.inspect(|block| {
             finish_seen |= block.recovered_block().hash() == finish.hash;
-            overlay.push(block.clone());
         });
 
         let anchor_hash =
             anchor_for_parent_in(parent_hash, &mut in_mem_chain, partial_state_trie.hash);
-        let anchor = if anchor_hash == partial_state_trie.hash {
+        if anchor_hash == partial_state_trie.hash {
             BlockNumHash::new(partial_state_trie.number, anchor_hash)
         } else {
             let anchor_number = provider
                 .convert_hash_or_number(anchor_hash.into())?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
             BlockNumHash::new(anchor_number, anchor_hash)
-        };
-        (anchor, overlay)
+        }
     };
 
     finish_seen |= anchor.hash == finish.hash;
@@ -865,7 +853,7 @@ where
     // be sure that the in-memory chain is a superset of partial_state_trie+1..finish, and therefore
     // can be used without reverts.
     if finish_seen {
-        return Ok(AnchorForParent::NoReverts { anchor, overlay })
+        return Ok(AnchorForParent::NoReverts { anchor })
     }
 
     // Otherwise reverts are required; we check the changesets to make sure they are actually
@@ -885,7 +873,7 @@ where
         })
     }
 
-    Ok(AnchorForParent::RevertsRequired { anchor, finish, overlay })
+    Ok(AnchorForParent::RevertsRequired { anchor, finish })
 }
 
 #[cfg(test)]
@@ -1351,10 +1339,9 @@ mod tests {
         let provider = factory.provider().unwrap();
         let builder = manager.overlay_builder(blocks[1].recovered_block().hash());
         match builder.anchor_at_parent(&provider).unwrap() {
-            AnchorForParent::RevertsRequired { anchor, finish, overlay } => {
+            AnchorForParent::RevertsRequired { anchor, finish } => {
                 assert_eq!(anchor, blocks[1].recovered_block().num_hash());
                 assert_eq!(finish, blocks[3].recovered_block().num_hash());
-                assert!(overlay.is_empty());
             }
             AnchorForParent::NoReverts { .. } => {
                 panic!("persisted parent below Finish must require reverts")
@@ -1396,7 +1383,7 @@ mod tests {
         let parent_hash = B256::with_last_byte(1);
         let builder = OverlayManager::<EthPrimitives>::default().overlay_builder(parent_hash);
 
-        let (trie, state) = builder.resolve_state_trie_overlays(parent_hash, &[]).unwrap();
+        let (trie, state) = builder.resolve_state_trie_overlays(parent_hash).unwrap();
         assert!(trie.is_empty());
         assert!(state.is_empty());
     }
@@ -1407,7 +1394,7 @@ mod tests {
         let anchor_hash = B256::with_last_byte(2);
         let builder = OverlayManager::<EthPrimitives>::default().overlay_builder(parent_hash);
 
-        let err = builder.resolve_state_trie_overlays(anchor_hash, &[]).unwrap_err();
+        let err = builder.resolve_state_trie_overlays(anchor_hash).unwrap_err();
 
         assert!(err.to_string().contains("cannot be anchored"));
     }

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -605,7 +605,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         match &self.overlay_source {
             Some(OverlaySource::Managed) if anchor_hash != self.parent_hash => self
                 .overlay_manager
-                .execution_overlay_for_parent_with_blocks(self.parent_hash, anchor_hash, blocks)
+                .execution_overlay_for_blocks(self.parent_hash, anchor_hash, blocks)
                 .map_err(ProviderError::other),
             Some(OverlaySource::Managed) | None => Ok(Arc::new(ExecutionOverlay::default())),
             Some(OverlaySource::Immediate { .. }) => Err(ProviderError::other(

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -576,7 +576,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     ))
                 } else {
                     self.overlay_manager
-                        .overlay_for_parent_with_blocks(self.parent_hash, anchor_hash, blocks)
+                        .overlay_for_blocks(self.parent_hash, anchor_hash, blocks)
                         .map_err(ProviderError::other)
                 }
             }

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -239,7 +239,7 @@ pub struct OverlayBuilder<N: NodePrimitives = EthPrimitives> {
     /// Manager used for cached changesets and overlays.
     overlay_manager: OverlayManager<N>,
     /// Snapshot of the in-memory chain ending at the requested parent.
-    parent_state: Option<Arc<BlockState<N>>>,
+    parent_state: Option<BlockState<N>>,
     /// Anchor hash of the reused sparse trie, if this task reused one.
     reused_sparse_trie_anchor_hash: Option<B256>,
     /// Whether building the overlay may query revert changesets.
@@ -252,7 +252,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     /// Create a new manager-backed overlay builder.
     pub(crate) fn new(
         parent_hash: B256,
-        parent_state: Option<Arc<BlockState<N>>>,
+        parent_state: Option<BlockState<N>>,
         overlay_manager: OverlayManager<N>,
     ) -> Self {
         Self {

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -387,7 +387,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
         // Collect any reverts which are required to bring the DB view back to the anchor hash.
         let (trie_updates, hashed_post_state) = match &anchor_for_parent {
-            AnchorForParent::RevertsRequired { anchor, .. } => {
+            AnchorForParent::RevertsRequired { anchor, finish } => {
                 let revert_blocks =
                     self.revert_blocks(&anchor_for_parent)?.expect("reverts are required");
 
@@ -403,7 +403,8 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         .entered();
                     let start = Instant::now();
                     let accumulated_reverts =
-                        self.overlay_manager.get_or_compute_cached_changesets_range_at_frontiers(
+                        self.overlay_manager.changeset_cache().get_or_compute_range(
+                            self.clone().with_parent_state_at(*finish),
                             provider,
                             revert_blocks.clone(),
                             state_trie_tip_block,
@@ -632,6 +633,19 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                 Ok(Some(anchor.number + 1..=finish.number))
             }
         }
+    }
+
+    /// Reuses this builder's snapshot at `parent`, discarding any newer blocks.
+    fn with_parent_state_at(mut self, parent: BlockNumHash) -> Self {
+        self.parent_hash = parent.hash;
+        self.parent_state = self.parent_state.as_ref().and_then(|state| {
+            state
+                .chain()
+                .find(|state| state.block_ref().recovered_block().num_hash() == parent)
+                .cloned()
+        });
+        self.reused_sparse_trie_anchor_hash = None;
+        self
     }
 
     /// Returns true if managed overlay resolution can be skipped for this builder.
@@ -1347,6 +1361,30 @@ mod tests {
                 panic!("persisted parent below Finish must require reverts")
             }
         }
+    }
+
+    #[test]
+    fn builder_trims_parent_state_to_checkpoint() {
+        let manager = OverlayManager::default();
+        let blocks = test_blocks();
+        for block in &blocks {
+            manager.insert_block(block.clone());
+        }
+
+        let builder = manager
+            .overlay_builder(blocks[4].recovered_block().hash())
+            .with_parent_state_at(blocks[2].recovered_block().num_hash());
+        let hashes =
+            builder.parent_state.unwrap().chain().map(BlockState::hash).collect::<Vec<_>>();
+
+        assert_eq!(
+            hashes,
+            blocks[..=2]
+                .iter()
+                .rev()
+                .map(|block| block.recovered_block().hash())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -7,7 +7,7 @@
 //! - **Reorg support**: Quickly access changesets to revert blocks during chain reorganizations
 //! - **Memory efficiency**: Explicit eviction releases persisted changesets
 
-use crate::{database_state_frontiers, OverlayBuilder, OverlayManager, OverlayStateProvider};
+use crate::{database_state_frontiers, OverlayManager, OverlayStateProvider};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{map::B256Map, BlockNumber, B256};
 use parking_lot::RwLock;
@@ -115,7 +115,7 @@ where
 
     // Step 2: Get the trie reverts for the state after the target block using the cache
     let reverts = cache.get_or_compute_range(
-        overlay_manager.overlay_builder(finish.hash),
+        overlay_manager,
         provider,
         (block_number + 1)..=finish.number,
         partial_state_trie,
@@ -230,7 +230,7 @@ impl ChangesetCache {
             + StorageSettingsCache,
     {
         self.get_or_compute_range(
-            overlay_manager.overlay_builder(finish.hash),
+            overlay_manager,
             provider,
             block_number..=block_number,
             partial_state_trie,
@@ -266,7 +266,7 @@ impl ChangesetCache {
     /// - Changeset computation fails
     pub(crate) fn get_or_compute_range<N, P>(
         &self,
-        overlay_builder: OverlayBuilder<N>,
+        overlay_manager: &OverlayManager<N>,
         provider: &P,
         range: RangeInclusive<BlockNumber>,
         partial_state_trie: BlockNumHash,
@@ -400,11 +400,10 @@ impl ChangesetCache {
             "Changeset cache MISS in range, falling back to aggregate DB-based computation"
         );
 
-        let overlay = overlay_builder.with_no_reverts().build_state_trie_overlay_at_frontiers(
-            provider,
-            partial_state_trie,
-            finish,
-        )?;
+        let overlay = overlay_manager
+            .overlay_builder(finish.hash)
+            .with_no_reverts()
+            .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish)?;
         let state_trie_provider = OverlayStateProvider::<&P, N>::new_with_state_trie(
             provider,
             overlay,
@@ -832,13 +831,7 @@ mod tests {
         let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();
         let (partial_state_trie, finish) = database_state_frontiers(&*provider).unwrap();
         let accumulated = cache
-            .get_or_compute_range(
-                overlay_manager.overlay_builder(finish.hash),
-                &*provider,
-                1..=2,
-                partial_state_trie,
-                finish,
-            )
+            .get_or_compute_range(&overlay_manager, &*provider, 1..=2, partial_state_trie, finish)
             .unwrap();
         assert_eq!(accumulated.account_nodes_ref(), &[(path, Some(older_node))]);
     }
@@ -928,13 +921,7 @@ mod tests {
         let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();
         let (partial_state_trie, finish) = database_state_frontiers(&*provider).unwrap();
         let from_cache_api = cache
-            .get_or_compute_range(
-                overlay_manager.overlay_builder(finish.hash),
-                &*provider,
-                1..=3,
-                partial_state_trie,
-                finish,
-            )
+            .get_or_compute_range(&overlay_manager, &*provider, 1..=3, partial_state_trie, finish)
             .unwrap();
         assert_eq!(*from_cache_api, actual);
         assert_eq!(cache.inner.read().entries.len(), 1);

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -7,7 +7,7 @@
 //! - **Reorg support**: Quickly access changesets to revert blocks during chain reorganizations
 //! - **Memory efficiency**: Explicit eviction releases persisted changesets
 
-use crate::{database_state_frontiers, OverlayManager, OverlayStateProvider};
+use crate::{database_state_frontiers, OverlayBuilder, OverlayManager, OverlayStateProvider};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{map::B256Map, BlockNumber, B256};
 use parking_lot::RwLock;
@@ -115,7 +115,7 @@ where
 
     // Step 2: Get the trie reverts for the state after the target block using the cache
     let reverts = cache.get_or_compute_range(
-        overlay_manager,
+        overlay_manager.overlay_builder(finish.hash),
         provider,
         (block_number + 1)..=finish.number,
         partial_state_trie,
@@ -230,7 +230,7 @@ impl ChangesetCache {
             + StorageSettingsCache,
     {
         self.get_or_compute_range(
-            overlay_manager,
+            overlay_manager.overlay_builder(finish.hash),
             provider,
             block_number..=block_number,
             partial_state_trie,
@@ -266,7 +266,7 @@ impl ChangesetCache {
     /// - Changeset computation fails
     pub(crate) fn get_or_compute_range<N, P>(
         &self,
-        overlay_manager: &OverlayManager<N>,
+        overlay_builder: OverlayBuilder<N>,
         provider: &P,
         range: RangeInclusive<BlockNumber>,
         partial_state_trie: BlockNumHash,
@@ -400,10 +400,11 @@ impl ChangesetCache {
             "Changeset cache MISS in range, falling back to aggregate DB-based computation"
         );
 
-        let overlay = overlay_manager
-            .overlay_builder(finish.hash)
-            .with_no_reverts()
-            .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish)?;
+        let overlay = overlay_builder.with_no_reverts().build_state_trie_overlay_at_frontiers(
+            provider,
+            partial_state_trie,
+            finish,
+        )?;
         let state_trie_provider = OverlayStateProvider::<&P, N>::new_with_state_trie(
             provider,
             overlay,
@@ -831,7 +832,13 @@ mod tests {
         let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();
         let (partial_state_trie, finish) = database_state_frontiers(&*provider).unwrap();
         let accumulated = cache
-            .get_or_compute_range(&overlay_manager, &*provider, 1..=2, partial_state_trie, finish)
+            .get_or_compute_range(
+                overlay_manager.overlay_builder(finish.hash),
+                &*provider,
+                1..=2,
+                partial_state_trie,
+                finish,
+            )
             .unwrap();
         assert_eq!(accumulated.account_nodes_ref(), &[(path, Some(older_node))]);
     }
@@ -921,7 +928,13 @@ mod tests {
         let overlay_manager = OverlayManager::<reth_ethereum_primitives::EthPrimitives>::default();
         let (partial_state_trie, finish) = database_state_frontiers(&*provider).unwrap();
         let from_cache_api = cache
-            .get_or_compute_range(&overlay_manager, &*provider, 1..=3, partial_state_trie, finish)
+            .get_or_compute_range(
+                overlay_manager.overlay_builder(finish.hash),
+                &*provider,
+                1..=3,
+                partial_state_trie,
+                finish,
+            )
             .unwrap();
         assert_eq!(*from_cache_api, actual);
         assert_eq!(cache.inner.read().entries.len(), 1);

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -42,14 +42,12 @@ use tracing::{debug, trace};
 #[derive(Clone)]
 pub struct OverlayManager<N: NodePrimitives = EthPrimitives> {
     blocks: Arc<DashMap<B256, ExecutedBlock<N>>>,
-    state_trie_overlays: OverlayCache<TrieInputSorted>,
-    execution_overlays: OverlayCache<ExecutionOverlay>,
+    state_trie_overlays: OverlayCache<TrieInputSorted, StateTrieOverlayMetrics>,
+    execution_overlays: OverlayCache<ExecutionOverlay, ExecutionOverlayMetrics>,
     changeset_cache: ChangesetCache,
     preserved_sparse_trie: Arc<Mutex<Option<PreservedSparseTrie>>>,
     #[cfg(feature = "rayon")]
     worker_pool: Option<Arc<WorkerPool>>,
-    metrics: StateTrieOverlayMetrics,
-    execution_metrics: ExecutionOverlayMetrics,
 }
 
 impl<N: NodePrimitives> Default for OverlayManager<N> {
@@ -62,8 +60,6 @@ impl<N: NodePrimitives> Default for OverlayManager<N> {
             preserved_sparse_trie: Default::default(),
             #[cfg(feature = "rayon")]
             worker_pool: None,
-            metrics: Default::default(),
-            execution_metrics: Default::default(),
         }
     }
 }
@@ -89,8 +85,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
             changeset_cache: Default::default(),
             preserved_sparse_trie: Default::default(),
             worker_pool: Some(worker_pool),
-            metrics: Default::default(),
-            execution_metrics: Default::default(),
         }
     }
 
@@ -366,10 +360,10 @@ impl<N: NodePrimitives> OverlayManager<N> {
         let input = self
             .get_or_compute_overlay(
                 &self.state_trie_overlays,
-                &self.metrics,
                 parent_hash,
                 anchor_hash,
-                OverlayRequest { blocks, wait_for_pending: true },
+                blocks,
+                true,
                 |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
             )?
             .expect("required overlay lookup cannot skip an in-progress computation");
@@ -390,11 +384,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         blocks: &[ExecutedBlock<N>],
     ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
         Ok(self
-            .execution_overlay_for_blocks_inner(
-                parent_hash,
-                anchor_hash,
-                OverlayRequest { blocks, wait_for_pending: true },
-            )?
+            .execution_overlay_for_blocks_inner(parent_hash, anchor_hash, blocks, true)?
             .expect("required overlay lookup cannot skip an in-progress computation"))
     }
 
@@ -435,28 +425,25 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
 
         let blocks = parent_state.chain().map(BlockState::block).collect::<Vec<_>>();
-        self.execution_overlay_for_blocks_inner(
-            parent_hash,
-            anchor_hash,
-            OverlayRequest { blocks: &blocks, wait_for_pending: false },
-        )
+        self.execution_overlay_for_blocks_inner(parent_hash, anchor_hash, &blocks, false)
     }
 
     fn execution_overlay_for_blocks_inner(
         &self,
         parent_hash: B256,
         anchor_hash: B256,
-        request: OverlayRequest<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+        wait_for_pending: bool,
     ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
         if parent_hash == anchor_hash {
             return Ok(Some(Arc::new(ExecutionOverlay::default())))
         }
         self.get_or_compute_overlay(
             &self.execution_overlays,
-            &self.execution_metrics,
             parent_hash,
             anchor_hash,
-            request,
+            blocks,
+            wait_for_pending,
             |input, span| self.compute_execution_overlay(input, anchor_hash, span),
         )
     }
@@ -475,11 +462,11 @@ impl<N: NodePrimitives> OverlayManager<N> {
     )]
     fn get_or_compute_overlay<T, M>(
         &self,
-        cache: &OverlayCache<T>,
-        metrics: &M,
+        cache: &OverlayCache<T, M>,
         tip_hash: B256,
         anchor_hash: B256,
-        request: OverlayRequest<'_, N>,
+        blocks: &[ExecutedBlock<N>],
+        wait_for_pending: bool,
         compute: impl FnOnce(ComputeOverlayInput<N, T>, tracing::Span) -> T,
     ) -> Result<Option<Arc<T>>, StateTrieOverlayError>
     where
@@ -487,10 +474,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
     {
         let key = OverlayCacheKey { anchor_hash, tip_hash };
         let span = tracing::Span::current();
-        let wait_for_pending = request.wait_for_pending;
-
         if let Some(entry) = cache.entries.get(&key).map(|entry| entry.value().clone()) {
-            metrics.record_cache_reuse();
+            cache.metrics.record_cache_reuse();
             span.record("cache_reused", true);
             return match entry {
                 OverlayCacheEntry::Ready(input) => Ok(Some(input)),
@@ -501,7 +486,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         span.record("cache_reused", false);
 
         // Resolve the block path and any cached parent overlay before locking the child entry.
-        let mut blocks = Self::provided_blocks_for_parent(tip_hash, anchor_hash, request.blocks)?;
+        let mut blocks = Self::provided_blocks_for_parent(tip_hash, anchor_hash, blocks)?;
         span.record("block_count", blocks.len());
         enum CacheAction<T> {
             Ready(Arc<T>),
@@ -512,7 +497,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         let action = match cache.entries.entry(key) {
             Entry::Occupied(entry) => {
                 let entry = entry.get().clone();
-                metrics.record_cache_reuse();
+                cache.metrics.record_cache_reuse();
                 span.record("cache_reused", true);
                 match entry {
                     OverlayCacheEntry::Ready(input) => CacheAction::Ready(input),
@@ -521,7 +506,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 }
             }
             Entry::Vacant(entry) => {
-                metrics.record_cache_fill();
+                cache.metrics.record_cache_fill();
                 let waiter = Arc::new(OverlayWaiter::new());
                 entry.insert(OverlayCacheEntry::Computing(Arc::clone(&waiter)));
                 CacheAction::Compute(waiter)
@@ -651,7 +636,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         {
             if let Some(worker_pool) = &self.worker_pool {
                 let compute_span = _span;
-                let metrics = self.metrics.clone();
+                let metrics = self.state_trie_overlays.metrics.clone();
                 return worker_pool.spawn_and_wait(move || {
                     let _guard = compute_span.enter();
                     compute_overlay(compute_input, anchor_hash, &metrics)
@@ -659,7 +644,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
             }
         }
 
-        compute_overlay(compute_input, anchor_hash, &self.metrics)
+        compute_overlay(compute_input, anchor_hash, &self.state_trie_overlays.metrics)
     }
 
     fn compute_execution_overlay(
@@ -672,7 +657,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         {
             if let Some(worker_pool) = &self.worker_pool {
                 let compute_span = _span;
-                let metrics = self.execution_metrics.clone();
+                let metrics = self.execution_overlays.metrics.clone();
                 return worker_pool.spawn_and_wait(move || {
                     let _guard = compute_span.enter();
                     compute_execution_overlay_inner(compute_input, anchor_hash, &metrics)
@@ -680,7 +665,11 @@ impl<N: NodePrimitives> OverlayManager<N> {
             }
         }
 
-        compute_execution_overlay_inner(compute_input, anchor_hash, &self.execution_metrics)
+        compute_execution_overlay_inner(
+            compute_input,
+            anchor_hash,
+            &self.execution_overlays.metrics,
+        )
     }
 }
 
@@ -711,23 +700,24 @@ struct OverlayCacheKey {
     tip_hash: B256,
 }
 
-struct OverlayCache<T> {
+struct OverlayCache<T, M> {
     entries: Arc<DashMap<OverlayCacheKey, OverlayCacheEntry<T>>>,
+    metrics: M,
 }
 
-impl<T> Default for OverlayCache<T> {
+impl<T, M: Default> Default for OverlayCache<T, M> {
     fn default() -> Self {
-        Self { entries: Default::default() }
+        Self { entries: Default::default(), metrics: Default::default() }
     }
 }
 
-impl<T> Clone for OverlayCache<T> {
+impl<T, M: Clone> Clone for OverlayCache<T, M> {
     fn clone(&self) -> Self {
-        Self { entries: Arc::clone(&self.entries) }
+        Self { entries: Arc::clone(&self.entries), metrics: self.metrics.clone() }
     }
 }
 
-impl<T> OverlayCache<T> {
+impl<T, M> OverlayCache<T, M> {
     fn len(&self) -> usize {
         self.entries.len()
     }
@@ -778,11 +768,6 @@ impl<T> OverlayWaiter<T> {
     fn finish(&self, computed: Arc<T>) {
         let _ = self.input.set(computed);
     }
-}
-
-struct OverlayRequest<'a, N: NodePrimitives> {
-    blocks: &'a [ExecutedBlock<N>],
-    wait_for_pending: bool,
 }
 
 enum ComputeOverlayInput<N: NodePrimitives, T> {

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -411,7 +411,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
         self.execution_overlay_for_parent_inner(&parent_state, anchor_hash, false).map(drop)
     }
 
-    #[cfg(feature = "rayon")]
     fn execution_overlay_for_parent_inner(
         &self,
         parent_state: &BlockState<N>,

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -96,12 +96,12 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
     /// Creates an overlay builder for `parent_hash`.
     pub fn overlay_builder(&self, parent_hash: B256) -> OverlayBuilder<N> {
-        let parent_state = self
-            .parent_chain(parent_hash)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .fold(None, |parent, block| Some(Arc::new(BlockState::with_parent(block, parent))));
+        let mut blocks = self.parent_chain(parent_hash).collect::<Vec<_>>();
+        let parent_state = blocks.pop().map(|oldest| {
+            blocks.into_iter().rev().fold(BlockState::new(oldest), |parent, block| {
+                BlockState::with_parent(block, Some(Arc::new(parent)))
+            })
+        });
         OverlayBuilder::new(parent_hash, parent_state, self.clone())
     }
 

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -388,19 +388,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
             .expect("required overlay lookup cannot skip an in-progress computation"))
     }
 
-    #[cfg(test)]
-    fn execution_overlay_for_parent(
-        &self,
-        parent_hash: B256,
-        anchor_hash: B256,
-    ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
-        let blocks = (parent_hash != anchor_hash)
-            .then(|| self.blocks_for_parent(parent_hash, anchor_hash))
-            .transpose()?
-            .unwrap_or_default();
-        self.execution_overlay_for_blocks(parent_hash, anchor_hash, &blocks)
-    }
-
     #[cfg(feature = "rayon")]
     fn precompute_execution_overlay_for_parent(
         &self,
@@ -551,27 +538,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
                 Ok(Some(input))
             }
-        }
-    }
-
-    #[cfg(test)]
-    fn blocks_for_parent(
-        &self,
-        tip_hash: B256,
-        anchor_hash: B256,
-    ) -> Result<Vec<ExecutedBlock<N>>, StateTrieOverlayError> {
-        let mut hash = tip_hash;
-        let mut blocks = Vec::new();
-        loop {
-            let block =
-                self.blocks.get(&hash).ok_or(StateTrieOverlayError { tip_hash, anchor_hash })?;
-            let parent_hash = block.recovered_block().parent_hash();
-            blocks.push(block.clone());
-
-            if parent_hash == anchor_hash {
-                return Ok(blocks)
-            }
-            hash = parent_hash;
         }
     }
 
@@ -1011,12 +977,46 @@ mod tests {
             .collect()
     }
 
+    fn blocks_for_parent(
+        manager: &OverlayManager,
+        tip_hash: B256,
+        anchor_hash: B256,
+    ) -> Result<Vec<ExecutedBlock<EthPrimitives>>, StateTrieOverlayError> {
+        let mut hash = tip_hash;
+        let mut blocks = Vec::new();
+        loop {
+            let block =
+                manager.blocks.get(&hash).ok_or(StateTrieOverlayError { tip_hash, anchor_hash })?;
+            let parent_hash = block.recovered_block().parent_hash();
+            blocks.push(block.clone());
+
+            if parent_hash == anchor_hash {
+                return Ok(blocks)
+            }
+            hash = parent_hash;
+        }
+    }
+
+    impl OverlayManager {
+        fn execution_overlay_for_parent(
+            &self,
+            parent_hash: B256,
+            anchor_hash: B256,
+        ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
+            let blocks = (parent_hash != anchor_hash)
+                .then(|| blocks_for_parent(self, parent_hash, anchor_hash))
+                .transpose()?
+                .unwrap_or_default();
+            self.execution_overlay_for_blocks(parent_hash, anchor_hash, &blocks)
+        }
+    }
+
     fn overlay_for_parent(
         manager: &OverlayManager,
         parent_hash: B256,
         anchor_hash: B256,
     ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
-        let blocks = manager.blocks_for_parent(parent_hash, anchor_hash)?;
+        let blocks = blocks_for_parent(manager, parent_hash, anchor_hash)?;
         manager.overlay_for_blocks(parent_hash, anchor_hash, &blocks)
     }
 

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -42,12 +42,14 @@ use tracing::{debug, trace};
 #[derive(Clone)]
 pub struct OverlayManager<N: NodePrimitives = EthPrimitives> {
     blocks: Arc<DashMap<B256, ExecutedBlock<N>>>,
-    state_trie_overlays: OverlayCache<TrieInputSorted, StateTrieOverlayMetrics>,
-    execution_overlays: OverlayCache<ExecutionOverlay, ExecutionOverlayMetrics>,
+    state_trie_overlays: OverlayCache<TrieInputSorted>,
+    execution_overlays: OverlayCache<ExecutionOverlay>,
     changeset_cache: ChangesetCache,
     preserved_sparse_trie: Arc<Mutex<Option<PreservedSparseTrie>>>,
     #[cfg(feature = "rayon")]
     worker_pool: Option<Arc<WorkerPool>>,
+    metrics: StateTrieOverlayMetrics,
+    execution_metrics: ExecutionOverlayMetrics,
 }
 
 impl<N: NodePrimitives> Default for OverlayManager<N> {
@@ -60,6 +62,8 @@ impl<N: NodePrimitives> Default for OverlayManager<N> {
             preserved_sparse_trie: Default::default(),
             #[cfg(feature = "rayon")]
             worker_pool: None,
+            metrics: Default::default(),
+            execution_metrics: Default::default(),
         }
     }
 }
@@ -85,6 +89,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
             changeset_cache: Default::default(),
             preserved_sparse_trie: Default::default(),
             worker_pool: Some(worker_pool),
+            metrics: Default::default(),
+            execution_metrics: Default::default(),
         }
     }
 
@@ -343,14 +349,20 @@ impl<N: NodePrimitives> OverlayManager<N> {
         level = "trace",
         target = "storage::overlay::manager",
         skip_all,
-        fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
+        fields(tip_hash = %parent_state.hash(), anchor_hash = %anchor_hash)
     )]
-    pub(crate) fn overlay_for_blocks(
+    pub(crate) fn overlay_for_parent(
         &self,
-        parent_hash: B256,
+        parent_state: &BlockState<N>,
         anchor_hash: B256,
-        blocks: &[ExecutedBlock<N>],
     ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
+        let parent_hash = parent_state.hash();
+        if parent_hash == anchor_hash {
+            return Ok((
+                Arc::new(TrieUpdatesSorted::default()),
+                Arc::new(HashedPostStateSorted::default()),
+            ))
+        }
         debug!(
             target: "storage::overlay::manager",
             tip_hash = %parent_hash,
@@ -360,9 +372,9 @@ impl<N: NodePrimitives> OverlayManager<N> {
         let input = self
             .get_or_compute_overlay(
                 &self.state_trie_overlays,
-                parent_hash,
+                &self.metrics,
                 anchor_hash,
-                blocks,
+                parent_state,
                 true,
                 |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
             )?
@@ -375,16 +387,15 @@ impl<N: NodePrimitives> OverlayManager<N> {
         level = "trace",
         target = "storage::overlay::manager",
         skip_all,
-        fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
+        fields(tip_hash = %parent_state.hash(), anchor_hash = %anchor_hash)
     )]
-    pub(crate) fn execution_overlay_for_blocks(
+    pub(crate) fn execution_overlay_for_block_state(
         &self,
-        parent_hash: B256,
+        parent_state: &BlockState<N>,
         anchor_hash: B256,
-        blocks: &[ExecutedBlock<N>],
     ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
         Ok(self
-            .execution_overlay_for_blocks_inner(parent_hash, anchor_hash, blocks, true)?
+            .execution_overlay_for_parent_inner(parent_state, anchor_hash, true)?
             .expect("required overlay lookup cannot skip an in-progress computation"))
     }
 
@@ -397,39 +408,26 @@ impl<N: NodePrimitives> OverlayManager<N> {
         let parent_state = self
             .block_state(parent_hash)
             .ok_or(StateTrieOverlayError { tip_hash: parent_hash, anchor_hash })?;
-        self.execution_overlay_for_parent_inner(parent_state, anchor_hash).map(drop)
+        self.execution_overlay_for_parent_inner(&parent_state, anchor_hash, false).map(drop)
     }
 
     #[cfg(feature = "rayon")]
     fn execution_overlay_for_parent_inner(
         &self,
-        parent_state: BlockState<N>,
+        parent_state: &BlockState<N>,
         anchor_hash: B256,
-    ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
-        let parent_hash = parent_state.block().recovered_block().hash();
-        if parent_hash == anchor_hash {
-            return Ok(Some(Arc::new(ExecutionOverlay::default())))
-        }
-
-        let blocks = parent_state.chain().map(BlockState::block).collect::<Vec<_>>();
-        self.execution_overlay_for_blocks_inner(parent_hash, anchor_hash, &blocks, false)
-    }
-
-    fn execution_overlay_for_blocks_inner(
-        &self,
-        parent_hash: B256,
-        anchor_hash: B256,
-        blocks: &[ExecutedBlock<N>],
         wait_for_pending: bool,
     ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
+        let parent_hash = parent_state.hash();
         if parent_hash == anchor_hash {
             return Ok(Some(Arc::new(ExecutionOverlay::default())))
         }
+
         self.get_or_compute_overlay(
             &self.execution_overlays,
-            parent_hash,
+            &self.execution_metrics,
             anchor_hash,
-            blocks,
+            parent_state,
             wait_for_pending,
             |input, span| self.compute_execution_overlay(input, anchor_hash, span),
         )
@@ -440,7 +438,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         target = "storage::overlay::manager",
         skip_all,
         fields(
-            tip_hash = %tip_hash,
+            tip_hash = %parent_state.hash(),
             anchor_hash = %anchor_hash,
             cache_reused = tracing::field::Empty,
             block_count = tracing::field::Empty,
@@ -449,20 +447,21 @@ impl<N: NodePrimitives> OverlayManager<N> {
     )]
     fn get_or_compute_overlay<T, M>(
         &self,
-        cache: &OverlayCache<T, M>,
-        tip_hash: B256,
+        cache: &OverlayCache<T>,
+        metrics: &M,
         anchor_hash: B256,
-        blocks: &[ExecutedBlock<N>],
+        parent_state: &BlockState<N>,
         wait_for_pending: bool,
         compute: impl FnOnce(ComputeOverlayInput<N, T>, tracing::Span) -> T,
     ) -> Result<Option<Arc<T>>, StateTrieOverlayError>
     where
         M: OverlayCacheMetrics,
     {
+        let tip_hash = parent_state.hash();
         let key = OverlayCacheKey { anchor_hash, tip_hash };
         let span = tracing::Span::current();
         if let Some(entry) = cache.entries.get(&key).map(|entry| entry.value().clone()) {
-            cache.metrics.record_cache_reuse();
+            metrics.record_cache_reuse();
             span.record("cache_reused", true);
             return match entry {
                 OverlayCacheEntry::Ready(input) => Ok(Some(input)),
@@ -473,7 +472,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         span.record("cache_reused", false);
 
         // Resolve the block path and any cached parent overlay before locking the child entry.
-        let mut blocks = Self::provided_blocks_for_parent(tip_hash, anchor_hash, blocks)?;
+        let mut blocks = Self::blocks_from_parent_state(parent_state, anchor_hash)?;
         span.record("block_count", blocks.len());
         enum CacheAction<T> {
             Ready(Arc<T>),
@@ -484,7 +483,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         let action = match cache.entries.entry(key) {
             Entry::Occupied(entry) => {
                 let entry = entry.get().clone();
-                cache.metrics.record_cache_reuse();
+                metrics.record_cache_reuse();
                 span.record("cache_reused", true);
                 match entry {
                     OverlayCacheEntry::Ready(input) => CacheAction::Ready(input),
@@ -493,7 +492,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 }
             }
             Entry::Vacant(entry) => {
-                cache.metrics.record_cache_fill();
+                metrics.record_cache_fill();
                 let waiter = Arc::new(OverlayWaiter::new());
                 entry.insert(OverlayCacheEntry::Computing(Arc::clone(&waiter)));
                 CacheAction::Compute(waiter)
@@ -541,21 +540,22 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
     }
 
-    fn provided_blocks_for_parent(
-        tip_hash: B256,
+    fn blocks_from_parent_state(
+        parent_state: &BlockState<N>,
         anchor_hash: B256,
-        blocks: &[ExecutedBlock<N>],
     ) -> Result<Vec<ExecutedBlock<N>>, StateTrieOverlayError> {
+        let tip_hash = parent_state.hash();
         let mut hash = tip_hash;
-        let mut resolved = Vec::with_capacity(blocks.len());
-        for block in blocks {
+        let mut blocks = Vec::new();
+        for state in parent_state.chain() {
+            let block = state.block();
             if block.recovered_block().hash() != hash {
                 return Err(StateTrieOverlayError { tip_hash, anchor_hash })
             }
             hash = block.recovered_block().parent_hash();
-            resolved.push(block.clone());
+            blocks.push(block);
             if hash == anchor_hash {
-                return Ok(resolved)
+                return Ok(blocks)
             }
         }
         Err(StateTrieOverlayError { tip_hash, anchor_hash })
@@ -602,7 +602,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         {
             if let Some(worker_pool) = &self.worker_pool {
                 let compute_span = _span;
-                let metrics = self.state_trie_overlays.metrics.clone();
+                let metrics = self.metrics.clone();
                 return worker_pool.spawn_and_wait(move || {
                     let _guard = compute_span.enter();
                     compute_overlay(compute_input, anchor_hash, &metrics)
@@ -610,7 +610,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
             }
         }
 
-        compute_overlay(compute_input, anchor_hash, &self.state_trie_overlays.metrics)
+        compute_overlay(compute_input, anchor_hash, &self.metrics)
     }
 
     fn compute_execution_overlay(
@@ -623,7 +623,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         {
             if let Some(worker_pool) = &self.worker_pool {
                 let compute_span = _span;
-                let metrics = self.execution_overlays.metrics.clone();
+                let metrics = self.execution_metrics.clone();
                 return worker_pool.spawn_and_wait(move || {
                     let _guard = compute_span.enter();
                     compute_execution_overlay_inner(compute_input, anchor_hash, &metrics)
@@ -631,11 +631,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
             }
         }
 
-        compute_execution_overlay_inner(
-            compute_input,
-            anchor_hash,
-            &self.execution_overlays.metrics,
-        )
+        compute_execution_overlay_inner(compute_input, anchor_hash, &self.execution_metrics)
     }
 }
 
@@ -666,24 +662,23 @@ struct OverlayCacheKey {
     tip_hash: B256,
 }
 
-struct OverlayCache<T, M> {
+struct OverlayCache<T> {
     entries: Arc<DashMap<OverlayCacheKey, OverlayCacheEntry<T>>>,
-    metrics: M,
 }
 
-impl<T, M: Default> Default for OverlayCache<T, M> {
+impl<T> Default for OverlayCache<T> {
     fn default() -> Self {
-        Self { entries: Default::default(), metrics: Default::default() }
+        Self { entries: Default::default() }
     }
 }
 
-impl<T, M: Clone> Clone for OverlayCache<T, M> {
+impl<T> Clone for OverlayCache<T> {
     fn clone(&self) -> Self {
-        Self { entries: Arc::clone(&self.entries), metrics: self.metrics.clone() }
+        Self { entries: Arc::clone(&self.entries) }
     }
 }
 
-impl<T, M> OverlayCache<T, M> {
+impl<T> OverlayCache<T> {
     fn len(&self) -> usize {
         self.entries.len()
     }
@@ -977,37 +972,19 @@ mod tests {
             .collect()
     }
 
-    fn blocks_for_parent(
-        manager: &OverlayManager,
-        tip_hash: B256,
-        anchor_hash: B256,
-    ) -> Result<Vec<ExecutedBlock<EthPrimitives>>, StateTrieOverlayError> {
-        let mut hash = tip_hash;
-        let mut blocks = Vec::new();
-        loop {
-            let block =
-                manager.blocks.get(&hash).ok_or(StateTrieOverlayError { tip_hash, anchor_hash })?;
-            let parent_hash = block.recovered_block().parent_hash();
-            blocks.push(block.clone());
-
-            if parent_hash == anchor_hash {
-                return Ok(blocks)
-            }
-            hash = parent_hash;
-        }
-    }
-
     impl OverlayManager {
         fn execution_overlay_for_parent(
             &self,
             parent_hash: B256,
             anchor_hash: B256,
         ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
-            let blocks = (parent_hash != anchor_hash)
-                .then(|| blocks_for_parent(self, parent_hash, anchor_hash))
-                .transpose()?
-                .unwrap_or_default();
-            self.execution_overlay_for_blocks(parent_hash, anchor_hash, &blocks)
+            if parent_hash == anchor_hash {
+                return Ok(Arc::new(ExecutionOverlay::default()))
+            }
+            let parent_state = self
+                .block_state(parent_hash)
+                .ok_or(StateTrieOverlayError { tip_hash: parent_hash, anchor_hash })?;
+            self.execution_overlay_for_block_state(&parent_state, anchor_hash)
         }
     }
 
@@ -1016,8 +993,10 @@ mod tests {
         parent_hash: B256,
         anchor_hash: B256,
     ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
-        let blocks = blocks_for_parent(manager, parent_hash, anchor_hash)?;
-        manager.overlay_for_blocks(parent_hash, anchor_hash, &blocks)
+        let parent_state = manager
+            .block_state(parent_hash)
+            .ok_or(StateTrieOverlayError { tip_hash: parent_hash, anchor_hash })?;
+        manager.overlay_for_parent(&parent_state, anchor_hash)
     }
 
     #[test]
@@ -1308,9 +1287,11 @@ mod tests {
     #[test]
     fn required_lookup_waits_for_in_progress_overlay() {
         let manager = OverlayManager::<EthPrimitives>::default();
+        let block = test_blocks().remove(0);
+        let parent_state = BlockState::new(block);
         let key = OverlayCacheKey {
-            anchor_hash: B256::with_last_byte(1),
-            tip_hash: B256::with_last_byte(2),
+            anchor_hash: parent_state.block_ref().recovered_block().parent_hash(),
+            tip_hash: parent_state.hash(),
         };
         let waiter = Arc::new(OverlayWaiter::new());
         manager
@@ -1320,9 +1301,8 @@ mod tests {
 
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
-            let res = manager
-                .overlay_for_blocks(key.tip_hash, key.anchor_hash, &[])
-                .map(|(_, state)| state);
+            let res =
+                manager.overlay_for_parent(&parent_state, key.anchor_hash).map(|(_, state)| state);
             tx.send(res).unwrap();
         });
 

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -96,13 +96,16 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
     /// Creates an overlay builder for `parent_hash`.
     pub fn overlay_builder(&self, parent_hash: B256) -> OverlayBuilder<N> {
+        OverlayBuilder::new(parent_hash, self.block_state(parent_hash), self.clone())
+    }
+
+    fn block_state(&self, parent_hash: B256) -> Option<BlockState<N>> {
         let mut blocks = self.parent_chain(parent_hash).collect::<Vec<_>>();
-        let parent_state = blocks.pop().map(|oldest| {
+        blocks.pop().map(|oldest| {
             blocks.into_iter().rev().fold(BlockState::new(oldest), |parent, block| {
                 BlockState::with_parent(block, Some(Arc::new(parent)))
             })
-        });
-        OverlayBuilder::new(parent_hash, parent_state, self.clone())
+        })
     }
 
     pub(crate) const fn changeset_cache(&self) -> &ChangesetCache {
@@ -366,7 +369,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 &self.metrics,
                 parent_hash,
                 anchor_hash,
-                OverlayBlockSource::Provided(blocks),
+                OverlayRequest { blocks, wait_for_pending: true },
                 |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
             )?
             .expect("required overlay lookup cannot skip an in-progress computation");
@@ -380,33 +383,32 @@ impl<N: NodePrimitives> OverlayManager<N> {
         skip_all,
         fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
     )]
-    pub fn execution_overlay_for_parent(
-        &self,
-        parent_hash: B256,
-        anchor_hash: B256,
-    ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
-        Ok(self
-            .execution_overlay_for_parent_inner(
-                parent_hash,
-                anchor_hash,
-                OverlayBlockSource::Managed { wait_for_pending: true },
-            )?
-            .expect("required overlay lookup cannot skip an in-progress computation"))
-    }
-
-    pub(crate) fn execution_overlay_for_parent_with_blocks(
+    pub(crate) fn execution_overlay_for_blocks(
         &self,
         parent_hash: B256,
         anchor_hash: B256,
         blocks: &[ExecutedBlock<N>],
     ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
         Ok(self
-            .execution_overlay_for_parent_inner(
+            .execution_overlay_for_blocks_inner(
                 parent_hash,
                 anchor_hash,
-                OverlayBlockSource::Provided(blocks),
+                OverlayRequest { blocks, wait_for_pending: true },
             )?
             .expect("required overlay lookup cannot skip an in-progress computation"))
+    }
+
+    #[cfg(test)]
+    fn execution_overlay_for_parent(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+    ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
+        let blocks = (parent_hash != anchor_hash)
+            .then(|| self.blocks_for_parent(parent_hash, anchor_hash))
+            .transpose()?
+            .unwrap_or_default();
+        self.execution_overlay_for_blocks(parent_hash, anchor_hash, &blocks)
     }
 
     #[cfg(feature = "rayon")]
@@ -415,30 +417,46 @@ impl<N: NodePrimitives> OverlayManager<N> {
         parent_hash: B256,
         anchor_hash: B256,
     ) -> Result<(), StateTrieOverlayError> {
-        self.execution_overlay_for_parent_inner(
-            parent_hash,
-            anchor_hash,
-            OverlayBlockSource::Managed { wait_for_pending: false },
-        )
-        .map(drop)
+        let parent_state = self
+            .block_state(parent_hash)
+            .ok_or(StateTrieOverlayError { tip_hash: parent_hash, anchor_hash })?;
+        self.execution_overlay_for_parent_inner(parent_state, anchor_hash).map(drop)
     }
 
+    #[cfg(feature = "rayon")]
     fn execution_overlay_for_parent_inner(
         &self,
-        parent_hash: B256,
+        parent_state: BlockState<N>,
         anchor_hash: B256,
-        block_source: OverlayBlockSource<'_, N>,
     ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
+        let parent_hash = parent_state.block().recovered_block().hash();
         if parent_hash == anchor_hash {
             return Ok(Some(Arc::new(ExecutionOverlay::default())))
         }
 
+        let blocks = parent_state.chain().map(BlockState::block).collect::<Vec<_>>();
+        self.execution_overlay_for_blocks_inner(
+            parent_hash,
+            anchor_hash,
+            OverlayRequest { blocks: &blocks, wait_for_pending: false },
+        )
+    }
+
+    fn execution_overlay_for_blocks_inner(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+        request: OverlayRequest<'_, N>,
+    ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
+        if parent_hash == anchor_hash {
+            return Ok(Some(Arc::new(ExecutionOverlay::default())))
+        }
         self.get_or_compute_overlay(
             &self.execution_overlays,
             &self.execution_metrics,
             parent_hash,
             anchor_hash,
-            block_source,
+            request,
             |input, span| self.compute_execution_overlay(input, anchor_hash, span),
         )
     }
@@ -461,7 +479,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         metrics: &M,
         tip_hash: B256,
         anchor_hash: B256,
-        block_source: OverlayBlockSource<'_, N>,
+        request: OverlayRequest<'_, N>,
         compute: impl FnOnce(ComputeOverlayInput<N, T>, tracing::Span) -> T,
     ) -> Result<Option<Arc<T>>, StateTrieOverlayError>
     where
@@ -469,7 +487,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
     {
         let key = OverlayCacheKey { anchor_hash, tip_hash };
         let span = tracing::Span::current();
-        let wait_for_pending = block_source.wait_for_pending();
+        let wait_for_pending = request.wait_for_pending;
 
         if let Some(entry) = cache.entries.get(&key).map(|entry| entry.value().clone()) {
             metrics.record_cache_reuse();
@@ -483,12 +501,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         span.record("cache_reused", false);
 
         // Resolve the block path and any cached parent overlay before locking the child entry.
-        let mut blocks = match block_source {
-            OverlayBlockSource::Managed { .. } => self.blocks_for_parent(tip_hash, anchor_hash)?,
-            OverlayBlockSource::Provided(blocks) => {
-                Self::provided_blocks_for_parent(tip_hash, anchor_hash, blocks)?
-            }
-        };
+        let mut blocks = Self::provided_blocks_for_parent(tip_hash, anchor_hash, request.blocks)?;
         span.record("block_count", blocks.len());
         enum CacheAction<T> {
             Ready(Arc<T>),
@@ -556,6 +569,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
     }
 
+    #[cfg(test)]
     fn blocks_for_parent(
         &self,
         tip_hash: B256,
@@ -766,18 +780,9 @@ impl<T> OverlayWaiter<T> {
     }
 }
 
-enum OverlayBlockSource<'a, N: NodePrimitives> {
-    Managed { wait_for_pending: bool },
-    Provided(&'a [ExecutedBlock<N>]),
-}
-
-impl<N: NodePrimitives> OverlayBlockSource<'_, N> {
-    const fn wait_for_pending(&self) -> bool {
-        match self {
-            Self::Managed { wait_for_pending } => *wait_for_pending,
-            Self::Provided(_) => true,
-        }
-    }
+struct OverlayRequest<'a, N: NodePrimitives> {
+    blocks: &'a [ExecutedBlock<N>],
+    wait_for_pending: bool,
 }
 
 enum ComputeOverlayInput<N: NodePrimitives, T> {

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -10,6 +10,7 @@ use crate::{
     manager_metrics::{ExecutionOverlayMetrics, OverlayCacheMetrics, StateTrieOverlayMetrics},
     ChangesetCache, ExecutionOverlay, OverlayBuilder,
 };
+use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
 use reth_chain_state::{BlockState, ExecutedBlock, PreservedSparseTrie};
@@ -127,13 +128,31 @@ impl<N: NodePrimitives> OverlayManager<N> {
             + StorageSettingsCache,
     {
         let (partial_state_trie, finish) = database_state_frontiers(provider)?;
-        self.changeset_cache.get_or_compute_range(
-            self.overlay_builder(finish.hash),
+        self.get_or_compute_cached_changesets_range_at_frontiers(
             provider,
             range,
             partial_state_trie,
             finish,
         )
+    }
+
+    pub(crate) fn get_or_compute_cached_changesets_range_at_frontiers<P>(
+        &self,
+        provider: &P,
+        range: RangeInclusive<BlockNumber>,
+        partial_state_trie: BlockNumHash,
+        finish: BlockNumHash,
+    ) -> ProviderResult<Arc<TrieUpdatesSorted>>
+    where
+        P: DBProvider
+            + ChangeSetReader
+            + StorageChangeSetReader
+            + StageCheckpointReader
+            + PruneCheckpointReader
+            + BlockNumReader
+            + StorageSettingsCache,
+    {
+        self.changeset_cache.get_or_compute_range(self, provider, range, partial_state_trie, finish)
     }
 
     /// Evicts cached changesets for blocks below `up_to_block`.

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -10,7 +10,6 @@ use crate::{
     manager_metrics::{ExecutionOverlayMetrics, OverlayCacheMetrics, StateTrieOverlayMetrics},
     ChangesetCache, ExecutionOverlay, OverlayBuilder,
 };
-use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
 use reth_chain_state::{BlockState, ExecutedBlock, PreservedSparseTrie};
@@ -128,31 +127,13 @@ impl<N: NodePrimitives> OverlayManager<N> {
             + StorageSettingsCache,
     {
         let (partial_state_trie, finish) = database_state_frontiers(provider)?;
-        self.get_or_compute_cached_changesets_range_at_frontiers(
+        self.changeset_cache.get_or_compute_range(
+            self.overlay_builder(finish.hash),
             provider,
             range,
             partial_state_trie,
             finish,
         )
-    }
-
-    pub(crate) fn get_or_compute_cached_changesets_range_at_frontiers<P>(
-        &self,
-        provider: &P,
-        range: RangeInclusive<BlockNumber>,
-        partial_state_trie: BlockNumHash,
-        finish: BlockNumHash,
-    ) -> ProviderResult<Arc<TrieUpdatesSorted>>
-    where
-        P: DBProvider
-            + ChangeSetReader
-            + StorageChangeSetReader
-            + StageCheckpointReader
-            + PruneCheckpointReader
-            + BlockNumReader
-            + StorageSettingsCache,
-    {
-        self.changeset_cache.get_or_compute_range(self, provider, range, partial_state_trie, finish)
     }
 
     /// Evicts cached changesets for blocks below `up_to_block`.

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -13,7 +13,7 @@ use crate::{
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
-use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
+use reth_chain_state::{BlockState, ExecutedBlock, PreservedSparseTrie};
 use reth_errors::ProviderResult;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{
@@ -96,7 +96,13 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
     /// Creates an overlay builder for `parent_hash`.
     pub fn overlay_builder(&self, parent_hash: B256) -> OverlayBuilder<N> {
-        OverlayBuilder::new(parent_hash, self.clone())
+        let parent_state = self
+            .parent_chain(parent_hash)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .fold(None, |parent, block| Some(Arc::new(BlockState::with_parent(block, parent))));
+        OverlayBuilder::new(parent_hash, parent_state, self.clone())
     }
 
     pub(crate) const fn changeset_cache(&self) -> &ChangesetCache {
@@ -342,10 +348,37 @@ impl<N: NodePrimitives> OverlayManager<N> {
         skip_all,
         fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
     )]
+    #[cfg(test)]
     pub(crate) fn overlay_for_parent(
         &self,
         parent_hash: B256,
         anchor_hash: B256,
+    ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
+        self.overlay_for_parent_inner(
+            parent_hash,
+            anchor_hash,
+            OverlayBlockSource::Managed { wait_for_pending: true },
+        )
+    }
+
+    pub(crate) fn overlay_for_parent_with_blocks(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+        blocks: &[ExecutedBlock<N>],
+    ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
+        self.overlay_for_parent_inner(
+            parent_hash,
+            anchor_hash,
+            OverlayBlockSource::Provided(blocks),
+        )
+    }
+
+    fn overlay_for_parent_inner(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+        block_source: OverlayBlockSource<'_, N>,
     ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
         debug!(
             target: "storage::overlay::manager",
@@ -359,7 +392,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 &self.metrics,
                 parent_hash,
                 anchor_hash,
-                true,
+                block_source,
                 |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
             )?
             .expect("required overlay lookup cannot skip an in-progress computation");
@@ -379,7 +412,26 @@ impl<N: NodePrimitives> OverlayManager<N> {
         anchor_hash: B256,
     ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
         Ok(self
-            .execution_overlay_for_parent_inner(parent_hash, anchor_hash, true)?
+            .execution_overlay_for_parent_inner(
+                parent_hash,
+                anchor_hash,
+                OverlayBlockSource::Managed { wait_for_pending: true },
+            )?
+            .expect("required overlay lookup cannot skip an in-progress computation"))
+    }
+
+    pub(crate) fn execution_overlay_for_parent_with_blocks(
+        &self,
+        parent_hash: B256,
+        anchor_hash: B256,
+        blocks: &[ExecutedBlock<N>],
+    ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
+        Ok(self
+            .execution_overlay_for_parent_inner(
+                parent_hash,
+                anchor_hash,
+                OverlayBlockSource::Provided(blocks),
+            )?
             .expect("required overlay lookup cannot skip an in-progress computation"))
     }
 
@@ -389,14 +441,19 @@ impl<N: NodePrimitives> OverlayManager<N> {
         parent_hash: B256,
         anchor_hash: B256,
     ) -> Result<(), StateTrieOverlayError> {
-        self.execution_overlay_for_parent_inner(parent_hash, anchor_hash, false).map(drop)
+        self.execution_overlay_for_parent_inner(
+            parent_hash,
+            anchor_hash,
+            OverlayBlockSource::Managed { wait_for_pending: false },
+        )
+        .map(drop)
     }
 
     fn execution_overlay_for_parent_inner(
         &self,
         parent_hash: B256,
         anchor_hash: B256,
-        wait_for_pending: bool,
+        block_source: OverlayBlockSource<'_, N>,
     ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
         if parent_hash == anchor_hash {
             return Ok(Some(Arc::new(ExecutionOverlay::default())))
@@ -407,7 +464,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
             &self.execution_metrics,
             parent_hash,
             anchor_hash,
-            wait_for_pending,
+            block_source,
             |input, span| self.compute_execution_overlay(input, anchor_hash, span),
         )
     }
@@ -430,7 +487,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         metrics: &M,
         tip_hash: B256,
         anchor_hash: B256,
-        wait_for_pending: bool,
+        block_source: OverlayBlockSource<'_, N>,
         compute: impl FnOnce(ComputeOverlayInput<N, T>, tracing::Span) -> T,
     ) -> Result<Option<Arc<T>>, StateTrieOverlayError>
     where
@@ -438,6 +495,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
     {
         let key = OverlayCacheKey { anchor_hash, tip_hash };
         let span = tracing::Span::current();
+        let wait_for_pending = block_source.wait_for_pending();
 
         if let Some(entry) = cache.entries.get(&key).map(|entry| entry.value().clone()) {
             metrics.record_cache_reuse();
@@ -451,19 +509,12 @@ impl<N: NodePrimitives> OverlayManager<N> {
         span.record("cache_reused", false);
 
         // Resolve the block path and any cached parent overlay before locking the child entry.
-        let mut hash = tip_hash;
-        let mut blocks = Vec::new();
-        loop {
-            let block =
-                self.blocks.get(&hash).ok_or(StateTrieOverlayError { tip_hash, anchor_hash })?;
-            let parent_hash = block.recovered_block().parent_hash();
-            blocks.push(block.clone());
-
-            if parent_hash == anchor_hash {
-                break
+        let mut blocks = match block_source {
+            OverlayBlockSource::Managed { .. } => self.blocks_for_parent(tip_hash, anchor_hash)?,
+            OverlayBlockSource::Provided(blocks) => {
+                Self::provided_blocks_for_parent(tip_hash, anchor_hash, blocks)?
             }
-            hash = parent_hash;
-        }
+        };
         span.record("block_count", blocks.len());
         enum CacheAction<T> {
             Ready(Arc<T>),
@@ -529,6 +580,46 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 Ok(Some(input))
             }
         }
+    }
+
+    fn blocks_for_parent(
+        &self,
+        tip_hash: B256,
+        anchor_hash: B256,
+    ) -> Result<Vec<ExecutedBlock<N>>, StateTrieOverlayError> {
+        let mut hash = tip_hash;
+        let mut blocks = Vec::new();
+        loop {
+            let block =
+                self.blocks.get(&hash).ok_or(StateTrieOverlayError { tip_hash, anchor_hash })?;
+            let parent_hash = block.recovered_block().parent_hash();
+            blocks.push(block.clone());
+
+            if parent_hash == anchor_hash {
+                return Ok(blocks)
+            }
+            hash = parent_hash;
+        }
+    }
+
+    fn provided_blocks_for_parent(
+        tip_hash: B256,
+        anchor_hash: B256,
+        blocks: &[ExecutedBlock<N>],
+    ) -> Result<Vec<ExecutedBlock<N>>, StateTrieOverlayError> {
+        let mut hash = tip_hash;
+        let mut resolved = Vec::with_capacity(blocks.len());
+        for block in blocks {
+            if block.recovered_block().hash() != hash {
+                return Err(StateTrieOverlayError { tip_hash, anchor_hash })
+            }
+            hash = block.recovered_block().parent_hash();
+            resolved.push(block.clone());
+            if hash == anchor_hash {
+                return Ok(resolved)
+            }
+        }
+        Err(StateTrieOverlayError { tip_hash, anchor_hash })
     }
 
     /// Returns every in-memory block in the chain whose tip is `parent_hash`.
@@ -698,6 +789,20 @@ impl<T> OverlayWaiter<T> {
 
     fn finish(&self, computed: Arc<T>) {
         let _ = self.input.set(computed);
+    }
+}
+
+enum OverlayBlockSource<'a, N: NodePrimitives> {
+    Managed { wait_for_pending: bool },
+    Provided(&'a [ExecutedBlock<N>]),
+}
+
+impl<N: NodePrimitives> OverlayBlockSource<'_, N> {
+    const fn wait_for_pending(&self) -> bool {
+        match self {
+            Self::Managed { wait_for_pending } => *wait_for_pending,
+            Self::Provided(_) => true,
+        }
     }
 }
 

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -348,37 +348,11 @@ impl<N: NodePrimitives> OverlayManager<N> {
         skip_all,
         fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
     )]
-    #[cfg(test)]
-    pub(crate) fn overlay_for_parent(
-        &self,
-        parent_hash: B256,
-        anchor_hash: B256,
-    ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
-        self.overlay_for_parent_inner(
-            parent_hash,
-            anchor_hash,
-            OverlayBlockSource::Managed { wait_for_pending: true },
-        )
-    }
-
-    pub(crate) fn overlay_for_parent_with_blocks(
+    pub(crate) fn overlay_for_blocks(
         &self,
         parent_hash: B256,
         anchor_hash: B256,
         blocks: &[ExecutedBlock<N>],
-    ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
-        self.overlay_for_parent_inner(
-            parent_hash,
-            anchor_hash,
-            OverlayBlockSource::Provided(blocks),
-        )
-    }
-
-    fn overlay_for_parent_inner(
-        &self,
-        parent_hash: B256,
-        anchor_hash: B256,
-        block_source: OverlayBlockSource<'_, N>,
     ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
         debug!(
             target: "storage::overlay::manager",
@@ -392,7 +366,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
                 &self.metrics,
                 parent_hash,
                 anchor_hash,
-                block_source,
+                OverlayBlockSource::Provided(blocks),
                 |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
             )?
             .expect("required overlay lookup cannot skip an in-progress computation");
@@ -637,7 +611,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
     /// Returns true if `hash` is in the parent chain segment from `anchor_hash` inclusive to
     /// `parent_hash` inclusive.
-    pub fn contains_hash(&self, parent_hash: B256, anchor_hash: B256, hash: B256) -> bool {
+    fn contains_hash(&self, parent_hash: B256, anchor_hash: B256, hash: B256) -> bool {
         let mut current_hash = parent_hash;
 
         loop {
@@ -1047,13 +1021,22 @@ mod tests {
             .collect()
     }
 
+    fn overlay_for_parent(
+        manager: &OverlayManager,
+        parent_hash: B256,
+        anchor_hash: B256,
+    ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
+        let blocks = manager.blocks_for_parent(parent_hash, anchor_hash)?;
+        manager.overlay_for_blocks(parent_hash, anchor_hash, &blocks)
+    }
+
     #[test]
     fn errors_for_unknown_parent() {
         let manager = OverlayManager::<EthPrimitives>::default();
         let parent = B256::random();
         let anchor = B256::random();
 
-        let err = manager.overlay_for_parent(parent, anchor).unwrap_err();
+        let err = overlay_for_parent(&manager, parent, anchor).unwrap_err();
 
         assert_eq!(err.tip_hash, parent);
         assert_eq!(err.anchor_hash, anchor);
@@ -1070,15 +1053,15 @@ mod tests {
         let anchor_hash = blocks[0].recovered_block().parent_hash();
 
         let (_, state) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), anchor_hash).unwrap();
         assert_eq!(state.accounts.len(), 3);
 
         let short_anchor = blocks[1].recovered_block().hash();
         let (_, short) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), short_anchor).unwrap();
         assert_eq!(short.accounts.len(), 1);
         let (_, cached_short) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), short_anchor).unwrap();
         assert!(Arc::ptr_eq(&short, &cached_short));
     }
 
@@ -1147,10 +1130,10 @@ mod tests {
         let parent_key = OverlayCacheKey { anchor_hash, tip_hash: parent_hash };
         let child_key = OverlayCacheKey { anchor_hash, tip_hash: child_hash };
 
-        manager.overlay_for_parent(parent_hash, anchor_hash).unwrap();
+        overlay_for_parent(&manager, parent_hash, anchor_hash).unwrap();
         manager.execution_overlay_for_parent(parent_hash, anchor_hash).unwrap();
 
-        manager.overlay_for_parent(child_hash, anchor_hash).unwrap();
+        overlay_for_parent(&manager, child_hash, anchor_hash).unwrap();
         manager.execution_overlay_for_parent(child_hash, anchor_hash).unwrap();
 
         assert!(!manager.state_trie_overlays.entries.contains_key(&parent_key));
@@ -1172,7 +1155,7 @@ mod tests {
         let child_hash = blocks[2].recovered_block().hash();
         let parent_key = OverlayCacheKey { anchor_hash, tip_hash: parent_hash };
 
-        manager.overlay_for_parent(parent_hash, anchor_hash).unwrap();
+        overlay_for_parent(&manager, parent_hash, anchor_hash).unwrap();
         let state_parent = manager
             .state_trie_overlays
             .entries
@@ -1185,7 +1168,7 @@ mod tests {
         let execution_parent =
             manager.execution_overlay_for_parent(parent_hash, anchor_hash).unwrap();
 
-        let (_, child_state) = manager.overlay_for_parent(child_hash, anchor_hash).unwrap();
+        let (_, child_state) = overlay_for_parent(&manager, child_hash, anchor_hash).unwrap();
         let child_execution =
             manager.execution_overlay_for_parent(child_hash, anchor_hash).unwrap();
 
@@ -1347,8 +1330,9 @@ mod tests {
 
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
-            let res =
-                manager.overlay_for_parent(key.tip_hash, key.anchor_hash).map(|(_, state)| state);
+            let res = manager
+                .overlay_for_blocks(key.tip_hash, key.anchor_hash, &[])
+                .map(|(_, state)| state);
             tx.send(res).unwrap();
         });
 
@@ -1372,7 +1356,7 @@ mod tests {
         }
 
         let original_anchor = blocks[0].recovered_block().parent_hash();
-        manager.overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor).unwrap();
+        overlay_for_parent(&manager, blocks[2].recovered_block().hash(), original_anchor).unwrap();
         manager
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
             .unwrap();
@@ -1383,15 +1367,14 @@ mod tests {
         ]);
 
         let anchor_hash = blocks[1].recovered_block().hash();
-        assert!(manager
-            .overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
+        assert!(overlay_for_parent(&manager, blocks[2].recovered_block().hash(), original_anchor)
             .is_err());
         assert!(manager
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
             .is_err());
 
         let (_, state) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), anchor_hash).unwrap();
         assert_eq!(state.accounts.len(), 1);
         let execution = manager
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash)

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -1192,6 +1192,32 @@ mod tests {
     }
 
     #[test]
+    fn lazy_overlays_survive_manager_block_removal() {
+        let (factory, blocks) = setup_frontiers(1, 1);
+        let manager = OverlayManager::default();
+        for block in &blocks[2..=3] {
+            manager.insert_block(block.clone());
+        }
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            factory,
+            manager.overlay_builder(blocks[3].recovered_block().hash()),
+        );
+        let provider = state_provider_factory.database_provider_ro().unwrap();
+
+        manager.remove_blocks(blocks[2..=3].iter().map(|block| block.recovered_block().hash()));
+
+        let (execution_overlay, _) = provider.execution_overlay().unwrap();
+        assert_eq!(
+            execution_overlay.block_hashes(),
+            [blocks[2].recovered_block().num_hash(), blocks[3].recovered_block().num_hash()]
+        );
+        assert_eq!(
+            account_keys(provider.state_trie_overlay().unwrap()),
+            vec![B256::with_last_byte(3), B256::with_last_byte(4)]
+        );
+    }
+
+    #[test]
     fn skipped_state_trie_overlay_is_not_cached_or_used_for_state_roots() {
         let (factory, blocks) = setup_frontiers(3, 3);
         let manager = OverlayManager::default();


### PR DESCRIPTION
Fixes a potential race condition where persistence can finish between an OverlayStateProvider being created and it actually resolving its overlay. In this case persistence might remove necessary blocks from the OverlayManager and cause the state provider to error out.

This is less relevant now, when the OverlayStateProvider is only used by payload validating/building and is protected by #26559, but will be relevant in follow up PRs when it is used for RPC.

The solution is to snapshot the potentially required blocks into the OverlayProvider using a BlockState, and use that rather than the OverlayManager's DashMap. The OverlayManager is still required in the OverlayBuilder as it maintains the caches of the flattened overlays.

This eliminates the need for the changes from #26559, which were added to address the race-condition of blocks being removed from the overlay while payload building was ongoing. Now the provider factory which is passed to payload builder, which contains an OverlayBuilder, maintains a snapshot of the necessary in-memory blocks.