### PR TITLE
perf(rpc): store fee history entries behind Arc

### DIFF
--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -98,7 +98,7 @@ where
                 receipts,
             )
             .unwrap_or_default();
-            entries.insert(block.number(), fee_history_entry);
+            entries.insert(block.number(), Arc::new(fee_history_entry));
         }
 
         // enforce bounds by popping the oldest entries
@@ -145,7 +145,7 @@ where
         &self,
         start_block: u64,
         end_block: u64,
-    ) -> Option<Vec<FeeHistoryEntry<H>>> {
+    ) -> Option<Vec<Arc<FeeHistoryEntry<H>>>> {
         if end_block < start_block {
             // invalid range, return None
             return None
@@ -210,7 +210,7 @@ struct FeeHistoryCacheInner<H> {
     /// and max number of blocks
     config: FeeHistoryCacheConfig,
     /// Stores the entries of the cache
-    entries: tokio::sync::RwLock<BTreeMap<u64, FeeHistoryEntry<H>>>,
+    entries: tokio::sync::RwLock<BTreeMap<u64, Arc<FeeHistoryEntry<H>>>>,
 }
 
 /// Awaits for new chain events and directly inserts them into the cache so they're available


### PR DESCRIPTION
`FeeHistoryCache::get_history` deep-cloned every entry in the requested range. Each `FeeHistoryEntry` owns a full header plus a `rewards` vector sized `100 * resolution + 1` (401 `u128` by default), so a 1024-block `eth_feeHistory` request allocated and copied several megabytes that `fee_history` immediately dropped after reading a few scalars and one reward index per requested percentile.

The cache now stores `Arc<FeeHistoryEntry>` and `get_history` returns `Vec<Arc<FeeHistoryEntry>>`, so the range clone is one refcount bump per entry. Entries are never mutated after insertion, so sharing them is safe; the only caller reads them through a shared reference and needed no changes beyond deref coercion. `get_history` is public, so the return type change is visible to downstream users.

Measured with a throwaway test over a 1024-entry cache using a counting global allocator: 1033 allocations / 7.52 MB per call before, 9 allocations / 8 KB after. Wall clock in the same run went from 1.13 ms to 9.3 us per call, though the machine was loaded at the time so treat the timing as indicative rather than precise.