### PR TITLE
chore: bump versions to 2.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "ef-test-runner"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "clap",
  "ef-tests",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "ef-tests"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "example-full-contract-state"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "exex-subscription"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7654,7 +7654,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-node-bindings",
  "alloy-primitives",
@@ -7704,7 +7704,7 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "reth-bb"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7777,7 +7777,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7931,7 +7931,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7940,7 +7940,7 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8012,7 +8012,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8025,7 +8025,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8039,7 +8039,7 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8063,7 +8063,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8099,7 +8099,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8127,7 +8127,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8158,7 +8158,7 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8174,7 +8174,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8200,7 +8200,7 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8253,7 +8253,7 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8293,7 +8293,7 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8377,7 +8377,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8399,7 +8399,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8426,7 +8426,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8550,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8568,7 +8568,7 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8599,7 +8599,7 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8609,7 +8609,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8647,7 +8647,7 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8675,7 +8675,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8715,7 +8715,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "clap",
  "eyre",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.8",
@@ -8783,7 +8783,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8812,7 +8812,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8833,7 +8833,7 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "rayon",
@@ -8843,7 +8843,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8869,7 +8869,7 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8894,7 +8894,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8912,7 +8912,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8924,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8945,7 +8945,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8990,7 +8990,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -9021,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9038,7 +9038,7 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -9047,7 +9047,7 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "bytes",
  "futures",
@@ -9100,7 +9100,7 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "futures",
  "libc",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9146,7 +9146,7 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9160,7 +9160,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9229,7 +9229,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9253,7 +9253,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9277,7 +9277,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9294,7 +9294,7 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9307,7 +9307,7 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9325,7 +9325,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9348,7 +9348,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9419,7 +9419,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -9544,7 +9544,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9567,7 +9567,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9590,7 +9590,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "bytes",
  "eyre",
@@ -9619,7 +9619,7 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9653,7 +9653,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9664,7 +9664,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9688,7 +9688,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9697,7 +9697,7 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9739,7 +9739,7 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9794,7 +9794,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9825,7 +9825,7 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9845,7 +9845,7 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9861,7 +9861,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9941,7 +9941,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9971,7 +9971,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-e2e-tests"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -10069,7 +10069,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10105,7 +10105,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10151,7 +10151,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-rpc-types-engine",
  "brotli",
@@ -10222,7 +10222,7 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10252,7 +10252,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10315,7 +10315,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10349,7 +10349,7 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10365,7 +10365,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "assert_matches",
@@ -10388,7 +10388,7 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10406,7 +10406,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10433,7 +10433,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10449,7 +10449,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10479,7 +10479,7 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-rpc-provider"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10508,7 +10508,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10528,7 +10528,7 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10544,7 +10544,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10553,7 +10553,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "clap",
  "eyre",
@@ -10572,7 +10572,7 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10590,7 +10590,7 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10641,7 +10641,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10673,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10706,7 +10706,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10733,7 +10733,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10760,7 +10760,7 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.5.1"
+version = "2.5.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"

--- a/docs/vocs/vocs.config.ts
+++ b/docs/vocs/vocs.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     { text: 'Rustdocs', link: '/docs' },
     { text: 'GitHub', link: 'https://github.com/paradigmxyz/reth' },
     {
-      text: 'v2.5.1',
+      text: 'v2.5.2',
       items: [
         {
           text: 'Releases',


### PR DESCRIPTION
Bumps the workspace crates and docs release selector from 2.5.1 to 2.5.2.

Prompted by: @emmajam