### PR TITLE
perf(net): defer decoding of snap responses until correlated with a request

### DIFF
--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -942,12 +942,7 @@ impl RawResponse {
     /// Decodes the request id, the first element of the response list, without decoding the rest
     /// of the payload.
     pub fn request_id(&self) -> alloy_rlp::Result<u64> {
-        let buf = &mut self.payload.as_ref();
-        let header = Header::decode(buf)?;
-        if !header.list {
-            return Err(alloy_rlp::Error::UnexpectedString)
-        }
-        u64::decode(buf)
+        decode_request_id(&self.payload)
     }
 
     /// Decodes the response into its typed [`EthMessage`] variant according to the given
@@ -986,6 +981,16 @@ impl Debug for RawResponse {
             .field("payload_len", &self.payload.len())
             .finish()
     }
+}
+
+/// Decodes the request id of an RLP encoded `[request-id, payload...]` list without decoding the
+/// rest of the payload.
+pub(crate) fn decode_request_id(mut payload: &[u8]) -> alloy_rlp::Result<u64> {
+    let header = Header::decode(&mut payload)?;
+    if !header.list {
+        return Err(alloy_rlp::Error::UnexpectedString)
+    }
+    u64::decode(&mut payload)
 }
 
 #[cfg(test)]

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -573,9 +573,9 @@ impl RawSnapResponse {
     /// Creates a new raw response from the message id and the RLP encoded
     /// `[request-id, payload...]` list that follows the id on the wire.
     ///
-    /// The caller must ensure that `message_id` [is a response](SnapMessageId::is_response).
-    pub const fn new(message_id: SnapMessageId, payload: Bytes) -> Self {
-        Self { message_id, payload }
+    /// Returns `None` if `message_id` is not the id of a [response](SnapMessageId::is_response).
+    pub fn new(message_id: SnapMessageId, payload: Bytes) -> Option<Self> {
+        message_id.is_response().then_some(Self { message_id, payload })
     }
 
     /// Returns the id of the response message.
@@ -1066,8 +1066,12 @@ mod tests {
         });
         let encoded = msg.encode();
 
+        // only response ids can be wrapped
+        let payload: Bytes = encoded[1..].to_vec().into();
+        assert!(RawSnapResponse::new(SnapMessageId::GetAccountRange, payload.clone()).is_none());
+
         // the raw response is the encoded message without the leading message id
-        let raw = RawSnapResponse::new(SnapMessageId::AccountRange, encoded[1..].to_vec().into());
+        let raw = RawSnapResponse::new(SnapMessageId::AccountRange, payload).unwrap();
         assert_eq!(raw.request_id().unwrap(), 1337);
         assert_eq!(raw.decode().unwrap(), msg);
 
@@ -1075,7 +1079,8 @@ mod tests {
         let raw = RawSnapResponse::new(
             SnapMessageId::AccountRange,
             [&encoded[1..], &[0x00][..]].concat().into(),
-        );
+        )
+        .unwrap();
         assert!(matches!(
             raw.decode(),
             Err(SnapProtocolError::Rlp(alloy_rlp::Error::UnexpectedLength))

--- a/crates/net/eth-wire-types/src/snap.rs
+++ b/crates/net/eth-wire-types/src/snap.rs
@@ -83,6 +83,30 @@ impl SnapMessageId {
             }
         }
     }
+
+    /// Returns `true` if this is the id of a response message.
+    pub const fn is_response(self) -> bool {
+        matches!(
+            self,
+            Self::AccountRange | Self::StorageRanges | Self::ByteCodes | Self::BlockAccessLists
+        )
+    }
+
+    /// Returns the message id for the given wire value, or `None` if it isn't a known snap
+    /// message id.
+    pub const fn from_u8(id: u8) -> Option<Self> {
+        Some(match id {
+            0x00 => Self::GetAccountRange,
+            0x01 => Self::AccountRange,
+            0x02 => Self::GetStorageRanges,
+            0x03 => Self::StorageRanges,
+            0x04 => Self::GetByteCodes,
+            0x05 => Self::ByteCodes,
+            0x08 => Self::GetBlockAccessLists,
+            0x09 => Self::BlockAccessLists,
+            _ => return None,
+        })
+    }
 }
 
 /// Request for a range of accounts from the state trie.
