### PR TITLE
perf(discv5): don't block startup on boot node ENR requests

### DIFF
--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -540,6 +540,13 @@ pub fn build_local_enr(
 }
 
 /// Bootstraps underlying [`discv5::Discv5`] node with configured peers.
+///
+/// Boot nodes given as an ENR are added to the kbuckets right away. Boot nodes given as an enode
+/// need their ENR requested over the wire first, which is driven in the background: an unreachable
+/// boot node only answers after the discv5 request timeout, and waiting for that would stall node
+/// startup.
+///
+/// Stays `async` because spawning those requests requires a tokio runtime context.
 pub async fn bootstrap(
     bootstrap_nodes: HashSet<BootNode>,
     discv5: &Arc<discv5::Discv5>,
@@ -573,7 +580,11 @@ pub async fn bootstrap(
     }
 
     // If a session is established, the ENR is added straight away to discv5 kbuckets
-    Ok(_ = join_all(enr_requests).await)
+    if !enr_requests.is_empty() {
+        task::spawn(join_all(enr_requests));
+    }
+
+    Ok(())
 }
 
 /// Backgrounds regular look up queries, in order to keep kbuckets populated.


### PR DESCRIPTION
`Discv5::start` awaited an ENR request against every enode boot node before returning. An unreachable boot node only fails after discv5's 1s `request_timeout` and `join_all` waits for the slowest one, so node startup paid a flat ~1s for this.

Those requests now run in the background. Boot nodes given as an ENR are still added to the kbuckets synchronously, and for the enode ones an established session adds the ENR on its own, so nothing is lost by not waiting.

Instrumented `main()` -> engine service loop on a mainnet node with a warm datadir, `Discv5::start` -> `bootstrap()`:

| | ms |
| --- | ---: |
| before | 1006 |
| after | 0.4 |

The 1006ms was the same on every run, which is what you would expect from a fixed request timeout rather than real work.

Split out of #26927, the other half is #26930.