### PR TITLE
perf(net): defer decoding of eth responses until correlated with a request

### DIFF
--- a/crates/net/eth-wire-types/src/lib.rs
+++ b/crates/net/eth-wire-types/src/lib.rs
@@ -18,7 +18,7 @@ pub mod version;
 pub use version::{EthVersion, ProtocolVersion};
 
 pub mod message;
-pub use message::{EthMessage, EthMessageID, ProtocolMessage};
+pub use message::{EthMessage, EthMessageID, ProtocolMessage, RawResponse};
 
 pub mod header;
 pub use header::*;

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -915,6 +915,7 @@ where
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RawResponse {
     /// The id of the response message.
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_response_id"))]
     message_id: EthMessageID,
     /// The RLP encoded `[request-id, payload...]` list.
     payload: Bytes,
@@ -924,9 +925,9 @@ impl RawResponse {
     /// Creates a new raw response from the message id and the RLP encoded
     /// `[request-id, payload...]` list that follows the id on the wire.
     ///
-    /// The caller must ensure that `message_id` [is a response](EthMessageID::is_response).
-    pub const fn new(message_id: EthMessageID, payload: Bytes) -> Self {
-        Self { message_id, payload }
+    /// Returns `None` if `message_id` is not the id of a [response](EthMessageID::is_response).
+    pub fn new(message_id: EthMessageID, payload: Bytes) -> Option<Self> {
+        message_id.is_response().then_some(Self { message_id, payload })
     }
 
     /// Returns the id of the response message.
@@ -941,13 +942,12 @@ impl RawResponse {
 
     /// Decodes the request id, the first element of the response list, without decoding the rest
     /// of the payload.
+    ///
+    /// The id is read from within the list's declared payload, so an id that merely follows an
+    /// under-declared list is rejected instead of being taken at face value.
     pub fn request_id(&self) -> alloy_rlp::Result<u64> {
-        let buf = &mut self.payload.as_ref();
-        let header = Header::decode(buf)?;
-        if !header.list {
-            return Err(alloy_rlp::Error::UnexpectedString)
-        }
-        u64::decode(buf)
+        let mut list = Header::decode_bytes(&mut self.payload.as_ref(), true)?;
+        u64::decode(&mut list)
     }
 
     /// Decodes the response into its typed [`EthMessage`] variant according to the given
@@ -986,6 +986,19 @@ impl Debug for RawResponse {
             .field("payload_len", &self.payload.len())
             .finish()
     }
+}
+
+/// Deserializes the id of a [`RawResponse`], upholding that it is a response id.
+#[cfg(feature = "serde")]
+fn deserialize_response_id<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<EthMessageID, D::Error> {
+    use serde::Deserialize;
+    let message_id = EthMessageID::deserialize(deserializer)?;
+    if !message_id.is_response() {
+        return Err(serde::de::Error::custom("not a response message id"))
+    }
+    Ok(message_id)
 }
 
 #[cfg(test)]
@@ -1284,23 +1297,38 @@ mod tests {
         let encoded = encode(ProtocolMessage::from(msg.clone()));
 
         // the raw response is the encoded message without the leading message id
-        let raw = RawResponse::new(EthMessageID::BlockBodies, encoded[1..].to_vec().into());
+        let raw =
+            RawResponse::new(EthMessageID::BlockBodies, encoded[1..].to_vec().into()).unwrap();
         assert_eq!(raw.request_id().unwrap(), 1337);
         assert_eq!(raw.decode::<EthNetworkPrimitives>(EthVersion::Eth68).unwrap(), msg);
     }
 
     #[test]
     fn raw_response_request_id_rejects_malformed_payload() {
+        let raw = |payload: &[u8]| {
+            RawResponse::new(EthMessageID::BlockBodies, payload.to_vec().into()).unwrap()
+        };
+
         // a string instead of the `[request-id, payload]` list
-        let raw = RawResponse::new(EthMessageID::BlockBodies, hex!("820539").into());
-        assert!(matches!(raw.request_id(), Err(Error::UnexpectedString)));
+        assert!(matches!(raw(&hex!("820539")).request_id(), Err(Error::UnexpectedString)));
 
         // an empty list without a request id
-        let raw = RawResponse::new(EthMessageID::BlockBodies, hex!("c0").into());
-        assert!(matches!(raw.request_id(), Err(Error::InputTooShort)));
+        assert!(matches!(raw(&hex!("c0")).request_id(), Err(Error::InputTooShort)));
 
         // a list header that claims more bytes than the payload holds
-        let raw = RawResponse::new(EthMessageID::BlockBodies, hex!("c5820539").into());
-        assert!(matches!(raw.request_id(), Err(Error::InputTooShort)));
+        assert!(matches!(raw(&hex!("c5820539")).request_id(), Err(Error::InputTooShort)));
+
+        // an under-declared list: the id only follows the empty list instead of being in it
+        assert!(matches!(raw(&hex!("c005")).request_id(), Err(Error::InputTooShort)));
+
+        // bytes after the list are ignored, same as the full decoder does
+        assert_eq!(raw(&hex!("c105ff")).request_id().unwrap(), 5);
+    }
+
+    #[test]
+    fn raw_response_requires_response_id() {
+        assert!(RawResponse::new(EthMessageID::GetBlockBodies, hex!("c0").into()).is_none());
+        assert!(RawResponse::new(EthMessageID::Status, hex!("c0").into()).is_none());
+        assert!(RawResponse::new(EthMessageID::BlockBodies, hex!("c0").into()).is_some());
     }
 }

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -111,6 +111,24 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
         tx_memory_budget: usize,
     ) -> Result<Self, MessageError> {
         let message_type = EthMessageID::decode(buf)?;
+        let message = Self::decode_payload(version, message_type, buf, tx_memory_budget)?;
+        Ok(Self { message_type, message })
+    }
+
+    /// Decodes the payload of the message with the given id, that is the bytes following the
+    /// message id on the wire, according to the given [`EthVersion`].
+    ///
+    /// Returns [`MessageError::Invalid`] if the message id is not part of `version`. See
+    /// [`Self::decode_message_with_tx_memory_budget`] for `tx_memory_budget`.
+    pub fn decode_payload(
+        version: EthVersion,
+        message_type: EthMessageID,
+        buf: &mut &[u8],
+        tx_memory_budget: usize,
+    ) -> Result<EthMessage<N>, MessageError> {
+        if !message_type.is_valid_for_version(version) {
+            return Err(MessageError::Invalid(version, message_type))
+        }
 
         // For EIP-7642 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7642.md):
         // pre-merge (legacy) status messages include total difficulty, whereas eth/69 omits it.
@@ -156,18 +174,8 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                     PooledTransactions::decode_with_memory_budget(buf, tx_memory_budget)
                 })?)
             }