@@ -514,15 +538,75 @@ impl SnapProtocolMessage {
     /// Empty payload, invalid id, and malformed body are reported as distinct
     /// [`SnapProtocolError`] variants.
     pub fn decode_versioned(version: SnapVersion, bytes: &[u8]) -> Result<Self, SnapProtocolError> {
-        let (&id, mut body) = bytes.split_first().ok_or(SnapProtocolError::Empty)?;
+        let (&id, body) = bytes.split_first().ok_or(SnapProtocolError::Empty)?;
         if !version.supports_message_id(id) {
             return Err(SnapProtocolError::UnsupportedMessageId(id, version));
         }
+        Self::decode_body(id, body)
+    }
+
+    /// Decodes the RLP body of the message with the given id, rejecting trailing bytes.
+    fn decode_body(id: u8, mut body: &[u8]) -> Result<Self, SnapProtocolError> {
         let msg = Self::decode(id, &mut body)?;
         if !body.is_empty() {
             return Err(SnapProtocolError::Rlp(alloy_rlp::Error::UnexpectedLength));
         }
         Ok(msg)
+    }
+}
+
+/// A `snap` response message read from the wire whose payload is still RLP encoded.
+///
+/// The `snap` counterpart of [`RawResponse`](crate::message::RawResponse): only the message id
+/// and the [request id](Self::request_id) are exposed, the latter decoded on demand without
+/// touching the rest of the payload, so a consumer can correlate the response with its request
+/// before paying for [`Self::decode`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct RawSnapResponse {
+    /// The id of the response message.
+    message_id: SnapMessageId,
+    /// The RLP encoded `[request-id, payload...]` list.
+    payload: Bytes,
+}
+
+impl RawSnapResponse {
+    /// Creates a new raw response from the message id and the RLP encoded
+    /// `[request-id, payload...]` list that follows the id on the wire.
+    ///
+    /// The caller must ensure that `message_id` [is a response](SnapMessageId::is_response).
+    pub const fn new(message_id: SnapMessageId, payload: Bytes) -> Self {
+        Self { message_id, payload }
+    }
+
+    /// Returns the id of the response message.
+    pub const fn message_id(&self) -> SnapMessageId {
+        self.message_id
+    }
+
+    /// Returns the RLP encoded `[request-id, payload...]` list.
+    pub const fn payload(&self) -> &Bytes {
+        &self.payload
+    }
+
+    /// Decodes the request id, the first element of the response list, without decoding the rest
+    /// of the payload.
+    pub fn request_id(&self) -> alloy_rlp::Result<u64> {
+        crate::message::decode_request_id(&self.payload)
+    }
+
+    /// Decodes the response into its [`SnapProtocolMessage`] variant.
+    pub fn decode(&self) -> Result<SnapProtocolMessage, SnapProtocolError> {
+        SnapProtocolMessage::decode_body(self.message_id as u8, &self.payload)
+    }
+}
+
+impl core::fmt::Debug for RawSnapResponse {
+    /// Prints the payload length instead of the payload, which can be several MB.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RawSnapResponse")
+            .field("message_id", &self.message_id)
+            .field("payload_len", &self.payload.len())
+            .finish()
     }
 }
 
@@ -947,5 +1031,54 @@ mod tests {
         slot.data = [slot.data.as_ref(), &[0x00]].concat().into();
 
         assert!(slot.value().is_err());
+    }
+
+    #[test]
+    fn snap_message_id_from_u8_roundtrips() {
+        for id in [
+            SnapMessageId::GetAccountRange,
+            SnapMessageId::AccountRange,
+            SnapMessageId::GetStorageRanges,
+            SnapMessageId::StorageRanges,
+            SnapMessageId::GetByteCodes,
+            SnapMessageId::ByteCodes,
+            SnapMessageId::GetBlockAccessLists,
+            SnapMessageId::BlockAccessLists,
+        ] {
+            assert_eq!(SnapMessageId::from_u8(id as u8), Some(id));
+            assert_eq!(id.is_response(), id.response().is_none());
+        }
+        // the trie node messages removed by snap/2 and anything beyond the id space
+        for id in [0x06, 0x07, 0x0a] {
+            assert_eq!(SnapMessageId::from_u8(id), None);
+        }
+    }
+
+    #[test]
+    fn raw_snap_response_request_id_and_decode() {
+        let msg = SnapProtocolMessage::AccountRange(AccountRangeMessage {
+            request_id: 1337,
+            accounts: vec![AccountData {
+                hash: B256::repeat_byte(1),
+                body: Bytes::from_static(&[alloy_rlp::EMPTY_LIST_CODE]),
+            }],
+            proof: vec![Bytes::from_static(&[0x01])],
+        });
+        let encoded = msg.encode();
+
+        // the raw response is the encoded message without the leading message id
+        let raw = RawSnapResponse::new(SnapMessageId::AccountRange, encoded[1..].to_vec().into());
+        assert_eq!(raw.request_id().unwrap(), 1337);
+        assert_eq!(raw.decode().unwrap(), msg);
+
+        // trailing bytes are rejected, same as for eagerly decoded messages
+        let raw = RawSnapResponse::new(
+            SnapMessageId::AccountRange,
+            [&encoded[1..], &[0x00][..]].concat().into(),
+        );
+        assert!(matches!(
+            raw.decode(),
+            Err(SnapProtocolError::Rlp(alloy_rlp::Error::UnexpectedLength))
+        ));
     }
 }

