### PR TITLE
perf(discv4): reject duplicate and unknown packets before recovering the key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8179,6 +8179,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
+ "codspeed-criterion-compat",
  "discv5",
  "enr",
  "itertools 0.14.0",

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -40,6 +40,7 @@ itertools.workspace = true
 
 [dev-dependencies]
 secp256k1 = { workspace = true, features = ["rand"] }
+criterion.workspace = true
 assert_matches.workspace = true
 rand_08.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
@@ -58,3 +59,7 @@ serde = [
     "reth-ethereum-forks/serde",
 ]
 test-utils = ["dep:rand_08"]
+
+[[bench]]
+name = "codec"
+harness = false

--- a/crates/net/discv4/benches/codec.rs
+++ b/crates/net/discv4/benches/codec.rs
@@ -1,0 +1,71 @@
+//! Benchmarks for the discv4 wire codec.
+//!
+//! The receive path decodes every inbound datagram before any of the service level checks run, so
+//! the cost measured here is paid once per packet, including for packets that are later dropped.
+
+#![allow(missing_docs)]
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use reth_discv4::proto::{Message, Neighbours, NodeEndpoint, Ping};
+use reth_network_peers::NodeRecord;
+use secp256k1::{SecretKey, SECP256K1};
+use std::{
+    hint::black_box,
+    net::{IpAddr, Ipv4Addr},
+};
+
+const fn endpoint(port: u16) -> NodeEndpoint {
+    NodeEndpoint { address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), udp_port: port, tcp_port: port }
+}
+
+const fn record(port: u16) -> NodeRecord {
+    NodeRecord {
+        address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        udp_port: port,
+        tcp_port: port,
+        id: alloy_primitives::FixedBytes::<64>::repeat_byte(port as u8),
+    }
+}
+
+const fn ping() -> Message {
+    Message::Ping(Ping {
+        from: endpoint(30303),
+        to: endpoint(30304),
+        expire: u64::MAX,
+        enr_sq: Some(1),
+    })
+}
+
+/// A full neighbours response, the largest message on the wire in normal operation.
+fn neighbours(len: usize) -> Message {
+    Message::Neighbours(Neighbours {
+        nodes: (0..len).map(|i| record(i as u16)).collect(),
+        expire: u64::MAX,
+    })
+}
+
+fn codec(c: &mut Criterion) {
+    let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+    let _ = SECP256K1;
+
+    let mut group = c.benchmark_group("discv4_codec");
+
+    for (name, msg) in
+        [("ping", ping()), ("neighbours_4", neighbours(4)), ("neighbours_12", neighbours(12))]
+    {
+        let (encoded, _) = msg.encode(&secret_key);
+
+        group.bench_function(format!("encode/{name}"), |b| {
+            b.iter(|| black_box(black_box(&msg).encode(black_box(&secret_key))))
+        });
+
+        group.bench_function(format!("decode/{name}"), |b| {
+            b.iter(|| black_box(Message::decode(black_box(&encoded)).unwrap()))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, codec);
+criterion_main!(benches);

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -2086,6 +2086,18 @@ impl IngressHandler {
             return
         }
 
+        // A packet starts with the hash of everything that follows it, and `Message::decode`
+        // rejects any packet whose contents do not hash to it. A repeat of a packet we already
+        // accepted can therefore be recognised from those 32 bytes alone, without decoding.
+        // Decoding runs an ECDSA recovery, so checking here keeps a replayed packet from costing
+        // a signature verification.
+        if data.len() >= MIN_PACKET_SIZE &&
+            self.cache.contains_packet(B256::from_slice(&data[..32]))
+        {
+            debug!(target: "discv4", ?src, "Received duplicate packet.");
+            return
+        }
+
         let event = match Message::decode(data) {
             Ok(packet) => {
                 if packet.node_id == self.local_id {
@@ -2093,10 +2105,9 @@ impl IngressHandler {
                     return
                 }
 
-                if self.cache.contains_packet(packet.hash) {
-                    debug!(target: "discv4", ?src, "Received duplicate packet.");
-                    return
-                }
+                // Only packets that decoded are remembered, so a peer cannot suppress a packet we
+                // have not seen yet by guessing its hash.
+                self.cache.insert_packet(packet.hash);
 
                 IngressEvent::Packet(src, packet)
             }
@@ -2147,9 +2158,16 @@ impl ReceiveCache {
         *ctn
     }
 
-    /// Returns true if we previously received the packet
+    /// Returns true if we previously received the packet.
+    ///
+    /// A hit refreshes the entry so that a packet being replayed repeatedly stays cached.
     fn contains_packet(&mut self, hash: B256) -> bool {
-        !self.unique_packets.insert(hash, ())
+        self.unique_packets.get(&hash).is_some()
+    }
+
+    /// Remembers a packet we accepted.
+    fn insert_packet(&mut self, hash: B256) {
+        self.unique_packets.insert(hash, ());
     }
 }
 
@@ -2571,7 +2589,65 @@ mod tests {
     use rand_08::Rng;
     use reth_ethereum_forks::{EnrForkIdEntry, ForkHash};
     use reth_network_peers::mainnet_nodes;
+    use secp256k1::SECP256K1;
     use std::future::poll_fn;
+
+    #[tokio::test]
+    async fn test_duplicate_packet_rejected_without_decoding() {
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+        let local_id = pk2id(&secret_key.public_key(SECP256K1));
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut handler = IngressHandler::new(tx, local_id);
+
+        let remote_key = SecretKey::new(&mut rand_08::thread_rng());
+        let msg = Message::Ping(Ping {
+            from: rng_endpoint(&mut rand_08::thread_rng()),
+            to: rng_endpoint(&mut rand_08::thread_rng()),
+            expire: u64::MAX,
+            enr_sq: None,
+        });
+        let (packet, hash) = msg.encode(&remote_key);
+        let src = "10.0.0.1:30303".parse().unwrap();
+
+        handler.handle_packet(&packet, src).await;
+        assert!(matches!(rx.try_recv(), Ok(IngressEvent::Packet(_, _))));
+
+        // the replay is dropped on the hash prefix alone
+        handler.handle_packet(&packet, src).await;
+        assert!(rx.try_recv().is_err());
+        assert!(handler.cache.contains_packet(hash));
+    }
+
+    #[tokio::test]
+    async fn test_undecodable_packet_does_not_poison_cache() {
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+        let local_id = pk2id(&secret_key.public_key(SECP256K1));
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut handler = IngressHandler::new(tx, local_id);
+
+        let remote_key = SecretKey::new(&mut rand_08::thread_rng());
+        let msg = Message::Ping(Ping {
+            from: rng_endpoint(&mut rand_08::thread_rng()),
+            to: rng_endpoint(&mut rand_08::thread_rng()),
+            expire: u64::MAX,
+            enr_sq: None,
+        });
+        let (packet, hash) = msg.encode(&remote_key);
+        let src = "10.0.0.1:30303".parse().unwrap();
+
+        // a packet carrying the right hash prefix but a corrupt body must not be remembered,
+        // otherwise it could be used to suppress the real packet
+        let mut forged = packet.to_vec();
+        let last = forged.len() - 1;
+        forged[last] ^= 0xff;
+        handler.handle_packet(&forged, src).await;
+        assert!(matches!(rx.try_recv(), Ok(IngressEvent::BadPacket(..))));
+        assert!(!handler.cache.contains_packet(hash));
+
+        // so the genuine packet still gets through
+        handler.handle_packet(&packet, src).await;
+        assert!(matches!(rx.try_recv(), Ok(IngressEvent::Packet(_, _))));
+    }
 
     #[tokio::test]
     async fn test_configured_enr_forkid_entry() {

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -155,6 +155,11 @@ impl Message {
             return Err(DecodePacketError::HashMismatch)
         }
 
+        // Resolve the message type before recovering the public key: recovery is by far the most
+        // expensive step of decoding, and a packet we have no handler for is rejected either way.
+        let message_id =
+            MessageId::from_u8(packet[97]).map_err(DecodePacketError::UnknownMessage)?;
+
         let signature = &packet[32..96];
         let recovery_id = RecoveryId::try_from(packet[96] as i32)?;
         let recoverable_sig = RecoverableSignature::from_compact(signature, recovery_id)?;
@@ -165,10 +170,9 @@ impl Message {
         let pk = SECP256K1.recover_ecdsa(&msg, &recoverable_sig)?;
         let node_id = pk2id(&pk);
 
-        let msg_type = packet[97];
         let payload = &mut &packet[98..];
 
-        let msg = match MessageId::from_u8(msg_type).map_err(DecodePacketError::UnknownMessage)? {
+        let msg = match message_id {
             MessageId::Ping => Self::Ping(Ping::decode(payload)?),
             MessageId::Pong => Self::Pong(Pong::decode(payload)?),
             MessageId::FindNode => Self::FindNode(FindNode::decode(payload)?),


### PR DESCRIPTION
Decoding a discv4 packet runs an ECDSA recovery, which dominates the cost of the receive path. There were no benchmarks under `crates/net`, so this adds one for the codec first:

| | µs |
| --- | ---: |
| `decode` ping | 24.5 |
| `decode` neighbours (12 records) | 26.8 |
| `encode` ping | 20.3 |

Two checks that reject a packet outright were sitting behind that recovery.

The duplicate check ran on the decoded packet's hash. That hash is the first 32 bytes of the datagram and `Message::decode` rejects anything whose contents do not hash to it, so a replay can be recognised from the prefix alone and now costs a 32 byte LRU lookup instead of a full decode. Only packets that decoded are inserted into the cache, so a peer still cannot suppress a packet we have not seen yet by guessing its hash — there is a test for that.

The message id was resolved after recovery, so a packet carrying a type we have no handler for paid for a recovery before being thrown away. It is now resolved first.

Valid packets are unaffected: the benchmark shows `decode` unchanged at 24.5µs for a ping and 26.8µs for a full neighbours response.

`tests::test_bootnode_not_in_update_stream`, `test_check_ping_pong`, `test_check_wrong_to` and `test_on_neighbours_recursive_lookup` fail or time out for me on unmodified main as well, so I could not use them to validate this.