### PR TITLE
fix(dns): keep rechecking a tree whose root did not change

### DIFF
--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -235,7 +235,12 @@ impl<R: Resolver> DnsDiscoveryService<R> {
                 }
             },
             Err((err, link)) => {
-                debug!(target: "disc::dns",%err, ?link, "Failed to lookup root")
+                debug!(target: "disc::dns",%err, ?link, "Failed to lookup root");
+                // an already synced tree asked for this lookup and is waiting on it, so it has to
+                // be released even though the lookup failed
+                if let Some(tree) = self.trees.get_mut(&link) {
+                    tree.root_update_failed();
+                }
             }
         }
     }
@@ -413,6 +418,7 @@ mod tests {
     use std::{
         future::poll_fn,
         net::{IpAddr, Ipv4Addr},
+        num::NonZeroUsize,
     };
 
     fn entry_hash(entry_txt: &str) -> String {
@@ -609,6 +615,59 @@ mod tests {
             Poll::Ready(())
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_recheck_tree_survives_unchanged_root() {
+        reth_tracing::init_test_tracing();
+
+        let config = DnsDiscoveryConfig {
+            recheck_interval: Duration::from_millis(100),
+            // the default 3/s would leave the recheck lookup queued behind the initial tree walk
+            max_requests_per_sec: NonZeroUsize::new(50).unwrap(),
+            ..Default::default()
+        };
+
+        let secret_key = SecretKey::new(&mut thread_rng());
+        let resolver = Arc::new(MapResolver::default());
+        let s = "enrtree-root:v1 e=QFT4PBCRX4XQCV3VUYJ6BTCEPU l=JGUFMSAGI7KZYB3P7IZW4S5Y3A seq=3 sig=3FmXuVwpa8Y7OstZTx9PIb1mt8FrW7VpDOFv4AaGCsZ2EIHmhraWhe4NxYhQDlw5MjeFXYMbJjsPeKlHzmJREQE";
+        let mut root: TreeRootEntry = s.parse().unwrap();
+        root.sign(&secret_key).unwrap();
+
+        let link =
+            LinkEntry { domain: "nodes.example.org".to_string(), pubkey: secret_key.public() };
+        resolver.insert(link.domain.clone(), root.to_string());
+
+        let mut service = DnsDiscoveryService::new(Arc::clone(&resolver), config.clone());
+        service.sync_tree_with_link(link.clone());
+
+        // first recheck sees the very same root, which must not take the tree out of rotation
+        for _ in 0..10 {
+            poll_fn(|cx| {
+                let _ = service.poll(cx);
+                Poll::Ready(())
+            })
+            .await;
+            tokio::time::sleep(config.recheck_interval / 2).await;
+        }
+
+        // now publish a change and expect the tree to still pick it up
+        let mut new_root = root.clone();
+        new_root.sequence_number = new_root.sequence_number.saturating_add(1);
+        let enr = Enr::empty(&secret_key).unwrap();
+        let enr_txt = enr.to_base64();
+        new_root.enr_root = entry_hash(&enr_txt);
+        new_root.sign(&secret_key).unwrap();
+        resolver.insert(link.domain.clone(), new_root.to_string());
+        resolver.insert(format!("{}.{}", new_root.enr_root.clone(), link.domain), enr_txt);
+
+        let event = tokio::time::timeout(Duration::from_secs(10), poll_fn(|cx| service.poll(cx)))
+            .await
+            .expect("tree stopped rechecking after an unchanged root");
+
+        match event {
+            DnsDiscoveryEvent::Enr(discovered) => assert_eq!(discovered, enr),
+        }
     }
 
     #[tokio::test]

--- a/crates/net/dns/src/lib.rs
+++ b/crates/net/dns/src/lib.rs
@@ -41,6 +41,7 @@ use tokio::{
         oneshot,
     },
     task::JoinHandle,
+    time::{Interval, MissedTickBehavior},
 };
 use tokio_stream::{
     wrappers::{ReceiverStream, UnboundedReceiverStream},
@@ -107,6 +108,12 @@ pub struct DnsDiscoveryService<R: Resolver = DnsResolver> {
     queued_events: VecDeque<DnsDiscoveryEvent>,
     /// The rate at which trees should be updated.
     recheck_interval: Duration,
+    /// Wakes the service up so due trees are rechecked.
+    ///
+    /// [`SyncTree::poll`] decides that a recheck is due by comparing timestamps, which registers
+    /// no waker, and once the initial walk is done there is nothing else to poll. Without this the
+    /// spawned service would sleep until an unrelated command or query happened to wake it.
+    recheck_tick: Interval,
     /// Links to the DNS networks to bootstrap.
     bootstrap_dns_networks: HashSet<LinkEntry>,
 }
@@ -145,6 +152,7 @@ impl<R: Resolver> DnsDiscoveryService<R> {
             dns_record_cache: LruMap::new(ByLength::new(dns_record_cache_limit.get())),
             queued_events: Default::default(),
             recheck_interval,
+            recheck_tick: recheck_tick(recheck_interval),
             bootstrap_dns_networks: bootstrap_dns_networks.unwrap_or_default(),
         }
     }
@@ -351,11 +359,24 @@ impl<R: Resolver> DnsDiscoveryService<R> {
                 self.sync_tree_with_link(link)
             }
 
+            // Register the wake-up for the next recheck. Polled to `Pending` so the waker is
+            // always armed; a ready tick needs no extra work because the trees were already polled
+            // with a current timestamp above.
+            while self.recheck_tick.poll_tick(cx).is_ready() {}
+
             if !progress && self.queued_events.is_empty() {
                 return Poll::Pending
             }
         }
     }
