### PR TITLE
perf(stages): avoid cloning ExecutionOutcome for ExEx notification

### DIFF
--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -448,7 +448,6 @@ where
             let prune_modes = provider.prune_modes_ref();
 
             if !blocks.is_empty() &&
-                exex_state.is_none() &&
                 prune_modes.account_history.is_some() &&
                 prune_modes.storage_history.is_some()
             {

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -438,26 +438,6 @@ where
             "Finished executing block range"
         );
 
-        // Prepare the input for post execute commit hook, where an `ExExNotification` will be sent.
-        //
-        // Note: Since we only write to `blocks` if there are any ExExes, we don't need to perform
-        // the `has_exexs` check here as well
-        if !blocks.is_empty() {
-            let previous_input = self.post_execute_commit_input.replace(Chain::new(
-                blocks,
-                state.clone(),
-                BTreeMap::new(),
-            ));
-
-            if previous_input.is_some() {
-                // Not processing the previous post execute commit input is a critical error, as it
-                // means that we didn't send the notification to ExExes
-                return Err(StageError::PostExecuteCommit(
-                    "Previous post execute commit input wasn't processed",
-                ))
-            }
-        }
-
         let time = Instant::now();
 
         if self.can_prune_changesets(provider, start_block, max_block)? {
@@ -525,6 +505,23 @@ where
             write = ?db_write_duration,
             "Execution time"
         );
+
+        // Prepare the input for post execute commit hook, where an `ExExNotification` will be sent.
+        //
+        // Note: Since we only write to `blocks` if there are any ExExes, we don't need to perform
+        // the `has_exexs` check here as well
+        if !blocks.is_empty() {
+            let previous_input =
+                self.post_execute_commit_input.replace(Chain::new(blocks, state, BTreeMap::new()));
+
+            if previous_input.is_some() {
+                // Not processing the previous post execute commit input is a critical error, as it
+                // means that we didn't send the notification to ExExes
+                return Err(StageError::PostExecuteCommit(
+                    "Previous post execute commit input wasn't processed",
+                ))
+            }
+        }
 
         let done = stage_progress == max_block;
         Ok(ExecOutput {

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -438,10 +438,22 @@ where
             "Finished executing block range"
         );
 
+        // The ExEx notification must carry the outcome as executed, so a copy is only taken if the
+        // state is modified below before it is written.
+        let mut exex_state = None;
+
         let time = Instant::now();
 
         if self.can_prune_changesets(provider, start_block, max_block)? {
             let prune_modes = provider.prune_modes_ref();
+
+            if !blocks.is_empty() &&
+                exex_state.is_none() &&
+                prune_modes.account_history.is_some() &&
+                prune_modes.storage_history.is_some()
+            {
+                exex_state = Some(state.clone());
+            }
 
             // Iterate over all reverts and clear them if pruning is configured.
             for block_number in start_block..=max_block {
@@ -478,6 +490,9 @@ where
 
             let path = provider.storage_path().join("preimage");
             if !provider.chain_spec().is_cancun_active_at_timestamp(start_header.timestamp()) {
+                if !blocks.is_empty() && exex_state.is_none() {
+                    exex_state = Some(state.clone());
+                }
                 slot_preimages::inject_plain_wipe_slots(&path, provider, &mut state)?;
             } else if path.exists() {
                 // Post-Cancun: no more self-destructs, preimage db is no longer needed.
@@ -511,8 +526,11 @@ where
         // Note: Since we only write to `blocks` if there are any ExExes, we don't need to perform
         // the `has_exexs` check here as well
         if !blocks.is_empty() {
-            let previous_input =
-                self.post_execute_commit_input.replace(Chain::new(blocks, state, BTreeMap::new()));
+            let previous_input = self.post_execute_commit_input.replace(Chain::new(
+                blocks,
+                exex_state.unwrap_or(state),
+                BTreeMap::new(),
+            ));
 
             if previous_input.is_some() {
                 // Not processing the previous post execute commit input is a critical error, as it


### PR DESCRIPTION
The execution stage built the ExEx `Chain` before writing the batch, which forced a deep clone of the whole `ExecutionOutcome` on every batch: the owned `BundleState` with every account and storage slot touched by the batch, plus the receipts of every block in it. The clone existed only because `state` was still needed by `write_state` and `hashed_post_state` further down. The block that fills `post_execute_commit_input` now runs after those writes, so the outcome is moved instead.

What ExExes receive is unchanged. `state` is modified between the two points in two cases -- reverts are cleared when changeset pruning is configured, and plain wipe slots are injected on storage-v2 pre-Cancun ranges -- so in those cases a copy is taken just before the modification and handed to the notification. That leaves the clone happening only when the outcome is actually modified before being written, and only when an ExEx is installed, since `blocks` is only populated then.

If the state writes fail, the stage now returns before replacing `post_execute_commit_input` rather than after. The transaction is not committed either way, so the "previous input wasn't processed" check keeps its meaning.
