### PR TITLE
perf(nippy-jar): only commit a jar when the consistency checker healed it

### DIFF
--- a/crates/storage/nippy-jar/src/consistency.rs
+++ b/crates/storage/nippy-jar/src/consistency.rs
@@ -25,6 +25,8 @@ pub struct NippyJarChecker<H: NippyJarHeader = ()> {
     pub(crate) data_file: Option<BufWriter<File>>,
     /// File handle to where the offsets are stored.
     pub(crate) offsets_file: Option<BufWriter<File>>,
+    /// Whether a heal changed the jar on disk and therefore needs to be committed.
+    pub(crate) healed: bool,
 }
 
 impl<H: NippyJarHeader> NippyJarChecker<H> {
@@ -34,7 +36,15 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
     /// the data or offsets files. The [`NippyJar`] passed in contains all necessary
     /// configurations for handling data.
     pub const fn new(jar: NippyJar<H>) -> Self {
-        Self { jar, data_file: None, offsets_file: None }
+        Self { jar, data_file: None, offsets_file: None, healed: false }
+    }
+
+    /// Whether the last [`Self::ensure_consistency`] call healed the jar.
+    ///
+    /// A healed jar has pending file truncations and/or a changed row count that the caller must
+    /// commit to disk.
+    pub const fn healed(&self) -> bool {
+        self.healed
     }
 
     /// It will throw an error if the [`NippyJar`] is in an inconsistent state.
@@ -81,6 +91,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 drop(reader);
 
                 self.offsets_file().get_mut().set_len(expected_offsets_file_size)?;
+                self.healed = true;
                 reader = self.jar.open_data_reader()?;
             }
             Ordering::Greater => {
@@ -94,6 +105,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
 
                 // Freeze row count changed
                 self.jar.freeze_config()?;
+                self.healed = true;
             }
             Ordering::Equal => {}
         }
@@ -115,6 +127,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                 // Happened during an appending job, so we need to truncate the data, since there's
                 // no way to recover it.
                 self.data_file().get_mut().set_len(last_offset)?;
+                self.healed = true;
             }
             Ordering::Greater => {
                 // Happened during a pruning job, so we need to reverse iterate offsets until we
@@ -134,6 +147,7 @@ impl<H: NippyJarHeader> NippyJarChecker<H> {
                         drop(reader);
 
                         self.offsets_file().get_mut().set_len(new_len)?;
+                        self.healed = true;
 
                         // Since we decrease the offset list, we need to check the consistency of
                         // `self.jar.rows` again

--- a/crates/storage/nippy-jar/src/writer.rs
+++ b/crates/storage/nippy-jar/src/writer.rs
@@ -53,21 +53,21 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
         let (data_file, offsets_file, is_created) =
             Self::create_or_open_files(jar.data_path(), &jar.offsets_path())?;
 
-        let (jar, data_file, offsets_file) = if is_created {
+        let (jar, data_file, offsets_file, healed) = if is_created {
             // Makes sure we don't have dangling data and offset files when we just created the file
             jar.freeze_config()?;
 
-            (jar, BufWriter::new(data_file), BufWriter::new(offsets_file))
+            (jar, BufWriter::new(data_file), BufWriter::new(offsets_file), false)
         } else {
             // If we are opening a previously created jar, we need to check its consistency, and
             // make changes if necessary.
             let mut checker = NippyJarChecker::new(jar);
             checker.ensure_consistency()?;
 
-            let NippyJarChecker { jar, data_file, offsets_file } = checker;
+            let NippyJarChecker { jar, data_file, offsets_file, healed } = checker;
 
             // Calling ensure_consistency, will fill data_file and offsets_file
-            (jar, data_file.expect("qed"), offsets_file.expect("qed"))
+            (jar, data_file.expect("qed"), offsets_file.expect("qed"), healed)
         };
 
         let mut writer = Self {
@@ -81,8 +81,9 @@ impl<H: NippyJarHeader> NippyJarWriter<H> {
             dirty: false,
         };
 
-        if !is_created {
-            // Commit any potential heals done above.
+        if healed {
+            // Commit the heals done above. A jar that was already consistent has nothing to write,
+            // and committing it anyway costs four fsyncs per segment on every startup.
             writer.commit()?;
         }
 

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -369,12 +369,7 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             "Ensuring end range consistency"
         );
 
-        // Only the header prune above dirties the writer here; `NippyJarWriter::new` has already
-        // committed any file level heal. Committing a segment that did not change costs four
-        // fsyncs, once per segment, on every startup.
-        if self.writer.is_dirty() {
-            self.writer.commit().map_err(ProviderError::other)?;
-        }
+        self.writer.commit().map_err(ProviderError::other)?;
 
         // Updates the [SnapshotProvider] manager
         self.update_index()?;

--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -369,7 +369,12 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             "Ensuring end range consistency"
         );
 
-        self.writer.commit().map_err(ProviderError::other)?;
+        // Only the header prune above dirties the writer here; `NippyJarWriter::new` has already
+        // committed any file level heal. Committing a segment that did not change costs four
+        // fsyncs, once per segment, on every startup.
+        if self.writer.is_dirty() {
+            self.writer.commit().map_err(ProviderError::other)?;
+        }
 
         // Updates the [SnapshotProvider] manager
         self.update_index()?;


### PR DESCRIPTION
`NippyJarWriter::new` committed every jar it opened, to persist "potential heals" from `NippyJarChecker::ensure_consistency`. A commit is two `sync_all` calls plus an atomic config rewrite (file + directory fsync), so opening a jar that was already consistent cost four fsyncs for no writes.

`NippyJarChecker` now records whether it actually truncated a file or changed the row count, and `NippyJarWriter::new` only commits when it did.

Reth opens one writer per static file segment during `ProviderFactory::check_consistency` on every startup, so this ran six times per start on an otherwise healthy node.

Independent of #26932, which removes the other unconditional commit on the same path one layer up in `StaticFileProviderRW::ensure_end_range_consistency`. Either can land alone; together they take `check_consistency` from 235ms to 6ms on a mainnet node with a warm datadir (macOS/APFS, where an fsync is expensive).

Split out of #26927 along with #26929.