-            EthMessageID::GetNodeData => {
-                if version >= EthVersion::Eth67 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetNodeData))
-                }
-                EthMessage::GetNodeData(RequestPair::decode(buf)?)
-            }
-            EthMessageID::NodeData => {
-                if version >= EthVersion::Eth67 {
-                    return Err(MessageError::Invalid(version, EthMessageID::NodeData))
-                }
-                EthMessage::NodeData(RequestPair::decode(buf)?)
-            }
+            EthMessageID::GetNodeData => EthMessage::GetNodeData(RequestPair::decode(buf)?),
+            EthMessageID::NodeData => EthMessage::NodeData(RequestPair::decode(buf)?),
             EthMessageID::GetReceipts => {
                 if version >= EthVersion::Eth70 {
                     EthMessage::GetReceipts70(RequestPair::decode(buf)?)
@@ -194,35 +202,16 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 }
             }
             EthMessageID::BlockRangeUpdate => {
-                if version < EthVersion::Eth69 {
-                    return Err(MessageError::Invalid(version, EthMessageID::BlockRangeUpdate))
-                }
                 EthMessage::BlockRangeUpdate(BlockRangeUpdate::decode(buf)?)
             }
             EthMessageID::GetBlockAccessLists => {
-                if version < EthVersion::Eth71 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetBlockAccessLists))
-                }
                 EthMessage::GetBlockAccessLists(RequestPair::decode(buf)?)
             }
             EthMessageID::BlockAccessLists => {
-                if version < EthVersion::Eth71 {
-                    return Err(MessageError::Invalid(version, EthMessageID::BlockAccessLists))
-                }
                 EthMessage::BlockAccessLists(RequestPair::decode(buf)?)
             }
-            EthMessageID::Cells => {
-                if version < EthVersion::Eth72 {
-                    return Err(MessageError::Invalid(version, EthMessageID::Cells))
-                }
-                EthMessage::Cells(RequestPair::decode(buf)?)
-            }
-            EthMessageID::GetCells => {
-                if version < EthVersion::Eth72 {
-                    return Err(MessageError::Invalid(version, EthMessageID::GetCells))
-                }
-                EthMessage::GetCells(RequestPair::decode(buf)?)
-            }
+            EthMessageID::Cells => EthMessage::Cells(RequestPair::decode(buf)?),
+            EthMessageID::GetCells => EthMessage::GetCells(RequestPair::decode(buf)?),
             EthMessageID::Other(_) => {
                 let raw_payload = Bytes::copy_from_slice(buf);
                 buf.advance(raw_payload.len());
@@ -232,7 +221,7 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 ))
             }
         };
-        Ok(Self { message_type, message })
+        Ok(message)
     }
 }
 
@@ -406,6 +395,10 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
         serde(bound = "N::BroadcastedTransaction: serde::Serialize + serde::de::DeserializeOwned")
     )]
     BlockRangeUpdate(BlockRangeUpdate),
+    /// Represents a response message whose payload is still RLP encoded.
+    ///
+    /// Only produced by streams that defer response decoding, see [`RawResponse`].
+    RawResponse(RawResponse),
     /// Represents an encoded message that doesn't match any other variant
     Other(RawCapabilityMessage),
 }
@@ -436,39 +429,19 @@ impl<N: NetworkPrimitives> EthMessage<N> {
             Self::BlockAccessLists(_) => EthMessageID::BlockAccessLists,
             Self::Cells(_) => EthMessageID::Cells,
             Self::GetCells(_) => EthMessageID::GetCells,
+            Self::RawResponse(resp) => resp.message_id(),
             Self::Other(msg) => EthMessageID::Other(msg.id as u8),
         }
     }
 
     /// Returns true if the message variant is a request.
     pub const fn is_request(&self) -> bool {
-        matches!(
-            self,
-            Self::GetBlockBodies(_) |
-                Self::GetBlockHeaders(_) |
-                Self::GetReceipts(_) |
-                Self::GetReceipts70(_) |
-                Self::GetBlockAccessLists(_) |
-                Self::GetCells(_) |
-                Self::GetPooledTransactions(_) |
-                Self::GetNodeData(_)
-        )
+        self.message_id().is_request()
     }
 
     /// Returns true if the message variant is a response to a request.
     pub const fn is_response(&self) -> bool {
-        matches!(
-            self,
-            Self::PooledTransactions(_) |
-                Self::Receipts(_) |
-                Self::Receipts69(_) |
-                Self::Receipts70(_) |
-                Self::BlockAccessLists(_) |
-                Self::BlockHeaders(_) |
-                Self::BlockBodies(_) |
-                Self::NodeData(_) |
-                Self::Cells(_)
-        )
+        self.message_id().is_response()
     }
 
     /// Converts the message types where applicable.
