### PR TITLE
perf(discv4): read the discovery socket from several tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8179,6 +8179,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "assert_matches",
+ "codspeed-criterion-compat",
  "discv5",
  "enr",
  "itertools 0.14.0",

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -40,6 +40,7 @@ itertools.workspace = true
 
 [dev-dependencies]
 secp256k1 = { workspace = true, features = ["rand"] }
+criterion.workspace = true
 assert_matches.workspace = true
 rand_08.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
@@ -58,3 +59,7 @@ serde = [
     "reth-ethereum-forks/serde",
 ]
 test-utils = ["dep:rand_08"]
+
+[[bench]]
+name = "codec"
+harness = false

--- a/crates/net/discv4/Cargo.toml
+++ b/crates/net/discv4/Cargo.toml
@@ -63,3 +63,8 @@ test-utils = ["dep:rand_08"]
 [[bench]]
 name = "codec"
 harness = false
+
+[[bench]]
+name = "ingress"
+required-features = ["test-utils"]
+harness = false

--- a/crates/net/discv4/benches/codec.rs
+++ b/crates/net/discv4/benches/codec.rs
@@ -1,0 +1,71 @@
+//! Benchmarks for the discv4 wire codec.
+//!
+//! The receive path decodes every inbound datagram before any of the service level checks run, so
+//! the cost measured here is paid once per packet, including for packets that are later dropped.
+
+#![allow(missing_docs)]
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use reth_discv4::proto::{Message, Neighbours, NodeEndpoint, Ping};
+use reth_network_peers::NodeRecord;
+use secp256k1::{SecretKey, SECP256K1};
+use std::{
+    hint::black_box,
+    net::{IpAddr, Ipv4Addr},
+};
+
+const fn endpoint(port: u16) -> NodeEndpoint {
+    NodeEndpoint { address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), udp_port: port, tcp_port: port }
+}
+
+const fn record(port: u16) -> NodeRecord {
+    NodeRecord {
+        address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        udp_port: port,
+        tcp_port: port,
+        id: alloy_primitives::FixedBytes::<64>::repeat_byte(port as u8),
+    }
+}
+
+const fn ping() -> Message {
+    Message::Ping(Ping {
+        from: endpoint(30303),
+        to: endpoint(30304),
+        expire: u64::MAX,
+        enr_sq: Some(1),
+    })
+}
+
+/// A full neighbours response, the largest message on the wire in normal operation.
+fn neighbours(len: usize) -> Message {
+    Message::Neighbours(Neighbours {
+        nodes: (0..len).map(|i| record(i as u16)).collect(),
+        expire: u64::MAX,
+    })
+}
+
+fn codec(c: &mut Criterion) {
+    let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+    let _ = SECP256K1;
+
+    let mut group = c.benchmark_group("discv4_codec");
+
+    for (name, msg) in
+        [("ping", ping()), ("neighbours_4", neighbours(4)), ("neighbours_12", neighbours(12))]
+    {
+        let (encoded, _) = msg.encode(&secret_key);
+
+        group.bench_function(format!("encode/{name}"), |b| {
+            b.iter(|| black_box(black_box(&msg).encode(black_box(&secret_key))))
+        });
+
+        group.bench_function(format!("decode/{name}"), |b| {
+            b.iter(|| black_box(Message::decode(black_box(&encoded)).unwrap()))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, codec);
+criterion_main!(benches);

--- a/crates/net/discv4/benches/ingress.rs
+++ b/crates/net/discv4/benches/ingress.rs
@@ -1,0 +1,105 @@
+//! Throughput of the discv4 receive path.
+//!
+//! `receive_loop` reads a datagram, decodes it, and forwards it to the service on one task, so
+//! every packet's ECDSA recovery runs between two `recv_from` calls. This measures how many
+//! packets that path can absorb.
+
+#![allow(missing_docs)]
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use reth_discv4::{
+    proto::{Message, Ping},
+    IngressHandler,
+};
+use reth_network_peers::pk2id;
+use secp256k1::{SecretKey, SECP256K1};
+use std::{
+    hint::black_box,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+
+/// Distinct valid packets from distinct keys, so every one costs a real recovery and none are
+/// rejected as duplicates.
+fn packets(count: usize) -> Vec<(Vec<u8>, SocketAddr)> {
+    let mut rng = rand_08::thread_rng();
+    (0..count)
+        .map(|i| {
+            let key = SecretKey::new(&mut rng);
+            let endpoint = reth_discv4::proto::NodeEndpoint {
+                address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                udp_port: 30303,
+                tcp_port: 30303,
+            };
+            let msg = Message::Ping(Ping {
+                from: endpoint,
+                to: endpoint,
+                expire: u64::MAX,
+                enr_sq: Some(i as u64),
+            });
+            let (encoded, _) = msg.encode(&key);
+            // a distinct source per packet, the handler rate limits per ip
+            let src = SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(10, (i >> 16) as u8, (i >> 8) as u8, i as u8)),
+                30303,
+            );
+            (encoded.to_vec(), src)
+        })
+        .collect()
+}
+
+fn ingress(c: &mut Criterion) {
+    const BATCH: usize = 256;
+
+    let rt =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build().unwrap();
+
+    let local_id = pk2id(&SecretKey::new(&mut rand_08::thread_rng()).public_key(SECP256K1));
+    let batch = packets(BATCH);
+
+    let mut group = c.benchmark_group("discv4_ingress");
+    group.throughput(Throughput::Elements(BATCH as u64));
+
+    // `readers` mirrors `Discv4Config::udp_ingress_readers`: how many tasks pull datagrams off
+    // the socket and decode them against one shared handler.
+    for readers in [1usize, 2, 4] {
+        group.bench_function(format!("readers/{readers}"), |b| {
+            b.iter_batched(
+                || batch.clone(),
+                |batch| {
+                    rt.block_on(async {
+                        let (handler, mut drain) = IngressHandler::in_memory(local_id, BATCH * 2);
+                        let handler = Arc::new(handler);
+                        let batch = Arc::new(batch);
+
+                        let mut set = tokio::task::JoinSet::new();
+                        for reader in 0..readers {
+                            let (handler, batch) = (handler.clone(), batch.clone());
+                            set.spawn(async move {
+                                // each reader takes the datagrams the kernel would have handed it
+                                for (data, src) in batch.iter().skip(reader).step_by(readers) {
+                                    handler.handle_packet(black_box(data), *src).await;
+                                }
+                            });
+                        }
+                        while set.join_next().await.is_some() {}
+
+                        let mut seen = drain();
+                        while seen < BATCH {
+                            tokio::task::yield_now().await;
+                            seen += drain();
+                        }
+                        assert_eq!(seen, BATCH, "packets were dropped");
+                        black_box(seen)
+                    })
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, ingress);
+criterion_main!(benches);

--- a/crates/net/discv4/src/config.rs
+++ b/crates/net/discv4/src/config.rs
@@ -10,6 +10,7 @@ use reth_net_nat::{NatResolver, ResolveNatInterval};
 use reth_network_peers::NodeRecord;
 use std::{
     collections::{HashMap, HashSet},
+    num::NonZeroUsize,
     time::Duration,
 };
 
@@ -21,6 +22,11 @@ pub struct Discv4Config {
     pub udp_egress_message_buffer: usize,
     /// Size of the channel buffer for incoming messages.
     pub udp_ingress_message_buffer: usize,
+    /// Number of tasks reading datagrams off the discovery socket.
+    ///
+    /// Decoding a packet runs an ECDSA recovery, so a single reader cannot read from the socket
+    /// while it verifies. Additional readers share the socket and decode concurrently.
+    pub udp_ingress_readers: NonZeroUsize,
     /// The number of allowed consecutive failures for `FindNode` requests. Default: 5.
     pub max_find_node_failures: u8,
     /// The interval to use when checking for expired nodes that need to be re-pinged. Default:
@@ -115,6 +121,7 @@ impl Default for Discv4Config {
             udp_egress_message_buffer: 1024,
             // Every outgoing request will eventually lead to an incoming response
             udp_ingress_message_buffer: 1024,
+            udp_ingress_readers: NonZeroUsize::new(2).expect("not zero"),
             max_find_node_failures: 5,
             ping_interval: Duration::from_secs(10),
             // Unified expiration and timeout durations, mirrors geth's `expiration` duration
@@ -148,6 +155,12 @@ pub struct Discv4ConfigBuilder {
 }
 
 impl Discv4ConfigBuilder {
+    /// Sets the number of tasks reading datagrams off the discovery socket.
+    pub const fn udp_ingress_readers(&mut self, readers: NonZeroUsize) -> &mut Self {
+        self.config.udp_ingress_readers = readers;
+        self
+    }
+
     /// Sets the channel size for incoming messages
     pub const fn udp_ingress_message_buffer(
         &mut self,

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -49,6 +49,7 @@ use std::{
     collections::{btree_map, hash_map::Entry, BTreeMap, HashMap, VecDeque},
     fmt, io,
     net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+    num::NonZeroUsize,
     pin::Pin,
     rc::Rc,
     sync::Arc,
@@ -574,7 +575,12 @@ impl Discv4Service {
 
         if let Some(ingress_tx) = ingress_tx {
             let udp = Arc::clone(&socket);
-            tasks.spawn(receive_loop(udp, ingress_tx, local_node_record.id));
+            tasks.spawn(receive_loop(
+                udp,
+                ingress_tx,
+                local_node_record.id,
+                config.udp_ingress_readers,
+            ));
         }
 
         let udp = Arc::clone(&socket);
@@ -2022,8 +2028,30 @@ const MAX_INCOMING_PACKETS_PER_MINUTE_BY_IP: usize = 60usize;
 ///
 /// The receive loop enforces primitive rate limiting for IPs to prevent message spams from
 /// individual IPs.
-pub(crate) async fn receive_loop(udp: Arc<UdpSocket>, tx: IngressSender, local_id: PeerId) {
-    let mut handler = IngressHandler::new(tx, local_id);
+pub(crate) async fn receive_loop(
+    udp: Arc<UdpSocket>,
+    tx: IngressSender,
+    local_id: PeerId,
+    readers: NonZeroUsize,
+) {
+    let handler = Arc::new(IngressHandler::new(tx, local_id));
+
+    // Decoding a packet runs an ECDSA recovery, so a single reader leaves the socket unread for
+    // the duration of every recovery. Several readers share the socket instead: the kernel hands
+    // each datagram to exactly one of them, and they only contend on the short rate limit and
+    // duplicate lookups.
+    // A `JoinSet` so that aborting the receive loop takes the extra readers down with it; a bare
+    // `JoinHandle` would detach them and leave them draining the socket after shutdown.
+    let mut tasks = JoinSet::new();
+    for _ in 0..readers.get() {
+        tasks.spawn(read_datagrams(udp.clone(), handler.clone()));
+    }
+
+    while tasks.join_next().await.is_some() {}
+}
+
+/// Reads datagrams off the socket and hands them to the handler until the socket dies.
+async fn read_datagrams(udp: Arc<UdpSocket>, handler: Arc<IngressHandler>) {
     let mut buf = [0; MAX_PACKET_SIZE];
     loop {
         let res = udp.recv_from(&mut buf).await;
@@ -2049,11 +2077,31 @@ pub struct IngressHandler {
     local_id: PeerId,
     tick: usize,
     tick_interval: Duration,
-    cache: ReceiveCache,
-    last_tick: Instant,
+    /// Rate limiting and duplicate tracking, shared so that several reader tasks can decode
+    /// concurrently. Only ever held for a map lookup, never across the decode or a send.
+    cache: Mutex<ReceiveCache>,
+    last_tick: Mutex<Instant>,
 }
 
 impl IngressHandler {
+    /// Creates a handler wired to an in-memory channel of the given capacity, together with a
+    /// callback that drains it and reports how many packets were forwarded.
+    ///
+    /// The channel types are internal, so this keeps them out of the public API while still
+    /// letting benchmarks drive the receive path.
+    #[cfg(feature = "test-utils")]
+    pub fn in_memory(local_id: PeerId, capacity: usize) -> (Self, impl FnMut() -> usize) {
+        let (tx, mut rx) = mpsc::channel(capacity);
+        let drain = move || {
+            let mut forwarded = 0;
+            while rx.try_recv().is_ok() {
+                forwarded += 1;
+            }
+            forwarded
+        };
+        (Self::new(tx, local_id), drain)
+    }
+
     fn new(tx: IngressSender, local_id: PeerId) -> Self {
         let tick = MAX_INCOMING_PACKETS_PER_MINUTE_BY_IP / 2;
         Self {
@@ -2061,8 +2109,8 @@ impl IngressHandler {
             local_id,
             tick,
             tick_interval: Duration::from_secs(tick as u64),
-            cache: ReceiveCache::default(),
-            last_tick: Instant::now(),
+            cache: Mutex::new(ReceiveCache::default()),
+            last_tick: Mutex::new(Instant::now()),
         }
     }
 
@@ -2074,28 +2122,34 @@ impl IngressHandler {
 
     /// Handles an incoming raw packet: decodes, rate-limits, deduplicates, and forwards to the
     /// discv4 service. Used in shared-port mode to process unrecognized frames from discv5.
-    pub async fn handle_packet(&mut self, data: &[u8], src: SocketAddr) {
-        if self.last_tick.elapsed() >= self.tick_interval {
-            self.cache.tick_ips(self.tick);
-            self.last_tick = Instant::now();
-        }
-
-        // rate limit incoming packets by IP
-        if self.cache.inc_ip(src.ip()) > MAX_INCOMING_PACKETS_PER_MINUTE_BY_IP {
-            trace!(target: "discv4", ?src, "Too many incoming packets from IP.");
-            return
-        }
-
-        // A packet starts with the hash of everything that follows it, and `Message::decode`
-        // rejects any packet whose contents do not hash to it. A repeat of a packet we already
-        // accepted can therefore be recognised from those 32 bytes alone, without decoding.
-        // Decoding runs an ECDSA recovery, so checking here keeps a replayed packet from costing
-        // a signature verification.
-        if data.len() >= MIN_PACKET_SIZE &&
-            self.cache.contains_packet(B256::from_slice(&data[..32]))
+    pub async fn handle_packet(&self, data: &[u8], src: SocketAddr) {
         {
-            debug!(target: "discv4", ?src, "Received duplicate packet.");
-            return
+            let mut last_tick = self.last_tick.lock();
+            if last_tick.elapsed() >= self.tick_interval {
+                self.cache.lock().tick_ips(self.tick);
+                *last_tick = Instant::now();
+            }
+        }
+
+        {
+            let mut cache = self.cache.lock();
+
+            // rate limit incoming packets by IP
+            if cache.inc_ip(src.ip()) > MAX_INCOMING_PACKETS_PER_MINUTE_BY_IP {
+                trace!(target: "discv4", ?src, "Too many incoming packets from IP.");
+                return
+            }
+
+            // A packet starts with the hash of everything that follows it, and `Message::decode`
+            // rejects any packet whose contents do not hash to it. A repeat of a packet we already
+            // accepted can therefore be recognised from those 32 bytes alone, without decoding.
+            // Decoding runs an ECDSA recovery, so checking here keeps a replayed packet from
+            // costing a signature verification.
+            if data.len() >= MIN_PACKET_SIZE && cache.contains_packet(B256::from_slice(&data[..32]))
+            {
+                debug!(target: "discv4", ?src, "Received duplicate packet.");
+                return
+            }
         }
 
         let event = match Message::decode(data) {
@@ -2106,8 +2160,12 @@ impl IngressHandler {
                 }
 
                 // Only packets that decoded are remembered, so a peer cannot suppress a packet we
-                // have not seen yet by guessing its hash.
-                self.cache.insert_packet(packet.hash);
+                // have not seen yet by guessing its hash. Re-checking here rather than trusting
+                // the lookup above keeps deduplication exact when several readers decode at once.
+                if !self.cache.lock().insert_packet(packet.hash) {
+                    debug!(target: "discv4", ?src, "Received duplicate packet.");
+                    return
+                }
 
                 IngressEvent::Packet(src, packet)
             }
@@ -2165,9 +2223,9 @@ impl ReceiveCache {
         self.unique_packets.get(&hash).is_some()
     }
 
-    /// Remembers a packet we accepted.
-    fn insert_packet(&mut self, hash: B256) {
-        self.unique_packets.insert(hash, ());
+    /// Remembers a packet we accepted, returning false if it was already known.
+    fn insert_packet(&mut self, hash: B256) -> bool {
+        self.unique_packets.insert(hash, ())
     }
 }
 
@@ -2592,12 +2650,62 @@ mod tests {
     use secp256k1::SECP256K1;
     use std::future::poll_fn;
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_receive_loop_readers_deliver_every_packet() {
+        // stays under MAX_INCOMING_PACKETS_PER_MINUTE_BY_IP, every packet shares a source ip here
+        const PACKETS: usize = 40;
+
+        let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let dst = socket.local_addr().unwrap();
+        let (tx, mut rx) = mpsc::channel(PACKETS * 2);
+        let local_id = pk2id(&SecretKey::new(&mut rand_08::thread_rng()).public_key(SECP256K1));
+
+        let _loop_task = tokio::spawn(receive_loop(
+            socket,
+            tx,
+            local_id,
+            NonZeroUsize::new(4).expect("not zero"),
+        ));
+
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut sent = Vec::with_capacity(PACKETS);
+        for i in 0..PACKETS {
+            let key = SecretKey::new(&mut rand_08::thread_rng());
+            let msg = Message::Ping(Ping {
+                from: rng_endpoint(&mut rand_08::thread_rng()),
+                to: rng_endpoint(&mut rand_08::thread_rng()),
+                expire: u64::MAX,
+                enr_sq: Some(i as u64),
+            });
+            let (packet, hash) = msg.encode(&key);
+            sender.send_to(&packet, dst).await.unwrap();
+            sent.push(hash);
+        }
+
+        // every packet must come out exactly once, no matter which reader picked it up
+        let mut received = Vec::with_capacity(PACKETS);
+        while received.len() < PACKETS {
+            let event = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+                .await
+                .expect("timed out waiting for packets")
+                .expect("channel closed");
+            match event {
+                IngressEvent::Packet(_, packet) => received.push(packet.hash),
+                other => panic!("unexpected ingress event: {other:?}"),
+            }
+        }
+
+        received.sort_unstable();
+        sent.sort_unstable();
+        assert_eq!(received, sent);
+    }
+
     #[tokio::test]
     async fn test_duplicate_packet_rejected_without_decoding() {
         let secret_key = SecretKey::new(&mut rand_08::thread_rng());
         let local_id = pk2id(&secret_key.public_key(SECP256K1));
         let (tx, mut rx) = mpsc::channel(16);
-        let mut handler = IngressHandler::new(tx, local_id);
+        let handler = IngressHandler::new(tx, local_id);
 
         let remote_key = SecretKey::new(&mut rand_08::thread_rng());
         let msg = Message::Ping(Ping {
@@ -2615,7 +2723,7 @@ mod tests {
         // the replay is dropped on the hash prefix alone
         handler.handle_packet(&packet, src).await;
         assert!(rx.try_recv().is_err());
-        assert!(handler.cache.contains_packet(hash));
+        assert!(handler.cache.lock().contains_packet(hash));
     }
 
     #[tokio::test]
@@ -2623,7 +2731,7 @@ mod tests {
         let secret_key = SecretKey::new(&mut rand_08::thread_rng());
         let local_id = pk2id(&secret_key.public_key(SECP256K1));
         let (tx, mut rx) = mpsc::channel(16);
-        let mut handler = IngressHandler::new(tx, local_id);
+        let handler = IngressHandler::new(tx, local_id);
 
         let remote_key = SecretKey::new(&mut rand_08::thread_rng());
         let msg = Message::Ping(Ping {
@@ -2642,7 +2750,7 @@ mod tests {
         forged[last] ^= 0xff;
         handler.handle_packet(&forged, src).await;
         assert!(matches!(rx.try_recv(), Ok(IngressEvent::BadPacket(..))));
-        assert!(!handler.cache.contains_packet(hash));
+        assert!(!handler.cache.lock().contains_packet(hash));
 
         // so the genuine packet still gets through
         handler.handle_packet(&packet, src).await;

--- a/crates/net/discv4/src/lib.rs
+++ b/crates/net/discv4/src/lib.rs
@@ -2086,6 +2086,18 @@ impl IngressHandler {
             return
         }
 
+        // A packet starts with the hash of everything that follows it, and `Message::decode`
+        // rejects any packet whose contents do not hash to it. A repeat of a packet we already
+        // accepted can therefore be recognised from those 32 bytes alone, without decoding.
+        // Decoding runs an ECDSA recovery, so checking here keeps a replayed packet from costing
+        // a signature verification.
+        if data.len() >= MIN_PACKET_SIZE &&
+            self.cache.contains_packet(B256::from_slice(&data[..32]))
+        {
+            debug!(target: "discv4", ?src, "Received duplicate packet.");
+            return
+        }
+
         let event = match Message::decode(data) {
             Ok(packet) => {
                 if packet.node_id == self.local_id {
@@ -2093,10 +2105,9 @@ impl IngressHandler {
                     return
                 }
 
-                if self.cache.contains_packet(packet.hash) {
-                    debug!(target: "discv4", ?src, "Received duplicate packet.");
-                    return
-                }
+                // Only packets that decoded are remembered, so a peer cannot suppress a packet we
+                // have not seen yet by guessing its hash.
+                self.cache.insert_packet(packet.hash);
 
                 IngressEvent::Packet(src, packet)
             }
@@ -2147,9 +2158,16 @@ impl ReceiveCache {
         *ctn
     }
 
-    /// Returns true if we previously received the packet
+    /// Returns true if we previously received the packet.
+    ///
+    /// A hit refreshes the entry so that a packet being replayed repeatedly stays cached.
     fn contains_packet(&mut self, hash: B256) -> bool {
-        !self.unique_packets.insert(hash, ())
+        self.unique_packets.get(&hash).is_some()
+    }
+
+    /// Remembers a packet we accepted.
+    fn insert_packet(&mut self, hash: B256) {
+        self.unique_packets.insert(hash, ());
     }
 }
 
@@ -2571,7 +2589,65 @@ mod tests {
     use rand_08::Rng;
     use reth_ethereum_forks::{EnrForkIdEntry, ForkHash};
     use reth_network_peers::mainnet_nodes;
+    use secp256k1::SECP256K1;
     use std::future::poll_fn;
+
+    #[tokio::test]
+    async fn test_duplicate_packet_rejected_without_decoding() {
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+        let local_id = pk2id(&secret_key.public_key(SECP256K1));
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut handler = IngressHandler::new(tx, local_id);
+
+        let remote_key = SecretKey::new(&mut rand_08::thread_rng());
+        let msg = Message::Ping(Ping {
+            from: rng_endpoint(&mut rand_08::thread_rng()),
+            to: rng_endpoint(&mut rand_08::thread_rng()),
+            expire: u64::MAX,
+            enr_sq: None,
+        });
+        let (packet, hash) = msg.encode(&remote_key);
+        let src = "10.0.0.1:30303".parse().unwrap();
+
+        handler.handle_packet(&packet, src).await;
+        assert!(matches!(rx.try_recv(), Ok(IngressEvent::Packet(_, _))));
+
+        // the replay is dropped on the hash prefix alone
+        handler.handle_packet(&packet, src).await;
+        assert!(rx.try_recv().is_err());
+        assert!(handler.cache.contains_packet(hash));
+    }
+
+    #[tokio::test]
+    async fn test_undecodable_packet_does_not_poison_cache() {
+        let secret_key = SecretKey::new(&mut rand_08::thread_rng());
+        let local_id = pk2id(&secret_key.public_key(SECP256K1));
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut handler = IngressHandler::new(tx, local_id);
+
+        let remote_key = SecretKey::new(&mut rand_08::thread_rng());
+        let msg = Message::Ping(Ping {
+            from: rng_endpoint(&mut rand_08::thread_rng()),
+            to: rng_endpoint(&mut rand_08::thread_rng()),
+            expire: u64::MAX,
+            enr_sq: None,
+        });
+        let (packet, hash) = msg.encode(&remote_key);
+        let src = "10.0.0.1:30303".parse().unwrap();
+
+        // a packet carrying the right hash prefix but a corrupt body must not be remembered,
+        // otherwise it could be used to suppress the real packet
+        let mut forged = packet.to_vec();
+        let last = forged.len() - 1;
+        forged[last] ^= 0xff;
+        handler.handle_packet(&forged, src).await;
+        assert!(matches!(rx.try_recv(), Ok(IngressEvent::BadPacket(..))));
+        assert!(!handler.cache.contains_packet(hash));
+
+        // so the genuine packet still gets through
+        handler.handle_packet(&packet, src).await;
+        assert!(matches!(rx.try_recv(), Ok(IngressEvent::Packet(_, _))));
+    }
 
     #[tokio::test]
     async fn test_configured_enr_forkid_entry() {

--- a/crates/net/discv4/src/proto.rs
+++ b/crates/net/discv4/src/proto.rs
@@ -155,6 +155,11 @@ impl Message {
             return Err(DecodePacketError::HashMismatch)
         }
 
+        // Resolve the message type before recovering the public key: recovery is by far the most
+        // expensive step of decoding, and a packet we have no handler for is rejected either way.
+        let message_id =
+            MessageId::from_u8(packet[97]).map_err(DecodePacketError::UnknownMessage)?;
+
         let signature = &packet[32..96];
         let recovery_id = RecoveryId::try_from(packet[96] as i32)?;
         let recoverable_sig = RecoverableSignature::from_compact(signature, recovery_id)?;
@@ -165,10 +170,9 @@ impl Message {
         let pk = SECP256K1.recover_ecdsa(&msg, &recoverable_sig)?;
         let node_id = pk2id(&pk);
 
-        let msg_type = packet[97];
         let payload = &mut &packet[98..];
 
-        let msg = match MessageId::from_u8(msg_type).map_err(DecodePacketError::UnknownMessage)? {
+        let msg = match message_id {
             MessageId::Ping => Self::Ping(Ping::decode(payload)?),
             MessageId::Pong => Self::Pong(Pong::decode(payload)?),
             MessageId::FindNode => Self::FindNode(FindNode::decode(payload)?),

--- a/crates/net/discv4/src/test_utils.rs
+++ b/crates/net/discv4/src/test_utils.rs
@@ -66,7 +66,12 @@ impl MockDiscovery {
         let mut tasks = JoinSet::<()>::new();
 
         let udp = Arc::clone(&socket);
-        tasks.spawn(receive_loop(udp, ingress_tx, local_enr.id));
+        tasks.spawn(receive_loop(
+            udp,
+            ingress_tx,
+            local_enr.id,
+            Discv4Config::default().udp_ingress_readers,
+        ));
 
         let udp = Arc::clone(&socket);
         tasks.spawn(send_loop(udp, egress_rx));

--- a/crates/net/network/src/discovery.rs
+++ b/crates/net/network/src/discovery.rs
@@ -197,7 +197,7 @@ impl Discovery {
         // a new channel that `Discovery::poll` reads. This keeps both protocols moving without
         // requiring the main `Discovery::poll` loop to be driven for packets to be routed.
         let (discv5_updates, _discv5_forwarder) = match (discv4_ingress, discv5_updates) {
-            (Some(mut ingress), Some(mut updates)) => {
+            (Some(ingress), Some(mut updates)) => {
                 let (tx, rx) = mpsc::channel(updates.max_capacity());
                 let handle = tokio::spawn(async move {
                     while let Some(event) = updates.recv().await {


### PR DESCRIPTION
Builds on #26935.

Decoding a discv4 packet runs an ECDSA recovery, ~24µs of the ~24-27µs a decode costs. `receive_loop` did that inline between two `recv_from` calls, so the socket went unread for the duration of every verification and the receive path was capped at one recovery at a time.

Datagrams are now read by `udp_ingress_readers` tasks sharing the socket. The kernel hands each datagram to exactly one of them, so there is no dispatch queue and no per packet buffer copy; the readers only contend on the rate limit and duplicate lookups, which are map operations next to the recovery. The readers live in a `JoinSet` so aborting the receive loop takes them down with it.

Deduplication stays exact. The check on the hash prefix is now only an early out, and the insert after decoding reports whether the packet was already known, so two readers decoding the same packet still forward it once.

Throughput of the receive path, measured over 256 packet batches with a new `ingress` bench:

| readers | Kelem/s |
| ---: | ---: |
| 1 | 38.8 |
| 2 | 73.6 |
| 4 | 142.0 |

Scaling is close to linear because the shared state is only touched for a hash map and LRU lookup per packet. For reference, decoding the same batch with no rate limiting or deduplication at all reaches 138.7 Kelem/s on this machine, so the shared handler is not adding meaningful overhead at 4 readers.

Defaults to 2 to be conservative; the numbers above are there so the default can be argued up.

Correctness of the socket path is covered by `test_receive_loop_readers_deliver_every_packet`, which pushes 40 distinct packets through 4 readers over loopback and asserts each is forwarded exactly once. Worth noting that `test_check_ping_pong`, `test_check_wrong_to`, `test_on_neighbours_recursive_lookup`, `test_bootnode_not_in_update_stream` and `test_utils::tests::can_mock_discovery` fail or time out for me on unmodified main too, so they could not be used to validate this — plain UDP loopback works here, so it seems to be something else about those tests rather than the sandbox.