### PR TITLE
feat(consensus): expose receipt validation helpers

### DIFF
--- a/crates/ethereum/consensus/src/lib.rs
+++ b/crates/ethereum/consensus/src/lib.rs
@@ -33,7 +33,9 @@ use reth_primitives_traits::{
 };
 
 mod validation;
-pub use validation::validate_block_post_execution;
+pub use validation::{
+    compare_receipts_root_and_logs_bloom, validate_block_post_execution, verify_receipts,
+};
 
 /// Ethereum beacon consensus
 ///

--- a/crates/ethereum/consensus/src/validation.rs
+++ b/crates/ethereum/consensus/src/validation.rs
@@ -131,7 +131,7 @@ where
 
 /// Calculate the receipts root, and compare it against the expected receipts root and logs
 /// bloom.
-fn verify_receipts<R: Receipt>(
+pub fn verify_receipts<R: Receipt>(
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
     receipts: &[R],
@@ -153,7 +153,7 @@ fn verify_receipts<R: Receipt>(
 
 /// Compare the calculated receipts root with the expected receipts root, also compare
 /// the calculated logs bloom with the expected logs bloom.
-fn compare_receipts_root_and_logs_bloom(
+pub fn compare_receipts_root_and_logs_bloom(
     calculated_receipts_root: B256,
     calculated_logs_bloom: Bloom,
     expected_receipts_root: B256,


### PR DESCRIPTION
Expose receipt root and logs bloom verification helpers for downstream consensus consumers. This lets callers validate fetched receipts without constructing a full post-execution validation context.

Prompted by: @shekhirin