### PR TITLE
chore(net): trace duplicate discovery packets

### DIFF
--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -2094,7 +2094,7 @@ impl IngressHandler {
         if data.len() >= MIN_PACKET_SIZE &&
             self.cache.contains_packet(B256::from_slice(&data[..32]))
         {
-            debug!(target: "discv4", ?src, "Received duplicate packet.");
+            trace!(target: "discv4", ?src, "Received duplicate packet.");
             return
         }
 


### PR DESCRIPTION
Lowers the duplicate discovery packet event from debug to trace to reduce routine logging noise in a floodable ingress path.

Tested with `cargo test -p reth-discv4`.

Prompted by: @mattsse