--- a/crates/net/eth-wire/src/eth_snap.rs
+++ b/crates/net/eth-wire/src/eth_snap.rs
@@ -13,10 +13,10 @@ use crate::{
     Capability, EthMessage, EthNetworkPrimitives, EthStreamInner, EthVersion, NetworkPrimitives,
     P2PStream, UnifiedStatus, HANDSHAKE_TIMEOUT,
 };
-use alloy_primitives::bytes::{Bytes, BytesMut};
+use alloy_primitives::bytes::{BufMut, Bytes, BytesMut};
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use reth_eth_wire_types::{
-    snap::{SnapProtocolMessage, SnapVersion},
+    snap::{RawSnapResponse, SnapMessageId, SnapProtocolError, SnapProtocolMessage, SnapVersion},
     RawCapabilityMessage, RawResponse,
 };
 use reth_ethereum_forks::ForkFilter;
@@ -87,8 +87,9 @@ impl<St, N: NetworkPrimitives> EthSnapStream<St, N> {
         self.eth.set_reject_block_announcements(reject);
     }
 
-    /// Sets whether to defer decoding of `eth` response messages, see
-    /// [`EthStreamInner::set_lazy_responses`].
+    /// Sets whether to defer decoding of response messages of both protocols: `eth` responses are
+    /// then yielded as [`EthMessage::RawResponse`] and `snap/2` responses as
+    /// [`EthSnapMessage::RawSnapResponse`], see [`EthStreamInner::set_lazy_responses`].
     #[inline]
     pub const fn set_lazy_responses(&mut self, lazy: bool) {
         self.eth.set_lazy_responses(lazy);
@@ -149,6 +150,11 @@ pub enum EthSnapMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
     Eth(EthMessage<N>),
     /// A `snap/2` (EIP-8189) protocol message.
     Snap(SnapProtocolMessage),
+    /// A `snap/2` response whose payload is still RLP encoded.
+    ///
+    /// Only yielded when response decoding is deferred, see
+    /// [`EthSnapStream::set_lazy_responses`].
+    RawSnapResponse(RawSnapResponse),
 }
 
 impl<St, N> Stream for EthSnapStream<St, N>
@@ -177,6 +183,25 @@ where
             return Poll::Ready(Some(this.eth.decode_message(bytes).map(EthSnapMessage::Eth)))
         };
         bytes[0] = snap_id;
+
+        if this.eth.lazy_responses() &&
+            let Some(message_id) = SnapMessageId::from_u8(snap_id) &&
+            message_id.is_response()
+        {
+            if !SnapVersion::V2.supports_message_id(snap_id) {
+                return Poll::Ready(Some(Err(SnapProtocolError::UnsupportedMessageId(
+                    snap_id,
+                    SnapVersion::V2,
+                )
+                .into())))
+            }
+            let payload = bytes.split_off(1).freeze();
+            return Poll::Ready(Some(Ok(EthSnapMessage::RawSnapResponse(RawSnapResponse::new(
+                message_id,
+                payload.into(),
+            )))))
+        }
+
         Poll::Ready(Some(
             SnapProtocolMessage::decode_versioned(SnapVersion::V2, &bytes)
                 .map(EthSnapMessage::Snap)
@@ -205,6 +230,13 @@ where
                 // rebase the snap-relative id into the combined message space.
                 let mut buf =
                     msg.encode().0.try_into_mut().unwrap_or_else(|b| BytesMut::from(b.as_ref()));
+                mask_snap(&mut buf, this.snap_offset)?;
+                buf.freeze()
+            }
+            EthSnapMessage::RawSnapResponse(resp) => {
+                let mut buf = BytesMut::with_capacity(1 + resp.payload().len());
+                buf.put_u8(resp.message_id() as u8);
+                buf.extend_from_slice(resp.payload());
                 mask_snap(&mut buf, this.snap_offset)?;
                 buf.freeze()
             }
@@ -472,5 +504,84 @@ mod tests {
                 "unexpected error for removed snap id {removed_snap_id:#x}: {error}"
             );
         }
