### PR TITLE
perf(engine): skip prewarm tx clones when nothing consumes them

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -186,8 +186,14 @@ where
             + HistoryReader
             + 'static,
     {
-        let (prewarm_rx, execution_rx) =
-            self.spawn_tx_iterator(transactions, env.transaction_count, parallel_bal_execution);
+        let prewarm_transactions =
+            self.prewarms_transactions(env.transaction_count, parallel_bal_execution);
+        let (prewarm_rx, execution_rx) = self.spawn_tx_iterator(
+            transactions,
+            env.transaction_count,
+            parallel_bal_execution,
+            prewarm_transactions,
+        );
         let prewarm_handle = self.spawn_caching_with(
             env,
             prewarm_rx,
@@ -197,6 +203,22 @@ where
             parallel_bal_execution,
         );
         PayloadHandle { prewarm_handle, transactions: execution_rx, _span: Span::current() }
+    }
+
+    /// Whether the prewarm task will consume converted transactions, i.e. whether
+    /// [`Self::spawn_caching_with`] ends up in [`PrewarmMode::Transactions`].
+    ///
+    /// This is the only place the decision is made: the tx iterator uses it to skip creating the
+    /// prewarm channel and cloning every transaction into it, and the resulting `Option` receiver
+    /// then selects the mode, so the two cannot disagree.
+    const fn prewarms_transactions(
+        &self,
+        transaction_count: usize,
+        parallel_bal_execution: bool,
+    ) -> bool {
+        !parallel_bal_execution &&
+            !self.disable_transaction_prewarming &&
+            transaction_count >= SMALL_BLOCK_TX_THRESHOLD
     }
 
     /// Transaction count threshold below which sequential conversion is used.
@@ -227,14 +249,19 @@ where
     ///
     /// When `parallel_bal_execution` is disabled, preserves the original transaction order.
     /// Otherwise, streams results as they become available.
