### PR TITLE
perf(exex): buffer WAL notification serialization

### DIFF
--- a/crates/exex/exex/src/wal/storage.rs
+++ b/crates/exex/exex/src/wal/storage.rs
@@ -1,5 +1,6 @@
 use std::{
     fs::File,
+    io::{BufReader, BufWriter, Write},
     path::{Path, PathBuf},
 };
 
@@ -138,7 +139,7 @@ where
 
         // Deserialize using the bincode- and msgpack-compatible serde wrapper
         let notification: reth_exex_types::serde_bincode_compat::ExExNotification<'_, N> =
-            rmp_serde::decode::from_read(&mut file)
+            rmp_serde::decode::from_read(BufReader::new(&mut file))
                 .map_err(|err| WalError::Decode(file_id, file_path, err))?;
 
         Ok(Some((notification.into(), size)))
@@ -163,7 +164,12 @@ where
             reth_exex_types::serde_bincode_compat::ExExNotification::<N>::from(notification);
 
         reth_fs_util::atomic_write_file(&file_path, |file| {
-            rmp_serde::encode::write(file, &notification)
+            let mut writer = BufWriter::new(file);
+            rmp_serde::encode::write(&mut writer, &notification)?;
+            // a `BufWriter` dropped without an explicit flush discards write errors, and
+            // `atomic_write_file` fsyncs as soon as this returns
+            writer.flush()?;
+            Ok::<_, Box<dyn core::error::Error + Send + Sync>>(())
         })?;
 
         Ok(file_path.metadata().map_err(|err| WalError::FileMetadata(file_id, err))?.len())


### PR DESCRIPTION
The WAL serializes each notification straight into a raw `File`, and rmp-serde issues a separate `write`/`read` call per msgpack value, so a chain notification costs thousands of syscalls in each direction. Wrapping the encoder in a `BufWriter` and the decoder in a `BufReader` collapses that into 8 KiB chunks. The explicit flush matters because a `BufWriter` dropped without one discards write errors; durability is unchanged since `atomic_write_file` fsyncs after the closure returns.

Measured on a 650 KB synthetic notification (20 blocks, 50 txs each, receipts with logs): the write path goes from 6200 to 89 `write` calls and the read path from 6207 to 82, with a debug-build round trip dropping from ~30ms/5.9ms to ~13.6ms/3.7ms (write/read).
