### PR TITLE
perf(trie): avoid formatting storage root for disabled span

### DIFF
--- a/crates/trie/trie/src/trie.rs
+++ b/crates/trie/trie/src/trie.rs
@@ -791,7 +791,7 @@ where
             (!retain_updates || prefix_set.is_empty()) &&
             hashed_storage_cursor.is_storage_empty()?
         {
-            Span::current().record("storage_root", format!("{EMPTY_ROOT_HASH:?}"));
+            Span::current().record("storage_root", tracing::field::debug(EMPTY_ROOT_HASH));
             return Ok(StorageRootProgress::Complete(
                 EMPTY_ROOT_HASH,
                 0,
@@ -869,7 +869,7 @@ where
         }
 
         let root = hash_builder.root();
-        Span::current().record("storage_root", format!("{root:?}"));
+        Span::current().record("storage_root", tracing::field::debug(root));
 
         let removed_keys = storage_node_iter.walker.take_removed_keys();
         trie_updates.finalize(hash_builder, removed_keys);


### PR DESCRIPTION
`StorageRoot::calculate_with_cursors` recorded the storage root into the current span with `format!`. Macro arguments are evaluated eagerly, so each call allocated a `String` and hex-formatted 32 bytes regardless of whether anyone was listening. The `storage_root` field only exists on the trace-level spans of `calculate` and `calculate_with_cursor`; when the state root walk calls into the cursor-based path the current span is `Span::none()`, so this happened once per account leaf and the result was thrown away. The early return for accounts with empty storage — the common case — pays it too.

Passing `tracing::field::debug` instead defers the formatting to the subscriber, which only runs it if the span is enabled. The recorded value is unchanged for an enabled span: `DebugValue` forwards to the inner `Debug` impl, which is what `format!("{root:?}")` used.

Not benchmarked; the machine was too loaded for a meaningful micro-benchmark and the removed work is a per-leaf allocation that no longer happens at all.