### PR TITLE
perf(static-files): use btree range lookup for block index

### DIFF
--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -356,16 +356,15 @@ impl<N: NodePrimitives> StaticFileProviderInner<N> {
 
         if let Some(block_index) = block_index {
             // Find first block range that contains the requested block
-            if let Some((_, range)) = block_index.iter().find(|(max_block, _)| block <= **max_block)
-            {
+            if let Some((_, range)) = block_index.range(block..).next() {
                 // Found matching range for an existing file using block index
                 return *range;
             } else if let Some((_, range)) = block_index.last_key_value() {
                 // Didn't find matching range for an existing file, derive a new range from the end
                 // of the last existing file range.
                 //
-                // `block` is always higher than `range.end()` here, because we iterated over all
-                // `block_index` ranges above and didn't find one that contains our block
+                // `block` is always higher than `range.end()` here, because `block_index` holds no
+                // range with a `max_block` greater than or equal to `block`
                 let blocks_after_last_range = block - range.end();
                 let segments_to_skip = (blocks_after_last_range - 1) / blocks_per_file;
                 let start = range.end() + 1 + segments_to_skip * blocks_per_file;


### PR DESCRIPTION
`find_fixed_range_with_block_index` located the static file holding a block with a linear `iter().find()` over the block index, a `BTreeMap` keyed by each file's max block. The iteration is ascending, so the oldest file is checked first and the hot case, a block at or near the tip, scans the entire map before matching. On mainnet that is dozens of entries today and grows with chain length, and it happens under the held index read lock on every block-keyed static file lookup: header_by_number, sealed_header, block_hash for BLOCKHASH and RPC, changeset segments, and via the transaction path every tx, receipt and sender lookup.

Replaces the scan with `block_index.range(block..).next()`, which returns the same first entry whose max block is greater than or equal to the requested block in O(log n). The fallback branches that derive a new range from the last file, or from the fixed blocks-per-file when no index exists, are unchanged.