### PR TITLE
fix(engine): include prewarm accesses in cache metrics

### DIFF
--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -136,10 +136,12 @@ impl<S> CachedStateProvider<S> {
     }
 
     /// Creates a cache-filling [`CachedStateProvider`].
-    ///
-    /// Doesn't accept metrics because prewarming path does not need to report hit/misses.
-    pub const fn new_prewarm(state_provider: S, caches: ExecutionCache) -> Self {
-        Self::new_with_mode(state_provider, caches, CacheFillMode::FillOnMiss, None, None)
+    pub const fn new_prewarm(
+        state_provider: S,
+        caches: ExecutionCache,
+        metrics: Option<CachedStateMetrics>,
+    ) -> Self {
+        Self::new_with_mode(state_provider, caches, CacheFillMode::FillOnMiss, metrics, None)
     }
 
     /// Creates a [`CachedStateProvider`] with explicit cache fill behavior and optional
@@ -1467,6 +1469,31 @@ mod tests {
         let res = state_provider.storage(address, storage_key);
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), Some(storage_value));
+    }
+
+    #[test]
+    fn test_prewarm_cache_metrics_include_fill_miss() {
+        let address = Address::random();
+        let storage_key = StorageKey::random();
+        let storage_value = U256::from(1);
+        let account =
+            ExtendedAccount::new(0, U256::ZERO).extend_storage(vec![(storage_key, storage_value)]);
+
+        let provider = MockEthProvider::default();
+        provider.extend_accounts(vec![(address, account)]);
+
+        let state_provider = CachedStateProvider::new_prewarm(
+            provider,
+            ExecutionCache::new(1000),
+            Some(CachedStateMetrics::zeroed(CachedStateMetricsSource::Test)),
+        );
+
+        assert_eq!(state_provider.storage(address, storage_key).unwrap(), Some(storage_value));
+        assert_eq!(state_provider.storage(address, storage_key).unwrap(), Some(storage_value));
+        assert_eq!(
+            state_provider.execution_metric_counts.take(),
+            CacheMetricSnapshot { storage_hits: 1, storage_misses: 1, ..Default::default() }
+        );
     }
 
     #[test]

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -1,7 +1,9 @@
 //! BAL read-set prewarming pool.
 
 use alloy_primitives::{Address, StorageKey};
-use reth_execution_cache::{CachedStateProvider, ExecutionCache, TxPoolPrewarmCacheSnapshot};
+use reth_execution_cache::{
+    CachedStateMetrics, CachedStateProvider, ExecutionCache, TxPoolPrewarmCacheSnapshot,
+};
 use reth_provider::{
     AccountReader, BytecodeReader, ProviderResult, StateProvider, StateProviderBox,
 };
@@ -33,6 +35,7 @@ enum PrewarmMsg {
         build: Arc<BuildProviderFn>,
         caches: ExecutionCache,
         txpool_snapshot: Option<TxPoolPrewarmCacheSnapshot>,
+        cache_metrics: Option<Arc<CachedStateMetrics>>,
     },
     /// Warm one target into the held provider's cache. Ignored if no provider is held.
     Warm(PrewarmTarget),
@@ -77,12 +80,15 @@ impl BalPrewarmPool {
         build: Arc<BuildProviderFn>,
         caches: ExecutionCache,
         txpool_snapshot: Option<TxPoolPrewarmCacheSnapshot>,
+        cache_metrics: Option<CachedStateMetrics>,
     ) {
+        let cache_metrics = cache_metrics.map(Arc::new);
         for worker in &self.workers {
             let _ = worker.send(PrewarmMsg::BeginBlock {
                 build: build.clone(),
                 caches: caches.clone(),
                 txpool_snapshot: txpool_snapshot.clone(),
+                cache_metrics: cache_metrics.clone(),
             });
         }
     }
@@ -149,11 +155,15 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // Blocks when idle; the channel disconnects (and the loop ends) when the pool is dropped.
     while let Ok(msg) = rx.recv() {
         match msg {
-            PrewarmMsg::BeginBlock { build, caches, txpool_snapshot } => {
+            PrewarmMsg::BeginBlock { build, caches, txpool_snapshot, cache_metrics } => {
                 provider = match (build)() {
                     Ok(inner) => Some(
-                        CachedStateProvider::new_prewarm(inner, caches)
-                            .with_txpool_snapshot(txpool_snapshot),
+                        CachedStateProvider::new_prewarm(
+                            inner,
+                            caches,
+                            cache_metrics.as_deref().cloned(),
+                        )
+                        .with_txpool_snapshot(txpool_snapshot),
                     ),
                     Err(err) => {
                         trace!(target: "engine::tree::bal_prewarm_pool", %err, "failed to build provider");

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -428,7 +428,12 @@ where
                     .map(|provider| Box::new(provider) as _)
             });
 
-            pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
+            pool.begin_block(
+                build,
+                caches,
+                ctx.env.txpool_snapshot.clone(),
+                ctx.cache_metrics.clone(),
+            );
             for account in prefetch_bal.as_bal() {
                 pool.warm_account(account.address);
                 for change in &account.storage_changes {
@@ -609,8 +614,12 @@ where
         if let Some(saved_cache) = &self.saved_cache {
             let caches = saved_cache.cache().clone();
             state_provider = Box::new(
-                CachedStateProvider::new_prewarm(state_provider, caches)
-                    .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
+                CachedStateProvider::new_prewarm(
+                    state_provider,
+                    caches,
+                    self.cache_metrics.clone(),
+                )
+                .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
             );
         }
 
@@ -729,8 +738,12 @@ where
                         (false, Some(saved)) => {
                             let caches = saved.cache().clone();
                             Box::new(
-                                CachedStateProvider::new_prewarm(inner, caches)
-                                    .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
+                                CachedStateProvider::new_prewarm(
+                                    inner,
+                                    caches,
+                                    self.cache_metrics.clone(),
+                                )
+                                .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
                             )
                         }
                         _ => Box::new(inner),


### PR DESCRIPTION
Counts execution-cache hits and misses from transaction and BAL prewarming in the existing source-labelled metrics. This prevents cache-filling reads from being omitted while later warmed reads are counted as hits.

Prompted by: @onbjerg