### PR TITLE
perf(storage): skip committing static file segments that did not change

### DIFF
--- a/crates/storage/provider/src/providers/static_file/writer.rs
+++ b/crates/storage/provider/src/providers/static_file/writer.rs
@@ -369,7 +369,12 @@ impl<N: NodePrimitives> StaticFileProviderRW<N> {
             "Ensuring end range consistency"
         );
 
-        self.writer.commit().map_err(ProviderError::other)?;
+        // Only the header prune above dirties the writer here; `NippyJarWriter::new` has already
+        // committed any file level heal. Committing a segment that did not change costs four
+        // fsyncs, once per segment, on every startup.
+        if self.writer.is_dirty() {
+            self.writer.commit().map_err(ProviderError::other)?;
+        }
 
         // Updates the [SnapshotProvider] manager
         self.update_index()?;


### PR DESCRIPTION
`StaticFileProviderRW::ensure_end_range_consistency` runs for every segment opened during `check_consistency` and committed unconditionally. A commit is two `sync_all` calls plus an atomic config rewrite (file + directory fsync), so a node paid four fsyncs per segment on every startup even when the segment was consistent and the header was untouched.

`NippyJarWriter::new` has already persisted any file level heal by the time this runs, and only the header prune above it dirties the writer, so the commit can be skipped when the writer is clean.

Independent of #26930, which removes the other unconditional commit on the same path one layer down in `NippyJarWriter::new`. Either can land alone; together they take `ProviderFactory::check_consistency` over the six segments from 235ms to 6ms on a mainnet node with a warm datadir (macOS/APFS, where an fsync is expensive).