+    }
+
+    /// End-to-end with deferred response decoding on both sides: the request still arrives
+    /// decoded, while the response arrives as a [`RawSnapResponse`] that decodes on demand.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lazy_snap_responses_defer_decoding() {
+        reth_tracing::init_test_tracing();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let (status, fork_filter) = eth_handshake();
+        let server_status = status;
+        let server_fork_filter = fork_filter.clone();
+
+        let server = tokio::spawn(async move {
+            let (incoming, _) = listener.accept().await.unwrap();
+            let stream = crate::PassthroughCodec::default().framed(incoming);
+            let (conn, _) =
+                UnauthedP2PStream::new(stream).handshake(eth_snap_hello()).await.unwrap();
+            let (mut stream, _) = EthSnapStream::<_, EthNetworkPrimitives>::handshake(
+                conn,
+                server_status,
+                server_fork_filter,
+                Arc::new(EthHandshake::default()),
+                MAX_MESSAGE_SIZE,
+            )
+            .await
+            .unwrap();
+            stream.set_lazy_responses(true);
+
+            while let Some(Ok(msg)) = stream.next().await {
+                if let EthSnapMessage::Snap(SnapProtocolMessage::GetBlockAccessLists(req)) = msg {
+                    let response = SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
+                        request_id: req.request_id,
+                        block_access_lists: reth_eth_wire_types::BlockAccessLists(vec![None]),
+                    });
+                    stream.send(EthSnapMessage::Snap(response)).await.unwrap();
+                }
+            }
+        });
+
+        let conn = connect_passthrough(local_addr, eth_snap_hello()).await;
+        let (mut stream, _) = EthSnapStream::<_, EthNetworkPrimitives>::handshake(
+            conn,
+            status,
+            fork_filter,
+            Arc::new(EthHandshake::default()),
+            MAX_MESSAGE_SIZE,
+        )
+        .await
+        .unwrap();
+        stream.set_lazy_responses(true);
+
+        stream
+            .send(EthSnapMessage::Snap(SnapProtocolMessage::GetBlockAccessLists(
+                GetBlockAccessListsMessage {
+                    request_id: 7,
+                    block_hashes: Vec::new(),
+                    response_bytes: u64::MAX,
+                },
+            )))
+            .await
+            .unwrap();
+
+        let raw = loop {
+            if let EthSnapMessage::RawSnapResponse(raw) = stream.next().await.unwrap().unwrap() {
+                break raw;
+            }
+        };
+        assert_eq!(raw.message_id(), SnapMessageId::BlockAccessLists);
+        assert_eq!(raw.request_id().unwrap(), 7);
+        assert_eq!(
+            raw.decode().unwrap(),
+            SnapProtocolMessage::BlockAccessLists(BlockAccessListsMessage {
+                request_id: 7,
+                block_access_lists: reth_eth_wire_types::BlockAccessLists(vec![None]),
+            })
+        );
+
+        server.abort();
     }
 }

--- a/crates/net/eth-wire/src/eth_snap.rs
+++ b/crates/net/eth-wire/src/eth_snap.rs
@@ -183,10 +183,11 @@ where
             return Poll::Ready(Some(this.eth.decode_message(bytes).map(EthSnapMessage::Eth)))
         };
         bytes[0] = snap_id;
+        let bytes = bytes.freeze();
 
         if this.eth.lazy_responses() &&
             let Some(message_id) = SnapMessageId::from_u8(snap_id) &&
-            message_id.is_response()
+            let Some(resp) = RawSnapResponse::new(message_id, bytes.slice(1..).into())
         {
             if !SnapVersion::V2.supports_message_id(snap_id) {
                 return Poll::Ready(Some(Err(SnapProtocolError::UnsupportedMessageId(
@@ -195,11 +196,7 @@ where
                 )
                 .into())))
             }
-            let payload = bytes.split_off(1).freeze();
-            return Poll::Ready(Some(Ok(EthSnapMessage::RawSnapResponse(RawSnapResponse::new(
-                message_id,
-                payload.into(),
-            )))))
+            return Poll::Ready(Some(Ok(EthSnapMessage::RawSnapResponse(resp))))
         }
 
         Poll::Ready(Some(

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -162,6 +162,11 @@ where
         self.lazy_responses = lazy;
     }
 
+    /// Returns `true` if response decoding is deferred, see [`Self::set_lazy_responses`].
+    pub const fn lazy_responses(&self) -> bool {
+        self.lazy_responses
+    }
+
     /// Decodes incoming bytes into an [`EthMessage`].
     pub fn decode_message(&self, mut bytes: BytesMut) -> Result<EthMessage<N>, EthStreamError> {
         if bytes.len() > self.max_message_size {

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -33,8 +33,9 @@ use reth_eth_wire::{
     NewBlockPayload,
 };
 use reth_eth_wire_types::{
-    message::RequestPair, snap::SnapProtocolMessage, NewPooledTransactionHashes,
-    RawCapabilityMessage, RawResponse,
+    message::RequestPair,
+    snap::{RawSnapResponse, SnapProtocolError, SnapProtocolMessage},
+    NewPooledTransactionHashes, RawCapabilityMessage, RawResponse,
 };
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_network_api::{PeerRequest, RequestMessage};
@@ -318,9 +319,8 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
         }
 
         match msg {
-            message @ EthMessage::Status(_) => OnIncomingMessageOutcome::BadMessage {
+            EthMessage::Status(_) => OnIncomingMessageOutcome::BadMessage {
                 error: EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake),
-                message,
             },
             EthMessage::NewBlockHashes(msg) => {
                 self.try_emit_broadcast(PeerMessage::NewBlockHashes(msg)).into()
@@ -404,7 +404,6 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                             "invalid block range: earliest ({}) > latest ({})",
                             msg.earliest, msg.latest
                         ))),
-                        message: EthMessage::BlockRangeUpdate(msg),
                     };
                 }
 