@@ -528,6 +501,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::BlockAccessLists(block_access_lists) => block_access_lists.encode(out),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.encode(out),
             Self::Cells(cells) => cells.encode(out),
+            Self::RawResponse(resp) => out.put_slice(resp.payload()),
             Self::Other(unknown) => out.put_slice(&unknown.payload),
         }
     }
@@ -558,6 +532,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::BlockAccessLists(block_access_lists) => block_access_lists.length(),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.length(),
             Self::Cells(cells) => cells.length(),
+            Self::RawResponse(resp) => resp.payload().len(),
             Self::Other(unknown) => unknown.length(),
         }
     }
@@ -726,6 +701,48 @@ impl EthMessageID {
     pub const fn message_count(version: EthVersion) -> u8 {
         Self::max(version) + 1
     }
+
+    /// Returns `true` if this is the id of a request message.
+    pub const fn is_request(&self) -> bool {
+        matches!(
+            self,
+            Self::GetBlockHeaders |
+                Self::GetBlockBodies |
+                Self::GetPooledTransactions |
+                Self::GetNodeData |
+                Self::GetReceipts |
+                Self::GetBlockAccessLists |
+                Self::GetCells
+        )
+    }
+
+    /// Returns `true` if this is the id of a response message.
+    pub const fn is_response(&self) -> bool {
+        matches!(
+            self,
+            Self::BlockHeaders |
+                Self::BlockBodies |
+                Self::PooledTransactions |
+                Self::NodeData |
+                Self::Receipts |
+                Self::BlockAccessLists |
+                Self::Cells
+        )
+    }
+
+    /// Returns `true` if this message id is part of the given protocol version.
+    ///
+    /// `GetNodeData`/`NodeData` were removed in eth/67, `BlockRangeUpdate` was added in eth/69,
+    /// the block access list messages in eth/71 and the cell messages in eth/72.
+    pub fn is_valid_for_version(&self, version: EthVersion) -> bool {
+        match self {
+            Self::GetNodeData | Self::NodeData => version < EthVersion::Eth67,
+            Self::BlockRangeUpdate => version >= EthVersion::Eth69,
+            Self::GetBlockAccessLists | Self::BlockAccessLists => version >= EthVersion::Eth71,
+            Self::GetCells | Self::Cells => version >= EthVersion::Eth72,
+            _ => true,
+        }
+    }
 }
 
 impl Encodable for EthMessageID {
@@ -887,13 +904,97 @@ where
     }
 }
 
+/// A response message read from the wire whose payload is still RLP encoded.
+///
+/// Decoding a response is only worth it if it answers a request that is actually pending, so this
+/// keeps the payload encoded and only exposes the [message id](Self::message_id) and the
+/// [request id](Self::request_id), which is decoded on demand without touching the rest of the
+/// payload. The full payload is decoded with [`Self::decode`] once the response is known to be
+/// wanted.
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RawResponse {
+    /// The id of the response message.
+    message_id: EthMessageID,
+    /// The RLP encoded `[request-id, payload...]` list.
+    payload: Bytes,
+}
+
+impl RawResponse {
+    /// Creates a new raw response from the message id and the RLP encoded
+    /// `[request-id, payload...]` list that follows the id on the wire.
+    ///
+    /// The caller must ensure that `message_id` [is a response](EthMessageID::is_response).
+    pub const fn new(message_id: EthMessageID, payload: Bytes) -> Self {
+        Self { message_id, payload }
+    }
+
+    /// Returns the id of the response message.
+    pub const fn message_id(&self) -> EthMessageID {
+        self.message_id
+    }
+
+    /// Returns the RLP encoded `[request-id, payload...]` list.
+    pub const fn payload(&self) -> &Bytes {
+        &self.payload
+    }
+
+    /// Decodes the request id, the first element of the response list, without decoding the rest
+    /// of the payload.
+    pub fn request_id(&self) -> alloy_rlp::Result<u64> {
+        let buf = &mut self.payload.as_ref();
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString)
+        }
+        u64::decode(buf)
+    }
+
+    /// Decodes the response into its typed [`EthMessage`] variant according to the given
+    /// [`EthVersion`].
+    ///
+    /// See also [`ProtocolMessage::decode_message`].
+    pub fn decode<N: NetworkPrimitives>(
+        &self,
+        version: EthVersion,
+    ) -> Result<EthMessage<N>, MessageError> {
+        self.decode_with_tx_memory_budget(version, usize::MAX)
+    }
+
+    /// Like [`Self::decode`], but caps the cumulative in-memory size of decoded transactions in
+    /// `PooledTransactions` responses, see
+    /// [`ProtocolMessage::decode_message_with_tx_memory_budget`].
+    pub fn decode_with_tx_memory_budget<N: NetworkPrimitives>(
+        &self,
+        version: EthVersion,
+        tx_memory_budget: usize,
+    ) -> Result<EthMessage<N>, MessageError> {
+        ProtocolMessage::<N>::decode_payload(
+            version,
+            self.message_id,
+            &mut self.payload.as_ref(),
+            tx_memory_budget,
+        )
+    }
+}
+
+impl Debug for RawResponse {
+    /// Prints the payload length instead of the payload, which can be several MB.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RawResponse")
+            .field("message_id", &self.message_id)
+            .field("payload_len", &self.payload.len())
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::MessageError;
     use crate::{
         message::RequestPair, BlockAccessLists, EthMessage, EthMessageID, EthNetworkPrimitives,
         EthVersion, GetBlockAccessLists, GetNodeData, NodeData, ProtocolMessage,
-        RawCapabilityMessage,
+        RawCapabilityMessage, RawResponse,
     };
     use alloy_primitives::hex;
     use alloy_rlp::{Decodable, Encodable, Error};
@@ -1167,5 +1268,39 @@ mod tests {
             result,
             Err(MessageError::ExpectedStatusMessage(EthMessageID::GetBlockBodies))
         ));