+    ///
+    /// The prewarm channel is only created when `prewarm_transactions` is set, see
+    /// [`Self::prewarms_transactions`]; otherwise no transaction is cloned into it.
     #[instrument(level = "debug", target = "engine::tree::payload_processor", skip_all)]
     fn spawn_tx_iterator<I: ExecutableTxIterator<Evm>>(
         &self,
         transactions: I,
         transaction_count: usize,
         parallel_bal_execution: bool,
-    ) -> (IteratorPrewarmTxReceiver<Evm, I>, IteratorExecuteTxReceiver<Evm, I>) {
-        let (prewarm_tx, prewarm_rx) = mpsc::sync_channel(transaction_count);
+        prewarm_transactions: bool,
+    ) -> (Option<IteratorPrewarmTxReceiver<Evm, I>>, IteratorExecuteTxReceiver<Evm, I>) {
+        let (prewarm_tx, prewarm_rx) =
+            prewarm_transactions.then(|| mpsc::sync_channel(transaction_count)).unzip();
         let (execute_tx, execute_rx) = crossbeam_channel::bounded(transaction_count);
 
         if transaction_count == 0 {
@@ -249,7 +276,12 @@ where
             );
             self.executor.spawn_blocking_named("tx-iterator", move || {
                 let (transactions, convert) = transactions.into_parts();
-                convert_serial(transactions.into_iter(), &convert, &prewarm_tx, &execute_tx);
+                convert_serial(
+                    transactions.into_iter(),
+                    &convert,
+                    prewarm_tx.as_ref(),
+                    &execute_tx,
+                );
             });
         } else {
             // Parallel path — recover signatures in parallel on rayon, stream results
@@ -271,7 +303,9 @@ where
                             .for_each(|(idx, tx)| {
                                 let tx = tx.map(|tx| {
                                     let tx = WithTxEnv::new(tx);
-                                    let _ = prewarm_tx.send((idx, tx.clone()));
+                                    if let Some(prewarm_tx) = &prewarm_tx {
+                                        let _ = prewarm_tx.send((idx, tx.clone()));
+                                    }
                                     tx
                                 });
                                 let _ = execute_tx.send((idx, tx));
@@ -287,7 +321,12 @@ where
 
                     // Convert the first few transactions sequentially so execution can
                     // start immediately without waiting for rayon work-stealing.
-                    convert_serial(iter.by_ref().take(prefetch), &convert, &prewarm_tx, &execute_tx);
+                    convert_serial(
+                        iter.by_ref().take(prefetch),
+                        &convert,
+                        prewarm_tx.as_ref(),
+                        &execute_tx,
+                    );
 
                     let mut iter = iter.enumerate();
 
@@ -317,7 +356,7 @@ where
                                 .collect::<Vec<_>>();
 
                             for (idx, tx) in chunk {
-                                if let Ok(tx) = &tx {
+                                if let (Some(prewarm_tx), Ok(tx)) = (&prewarm_tx, &tx) {
                                     let _ = prewarm_tx.send((idx, tx.clone()));
                                 }
                                 let _ = execute_tx.send((idx, tx));
@@ -341,7 +380,9 @@ where
     fn spawn_caching_with<P>(
         &self,
         env: ExecutionEnv<Evm>,
-        transactions: mpsc::Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
+        transactions: Option<
+            mpsc::Receiver<(usize, impl ExecutableTxFor<Evm> + Clone + Send + 'static)>,
+        >,
         state_provider_factory: OverlayStateProviderFactory<P, Evm::Primitives>,
         hint_stream: Option<StateRootHintStream>,
         hashed_update_stream: Option<StateRootUpdateStream>,
@@ -365,12 +406,10 @@ where
                 bal: env.decoded_bal.clone().expect("BAL dispatch implies decoded BAL"),
                 updates: hashed_update_stream,
             }
-        } else if self.disable_transaction_prewarming ||
-            env.transaction_count < SMALL_BLOCK_TX_THRESHOLD
-        {
-            PrewarmMode::Skipped
+        } else if let Some(pending) = transactions {
+            PrewarmMode::Transactions { pending, hints: hint_stream }
         } else {
-            PrewarmMode::Transactions { pending: transactions, hints: hint_stream }
+            PrewarmMode::Skipped
         };
         let saved_cache = self.disable_state_cache.not().then(|| self.cache_for(env.parent_hash));
 
@@ -485,11 +524,12 @@ where
     }
 }
 
-/// Converts transactions sequentially and sends them to the prewarm and execute channels.
+/// Converts transactions sequentially and sends them to the execute channel, and to the prewarm
+/// channel if there is one.
 fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
     iter: impl Iterator<Item = RawTx>,
     convert: &C,
-    prewarm_tx: &mpsc::SyncSender<(usize, WithTxEnv<TxEnv, Recovered>)>,
+    prewarm_tx: Option<&mpsc::SyncSender<(usize, WithTxEnv<TxEnv, Recovered>)>>,
     execute_tx: &ExecuteTxSender<TxEnv, Recovered, Err>,
 ) where
     Tx: ExecutableTxParts<TxEnv, InnerTx, Recovered = Recovered>,
@@ -499,7 +539,7 @@ fn convert_serial<RawTx, Tx, TxEnv, InnerTx, Recovered, Err, C>(
     for (idx, raw_tx) in iter.enumerate() {
         let tx = convert.convert(raw_tx);
         let tx = tx.map(|tx| WithTxEnv::new(tx));
-        if let Ok(tx) = &tx {
+        if let (Some(prewarm_tx), Ok(tx)) = (prewarm_tx, &tx) {
             let _ = prewarm_tx.send((idx, tx.clone()));
         }
         let _ = execute_tx.send((idx, tx));


### PR DESCRIPTION
The transaction iterator cloned every converted transaction into the prewarm channel unconditionally, but only `PrewarmMode::Transactions` ever reads that channel. On a BAL block prewarming runs from the block access list, and with prewarming disabled or on small blocks it is skipped entirely; in both cases `spawn_caching_with` drops the receiver, so each clone was made and immediately thrown away. `WithTxEnv::clone` shares the recovered transaction behind an `Arc` but copies the `TxEnv` by value, including its access list, authorization list and blob hashes. That is one wasted deep copy per transaction per payload, plus a bounded channel sized to the transaction count. Since BAL parallel execution is on by default, this is the common path.

The decision of whether prewarm consumes transactions now lives in a single predicate. When it is false the prewarm channel is not created at all, `spawn_tx_iterator` gets no sender and skips the clone and send, and `spawn_caching_with` receives `None` and selects `PrewarmMode::Skipped`. The mode is derived from the presence of the receiver rather than re-deriving the condition, so the two sites cannot drift apart and silently disable prewarming.

Conditions are unchanged: the predicate is exactly the negation of the old mode selection in `spawn_caching_with`. No numbers here — the effect is a removed allocation on the newPayload path rather than something isolable in a local benchmark.
