### PR TITLE
perf(trie): keep changed leaf values inline in LeafUpdate

### DIFF
--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -28,8 +28,8 @@ use reth_trie_parallel::{
 };
 use reth_trie_sparse::{
     errors::{SparseStateTrieErrorKind, SparseTrieErrorKind, SparseTrieResult},
-    ArenaParallelSparseTrie, DeferredDrops, LeafUpdate, RevealableSparseTrie, SparseStateTrie,
-    SparseTrie, TrieNodeEpoch,
+    ArenaParallelSparseTrie, DeferredDrops, LeafUpdate, LeafValue, RevealableSparseTrie,
+    SparseStateTrie, SparseTrie, TrieNodeEpoch,
 };
 use tracing::{debug, debug_span, error, instrument, trace_span};
 
@@ -507,9 +507,9 @@ where
 
                 for (&slot, &value) in &storage.storage {
                     let encoded = if value.is_zero() {
-                        Vec::new()
+                        LeafValue::new()
                     } else {
-                        alloy_rlp::encode_fixed_size(&value).to_vec()
+                        LeafValue::from_slice(&alloy_rlp::encode_fixed_size(&value))
                     };
                     new_updates.insert(slot, LeafUpdate::Changed(encoded));
 
@@ -808,13 +808,13 @@ where
                 }
 
                 // Get the current account state either from the trie or from latest account update.