+}
+
+/// Builds the interval that wakes the service to look for trees due a recheck.
+fn recheck_tick(recheck_interval: Duration) -> Interval {
+    let mut tick = tokio::time::interval(recheck_interval);
+    // a service that was starved must not then fire a burst of catch-up ticks
+    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    tick
 }
 
 /// A Stream events, mainly used for debugging
@@ -615,6 +636,62 @@ mod tests {
             Poll::Ready(())
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn spawned_service_rechecks_without_outside_wakeups() {
+        reth_tracing::init_test_tracing();
+
+        let config = DnsDiscoveryConfig {
+            recheck_interval: Duration::from_millis(100),
+            max_requests_per_sec: NonZeroUsize::new(50).unwrap(),
+            ..Default::default()
+        };
+
+        let secret_key = SecretKey::new(&mut thread_rng());
+        let resolver = Arc::new(MapResolver::default());
+        let s = "enrtree-root:v1 e=QFT4PBCRX4XQCV3VUYJ6BTCEPU l=JGUFMSAGI7KZYB3P7IZW4S5Y3A seq=3 sig=3FmXuVwpa8Y7OstZTx9PIb1mt8FrW7VpDOFv4AaGCsZ2EIHmhraWhe4NxYhQDlw5MjeFXYMbJjsPeKlHzmJREQE";
+        let mut root: TreeRootEntry = s.parse().unwrap();
+        root.sign(&secret_key).unwrap();
+
+        let link =
+            LinkEntry { domain: "nodes.example.org".to_string(), pubkey: secret_key.public() };
+        resolver.insert(link.domain.clone(), root.to_string());
+
+        let mut service = DnsDiscoveryService::new(Arc::clone(&resolver), config.clone());
+        let mut node_records = service.node_record_stream();
+        service.sync_tree_with_link(link.clone());
+
+        // drive it the way the production path does: nothing polls the service except its own
+        // event stream, so only a wake-up the service arms itself can start a recheck
+        let handle = service.spawn();
+
+        // let the initial walk finish and the service go idle
+        tokio::time::sleep(config.recheck_interval * 3).await;
+
+        // publish a change that only a self-scheduled recheck can pick up
+        let mut new_root = root.clone();
+        new_root.sequence_number = new_root.sequence_number.saturating_add(1);
+        // needs an address, an ENR without one yields no node record
+        let enr = Enr::builder()
+            .ip4(Ipv4Addr::LOCALHOST)
+            .udp4(30303)
+            .tcp4(30303)
+            .build(&secret_key)
+            .unwrap();
+        let enr_txt = enr.to_base64();
+        new_root.enr_root = entry_hash(&enr_txt);
+        new_root.sign(&secret_key).unwrap();
+        resolver.insert(link.domain.clone(), new_root.to_string());
+        resolver.insert(format!("{}.{}", new_root.enr_root.clone(), link.domain), enr_txt);
+
+        let update = tokio::time::timeout(Duration::from_secs(10), node_records.next())
+            .await
+            .expect("service never woke up to recheck the tree")
+            .expect("record stream closed");
+        assert_eq!(update.enr, enr);
+
+        handle.abort();
     }
 
     #[tokio::test]

--- a/crates/net/dns/src/sync.rs
+++ b/crates/net/dns/src/sync.rs
@@ -96,8 +96,14 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
     /// so one failed lookup would take the tree out of rotation permanently. It retries at the
     /// next recheck instead.
     pub(crate) fn root_update_failed(&mut self) {
-        self.root_updated = Instant::now();
-        self.sync_state = SyncState::Active;
+        // Only a lookup this tree scheduled releases it. Root lookups are also started from
+        // bootstrap, from the public sync command and from link entries found in other trees, and
+        // those outcomes must not overwrite a walk that is still recorded in `Pending`/`Enr`/
+        // `Link`, or the tree would go quiet with its subtree unvisited.
+        if matches!(self.sync_state, SyncState::RootUpdate) {
+            self.root_updated = Instant::now();
+            self.sync_state = SyncState::Active;
+        }
     }
 
     /// Updates the root and returns what changed
@@ -109,13 +115,15 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
         self.root_updated = Instant::now();
 
         let state = match (enr_unchanged, link_unchanged) {
-            // both unchanged, nothing to resync, but the tree still has to go back to waiting for
-            // the next recheck: staying in `RootUpdate` would park `poll` on `None` forever and
-            // the tree would never pick up a later change
-            // both unchanged, nothing to resync, but the tree still has to go back to waiting for
-            // the next recheck: staying in `RootUpdate` would park `poll` on `None` forever and
-            // the tree would never pick up a later change
-            (true, true) => SyncState::Active,
+            // Nothing to resync. The tree still has to leave `RootUpdate`, which would otherwise
+            // park `poll` on `None` forever, but only when this answers its own recheck: an
+            // unsolicited lookup of an unchanged root must leave a walk in progress alone.
+            (true, true) => {
+                if !matches!(self.sync_state, SyncState::RootUpdate) {
+                    return
+                }
+                SyncState::Active
+            }
             // only ENR changed
             (false, true) => {
                 self.unresolved_nodes.clear();
@@ -206,6 +214,31 @@ mod tests {
         let same = base_root();
         tree.update_root(same);
         assert!(tree.poll(now, timeout).is_none());
+    }
+
+    #[test]
+    fn unsolicited_root_outcome_does_not_cancel_a_walk() {
+        let timeout = Duration::from_secs(60);
+
+        // a root lookup this tree did not schedule must not discard the walk it still owes. Root
+        // lookups are also started from bootstrap, the public sync command and link entries in
+        // other trees, and the query pool does not de-duplicate them.
+        for unsolicited in [true, false] {
+            let mut tree = make_tree();
+            // Pending -> emits Link, leaving the enr root still to walk
+            assert!(matches!(tree.poll(Instant::now(), timeout), Some(SyncAction::Link(_))));
+
+            if unsolicited {
+                tree.update_root(base_root());
+            } else {
+                tree.root_update_failed();
+            }
+
+            assert!(
+                matches!(tree.poll(Instant::now(), timeout), Some(SyncAction::Enr(_))),
+                "walk was cancelled by an unsolicited root outcome"
+            );
+        }
     }
 
     #[test]

--- a/crates/net/dns/src/sync.rs
+++ b/crates/net/dns/src/sync.rs
@@ -90,6 +90,16 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
         Some(SyncAction::Enr(enr))
     }
 
+    /// Records that the scheduled root lookup failed.
+    ///
+    /// Without this the tree would stay in [`SyncState::RootUpdate`] and stop polling entirely,
+    /// so one failed lookup would take the tree out of rotation permanently. It retries at the
+    /// next recheck instead.
+    pub(crate) fn root_update_failed(&mut self) {
+        self.root_updated = Instant::now();
+        self.sync_state = SyncState::Active;
+    }
+
     /// Updates the root and returns what changed
     pub(crate) fn update_root(&mut self, root: TreeRootEntry) {
         let enr_unchanged = root.enr_root == self.root.enr_root;
@@ -99,8 +109,13 @@ impl<K: EnrKeyUnambiguous> SyncTree<K> {
         self.root_updated = Instant::now();
 
         let state = match (enr_unchanged, link_unchanged) {
-            // both unchanged — no resync needed
-            (true, true) => return,
+            // both unchanged, nothing to resync, but the tree still has to go back to waiting for
+            // the next recheck: staying in `RootUpdate` would park `poll` on `None` forever and
+            // the tree would never pick up a later change
+            // both unchanged, nothing to resync, but the tree still has to go back to waiting for
+            // the next recheck: staying in `RootUpdate` would park `poll` on `None` forever and
+            // the tree would never pick up a later change
+            (true, true) => SyncState::Active,
             // only ENR changed
             (false, true) => {
                 self.unresolved_nodes.clear();
@@ -191,6 +206,48 @@ mod tests {
         let same = base_root();
         tree.update_root(same);
         assert!(tree.poll(now, timeout).is_none());
+    }
+
+    #[test]
+    fn update_root_unchanged_still_rechecks_later() {
+        let mut tree = make_tree();
+        let timeout = Duration::from_secs(60);
+        advance_to_active(&mut tree);
+
+        // the recheck interval elapses and the root is looked up again
+        let due = Instant::now() + timeout * 2;
+        assert!(matches!(tree.poll(due, timeout), Some(SyncAction::UpdateRoot)));
+
+        // it comes back unchanged, so there is nothing to resync right now
+        tree.update_root(base_root());
+        assert!(tree.poll(Instant::now(), timeout).is_none());
+
+        // but the tree has to keep rechecking, otherwise it never picks up later changes
+        let later = Instant::now() + timeout * 4;
+        assert!(
+            matches!(tree.poll(later, timeout), Some(SyncAction::UpdateRoot)),
+            "tree stopped rechecking its root after an unchanged update"
+        );
+    }
+
+    #[test]
+    fn failed_root_update_still_rechecks_later() {
+        let mut tree = make_tree();
+        let timeout = Duration::from_secs(60);
+        advance_to_active(&mut tree);
+
+        let due = Instant::now() + timeout * 2;
+        assert!(matches!(tree.poll(due, timeout), Some(SyncAction::UpdateRoot)));
+
+        // the lookup failed, which must not take the tree out of rotation for good
+        tree.root_update_failed();
+        assert!(tree.poll(Instant::now(), timeout).is_none());
+
+        let later = Instant::now() + timeout * 4;
+        assert!(
+            matches!(tree.poll(later, timeout), Some(SyncAction::UpdateRoot)),
+            "tree stopped rechecking its root after a failed lookup"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Went looking for something to optimise in DNS discovery and found this instead.

`SyncTree::poll` moves a tree into `SyncState::RootUpdate` once the recheck interval elapses, and returns `None` for as long as it stays there. Only `update_root` moves it out again, and its "nothing changed" arm returned before assigning the new state:

```rust
let state = match (enr_unchanged, link_unchanged) {
    // both unchanged — no resync needed
    (true, true) => return,
    ...
};
self.sync_state = state;
```

So the first time a recheck finds the root unchanged, the tree is parked in `RootUpdate` for good: it never rechecks its root again and never sees nodes published later. With the default 30 minute `recheck_interval`, a tree stops updating roughly half an hour after startup, whenever its first unchanged recheck lands.

A failed root lookup reached the same state from the other side. `on_resolved_root` only logged the error, so `update_root` was never called and the tree stayed in `RootUpdate` after a single transient DNS failure. It now goes back to waiting and retries at the next recheck rather than dropping out permanently.

The existing coverage missed this because `test_recheck_tree` publishes a *new* root before the recheck fires, so it only ever exercised the changed path. Added a unit test on the state machine and a service level test that lets an unchanged recheck complete before publishing a change; both fail on main and pass here.

No behaviour change when a root has actually changed.