### PR TITLE
perf(trie): reuse address hash across storage changeset rows

### DIFF
--- a/crates/trie/db/src/prefix_set.rs
+++ b/crates/trie/db/src/prefix_set.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{
     keccak256,
     map::{HashMap, HashSet},
-    BlockNumber, B256,
+    Address, BlockNumber, B256,
 };
 use core::ops::RangeInclusive;
 use reth_db_api::{
@@ -50,9 +50,20 @@ where
 
     // Walk storage changesets using the provider (handles static files + database)
     let storage_changesets = provider.storage_changesets_range(range)?;
+    // Rows are ordered by `BlockNumberAddress`, so all slots of one account arrive consecutively.
+    // Memoizing the last address avoids re-hashing it once per slot; the repeated account prefix
+    // insert can be skipped because `PrefixSetMut::freeze` deduplicates anyway.
+    let mut last_address: Option<(Address, B256)> = None;
     for (BlockNumberAddress((_, address)), storage_entry) in storage_changesets {
-        let hashed_address = keccak256(address);
-        account_prefix_set.insert(Nibbles::unpack(hashed_address));
+        let hashed_address = match last_address {
+            Some((last, hashed)) if last == address => hashed,
+            _ => {
+                let hashed = keccak256(address);
+                account_prefix_set.insert(Nibbles::unpack(hashed));
+                last_address = Some((address, hashed));
+                hashed
+            }
+        };
         storage_prefix_sets
             .entry(hashed_address)
             .or_default()

--- a/crates/trie/db/src/state.rs
+++ b/crates/trie/db/src/state.rs
@@ -1,5 +1,5 @@
 use crate::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
-use alloy_primitives::{keccak256, map::B256Map, BlockNumber, B256};
+use alloy_primitives::{keccak256, map::B256Map, Address, BlockNumber, B256};
 use reth_db_api::{
     models::{AccountBeforeTx, BlockNumberAddress},
     transaction::DbTx,
@@ -307,11 +307,21 @@ impl DatabaseHashedPostState for HashedPostStateSorted {
 
         if start < end {
             let end_inclusive = end.saturating_sub(1);
+            // Rows are ordered by `BlockNumberAddress`, so all slots of one account arrive
+            // consecutively and the address hash can be reused across them.
+            let mut last_address: Option<(Address, B256)> = None;
             for (BlockNumberAddress((_, address)), storage) in
                 provider.storage_changesets_range(start..=end_inclusive)?
             {
                 if seen_storage_keys.insert((address, storage.key)) {
-                    let hashed_address = keccak256(address);
+                    let hashed_address = match last_address {
+                        Some((last, hashed)) if last == address => hashed,
+                        _ => {
+                            let hashed = keccak256(address);
+                            last_address = Some((address, hashed));
+                            hashed
+                        }
+                    };
                     storages
                         .entry(hashed_address)
                         .or_default()


### PR DESCRIPTION
Storage changesets are keyed by `BlockNumberAddress`, so all slots touched by one account arrive as consecutive rows. Both `load_prefix_sets_with_provider` and `HashedPostStateSorted::from_reverts` were hashing the 20-byte address again for every one of those rows, and the prefix set loader also re-inserted the same account prefix each time. An account that writes many slots per block pays a keccak per slot instead of one per account, over every storage changeset row in the range.

Both loops now memoize the last `(address, hashed_address)` pair and reuse the hash while the address is unchanged. Skipping the repeated `account_prefix_set.insert` is a no-op because `PrefixSetMut::freeze` sorts and dedups the keys, and the memo only ever short-circuits on an exact address match, so a non-consecutive repeat of an address still hashes and inserts normally.

No numbers here: the path needs a populated database to exercise, and this machine was too loaded for a trustworthy measurement. `load_prefix_sets_with_provider` backs `incremental_root` and runs on every merkle stage execution.