-                let trie_account = match self.account_updates.get(addr) {
+                let trie_account: Option<&[u8]> = match self.account_updates.get(addr) {
                     Some(LeafUpdate::Changed(encoded)) => {
-                        Some(encoded).filter(|encoded| !encoded.is_empty())
+                        Some(encoded.as_slice()).filter(|encoded| !encoded.is_empty())
                     }
                     // Needs to be revealed first
                     Some(LeafUpdate::Touched) => return true,
-                    None => self.trie.get_account_value(addr),
+                    None => self.trie.get_account_value(addr).map(Vec::as_slice),
                 };
 
                 let trie_account = trie_account.map(|value| TrieAccount::decode(&mut &value[..]).expect("invalid account RLP"));
@@ -1053,14 +1053,14 @@ fn encode_account_leaf_value(
     account: Option<Account>,
     storage_root: B256,
     account_rlp_buf: &mut Vec<u8>,
-) -> Vec<u8> {
+) -> LeafValue {
     if account.is_none_or(|account| account.is_empty()) && storage_root == EMPTY_ROOT_HASH {
-        return Vec::new();
+        return LeafValue::new();
     }
 
     account_rlp_buf.clear();
     account.unwrap_or_default().into_trie_account(storage_root).encode(account_rlp_buf);
-    account_rlp_buf.clone()
+    LeafValue::from_slice(account_rlp_buf)
 }
 
 /// Pending proof targets queued for dispatch to proof workers, along with their count.
@@ -1217,7 +1217,7 @@ mod tests {
         assert_eq!(decoded.nonce, 7);
         assert_eq!(decoded.balance, U256::from(42));
         assert_eq!(decoded.storage_root, storage_root);
-        assert_eq!(account_rlp_buf, encoded);
+        assert_eq!(account_rlp_buf.as_slice(), encoded.as_slice());
     }
 
     #[test]

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -25,7 +25,7 @@ alloy-primitives.workspace = true
 # misc
 either = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
-smallvec = { workspace = true, optional = true }
+smallvec.workspace = true
 slotmap = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 
@@ -54,7 +54,6 @@ std = [
     "dep:either",
     "dep:rayon",
     "dep:reth-primitives-traits",
-    "dep:smallvec",
     "dep:slotmap",
     "dep:tracing",
     "alloy-primitives/std",

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2900,7 +2900,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
 mod tests {
     use super::TRACE_TARGET;
     use crate::{
-        ArenaParallelSparseTrie, ArenaParallelismThresholds, LeafUpdate, SparseTrie, TrieNodeEpoch,
+        ArenaParallelSparseTrie, ArenaParallelismThresholds, LeafUpdate, LeafValue, SparseTrie,
+        TrieNodeEpoch,
     };
     use alloy_primitives::{map::B256Map, B256, U256};
     use rand::{seq::SliceRandom, Rng, SeedableRng};
@@ -2964,9 +2965,9 @@ mod tests {
                 .iter()
                 .map(|(&slot, &value)| {
                     let rlp_value = if value == U256::ZERO {
-                        Vec::new()
+                        LeafValue::new()
                     } else {
-                        alloy_rlp::encode_fixed_size(&value).to_vec()
+                        LeafValue::from_slice(&alloy_rlp::encode_fixed_size(&value))
                     };
                     (slot, LeafUpdate::Changed(rlp_value))
                 })

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -560,7 +560,7 @@ impl<S: SparseTrieTrait + Clone> StorageTries<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ArenaParallelSparseTrie, LeafLookup, LeafUpdate};
+    use crate::{ArenaParallelSparseTrie, LeafLookup, LeafUpdate, LeafValue};
     use alloy_primitives::{
         b256,
         map::{HashMap, HashSet},
@@ -645,7 +645,7 @@ mod tests {
 
         // Remove the leaf node and check that the state trie does not contain the leaf node and
         // value
-        apply_account_update(&mut sparse, B256::ZERO, LeafUpdate::Changed(Vec::new()));
+        apply_account_update(&mut sparse, B256::ZERO, LeafUpdate::Changed(LeafValue::new()));
         assert!(matches!(
             sparse.state_trie_ref().unwrap().find_leaf(&full_path_0, None),
             Ok(LeafLookup::NonExistent)
@@ -708,7 +708,7 @@ mod tests {
 
         // Remove the leaf node and check that the storage trie does not contain the leaf node and
         // value
-        let mut updates = B256Map::from_iter([(B256::ZERO, LeafUpdate::Changed(Vec::new()))]);
+        let mut updates = B256Map::from_iter([(B256::ZERO, LeafUpdate::Changed(LeafValue::new()))]);
         sparse
             .storage_trie_mut(&B256::ZERO)
             .unwrap()
@@ -805,7 +805,9 @@ mod tests {
 
         let mut storage_updates = B256Map::from_iter([(
             slot,
-            LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&U256::from(2)).to_vec()),
+            LeafUpdate::Changed(LeafValue::from_slice(&alloy_rlp::encode_fixed_size(&U256::from(
+                2,
+            )))),
         )]);
         sparse
             .storage_trie_mut(&account)
@@ -823,7 +825,7 @@ mod tests {
         apply_account_update(
             &mut sparse,
             account,
-            LeafUpdate::Changed(alloy_rlp::encode(trie_account)),
+            LeafUpdate::Changed(LeafValue::from_vec(alloy_rlp::encode(trie_account))),
         );
         let root_before = sparse.root(epoch(10)).unwrap();
         sparse.prune(epoch(10));
@@ -905,7 +907,7 @@ mod tests {
         );
 
         // Remove the leaf node
-        apply_account_update(&mut sparse, B256::ZERO, LeafUpdate::Changed(Vec::new()));
+        apply_account_update(&mut sparse, B256::ZERO, LeafUpdate::Changed(LeafValue::new()));
         assert!(sparse.state_trie_ref().unwrap().get_leaf_value(&full_path_0).is_none());
     }
 
@@ -955,7 +957,7 @@ mod tests {
         );
 
         // Remove the leaf node
-        let mut updates = B256Map::from_iter([(B256::ZERO, LeafUpdate::Changed(Vec::new()))]);
+        let mut updates = B256Map::from_iter([(B256::ZERO, LeafUpdate::Changed(LeafValue::new()))]);
         sparse
             .storage_trie_mut(&B256::ZERO)
             .unwrap()
@@ -1076,11 +1078,13 @@ mod tests {
         apply_account_update(
             &mut sparse,
             address_3,
-            LeafUpdate::Changed(alloy_rlp::encode(trie_account_3)),
+            LeafUpdate::Changed(LeafValue::from_vec(alloy_rlp::encode(trie_account_3))),
         );
 
-        let mut updates =
-            B256Map::from_iter([(slot_3, LeafUpdate::Changed(alloy_rlp::encode(value_3)))]);
+        let mut updates = B256Map::from_iter([(
+            slot_3,
+            LeafUpdate::Changed(LeafValue::from_vec(alloy_rlp::encode(value_3))),
+        )]);
         sparse
             .storage_trie_mut(&address_1)
             .unwrap()
@@ -1091,7 +1095,7 @@ mod tests {
         apply_account_update(
             &mut sparse,
             address_1,
-            LeafUpdate::Changed(alloy_rlp::encode(trie_account_1)),
+            LeafUpdate::Changed(LeafValue::from_vec(alloy_rlp::encode(trie_account_1))),
         );
 
         sparse.root(epoch(0)).unwrap();

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -12,6 +12,7 @@ use reth_execution_errors::SparseTrieResult;
 use reth_trie_common::{
     BranchNodeMasks, Nibbles, ProofTrieNodeV2, ProofV2TargetParent, TrieNodeV2,
 };
+use smallvec::SmallVec;
 
 /// Modification epoch assigned to cached sparse trie nodes.
 ///
@@ -44,8 +45,8 @@ impl TrieNodeEpoch {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LeafUpdate {
     /// The leaf value has been changed to the given RLP-encoded value.
-    /// Empty Vec indicates the leaf has been removed.
-    Changed(Vec<u8>),
+    /// An empty value indicates the leaf has been removed.
+    Changed(LeafValue),
     /// The leaf value may have changed, but the new value is not yet known.
     /// Used for optimistic prewarming when the actual value is unavailable.
     Touched,
@@ -62,6 +63,13 @@ impl LeafUpdate {
         matches!(self, Self::Touched)
     }
 }
+
+/// RLP-encoded value carried by [`LeafUpdate::Changed`].
+///
+/// The inline capacity fits an RLP-encoded `U256` storage slot value, which dominates by volume: a
+/// block can change tens of thousands of slots, so holding those bytes inline avoids an allocation
+/// per slot. Account leaves are larger and spill to the heap, but are an order of magnitude rarer.
+pub type LeafValue = SmallVec<[u8; 33]>;
 
 /// Trait defining common operations for revealed sparse trie implementations.
 ///

--- a/crates/trie/sparse/tests/suite/get_leaf_value.rs
+++ b/crates/trie/sparse/tests/suite/get_leaf_value.rs
@@ -18,7 +18,7 @@ pub(super) fn test_get_leaf_value_after_update<T: SparseTrie>(new_trie: fn() -> 
     let new_value = U256::from(42);
     let new_value_rlp = encode_fixed_size(&new_value).to_vec();
     let mut leaf_updates: B256Map<LeafUpdate> =
-        once((key4, LeafUpdate::Changed(new_value_rlp.clone()))).collect();
+        once((key4, LeafUpdate::Changed(LeafValue::from_slice(&new_value_rlp)))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     assert_eq!(
@@ -31,7 +31,7 @@ pub(super) fn test_get_leaf_value_after_update<T: SparseTrie>(new_trie: fn() -> 
     let updated_value = U256::from(222);
     let updated_value_rlp = encode_fixed_size(&updated_value).to_vec();
     let mut leaf_updates: B256Map<LeafUpdate> =
-        once((key2, LeafUpdate::Changed(updated_value_rlp.clone()))).collect();
+        once((key2, LeafUpdate::Changed(LeafValue::from_slice(&updated_value_rlp)))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     assert_eq!(
@@ -61,7 +61,8 @@ pub(super) fn test_get_leaf_value_after_removal<T: SparseTrie>(new_trie: fn() ->
         "get_leaf_value should return Some before removal"
     );
 
-    // Remove key2 by setting its value to U256::ZERO (produces LeafUpdate::Changed(vec![])).
+    // Remove key2 by setting its value to U256::ZERO (produces
+    // LeafUpdate::Changed(LeafValue::new())).
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key2, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -415,7 +415,10 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<T: Sp
 
     // Step 3: Replace Touched with Changed(new_value) in the map.
     let new_value = U256::from(999);
-    leaf_updates.insert(target_key, LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
+    leaf_updates.insert(
+        target_key,
+        LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&new_value))),
+    );
 
     // Step 4: update_leaves again — key should now be drained.
     trie.update_leaves(&mut leaf_updates, |_, _| {})
@@ -472,7 +475,7 @@ pub(super) fn test_get_leaf_value_for_storage_root_lookup<T: SparseTrie>(new_tri
 
     // Step 4: Update the leaf with the re-encoded value.
     let mut leaf_updates: B256Map<LeafUpdate> =
-        once((key1, LeafUpdate::Changed(new_value_rlp))).collect();
+        once((key1, LeafUpdate::Changed(LeafValue::from_vec(new_value_rlp)))).collect();
     trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
 
     // Step 5: Compute root and verify against reference.
@@ -523,8 +526,11 @@ pub(super) fn test_find_leaf_before_update_to_check_existence<T: SparseTrie>(new
     let new_key2_value = U256::from(222);
     let new_insert_value = U256::from(444);
     let mut leaf_updates: B256Map<LeafUpdate> = [
-        (key2, LeafUpdate::Changed(encode_fixed_size(&new_key2_value).to_vec())),
-        (nonexistent_key, LeafUpdate::Changed(encode_fixed_size(&new_insert_value).to_vec())),
+        (key2, LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&new_key2_value)))),
+        (
+            nonexistent_key,
+            LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&new_insert_value))),
+        ),
     ]
     .into_iter()
     .collect();

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -22,7 +22,9 @@ use alloy_rlp::{encode_fixed_size, Decodable};
 use alloy_trie::EMPTY_ROOT_HASH;
 use reth_trie::test_utils::TrieTestHarness;
 use reth_trie_common::{Nibbles, ProofV2Target, TrieNodeV2};
-use reth_trie_sparse::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, TrieNodeEpoch};
+use reth_trie_sparse::{
+    LeafLookup, LeafLookupError, LeafUpdate, LeafValue, SparseTrie, TrieNodeEpoch,
+};
 use std::{collections::BTreeMap, iter::once};
 
 mod find_leaf;
@@ -79,9 +81,9 @@ impl SuiteTestHarness {
             .iter()
             .map(|(&slot, &value)| {
                 let rlp_value = if value == U256::ZERO {
-                    Vec::new()
+                    LeafValue::new()
                 } else {
-                    encode_fixed_size(&value).to_vec()
+                    LeafValue::from_slice(&encode_fixed_size(&value))
                 };
                 (slot, LeafUpdate::Changed(rlp_value))
             })

--- a/crates/trie/sparse/tests/suite/prune.rs
+++ b/crates/trie/sparse/tests/suite/prune.rs
@@ -150,7 +150,7 @@ pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie>(new_trie:
 
     let mut first_update = B256Map::from_iter([(
         keys[0],
-        LeafUpdate::Changed(encode_fixed_size(&U256::from(100)).to_vec()),
+        LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&U256::from(100)))),
     )]);
     trie.update_leaves(&mut first_update, |_, _| {
         panic!("fully revealed trie must not request proofs")
@@ -163,7 +163,7 @@ pub(super) fn test_prune_then_update_and_recompute_root<T: SparseTrie>(new_trie:
     let new_value = U256::from(999);
     let mut leaf_updates = B256Map::from_iter([(
         keys[0],
-        LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()),
+        LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&new_value))),
     )]);
     trie.update_leaves(&mut leaf_updates, |_, _| {
         panic!("leaf at the cutoff epoch should remain revealed")
@@ -201,7 +201,10 @@ pub(super) fn test_prune_then_reveal_pruned_subtree<T: SparseTrie>(new_trie: fn(
 
     let new_value = U256::from(777);
     let mut leaf_updates: B256Map<LeafUpdate> = B256Map::default();
-    leaf_updates.insert(keys[2], LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
+    leaf_updates.insert(
+        keys[2],
+        LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&new_value))),
+    );
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
     let root_after = trie.root(epoch(2));
@@ -278,7 +281,7 @@ pub(super) fn test_prune_then_update_no_panic<T: SparseTrie>(new_trie: fn() -> T
     new_key.0[0] = 0xFF;
     let value_bytes = encode_fixed_size(&U256::from(999));
     let mut leaf_updates =
-        B256Map::from_iter([(new_key, LeafUpdate::Changed(value_bytes.to_vec()))]);
+        B256Map::from_iter([(new_key, LeafUpdate::Changed(LeafValue::from_slice(&value_bytes)))]);
 
     // The update will hit blinded nodes — the reveal_and_update loop supplies proofs.
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
@@ -335,7 +338,7 @@ pub(super) fn test_prune_handles_small_subtrie_root_nodes<T: SparseTrie>(new_tri
     trie.root(epoch(0));
     let mut update = B256Map::from_iter([(
         small_key,
-        LeafUpdate::Changed(encode_fixed_size(&U256::from(2)).to_vec()),
+        LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&U256::from(2)))),
     )]);
     trie.update_leaves(&mut update, |_, _| panic!("fully revealed trie must not request proofs"))
         .expect("update_leaves should succeed");

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -232,7 +232,7 @@ pub(super) fn test_two_leaves_at_adjacent_keys_root_correctness<T: SparseTrie>(
     );
 }
 
-/// Remove a leaf via `LeafUpdate::Changed(vec![])` and verify root.
+/// Remove a leaf via `LeafUpdate::Changed(LeafValue::new())` and verify root.
 ///
 /// Starting from a 3-leaf trie, removing one key should produce a root hash
 /// matching a reference trie containing only the remaining 2 leaves.
@@ -247,7 +247,8 @@ pub(super) fn test_update_leaves_remove_leaf<T: SparseTrie>(new_trie: fn() -> T)
     let harness = SuiteTestHarness::new(base_storage);
     let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
 
-    // Remove key2 by setting its value to U256::ZERO (produces LeafUpdate::Changed(vec![])).
+    // Remove key2 by setting its value to U256::ZERO (produces
+    // LeafUpdate::Changed(LeafValue::new())).
     let mut leaf_updates = SuiteTestHarness::leaf_updates(&BTreeMap::from([(key2, U256::ZERO)]));
     harness.reveal_and_update(&mut trie, &mut leaf_updates);
 
@@ -994,9 +995,9 @@ pub(super) fn test_update_leaves_multiple_mixed_updates<T: SparseTrie>(new_trie:
     let new_value_a = U256::from(100);
     let updated_value_b = U256::from(999);
     let mut leaf_updates: B256Map<LeafUpdate> = [
-        (key_a, LeafUpdate::Changed(encode_fixed_size(&new_value_a).to_vec())),
-        (key_b, LeafUpdate::Changed(encode_fixed_size(&updated_value_b).to_vec())),
-        (key_c, LeafUpdate::Changed(Vec::new())), // removal
+        (key_a, LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&new_value_a)))),
+        (key_b, LeafUpdate::Changed(LeafValue::from_slice(&encode_fixed_size(&updated_value_b)))),
+        (key_c, LeafUpdate::Changed(LeafValue::new())), // removal
         (key_d, LeafUpdate::Touched),
     ]
     .into_iter()
@@ -1445,8 +1446,8 @@ pub(super) fn test_subtrie_collapse_touched_with_blinded_sibling<T: SparseTrie>(
     // The combination of Touched + removals with a blinded sibling (0xAC) is the
     // trigger for the bug.
     let mut leaf_updates: B256Map<LeafUpdate> = [
-        (key_ab1, LeafUpdate::Changed(Vec::new())),
-        (key_ab2, LeafUpdate::Changed(Vec::new())),
+        (key_ab1, LeafUpdate::Changed(LeafValue::new())),
+        (key_ab2, LeafUpdate::Changed(LeafValue::new())),
         (key_ab3, LeafUpdate::Touched),
     ]
     .into_iter()
@@ -1507,8 +1508,8 @@ pub(super) fn test_subtrie_emptied_by_deletes_with_touched<T: SparseTrie>(new_tr
     // Delete both 0xAB leaves + Touched on a third 0xAB key (not in the trie).
     // Touched is a no-op but must not prevent the might_empty_subtrie guard.
     let mut leaf_updates: B256Map<LeafUpdate> = [
-        (key_ab1, LeafUpdate::Changed(Vec::new())),
-        (key_ab2, LeafUpdate::Changed(Vec::new())),
+        (key_ab1, LeafUpdate::Changed(LeafValue::new())),
+        (key_ab2, LeafUpdate::Changed(LeafValue::new())),
         (key_ab3, LeafUpdate::Touched),
     ]
     .into_iter()

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -14,7 +14,7 @@ use reth_trie_common::{
     DecodedMultiProofV2, ExecutionWitnessMode, HashedPostState, MultiProofTargetsV2, ProofV2Target,
     TrieNodeV2,
 };
-use reth_trie_sparse::{LeafUpdate, SparseStateTrie, SparseTrie as _, TrieNodeEpoch};
+use reth_trie_sparse::{LeafUpdate, LeafValue, SparseStateTrie, SparseTrie as _, TrieNodeEpoch};
 
 /// State transition witness for the trie.
 #[derive(Debug)]
@@ -160,11 +160,13 @@ where
                     storage_removals
                         .entry(*hashed_address)
                         .or_default()
-                        .insert(hashed_slot, LeafUpdate::Changed(vec![]));
+                        .insert(hashed_slot, LeafUpdate::Changed(LeafValue::new()));
                 } else {
                     storage_upserts.entry(*hashed_address).or_default().insert(
                         hashed_slot,
-                        LeafUpdate::Changed(alloy_rlp::encode_fixed_size(value).to_vec()),
+                        LeafUpdate::Changed(LeafValue::from_slice(&alloy_rlp::encode_fixed_size(
+                            value,
+                        ))),
                     );
                 }
             }
@@ -251,11 +253,12 @@ where
                 };
 
             if account.is_empty() && storage_root == EMPTY_ROOT_HASH {
-                account_removals.insert(hashed_address, LeafUpdate::Changed(vec![]));
+                account_removals.insert(hashed_address, LeafUpdate::Changed(LeafValue::new()));
             } else {
                 let mut rlp = Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE);
                 account.into_trie_account(storage_root).encode(&mut rlp);
-                account_upserts.insert(hashed_address, LeafUpdate::Changed(rlp));
+                account_upserts
+                    .insert(hashed_address, LeafUpdate::Changed(LeafValue::from_vec(rlp)));
             }
         }
 


### PR DESCRIPTION
`LeafUpdate::Changed` carried a `Vec<u8>`, so the sparse trie state root task allocated once per changed storage slot just to hold an RLP-encoded `U256`, which is at most 33 bytes. On a large block that is tens of thousands of 1-33 byte mallocs, freed again as soon as `update_leaves` copies the bytes into the trie's leaf nodes.

The value is now a `SmallVec<[u8; 33]>` (`LeafValue`), so storage slot values stay inline while account leaves, which are larger but roughly an order of magnitude rarer, spill to the heap as before. Consumers already took `&[u8]`, so only the producers in the state root task and the witness builder change. Leaf nodes in the arena are untouched and still store `Vec<u8>`.

The tradeoff is per-entry size in the update maps: `size_of::<LeafUpdate>()` goes from 24 to 56 bytes.