### PR TITLE
perf: cut node startup latency from ~1.5s to ~0.3s

### DIFF
--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -540,6 +540,13 @@ pub fn build_local_enr(
 }
 
 /// Bootstraps underlying [`discv5::Discv5`] node with configured peers.
+///
+/// Boot nodes given as an ENR are added to the kbuckets right away. Boot nodes given as an enode
+/// need their ENR requested over the wire first, which is driven in the background: an unreachable
+/// boot node only answers after the discv5 request timeout, and waiting for that would stall node
+/// startup.
+///
+/// Stays `async` because spawning those requests requires a tokio runtime context.
 pub async fn bootstrap(
     bootstrap_nodes: HashSet<BootNode>,
     discv5: &Arc<discv5::Discv5>,
@@ -573,7 +580,11 @@ pub async fn bootstrap(
     }
 
     // If a session is established, the ENR is added straight away to discv5 kbuckets
-    Ok(_ = join_all(enr_requests).await)
+    if !enr_requests.is_empty() {
+        task::spawn(join_all(enr_requests));
+    }
+
+    Ok(())
 }
 
 /// Backgrounds regular look up queries, in order to keep kbuckets populated.

--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -25,6 +25,8 @@ pub struct NippyJarChecker<H: NippyJarHeader = ()> {
     pub(crate) data_file: Option<BufWriter<File>>,
     /// File handle to where the offsets are stored.
     pub(crate) offsets_file: Option<BufWriter<File>>,
+    /// Whether a heal changed the jar on disk and therefore needs to be committed.
+    pub(crate) healed: bool,
 }
 
 impl<H: NippyJarHeader> NippyJarChecker<H> {
@@ -34,7 +36,15 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
     /// the data or offsets files. The [`NippyJar`] passed in contains all necessary
     /// configurations for handling data.
     pub const fn new(jar: NippyJar<H>) -> Self {
-        Self { jar, data_file: None, offsets_file: None }
+        Self { jar, data_file: None, offsets_file: None, healed: false }
+    }
+
+    /// Whether the last [`Self::ensure_consistency`] call healed the jar.
+    ///
+    /// A healed jar has pending file truncations and/or a changed row count that the caller must
+    /// commit to disk.
+    pub const fn healed(&self) -> bool {
+        self.healed
     }
 
     /// It will throw an error if the [`NippyJar`] is in an inconsistent state.
@@ -81,6 +91,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 drop(reader);
 
                 self.offsets_file().get_mut().set_len(expected_offsets_file_size)?;
+                self.healed = true;
                 reader = self.jar.open_data_reader()?;
             }
             Ordering::Greater => {
@@ -94,6 +105,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
 
                 // Freeze row count changed
                 self.jar.freeze_config()?;
+                self.healed = true;
             }
             Ordering::Equal => {}
         }
@@ -115,6 +127,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 // Happened during an appending job, so we need to truncate the data, since there's
                 // no way to recover it.
                 self.data_file().get_mut().set_len(last_offset)?;
+                self.healed = true;
             }
             Ordering::Greater => {
                 // Happened during a pruning job, so we need to reverse iterate offsets until we
@@ -134,6 +147,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                         drop(reader);
 
                         self.offsets_file().get_mut().set_len(new_len)?;
+                        self.healed = true;
 
                         // Since we decrease the offset list, we need to check the consistency of
                         // `self.jar.rows` again

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -53,21 +53,21 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
         let (data_file, offsets_file, is_created) =
             Self::create_or_open_files(jar.data_path(), &jar.offsets_path())?;
 
-        let (jar, data_file, offsets_file) = if is_created {
+        let (jar, data_file, offsets_file, healed) = if is_created {
             // Makes sure we don't have dangling data and offset files when we just created the file
             jar.freeze_config()?;
 
-            (jar, BufWriter::new(data_file), BufWriter::new(offsets_file))
+            (jar, BufWriter::new(data_file), BufWriter::new(offsets_file), false)
         } else {
             // If we are opening a previously created jar, we need to check its consistency, and
             // make changes if necessary.
             let mut checker = NippyJarChecker::new(jar);
             checker.ensure_consistency()?;
 
-            let NippyJarChecker { jar, data_file, offsets_file } = checker;
+            let NippyJarChecker { jar, data_file, offsets_file, healed } = checker;
 
             // Calling ensure_consistency, will fill data_file and offsets_file
-            (jar, data_file.expect("qed"), offsets_file.expect("qed"))
+            (jar, data_file.expect("qed"), offsets_file.expect("qed"), healed)
         };
 
         let mut writer = Self {
@@ -81,8 +81,9 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
             dirty: false,
         };
 
-        if !is_created {
-            // Commit any potential heals done above.
+        if healed {
+            // Commit the heals done above. A jar that was already consistent has nothing to write,
+            // and committing it anyway costs four fsyncs per segment on every startup.
             writer.commit()?;
         }
 

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -369,7 +369,12 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             "Ensuring end range consistency"
         );
 
-        self.writer.commit().map_err(ProviderError::other)?;
+        // Only the header prune above dirties the writer here; `NippyJarWriter::new` has already
+        // committed any file level heal. Committing a segment that did not change costs four
+        // fsyncs, once per segment, on every startup.
+        if self.writer.is_dirty() {
+            self.writer.commit().map_err(ProviderError::other)?;
+        }
 
         // Updates the [SnapshotProvider] manager
         self.update_index()?;


### PR DESCRIPTION
Instrumented the launch path from `main()` to the point where the engine service loop is spawned. On a mainnet node with a warm datadir two steps dominated it.

`Discv5::start` awaited an ENR request against every enode boot node. An unreachable boot node only fails after discv5's 1s `request_timeout` and `join_all` waits for the slowest one, so every start paid a flat ~1s. Those requests now run in the background; boot nodes given as an ENR are still added synchronously, and an established session adds the enode's ENR to the kbuckets on its own.

Opening a static file writer committed the jar twice unconditionally: `NippyJarWriter::new` to persist "potential heals" from the consistency checker, and `StaticFileProviderRW::ensure_end_range_consistency` again right after. A commit is two `sync_all` calls plus an atomic config rewrite (file + directory fsync), so `check_consistency` spent 8 fsyncs per segment on every startup even when nothing had changed. The checker now reports whether it actually healed, and the provider only commits when the header prune dirtied the writer.

Measured with temporary instrumentation, mainnet chain, warm datadir, macOS/APFS on Apple Silicon:

| step | before | after |
| --- | ---: | ---: |
| `Discv5::start` -> `bootstrap()` | 1006ms | 0.4ms |
| `check_consistency` (6 segments) | 235ms | 6ms |
| total `main()` -> engine loop spawned | 1568ms | 286ms |

Both totals include a constant ~200ms of `quanta` TSC calibration inside `install_prometheus_recorder`, which is an artifact of this machine rather than something these changes affect. Apple Silicon's `cntvct_el0` ticks at 24MHz (41.67ns), and quanta's calibration only converges once the mean error drops below 10ns, so the loop always runs to its 200ms deadline here. quanta documents 10-20ms on hardware whose counter is fine grained enough to converge, which is the case for an x86_64 TSC. Subtract it from both columns for a server-representative figure; the savings themselves are a network timeout and fsyncs, so they do not depend on the platform.