@@ -414,7 +413,6 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                         error: EthStreamError::InvalidMessage(MessageError::Other(
                             "invalid block range: latest_hash cannot be zero".to_string(),
                         )),
-                        message: EthMessage::BlockRangeUpdate(msg),
                     };
                 }
 
@@ -434,61 +432,102 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
 
     /// Handles a response whose payload is still RLP encoded, see [`EthMessage::RawResponse`].
     ///
-    /// The response is correlated with its in-flight request first: unsolicited, late (already
-    /// timed out internally) and mismatched responses are settled on the request id alone, so a
-    /// peer can't make the session decode payloads it never asked for. Only a response the session
-    /// is still waiting for is decoded, and then delivered through the typed response handling in
+    /// The response is correlated with its in-flight request first, see
+    /// [`Self::correlate_raw_response`], so only a response the session is still waiting for is
+    /// decoded, and then delivered through the typed response handling in
     /// [`Self::on_incoming_message`].
     fn on_raw_response(&mut self, resp: RawResponse) -> OnIncomingMessageOutcome<N> {
         let request_id = match resp.request_id() {
             Ok(request_id) => request_id,
             Err(err) => {
+                debug!(target: "net::session", ?resp, remote_peer_id=?self.remote_peer_id, "received response with undecodable request id");
                 return OnIncomingMessageOutcome::BadMessage {
                     error: EthStreamError::InvalidMessage(err.into()),
-                    message: EthMessage::RawResponse(resp),
                 }
             }
         };
 
-        let expected = match self.inflight_requests.get(&request_id).map(|req| &req.request) {
-            Some(RequestState::Waiting(request)) => request.response_message_id(),
-            Some(RequestState::TimedOut) => {
-                // request was already timed out internally, the late response only updates the
-                // timeout estimate
-                if let Some(req) = self.inflight_requests.remove(&request_id) {
-                    self.update_request_timeout(req.timestamp, Instant::now());
-                }
-                return OnIncomingMessageOutcome::Ok
-            }
-            None => {
-                trace!(peer_id=?self.remote_peer_id, ?request_id, "received response to unknown request");
-                // we received a response to a request we never sent
-                self.on_bad_message();
-                return OnIncomingMessageOutcome::Ok
-            }
-        };
-
-        if expected != Some(resp.message_id()) {
-            // The peer replied to a request id we handed out, but with the wrong response type.
-            // This cancels the pending request, so it must cost the peer reputation. Without the
-            // penalty the peer can kill any request we send it, repeatedly and for free.
-            debug!(target: "net::session", ?request_id, msg_id=?resp.message_id(), remote_peer_id=?self.remote_peer_id, "received response of wrong type");
-            self.on_bad_message();
-            if let Some(InflightRequest { request: RequestState::Waiting(request), .. }) =
-                self.inflight_requests.remove(&request_id)
-            {
-                request.send_bad_response();
-            }
+        if !self.correlate_raw_response(request_id, |pending| {
+            pending.response_message_id() == Some(resp.message_id())
+        }) {
             return OnIncomingMessageOutcome::Ok
         }
 
         match self.conn.decode_raw_response(&resp) {
             Ok(msg) => self.on_incoming_message(msg),
-            Err(error) => OnIncomingMessageOutcome::BadMessage {
-                error,
-                message: EthMessage::RawResponse(resp),
-            },
+            Err(error) => OnIncomingMessageOutcome::BadMessage { error },
         }
+    }
+
+    /// Handles a `snap/2` response whose payload is still RLP encoded, see
+    /// [`EthSnapMessage::RawSnapResponse`].
+    ///
+    /// Same as [`Self::on_raw_response`]: correlated first, decoded only if the session is still
+    /// waiting for it, and then delivered through [`Self::on_incoming_snap_message`].
+    fn on_raw_snap_response(&mut self, resp: RawSnapResponse) -> OnIncomingMessageOutcome<N> {
+        let request_id = match resp.request_id() {
+            Ok(request_id) => request_id,
+            Err(err) => {
+                debug!(target: "net::session", ?resp, remote_peer_id=?self.remote_peer_id, "received snap response with undecodable request id");
+                return OnIncomingMessageOutcome::BadMessage {
+                    error: SnapProtocolError::from(err).into(),
+                }
+            }
+        };
+
+        if !self.correlate_raw_response(request_id, |pending| {
+            matches!(
+                pending,
+                PeerRequest::GetSnap { request, .. }
+                    if request.message_id().response() == Some(resp.message_id())
+            )
+        }) {
+            return OnIncomingMessageOutcome::Ok
+        }
+
+        match resp.decode() {
+            Ok(msg) => self.on_incoming_snap_message(msg),
+            Err(err) => OnIncomingMessageOutcome::BadMessage { error: err.into() },
+        }
+    }
+
+    /// Correlates a response with the in-flight request `request_id` before its payload is
+    /// decoded.
+    ///
+    /// Returns `true` if that request is still waiting and `expects` the response, the only case
+    /// worth decoding the payload for. Otherwise the response is settled here, without the peer
+    /// being able to make the session decode anything it never asked for: an unknown request id
+    /// is penalized, a late response to a request that already timed out internally only updates
+    /// the timeout estimate, and a response of the wrong type cancels the request and is
+    /// penalized, since without the penalty the peer could kill any request we send it,
+    /// repeatedly and for free.
+    fn correlate_raw_response(
+        &mut self,
+        request_id: u64,
+        expects: impl FnOnce(&PeerRequest<N>) -> bool,
+    ) -> bool {
+        match self.inflight_requests.get(&request_id).map(|req| &req.request) {
+            Some(RequestState::Waiting(pending)) if expects(pending) => return true,
+            Some(RequestState::Waiting(_)) => {
+                debug!(target: "net::session", ?request_id, remote_peer_id=?self.remote_peer_id, "received response of wrong type");
+                self.on_bad_message();
+                if let Some(InflightRequest { request: RequestState::Waiting(request), .. }) =
+                    self.inflight_requests.remove(&request_id)
+                {
+                    request.send_bad_response();
+                }
+            }
+            Some(RequestState::TimedOut) => {
+                if let Some(req) = self.inflight_requests.remove(&request_id) {
+                    self.update_request_timeout(req.timestamp, Instant::now());
+                }
+            }
+            None => {
+                trace!(peer_id=?self.remote_peer_id, ?request_id, "received response to unknown request");
+                self.on_bad_message();
+            }
+        }
+        false
     }
 
     /// Handles an inbound `snap/2` message.
@@ -497,6 +536,10 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     /// with eth requests in [`Self::inflight_requests`]) and type-checked against the originally
     /// sent request kind; unsolicited or mismatched ones count as bad messages. Inbound requests
     /// are routed upward as [`PeerRequest::GetSnap`], same as any other eth request.
+    ///
+    /// The connection yields responses as [`EthSnapMessage::RawSnapResponse`], which are
+    /// correlated in [`Self::on_raw_snap_response`] before they are decoded; decoded responses
+    /// only arrive here from there.
     fn on_incoming_snap_message(
         &mut self,
         mut msg: SnapProtocolMessage,
@@ -1007,14 +1050,17 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                                         this.on_incoming_message(msg)
                                     }
                                     EthSnapMessage::Snap(msg) => this.on_incoming_snap_message(msg),
+                                    EthSnapMessage::RawSnapResponse(resp) => {
+                                        this.on_raw_snap_response(resp)
+                                    }
                                 };
                                 match outcome {
                                     OnIncomingMessageOutcome::Ok => {
                                         // handled successfully
                                         progress = true;
                                     }
-                                    OnIncomingMessageOutcome::BadMessage { error, message } => {
-                                        debug!(target: "net::session", %error, msg=?message, remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
+                                    OnIncomingMessageOutcome::BadMessage { error } => {
+                                        debug!(target: "net::session", %error, remote_peer_id=?this.remote_peer_id, "received invalid protocol message");
                                         this.on_bad_message();
                                         return this
                                             .try_disconnect(DisconnectReason::ProtocolBreach, cx)
@@ -1156,7 +1202,7 @@ enum OnIncomingMessageOutcome<N: NetworkPrimitives> {
     /// Message successfully handled.
     Ok,
     /// Message is considered to be in violation of the protocol
-    BadMessage { error: EthStreamError, message: EthMessage<N> },
+    BadMessage { error: EthStreamError },
     /// Currently no capacity to handle the message
     NoCapacity(ActiveSessionMessage<N>),
 }
@@ -1400,7 +1446,7 @@ mod tests {
         message::MAX_MESSAGE_SIZE,
         snap::{
             AccountRangeMessage, BlockAccessListsMessage, GetAccountRangeMessage,
-            GetBlockAccessListsMessage,
+            GetBlockAccessListsMessage, SnapMessageId,
         },
         BlockAccessLists, EthMessageID, NewPooledTransactionHashes72,
     };
@@ -2015,21 +2061,35 @@ mod tests {
         builder.connect_incoming(incoming).await
     }
 
-    /// Builds a [`RawResponse`] carrying `request_id` followed by `body`, the raw RLP of the
-    /// response payload.
-    fn raw_response(message_id: EthMessageID, request_id: u64, body: &[u8]) -> RawResponse {
+    /// Encodes the `[request_id, body...]` list of a response payload, where `body` is the raw
+    /// RLP following the request id.
+    fn response_payload(request_id: u64, body: &[u8]) -> alloy_primitives::Bytes {
         let mut payload = Vec::new();
         alloy_rlp::Header { list: true, payload_length: request_id.length() + body.len() }
             .encode(&mut payload);
         request_id.encode(&mut payload);
         payload.extend_from_slice(body);
-        RawResponse::new(message_id, payload.into())
+        payload.into()
     }
 
-    /// Not a valid `BlockBodies` payload: decoding it is a protocol breach.
+    /// Builds a [`RawResponse`] carrying `request_id` followed by `body`.
+    fn raw_response(message_id: EthMessageID, request_id: u64, body: &[u8]) -> RawResponse {
+        RawResponse::new(message_id, response_payload(request_id, body))
+    }
+
+    /// Builds a [`RawSnapResponse`] carrying `request_id` followed by `body`.
+    fn raw_snap_response(
+        message_id: SnapMessageId,
+        request_id: u64,
+        body: &[u8],
+    ) -> RawSnapResponse {
+        RawSnapResponse::new(message_id, response_payload(request_id, body))
+    }
+
+    /// Not a valid `BlockBodies` or `BlockAccessLists` payload: decoding it is a protocol breach.
     const UNDECODABLE_BODY: &[u8] = &[0x01];
-    /// An empty `BlockBodies` payload.
-    const EMPTY_BODIES: &[u8] = &[alloy_rlp::EMPTY_LIST_CODE];
+    /// An empty `BlockBodies` or `BlockAccessLists` payload.
+    const EMPTY_LIST_BODY: &[u8] = &[alloy_rlp::EMPTY_LIST_CODE];
 
     #[tokio::test(flavor = "multi_thread")]
     async fn unsolicited_raw_response_is_penalized_without_decoding() {
@@ -2088,7 +2148,7 @@ mod tests {
         let mut session = idle_session(&mut builder).await;
         let (id, rx) = dispatch_block_bodies_request(&mut session);
 
-        let resp = raw_response(EthMessageID::BlockBodies, id, EMPTY_BODIES);
+        let resp = raw_response(EthMessageID::BlockBodies, id, EMPTY_LIST_BODY);
         let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
         assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
         assert!(!session.inflight_requests.contains_key(&id));
@@ -2112,6 +2172,82 @@ mod tests {
         // The response is expected, but its payload doesn't decode.
         let resp = raw_response(EthMessageID::BlockBodies, id, UNDECODABLE_BODY);
         let outcome = session.on_incoming_message(EthMessage::RawResponse(resp));
+        assert!(matches!(outcome, OnIncomingMessageOutcome::BadMessage { .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wrong_type_raw_snap_response_is_penalized_without_decoding() {
+        let mut builder = snap_session_builder();
+        let mut session = idle_session(&mut builder).await;
+        let (id, rx) = dispatch_snap_request(&mut session, 0);
+
+        // Answering the GetBlockAccessLists with an AccountRange is settled on the ids alone.
+        let resp = raw_snap_response(SnapMessageId::AccountRange, id, UNDECODABLE_BODY);
+        let outcome = session.on_raw_snap_response(resp);
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(!session.inflight_requests.contains_key(&id));
+        assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::BadResponse);
+        assert!(matches!(
+            futures::FutureExt::now_or_never(builder.active_session_rx.next()).flatten(),
+            Some(ActiveSessionMessage::BadMessage { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn raw_snap_response_to_eth_request_is_penalized_without_decoding() {
+        let mut builder = snap_session_builder();
+        let mut session = idle_session(&mut builder).await;
+        let (id, rx) = dispatch_block_bodies_request(&mut session);
+
+        let resp = raw_snap_response(SnapMessageId::BlockAccessLists, id, UNDECODABLE_BODY);
+        let outcome = session.on_raw_snap_response(resp);
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(!session.inflight_requests.contains_key(&id));
+        assert_eq!(rx.await.unwrap().unwrap_err(), RequestError::BadResponse);
+        assert!(matches!(
+            futures::FutureExt::now_or_never(builder.active_session_rx.next()).flatten(),
+            Some(ActiveSessionMessage::BadMessage { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn expected_raw_snap_response_is_decoded_and_delivered() {
+        let mut builder = snap_session_builder();
+        let mut session = idle_session(&mut builder).await;
+        let (id, rx) = dispatch_snap_request(&mut session, u64::MAX);
+
+        let resp = raw_snap_response(SnapMessageId::BlockAccessLists, id, EMPTY_LIST_BODY);
+        let outcome = session.on_raw_snap_response(resp);
+        assert!(matches!(outcome, OnIncomingMessageOutcome::Ok));
+        assert!(!session.inflight_requests.contains_key(&id));
+
+        // Delivered decoded, with the caller's original request id restored.
+        let response = rx.await.unwrap().unwrap();
+        assert!(matches!(
+            response,
+            SnapResponse::BlockAccessLists(m)
+                if m.request_id == u64::MAX && m.block_access_lists == BlockAccessLists(Vec::new())
+        ));
+        assert!(futures::FutureExt::now_or_never(builder.active_session_rx.next())
+            .flatten()
+            .is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn malformed_raw_snap_response_is_a_protocol_breach() {
+        let mut builder = snap_session_builder();
+        let mut session = idle_session(&mut builder).await;
+        let (id, _rx) = dispatch_snap_request(&mut session, 0);
+
+        // The request id can't be decoded at all.
+        let resp =
+            RawSnapResponse::new(SnapMessageId::BlockAccessLists, UNDECODABLE_BODY.to_vec().into());
+        let outcome = session.on_raw_snap_response(resp);
+        assert!(matches!(outcome, OnIncomingMessageOutcome::BadMessage { .. }));
+
+        // The response is expected, but its payload doesn't decode.
+        let resp = raw_snap_response(SnapMessageId::BlockAccessLists, id, UNDECODABLE_BODY);
+        let outcome = session.on_raw_snap_response(resp);
         assert!(matches!(outcome, OnIncomingMessageOutcome::BadMessage { .. }));
     }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -2083,7 +2083,7 @@ mod tests {
         request_id: u64,
         body: &[u8],
     ) -> RawSnapResponse {
-        RawSnapResponse::new(message_id, response_payload(request_id, body))
+        RawSnapResponse::new(message_id, response_payload(request_id, body)).unwrap()
     }
 
     /// Not a valid `BlockBodies` or `BlockAccessLists` payload: decoding it is a protocol breach.
@@ -2242,7 +2242,8 @@ mod tests {
 
         // The request id can't be decoded at all.
         let resp =
-            RawSnapResponse::new(SnapMessageId::BlockAccessLists, UNDECODABLE_BODY.to_vec().into());
+            RawSnapResponse::new(SnapMessageId::BlockAccessLists, UNDECODABLE_BODY.to_vec().into())
+                .unwrap();
         let outcome = session.on_raw_snap_response(resp);
         assert!(matches!(outcome, OnIncomingMessageOutcome::BadMessage { .. }));
 

--- a/crates/net/network/src/session/conn.rs
+++ b/crates/net/network/src/session/conn.rs
@@ -137,8 +137,9 @@ impl<N: NetworkPrimitives> EthRlpxConnection<N> {
         }
     }
 
-    /// Sets whether to defer decoding of `eth` response messages, which are then yielded as
-    /// [`EthMessage::RawResponse`] so the request id can be checked before paying for the decode.
+    /// Sets whether to defer decoding of response messages, which are then yielded as
+    /// [`EthMessage::RawResponse`] and [`EthSnapMessage::RawSnapResponse`] so the request id can
+    /// be checked before paying for the decode.
     pub fn set_lazy_responses(&mut self, lazy: bool) {
         match self {
             Self::EthOnly(conn) => conn.set_lazy_responses(lazy),

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -598,7 +598,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 }
 
                 // Responses are correlated with their request before their payload is decoded,
-                // see `ActiveSession::on_raw_response`.
+                // see `ActiveSession::correlate_raw_response`.
                 conn.set_lazy_responses(true);
 
                 let session = ActiveSession {


### PR DESCRIPTION
Follow-up to #26926, which this is stacked on: `snap/2` responses get the same deferred decoding as `eth` responses. Geth's ethereum/go-ethereum#33835 covers both protocols as well.

With deferred decoding enabled, `EthSnapStream` yields snap responses as `EthSnapMessage::RawSnapResponse`, carrying the message id and the still encoded `[request-id, payload...]` list, while requests keep arriving decoded. The session correlates the request id with its in-flight requests through a helper now shared with the `eth` path, so unsolicited, late and mismatched snap responses, including snap responses to pending `eth` requests, are settled without decoding the payload. Only an expected response is decoded and then delivered through the existing typed snap handling, which also restores the caller's request id as before.

`RawSnapResponse` lives in the wire types next to `SnapProtocolMessage` and reuses the request id extraction of the `eth` `RawResponse`. Since the session's bad-message outcome now also has to cover snap payloads, it only carries the error; the offending message details are logged where they are still available.