+    }
+
+    #[test]
+    fn raw_response_request_id_and_decode() {
+        let msg = EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
+            request_id: 1337,
+            message: vec![BlockBody {
+                transactions: vec![],
+                ommers: vec![],
+                withdrawals: Some(Default::default()),
+            }]
+            .into(),
+        });
+        let encoded = encode(ProtocolMessage::from(msg.clone()));
+
+        // the raw response is the encoded message without the leading message id
+        let raw = RawResponse::new(EthMessageID::BlockBodies, encoded[1..].to_vec().into());
+        assert_eq!(raw.request_id().unwrap(), 1337);
+        assert_eq!(raw.decode::<EthNetworkPrimitives>(EthVersion::Eth68).unwrap(), msg);
+    }
+
+    #[test]
+    fn raw_response_request_id_rejects_malformed_payload() {
+        // a string instead of the `[request-id, payload]` list
+        let raw = RawResponse::new(EthMessageID::BlockBodies, hex!("820539").into());
+        assert!(matches!(raw.request_id(), Err(Error::UnexpectedString)));
+
+        // an empty list without a request id
+        let raw = RawResponse::new(EthMessageID::BlockBodies, hex!("c0").into());
+        assert!(matches!(raw.request_id(), Err(Error::InputTooShort)));
+
+        // a list header that claims more bytes than the payload holds
+        let raw = RawResponse::new(EthMessageID::BlockBodies, hex!("c5820539").into());
+        assert!(matches!(raw.request_id(), Err(Error::InputTooShort)));
     }
 }

--- a/crates/net/eth-wire/src/eth_snap.rs
+++ b/crates/net/eth-wire/src/eth_snap.rs
@@ -17,7 +17,7 @@ use alloy_primitives::bytes::{Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use reth_eth_wire_types::{
     snap::{SnapProtocolMessage, SnapVersion},
-    RawCapabilityMessage,
+    RawCapabilityMessage, RawResponse,
 };
 use reth_ethereum_forks::ForkFilter;
 use std::{
@@ -85,6 +85,23 @@ impl<St, N: NetworkPrimitives> EthSnapStream<St, N> {
     #[inline]
     pub const fn set_reject_block_announcements(&mut self, reject: bool) {
         self.eth.set_reject_block_announcements(reject);
+    }
+
+    /// Sets whether to defer decoding of `eth` response messages, see
+    /// [`EthStreamInner::set_lazy_responses`].
+    #[inline]
+    pub const fn set_lazy_responses(&mut self, lazy: bool) {
+        self.eth.set_lazy_responses(lazy);
+    }
+
+    /// Decodes an `eth` response yielded as [`EthMessage::RawResponse`], see
+    /// [`EthStreamInner::decode_raw_response`].
+    #[inline]
+    pub fn decode_raw_response(
+        &self,
+        response: &RawResponse,
+    ) -> Result<EthMessage<N>, EthStreamError> {
+        self.eth.decode_raw_response(response)
     }
 
     /// Returns a reference to the underlying [`P2PStream`].

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -7,7 +7,10 @@
 use crate::{
     errors::{EthHandshakeError, EthStreamError},
     handshake::EthereumEthHandshake,
-    message::{EthBroadcastMessage, MAX_MESSAGE_SIZE, TX_MEMORY_BUDGET_MULTIPLIER},
+    message::{
+        EthBroadcastMessage, MessageError, RawResponse, MAX_MESSAGE_SIZE,
+        TX_MEMORY_BUDGET_MULTIPLIER,
+    },
     p2pstream::HANDSHAKE_TIMEOUT,
     CanDisconnect, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage,
     UnifiedStatus,
@@ -110,6 +113,9 @@ pub struct EthStreamInner<N> {
     /// When true, `NewBlock` (0x07) and `NewBlockHashes` (0x01) messages are rejected before RLP
     /// decoding to avoid any memory impact for non-PoW networks.
     reject_block_announcements: bool,
+    /// When true, response messages are yielded as [`EthMessage::RawResponse`] with their payload
+    /// still encoded, so the consumer can correlate the request id before decoding the payload.
+    lazy_responses: bool,
     _pd: std::marker::PhantomData<N>,
 }
 
@@ -128,6 +134,7 @@ where
             version,
             max_message_size,
             reject_block_announcements: false,
+            lazy_responses: false,
             _pd: std::marker::PhantomData,
         }
     }
@@ -144,8 +151,19 @@ where
         self.reject_block_announcements = reject;
     }
 
+    /// Sets whether to defer decoding of response messages.
+    ///
+    /// When enabled, responses (`BlockHeaders`, `BlockBodies`, `PooledTransactions`, `Receipts`,
+    /// ...) are yielded as [`EthMessage::RawResponse`] instead of their typed variants. The
+    /// consumer is expected to correlate the [request id](RawResponse::request_id) with its
+    /// pending requests first and only decode the payload of responses it actually asked for, via
+    /// [`Self::decode_raw_response`].
+    pub const fn set_lazy_responses(&mut self, lazy: bool) {
+        self.lazy_responses = lazy;
+    }
+
     /// Decodes incoming bytes into an [`EthMessage`].
-    pub fn decode_message(&self, bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
+    pub fn decode_message(&self, mut bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
         if bytes.len() > self.max_message_size {
             return Err(EthStreamError::MessageTooBig(bytes.len()));
         }
@@ -157,6 +175,18 @@ where
             return Err(EthStreamError::UnsupportedMessage { message_id: id });
         }
 
+        if self.lazy_responses &&
+            let Some(&id) = bytes.first() &&
+            let Ok(message_id) = EthMessageID::try_from(id as usize) &&
+            message_id.is_response()
+        {
+            if !message_id.is_valid_for_version(self.version) {
+                return Err(MessageError::Invalid(self.version, message_id).into());
+            }
+            let payload = bytes.split_off(1).freeze();
+            return Ok(EthMessage::RawResponse(RawResponse::new(message_id, payload.into())));
+        }
+
         let msg = match ProtocolMessage::decode_message_with_tx_memory_budget(
             self.version,
             &mut bytes.as_ref(),
@@ -164,14 +194,9 @@ where
         ) {
             Ok(m) => m,
             Err(err) => {
-                let msg = if bytes.len() > 50 {
-                    format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..])
-                } else {
-                    format!("{bytes:02x?}")
-                };
                 debug!(
                     version=?self.version,
-                    %msg,
+                    msg=%hex_snippet(&bytes),
                     "failed to decode protocol message"
                 );
                 return Err(EthStreamError::InvalidMessage(err));
@@ -183,6 +208,28 @@ where
         }
 
         Ok(msg.message)
+    }
+
+    /// Decodes a response yielded as [`EthMessage::RawResponse`] into its typed variant, applying
+    /// the same limits as [`Self::decode_message`].
+    pub fn decode_raw_response(
+        &self,
+        response: &RawResponse,
+    ) -> Result<EthMessage<N>, EthStreamError> {
+        response
+            .decode_with_tx_memory_budget(
+                self.version,
+                self.max_message_size * TX_MEMORY_BUDGET_MULTIPLIER,
+            )
+            .map_err(|err| {
+                debug!(
+                    version=?self.version,
+                    message_id=?response.message_id(),
+                    msg=%hex_snippet(response.payload()),
+                    "failed to decode response payload"
+                );
+                EthStreamError::InvalidMessage(err)
+            })
     }
 
     /// Encodes an [`EthMessage`] to bytes.
