### PR TITLE
perf(evm): reuse receipt blooms for the block logs bloom

### DIFF
--- a/crates/ethereum/evm/src/build.rs
+++ b/crates/ethereum/evm/src/build.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{Bloom, B256};
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::execute::{BlockAssembler, BlockAssemblerInput, BlockExecutionError};
 use reth_execution_types::BlockExecutionResult;
-use reth_primitives_traits::{logs_bloom as calculate_logs_bloom, Receipt, SignedTransaction};
+use reth_primitives_traits::{Receipt, SignedTransaction};
 use revm::context::Block as _;
 
 /// Block builder for Ethereum.
@@ -58,11 +58,21 @@ impl<ChainSpec: EthChainSpec + EthereumHardforks> EthBlockAssembler<ChainSpec> {
 
         let transactions_root =
             transactions_root.unwrap_or_else(|| proofs::calculate_transaction_root(&transactions));
-        let receipts_root = receipts_root.unwrap_or_else(|| {
-            calculate_receipt_root(&receipts.iter().map(|r| r.with_bloom_ref()).collect::<Vec<_>>())
-        });
-        let logs_bloom = logs_bloom
-            .unwrap_or_else(|| calculate_logs_bloom(receipts.iter().flat_map(|r| r.logs())));
+        let (receipts_root, logs_bloom) = match (receipts_root, logs_bloom) {
+            (Some(receipts_root), Some(logs_bloom)) => (receipts_root, logs_bloom),
+            (receipts_root, logs_bloom) => {
+                // The block bloom is the OR of the receipt blooms, so the blooms computed for the
+                // receipts root are reused instead of hashing every log a second time.
+                let receipts_with_bloom =
+                    receipts.iter().map(TxReceipt::with_bloom_ref).collect::<Vec<_>>();
+                (
+                    receipts_root.unwrap_or_else(|| calculate_receipt_root(&receipts_with_bloom)),
+                    logs_bloom.unwrap_or_else(|| {
+                        receipts_with_bloom.iter().fold(Bloom::ZERO, |acc, r| acc | r.bloom_ref())
+                    }),
+                )
+            }
+        };
 
         let withdrawals = self
             .chain_spec


### PR DESCRIPTION
`EthBlockAssembler::assemble_block` hashed every log twice. Computing the receipts root goes through `with_bloom_ref`, which builds each receipt's bloom from a keccak of every log address and topic, and the next line threw those blooms away and ran the identical keccaks again over all logs of the block to get the header bloom. `BlockAssembler::assemble_block` passes `None` for both values, and the payload builder calls it on every build iteration, so this is a few thousand redundant keccaks per block on each attempt.

A bloom is a plain OR accumulation, so the block bloom is the OR of the per-receipt blooms. The `ReceiptWithBloom` vec built for the root is now kept and folded into the header bloom, the same way `verify_receipts` in reth-ethereum-consensus already does it. The result is bit-identical. The vec is only built when one of the two values is missing, so callers that supply both precomputed values still skip it entirely.
