### PR TITLE
perf(rpc): bloom-filter blocks in log subscriptions and getLogs by hash

### DIFF
--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -36,6 +36,12 @@ where
         return Ok(vec![])
     }
 
+    // An empty address/topic set matches any bloom, so this can only skip blocks that have no
+    // matching logs.
+    if !filter.matches_bloom(header.logs_bloom()) {
+        return Ok(vec![])
+    }
+
     let mut all_logs = Vec::new();
     // Tracks the index of a log in the entire block.
     let mut log_index: u64 = 0;

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -512,6 +512,10 @@ where
                     .into());
                 }
 
+                if !filter.matches_bloom(header.logs_bloom()) {
+                    return Ok(Vec::new())
+                }
+
                 let mut all_logs = Vec::new();
                 append_matching_block_logs(
                     &mut all_logs,


### PR DESCRIPTION
`eth_subscribe("logs")` gives every subscriber its own canonical state stream, and the per-block helper it uses only checked the block hash and the numeric range before iterating every log of every receipt. With N subscribers a full block's logs get walked N times, including for filters that no log in the block can match. The `eth_getLogs` block-hash branch had the same gap.

Both now check the header's logs bloom first, which is the guard the `eth_getLogs` range path already applies before it loads receipts. The bloom is a conservative superset: an empty address or topic set matches every bloom, so a block is only skipped when it definitely holds no matching log.