### PR TITLE
perf(stages): use fast hasher for history index caches

### DIFF
--- a/crates/stages/stages/src/stages/utils.rs
+++ b/crates/stages/stages/src/stages/utils.rs
@@ -1,5 +1,8 @@
 //! Utils for `stages`.
-use alloy_primitives::{map::AddressMap, Address, BlockNumber, TxNumber, B256};
+use alloy_primitives::{
+    map::{AddressMap, HashMap},
+    Address, BlockNumber, TxNumber, B256,
+};
 use reth_config::config::EtlConfig;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
@@ -20,7 +23,7 @@ use reth_provider::{
 use reth_stages_api::StageError;
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{ChangeSetReader, StorageChangeSetReader};
-use std::{collections::HashMap, hash::Hash, ops::RangeBounds};
+use std::{hash::Hash, ops::RangeBounds};
 use tracing::info;
 
 /// Number of blocks before pushing indices from cache to [`Collector`]


### PR DESCRIPTION
The history index collectors cache `partial key -> block numbers` while walking changesets, and the storage variant keys that cache on `(Address, B256)`. Both it and the generic legacy collector used the std `HashMap`, so every changeset entry over the whole indexed range paid a SipHash-1-3 pass over a 52-byte key. The account collector next to them already uses alloy's fast-hasher map.

Switches both caches to `alloy_primitives::map::HashMap` (foldhash). Type and import change only: the caches are drained into the sorting ETL `Collector`, so map iteration order does not affect the output.

No numbers here, this only shows up on a real sync over a populated datadir.