@@ -236,6 +283,21 @@ impl<S, N: NetworkPrimitives> EthStream<S, N> {
     /// RLP decoding.
     pub const fn set_reject_block_announcements(&mut self, reject: bool) {
         self.eth.set_reject_block_announcements(reject);
+    }
+
+    /// Sets whether to defer decoding of response messages, see
+    /// [`EthStreamInner::set_lazy_responses`].
+    pub const fn set_lazy_responses(&mut self, lazy: bool) {
+        self.eth.set_lazy_responses(lazy);
+    }
+
+    /// Decodes a response yielded as [`EthMessage::RawResponse`], see
+    /// [`EthStreamInner::decode_raw_response`].
+    pub fn decode_raw_response(
+        &self,
+        response: &RawResponse,
+    ) -> Result<EthMessage<N>, EthStreamError> {
+        self.eth.decode_raw_response(response)
     }
 
     /// Returns the underlying stream.
@@ -353,6 +415,15 @@ where
     }
 }
 
+/// Formats the start and end of a message for logging, without dumping the whole message.
+fn hex_snippet(bytes: &[u8]) -> String {
+    if bytes.len() > 50 {
+        format!("{:02x?}...{:x?}", &bytes[..10], &bytes[bytes.len() - 10..])
+    } else {
+        format!("{bytes:02x?}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::UnauthedEthStream;
@@ -361,9 +432,10 @@ mod tests {
         errors::{EthHandshakeError, EthStreamError},
         ethstream::RawCapabilityMessage,
         hello::DEFAULT_TCP_PORT,
+        message::RequestPair,
         p2pstream::UnauthedP2PStream,
-        EthMessage, EthStream, EthVersion, HelloMessageWithProtocols, PassthroughCodec,
-        ProtocolVersion, Status, StatusMessage,
+        EthMessage, EthMessageID, EthStream, EthVersion, HelloMessageWithProtocols,
+        PassthroughCodec, ProtocolVersion, Status, StatusMessage,
     };
     use alloy_chains::NamedChain;
     use alloy_primitives::{bytes::Bytes, B256, U256};
@@ -826,6 +898,47 @@ mod tests {
             vec![BlockHashNumber { hash: B256::random(), number: 5 }].into(),
         );
         client_stream.send(test_msg).await.unwrap();
+
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn lazy_responses_defer_decoding() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
+        let response = EthMessage::<EthNetworkPrimitives>::BlockBodies(RequestPair {
+            request_id: 42,
+            message: Default::default(),
+        });
+        let broadcast = EthMessage::<EthNetworkPrimitives>::NewBlockHashes(
+            vec![BlockHashNumber { hash: B256::random(), number: 5 }].into(),
+        );
+
+        let (expected_response, expected_broadcast) = (response.clone(), broadcast.clone());
+        let handle = tokio::spawn(async move {
+            let (incoming, _) = listener.accept().await.unwrap();
+            let stream = PassthroughCodec::default().framed(incoming);
+            let mut stream = EthStream::<_, EthNetworkPrimitives>::new(EthVersion::Eth68, stream);
+            stream.set_lazy_responses(true);
+
+            // the response arrives with its payload still encoded
+            let EthMessage::RawResponse(raw) = stream.next().await.unwrap().unwrap() else {
+                panic!("expected a raw response")
+            };
+            assert_eq!(raw.message_id(), EthMessageID::BlockBodies);
+            assert_eq!(raw.request_id().unwrap(), 42);
+            assert_eq!(stream.decode_raw_response(&raw).unwrap(), expected_response);
+
+            // everything else is still decoded eagerly
+            assert_eq!(stream.next().await.unwrap().unwrap(), expected_broadcast);
+        });
+
+        let outgoing = TcpStream::connect(local_addr).await.unwrap();
+        let sink = PassthroughCodec::default().framed(outgoing);
+        let mut client_stream = EthStream::new(EthVersion::Eth68, sink);
+        client_stream.send(response).await.unwrap();
+        client_stream.send(broadcast).await.unwrap();
 
         handle.await.unwrap();
     }

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -163,7 +163,7 @@ where
     }
 
     /// Decodes incoming bytes into an [`EthMessage`].
-    pub fn decode_message(&self, mut bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
+    pub fn decode_message(&self, bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
         if bytes.len() > self.max_message_size {
             return Err(EthStreamError::MessageTooBig(bytes.len()));
         }
@@ -175,16 +175,16 @@ where
             return Err(EthStreamError::UnsupportedMessage { message_id: id });
         }
 
+        let bytes = bytes.freeze();
         if self.lazy_responses &&
             let Some(&id) = bytes.first() &&
             let Ok(message_id) = EthMessageID::try_from(id as usize) &&
-            message_id.is_response()
+            let Some(resp) = RawResponse::new(message_id, bytes.slice(1..).into())
         {
             if !message_id.is_valid_for_version(self.version) {
                 return Err(MessageError::Invalid(self.version, message_id).into());
             }
-            let payload = bytes.split_off(1).freeze();
-            return Ok(EthMessage::RawResponse(RawResponse::new(message_id, payload.into())));
+            return Ok(EthMessage::RawResponse(resp));
         }
 
         let msg = match ProtocolMessage::decode_message_with_tx_memory_budget(

--- a/crates/net/network-api/src/events.rs
+++ b/crates/net/network-api/src/events.rs
@@ -2,8 +2,8 @@
 
 use reth_eth_wire_types::{
     message::RequestPair, snap::SnapProtocolMessage, BlockAccessLists, BlockBodies, BlockHeaders,
-    Capabilities, Cells, DisconnectReason, EthMessage, EthNetworkPrimitives, EthVersion,
-    GetBlockAccessLists, GetBlockBodies, GetBlockHeaders, GetCells, GetNodeData,
+    Capabilities, Cells, DisconnectReason, EthMessage, EthMessageID, EthNetworkPrimitives,
+    EthVersion, GetBlockAccessLists, GetBlockBodies, GetBlockHeaders, GetCells, GetNodeData,
     GetPooledTransactions, GetReceipts, GetReceipts70, NetworkPrimitives, NodeData,
     PooledTransactions, Receipts, Receipts69, Receipts70, UnifiedStatus,
 };
@@ -326,6 +326,23 @@ impl<N: NetworkPrimitives> PeerRequest<N> {
             Self::GetBlockAccessLists { .. } => version >= EthVersion::Eth71,
             Self::GetCells { .. } => version >= EthVersion::Eth72,
             _ => true,
+        }
+    }
+
+    /// Returns the [`EthMessageID`] of the `eth` response this request expects, or `None` for
+    /// [`Self::GetSnap`] which is answered with a `snap/2` message.
+    pub const fn response_message_id(&self) -> Option<EthMessageID> {
+        match self {
+            Self::GetBlockHeaders { .. } => Some(EthMessageID::BlockHeaders),
+            Self::GetBlockBodies { .. } => Some(EthMessageID::BlockBodies),
+            Self::GetPooledTransactions { .. } => Some(EthMessageID::PooledTransactions),
+            Self::GetNodeData { .. } => Some(EthMessageID::NodeData),
+            Self::GetReceipts { .. } | Self::GetReceipts69 { .. } | Self::GetReceipts70 { .. } => {
+                Some(EthMessageID::Receipts)
+            }
+            Self::GetBlockAccessLists { .. } => Some(EthMessageID::BlockAccessLists),
+            Self::GetCells { .. } => Some(EthMessageID::Cells),
+            Self::GetSnap { .. } => None,
         }
     }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -2023,7 +2023,7 @@ mod tests {
             .encode(&mut payload);
         request_id.encode(&mut payload);
         payload.extend_from_slice(body);
-        RawResponse::new(message_id, payload.into())
+        RawResponse::new(message_id, payload.into()).unwrap()
     }
 
     /// Not a valid `BlockBodies` payload: decoding it is a protocol breach.
@@ -2105,7 +2105,8 @@ mod tests {
         let (id, _rx) = dispatch_block_bodies_request(&mut session);
 
         // The request id can't be decoded at all.
-        let resp = RawResponse::new(EthMessageID::BlockBodies, UNDECODABLE_BODY.to_vec().into());
+        let resp =
+            RawResponse::new(EthMessageID::BlockBodies, UNDECODABLE_BODY.to_vec().into()).unwrap();
         let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
         assert!(matches!(outcome, OnIncomingMessageOutcome::BadMessage { .. }));
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -34,7 +34,7 @@ use reth_eth_wire::{
 };
 use reth_eth_wire_types::{
     message::RequestPair, snap::SnapProtocolMessage, NewPooledTransactionHashes,
-    RawCapabilityMessage,
+    RawCapabilityMessage, RawResponse,
 };
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_network_api::{PeerRequest, RequestMessage};
@@ -256,6 +256,10 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     /// Handle a message read from the connection.
     ///
     /// Returns an error if the message is considered to be in violation of the protocol.
+    ///
+    /// The connection yields responses as [`EthMessage::RawResponse`], which are correlated with
+    /// their request in [`Self::on_raw_response`] before they are decoded; the typed response
+    /// variants are only reached from there.
     fn on_incoming_message(&mut self, msg: EthMessage<N>) -> OnIncomingMessageOutcome<N> {
         /// A macro that handles an incoming request
         /// This creates a new channel and tries to send the sender half to the session while
@@ -423,7 +427,67 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
             EthMessage::GetCells(resp) => {
                 on_request!(resp, Cells, GetCells)
             }
+            EthMessage::RawResponse(resp) => self.on_raw_response(resp),
             EthMessage::Other(bytes) => self.try_emit_broadcast(PeerMessage::Other(bytes)).into(),
+        }
+    }
+
+    /// Handles a response whose payload is still RLP encoded, see [`EthMessage::RawResponse`].
+    ///
+    /// The response is correlated with its in-flight request first: unsolicited, late (already
+    /// timed out internally) and mismatched responses are settled on the request id alone, so a
+    /// peer can't make the session decode payloads it never asked for. Only a response the session
+    /// is still waiting for is decoded, and then delivered through the typed response handling in
+    /// [`Self::on_incoming_message`].
+    fn on_raw_response(&mut self, resp: RawResponse) -> OnIncomingMessageOutcome<N> {
+        let request_id = match resp.request_id() {
+            Ok(request_id) => request_id,
+            Err(err) => {
+                return OnIncomingMessageOutcome::BadMessage {
+                    error: EthStreamError::InvalidMessage(err.into()),
+                    message: EthMessage::RawResponse(resp),
+                }
+            }
+        };
+
+        let expected = match self.inflight_requests.get(&request_id).map(|req| &req.request) {
+            Some(RequestState::Waiting(request)) => request.response_message_id(),
+            Some(RequestState::TimedOut) => {
+                // request was already timed out internally, the late response only updates the
+                // timeout estimate
+                if let Some(req) = self.inflight_requests.remove(&request_id) {
+                    self.update_request_timeout(req.timestamp, Instant::now());
+                }
+                return OnIncomingMessageOutcome::Ok
+            }
+            None => {
+                trace!(peer_id=?self.remote_peer_id, ?request_id, "received response to unknown request");
+                // we received a response to a request we never sent
+                self.on_bad_message();
+                return OnIncomingMessageOutcome::Ok
+            }
+        };
+
+        if expected != Some(resp.message_id()) {
+            // The peer replied to a request id we handed out, but with the wrong response type.
+            // This cancels the pending request, so it must cost the peer reputation. Without the
+            // penalty the peer can kill any request we send it, repeatedly and for free.
+            debug!(target: "net::session", ?request_id, msg_id=?resp.message_id(), remote_peer_id=?self.remote_peer_id, "received response of wrong type");
+            self.on_bad_message();
+            if let Some(InflightRequest { request: RequestState::Waiting(request), .. }) =
+                self.inflight_requests.remove(&request_id)
+            {
+                request.send_bad_response();
+            }
+            return OnIncomingMessageOutcome::Ok
+        }
+
+        match self.conn.decode_raw_response(&resp) {
+            Ok(msg) => self.on_incoming_message(msg),
+            Err(error) => OnIncomingMessageOutcome::BadMessage {
+                error,
+                message: EthMessage::RawResponse(resp),
+            },
         }
     }
 
@@ -1322,6 +1386,7 @@ mod tests {
     use crate::session::{handle::PendingSessionEvent, start_pending_incoming_session};
     use alloy_eips::eip2124::ForkFilter;
     use alloy_primitives::B256;
+    use alloy_rlp::Encodable;
     use futures::task::noop_waker;
     use reth_chainspec::MAINNET;
     use reth_ecies::stream::ECIESStream;
@@ -1436,9 +1501,10 @@ mod tests {
                     remote_addr,
                     peer_id,
                     capabilities,
-                    conn,
+                    mut conn,
                     ..
                 } => {
+                    conn.set_lazy_responses(true);
                     let (_to_session_tx, messages_rx) = mpsc::channel(10);
                     let (commands_to_session, commands_rx) = mpsc::channel(10);
                     let (_unbounded_tx, unbounded_rx) = mpsc::unbounded_channel();
@@ -1934,6 +2000,119 @@ mod tests {
         assert!(futures::FutureExt::now_or_never(builder.active_session_rx.next())
             .flatten()
             .is_none());
+    }
+
+    /// Returns an established session whose remote side just idles.
+    async fn idle_session(builder: &mut SessionBuilder) -> ActiveSession<EthNetworkPrimitives> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let fut = builder.with_client_stream(local_addr, async move |client_stream| {
+            let _client_stream = client_stream;
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        tokio::task::spawn(fut);
+        let (incoming, _) = listener.accept().await.unwrap();
+        builder.connect_incoming(incoming).await
+    }
+
+    /// Builds a [`RawResponse`] carrying `request_id` followed by `body`, the raw RLP of the
+    /// response payload.
+    fn raw_response(message_id: EthMessageID, request_id: u64, body: &[u8]) -> RawResponse {
+        let mut payload = Vec::new();
+        alloy_rlp::Header { list: true, payload_length: request_id.length() + body.len() }
+            .encode(&mut payload);
+        request_id.encode(&mut payload);
+        payload.extend_from_slice(body);
+        RawResponse::new(message_id, payload.into())
+    }
+
+    /// Not a valid `BlockBodies` payload: decoding it is a protocol breach.
+    const UNDECODABLE_BODY: &[u8] = &[0x01];
+    /// An empty `BlockBodies` payload.
+    const EMPTY_BODIES: &[u8] = &[alloy_rlp::EMPTY_LIST_CODE];
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unsolicited_raw_response_is_penalized_without_decoding() {
+        let mut builder = SessionBuilder::default();
+        let mut session = idle_session(&mut builder).await;
+
+        // Settled on the request id alone, the body is never decoded.
+        let resp = raw_response(EthMessageID::BlockBodies, 999, UNDECODABLE_BODY);
+        let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(matches!(
+            futures::FutureExt::now_or_never(builder.active_session_rx.next()).flatten(),
+            Some(ActiveSessionMessage::BadMessage { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wrong_type_raw_response_is_penalized_without_decoding() {
+        let mut builder = SessionBuilder::default();
+        let mut session = idle_session(&mut builder).await;
+        let (id, rx) = dispatch_block_bodies_request(&mut session);
+
+        let resp = raw_response(EthMessageID::BlockHeaders, id, UNDECODABLE_BODY);
+        let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(!session.inflight_requests.contains_key(&id));
+        assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::BadResponse);
+        assert!(matches!(
+            futures::FutureExt::now_or_never(builder.active_session_rx.next()).flatten(),
+            Some(ActiveSessionMessage::BadMessage { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn late_raw_response_is_consumed_without_decoding() {
+        let mut builder = SessionBuilder::default();
+        let mut session = idle_session(&mut builder).await;
+
+        session.internal_request_timeout.store(1, Ordering::Relaxed);
+        let (id, _rx) = dispatch_block_bodies_request(&mut session);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!session.check_timed_out_requests(Instant::now()));
+
+        let resp = raw_response(EthMessageID::BlockBodies, id, UNDECODABLE_BODY);
+        let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(!session.inflight_requests.contains_key(&id));
+        assert!(futures::FutureExt::now_or_never(builder.active_session_rx.next())
+            .flatten()
+            .is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn expected_raw_response_is_decoded_and_delivered() {
+        let mut builder = SessionBuilder::default();
+        let mut session = idle_session(&mut builder).await;
+        let (id, rx) = dispatch_block_bodies_request(&mut session);
+
+        let resp = raw_response(EthMessageID::BlockBodies, id, EMPTY_BODIES);
+        let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(!session.inflight_requests.contains_key(&id));
+        assert_eq!(rx.await.unwrap().unwrap(), BlockBodies::default());
+        assert!(futures::FutureExt::now_or_never(builder.active_session_rx.next())
+            .flatten()
+            .is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn malformed_raw_response_is_a_protocol_breach() {
+        let mut builder = SessionBuilder::default();
+        let mut session = idle_session(&mut builder).await;
+        let (id, _rx) = dispatch_block_bodies_request(&mut session);
+
+        // The request id can't be decoded at all.
+        let resp = RawResponse::new(EthMessageID::BlockBodies, UNDECODABLE_BODY.to_vec().into());
+        let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::BadMessage { .. }));
+
+        // The response is expected, but its payload doesn't decode.
+        let resp = raw_response(EthMessageID::BlockBodies, id, UNDECODABLE_BODY);
+        let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::BadMessage { .. }));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -10,7 +10,7 @@ use reth_eth_wire::{
     EthMessage, EthNetworkPrimitives, EthSnapMessage, EthSnapStream, EthStream, EthVersion,
     NetworkPrimitives, P2PStream,
 };
-use reth_eth_wire_types::RawCapabilityMessage;
+use reth_eth_wire_types::{RawCapabilityMessage, RawResponse};
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -134,6 +134,28 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
             Self::EthOnly(conn) => conn.set_reject_block_announcements(reject),
             Self::EthSnap(conn) => conn.set_reject_block_announcements(reject),
             Self::Satellite(conn) => conn.primary_mut().set_reject_block_announcements(reject),
+        }
+    }
+
+    /// Sets whether to defer decoding of `eth` response messages, which are then yielded as
+    /// [`EthMessage::RawResponse`] so the request id can be checked before paying for the decode.
+    pub fn set_lazy_responses(&mut self, lazy: bool) {
+        match self {
+            Self::EthOnly(conn) => conn.set_lazy_responses(lazy),
+            Self::EthSnap(conn) => conn.set_lazy_responses(lazy),
+            Self::Satellite(conn) => conn.primary_mut().set_lazy_responses(lazy),
+        }
+    }
+
+    /// Decodes a response yielded as [`EthMessage::RawResponse`] into its typed variant.
+    pub fn decode_raw_response(
+        &self,
+        response: &RawResponse,
+    ) -> Result<EthMessage<N>, EthStreamError> {
+        match self {
+            Self::EthOnly(conn) => conn.decode_raw_response(response),
+            Self::EthSnap(conn) => conn.decode_raw_response(response),
+            Self::Satellite(conn) => conn.primary().decode_raw_response(response),
         }
     }
 }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -597,6 +597,10 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     conn.set_reject_block_announcements(true);
                 }
 
+                // Responses are correlated with their request before their payload is decoded,
+                // see `ActiveSession::on_raw_response`.
+                conn.set_lazy_responses(true);
+
                 let session = ActiveSession {
                     next_id: 0,
                     remote_peer_id: peer_id,


### PR DESCRIPTION
The session decoded every inbound response in full before checking whether it answers a request we actually sent, so a peer could make us RLP-decode up to 10MB of bodies or receipts per message for responses that are discarded anyway: unsolicited ones, replies to requests that already timed out internally, or replies of the wrong type. Geth avoids this since ethereum/go-ethereum#33835 moved its response packets to `rlp.RawList` and checks the request tracker before materializing the items.

`EthStreamInner` gains an opt-in lazy mode in which responses are yielded as `EthMessage::RawResponse`, carrying the message id and the still encoded `[request-id, payload...]` list. The session enables it for its connections and correlates the request id with its in-flight requests first: unknown ids are penalized, late responses only feed the RTT estimate and mismatched types cancel the request, all without decoding the payload. Only an expected response is decoded, and then delivered through the existing typed handling. The public `EthStream` API keeps decoding eagerly by default.

The version gating of message ids moved into `EthMessageID::is_valid_for_version` so the lazy path applies the same rules as the full decoder. `snap/2` responses still decode eagerly; they can get the same treatment separately.
