### PR TITLE
perf(static-files): return jar rows without allocating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9317,6 +9317,7 @@ dependencies = [
  "rand 0.9.4",
  "reth-fs-util",
  "serde",
+ "smallvec",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/storage/db/src/static_file/cursor.rs
+++ b/crates/storage/db/src/static_file/cursor.rs
@@ -2,7 +2,7 @@ use super::mask::{ColumnSelectorOne, ColumnSelectorThree, ColumnSelectorTwo};
 use alloy_primitives::B256;
 use derive_more::{Deref, DerefMut};
 use reth_db_api::table::Decompress;
-use reth_nippy_jar::{DataReader, NippyJar, NippyJarCursor};
+use reth_nippy_jar::{DataReader, NippyJar, NippyJarCursor, RefRow};
 use reth_static_file_types::SegmentHeader;
 use reth_storage_errors::provider::{ProviderError, ProviderResult};
 use std::sync::Arc;
@@ -31,7 +31,7 @@ impl<'a> StaticFileCursor<'a> {
         &mut self,
         key_or_num: KeyOrNumber<'_>,
         mask: usize,
-    ) -> ProviderResult<Option<Vec<&'_ [u8]>>> {
+    ) -> ProviderResult<Option<RefRow<'_>>> {
         if self.jar().rows() == 0 {
             return Ok(None)
         }

--- a/crates/storage/nippy-jar/Cargo.toml
+++ b/crates/storage/nippy-jar/Cargo.toml
@@ -24,6 +24,7 @@ lz4_flex.workspace = true
 
 memmap2.workspace = true
 bincode.workspace = true
+smallvec.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 anyhow.workspace = true

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -2,6 +2,7 @@ use crate::{
     compression::{Compression, Compressors, Zstd},
     DataReader, NippyJar, NippyJarError, NippyJarHeader, RefRow,
 };
+use smallvec::SmallVec;
 use std::{ops::Range, sync::Arc};
 use zstd::bulk::Decompressor;
 
@@ -83,7 +84,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
             return Ok(None)
         }
 
-        let mut row = Vec::with_capacity(self.jar.columns);
+        let mut row = ValueRanges::with_capacity(self.jar.columns);
 
         // Retrieve all column values from the row
         for column in 0..self.jar.columns {
@@ -124,7 +125,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
         }
 
         let columns = self.jar.columns;
-        let mut row = Vec::with_capacity(columns);
+        let mut row = ValueRanges::with_capacity(columns);
 
         for column in 0..columns {
             if mask & (1 << column) != 0 {
@@ -144,11 +145,7 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
     }
 
     /// Takes the column index and reads the range value for the corresponding column.
-    fn read_value(
-        &mut self,
-        column: usize,
-        row: &mut Vec<ValueRange>,
-    ) -> Result<(), NippyJarError> {
+    fn read_value(&mut self, column: usize, row: &mut ValueRanges) -> Result<(), NippyJarError> {
         // Find out the offset of the column value
         let offset_pos = self.row as usize * self.jar.columns + column;
         let value_offset = self.reader.offset(offset_pos)? as usize;
@@ -205,3 +202,11 @@ enum ValueRange {
     Mmap(Range<usize>),
     Internal(Range<usize>),
 }
+
+/// The column value ranges of a single row, mirroring the inline capacity of [`RefRow`].
+///
+/// The ranges are collected before they are resolved into slices because [`read_value`] borrows the
+/// internal buffer mutably while filling it.
+///
+/// [`read_value`]: NippyJarCursor::read_value
+type ValueRanges = SmallVec<[ValueRange; 4]>;

--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -6,6 +6,14 @@ use smallvec::SmallVec;
 use std::{ops::Range, sync::Arc};
 use zstd::bulk::Decompressor;
 
+/// The column value ranges of a single row, mirroring the inline capacity of [`RefRow`].
+///
+/// The ranges are collected before they are resolved into slices because [`read_value`] borrows the
+/// internal buffer mutably while filling it.
+///
+/// [`read_value`]: NippyJarCursor::read_value
+type ValueRanges = SmallVec<[ValueRange; 4]>;
+
 /// Simple cursor implementation to retrieve data from [`NippyJar`].
 #[derive(Clone)]
 pub struct NippyJarCursor<'a, H = ()> {
@@ -202,11 +210,3 @@ enum ValueRange {
     Mmap(Range<usize>),
     Internal(Range<usize>),
 }
-
-/// The column value ranges of a single row, mirroring the inline capacity of [`RefRow`].
-///
-/// The ranges are collected before they are resolved into slices because [`read_value`] borrows the
-/// internal buffer mutably while filling it.
-///
-/// [`read_value`]: NippyJarCursor::read_value
-type ValueRanges = SmallVec<[ValueRange; 4]>;

--- a/crates/storage/nippy-jar/src/lib.rs
+++ b/crates/storage/nippy-jar/src/lib.rs
@@ -14,6 +14,7 @@
 
 use memmap2::Mmap;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use std::{
     error::Error as StdError,
     fs::File,
@@ -64,7 +65,10 @@ pub const CHANGESET_OFFSETS_FILE_EXTENSION: &str = "csoff";
 
 /// A [`RefRow`] is a list of column value slices pointing to either an internal buffer or a
 /// memory-mapped file.
-type RefRow<'a> = Vec<&'a [u8]>;
+///
+/// The inline capacity covers every segment used by reth (at most three columns), so reading a row
+/// does not allocate.
+pub type RefRow<'a> = SmallVec<[&'a [u8]; 4]>;
 
 /// Alias type for a column value wrapped in `Result`.
 pub type ColumnResult<T> = Result<T, Box<dyn StdError + Send + Sync>>;


### PR DESCRIPTION
`NippyJarCursor` built a `Vec` of column value ranges and then collected it into a second `Vec` for the returned `RefRow`, both dropped as soon as the caller decompressed the one to three columns it wanted. That is two mallocs on every static file row read, so on `header_by_number`, `block_hash`, `transaction_by_id`, `receipt`, `transaction_sender` and every range iterator built on them.

`RefRow` is now a `SmallVec` with inline capacity for four column slices, and the intermediate ranges use a matching `SmallVec`. The widest segment has three columns, so both stay on the stack; jars with more columns spill to the heap exactly as before. The two-phase shape is unchanged - the ranges still have to be collected before they can be resolved against `internal_buffer` - only the containers differ.

Counting allocations over 100k `row_by_number_with_cols` calls on a three-column jar (release build, throwaway counting global allocator) goes from 200,000 to 0. `StaticFileCursor::get` returns `RefRow` instead of `Vec<&[u8]>`; consumers index and iterate it through `Deref` and needed no changes.