### PR TITLE
perf(engine): batch BAL prewarm slot dispatch

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -19,10 +19,11 @@ use tracing::trace;
 /// generic over the provider factory; each worker builds its own per block.
 pub type BuildProviderFn = dyn Fn() -> ProviderResult<StateProviderBox> + Send + Sync;
 
-/// A single warm request: a whole account (basic account + its bytecode) or one storage slot.
+/// A single warm request: a whole account (basic account + its bytecode) followed by a batch of
+/// its storage slots, or a batch of storage slots on their own.
 enum PrewarmTarget {
-    Account(Address),
-    Storage(Address, StorageKey),
+    Account(Address, Box<[StorageKey]>),
+    Storage(Address, Box<[StorageKey]>),
 }
 
 /// A message in a worker's queue. The per-block lifecycle is explicit and ordered (the queue is
@@ -87,14 +88,23 @@ impl BalPrewarmPool {
         }
     }
 
-    /// Fire-and-forget: warm an account (basic account + bytecode) on some worker.
-    pub fn warm_account(&self, addr: Address) {
-        self.send_warm(PrewarmTarget::Account(addr));
-    }
+    /// Fire-and-forget: warm an account (basic account + bytecode) and its storage slots.
+    ///
+    /// The slots are dispatched in [`WARM_BATCH_SIZE`] chunks that are distributed independently,
+    /// so a single account with a large read-set does not serialize onto one worker;
+    /// [`end_block`](Self::end_block) waits for the slowest queue.
+    pub fn warm_account(&self, addr: Address, slots: impl IntoIterator<Item = StorageKey>) {
+        let mut slots = slots.into_iter();
+        let mut batch: Box<[StorageKey]> = slots.by_ref().take(WARM_BATCH_SIZE).collect();
+        self.send_warm(PrewarmTarget::Account(addr, batch));
 
-    /// Fire-and-forget: warm one storage slot on some worker.
-    pub fn warm_storage(&self, addr: Address, slot: StorageKey) {
-        self.send_warm(PrewarmTarget::Storage(addr, slot));
+        loop {
+            batch = slots.by_ref().take(WARM_BATCH_SIZE).collect();
+            if batch.is_empty() {
+                break
+            }
+            self.send_warm(PrewarmTarget::Storage(addr, batch));
+        }
     }
 
     /// Ends the block: every worker drops its provider (and read txn) once it has drained the warm
@@ -141,6 +151,13 @@ impl BalPrewarmPool {
 /// This should explain why this particular value is picked.
 pub const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
 
+/// Number of storage slots carried by one warm message.
+///
+/// Batching amortizes the send over many slots and hands the worker a run of slots that live
+/// close together in the storage table, while the cap keeps enough messages in flight to saturate
+/// the workers on blocks whose read-set is concentrated in a few accounts.
+const WARM_BATCH_SIZE: usize = 32;
+
 fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and
     // `EndBlock`. `None` while idle, so no read txn is pinned across the inter-block gap.
@@ -164,16 +181,17 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
             PrewarmMsg::Warm(target) => {
                 let Some(provider) = provider.as_ref() else { continue };
                 match target {
-                    PrewarmTarget::Account(addr) => {
+                    PrewarmTarget::Account(addr, slots) => {
                         if let Ok(Some(account)) = provider.basic_account(&addr) &&
                             let Some(code_hash) = account.bytecode_hash &&
                             code_hash != alloy_consensus::constants::KECCAK_EMPTY
                         {
                             let _ = provider.bytecode_by_hash(&code_hash);
                         }
+                        warm_slots(provider, addr, &slots);
                     }
-                    PrewarmTarget::Storage(addr, slot) => {
-                        let _ = provider.storage(addr, slot);
+                    PrewarmTarget::Storage(addr, slots) => {
+                        warm_slots(provider, addr, &slots);
                     }
                 }
             }
@@ -182,6 +200,16 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
                 drop(end_tx);
             }
         }
+    }
+}
+
+fn warm_slots(
+    provider: &CachedStateProvider<StateProviderBox>,
+    addr: Address,
+    slots: &[StorageKey],
+) {
+    for &slot in slots {
+        let _ = provider.storage(addr, slot);
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -156,7 +156,7 @@ pub const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
 /// Batching amortizes the send over many slots and hands the worker a run of slots that live
 /// close together in the storage table, while the cap keeps enough messages in flight to saturate
 /// the workers on blocks whose read-set is concentrated in a few accounts.
-const WARM_BATCH_SIZE: usize = 32;
+const WARM_BATCH_SIZE: usize = 8;
 
 fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -90,7 +90,7 @@ impl BalPrewarmPool {
 
     /// Fire-and-forget: warm an account (basic account + bytecode) and its storage slots.
     ///
-    /// The slots are dispatched in [`WARM_BATCH_SIZE`] chunks that are distributed independently,
+    /// The slots are dispatched in `WARM_BATCH_SIZE` chunks that are distributed independently,
     /// so a single account with a large read-set does not serialize onto one worker;
     /// [`end_block`](Self::end_block) waits for the slowest queue.
     pub fn warm_account(&self, addr: Address, slots: impl IntoIterator<Item = StorageKey>) {

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -188,10 +188,14 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
                         {
                             let _ = provider.bytecode_by_hash(&code_hash);
                         }
-                        warm_slots(provider, addr, &slots);
+                        for &slot in &slots {
+                            let _ = provider.storage(addr, slot);
+                        }
                     }
                     PrewarmTarget::Storage(addr, slots) => {
-                        warm_slots(provider, addr, &slots);
+                        for &slot in &slots {
+                            let _ = provider.storage(addr, slot);
+                        }
                     }
                 }
             }
@@ -202,17 +206,6 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
         }
     }
 }
-
-fn warm_slots(
-    provider: &CachedStateProvider<StateProviderBox>,
-    addr: Address,
-    slots: &[StorageKey],
-) {
-    for &slot in slots {
-        let _ = provider.storage(addr, slot);
-    }
-}
-
 struct SendOnDrop {
     sender: Option<oneshot::Sender<()>>,
 }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -429,15 +429,18 @@ where
             });
 
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
+            let dispatch_start = Instant::now();
             for account in prefetch_bal.as_bal() {
-                pool.warm_account(account.address);
-                for change in &account.storage_changes {
-                    pool.warm_storage(account.address, change.slot.into());
-                }
-                for &slot in &account.storage_reads {
-                    pool.warm_storage(account.address, slot.into());
-                }
+                pool.warm_account(
+                    account.address,
+                    account
+                        .storage_changes
+                        .iter()
+                        .map(|change| change.slot.into())
+                        .chain(account.storage_reads.iter().map(|&slot| slot.into())),
+                );
             }
+            ctx.metrics.bal_slot_iteration_duration.record(dispatch_start.elapsed());
             pool.end_block();
         }
 


### PR DESCRIPTION
The BAL prefetch dispatch loop sent one crossbeam message per account and one per storage slot, so a block whose access list touches tens of thousands of slots pays tens of thousands of sends plus a shared `fetch_add` each. That loop is serial and runs ahead of `end_block`, so its cost sits directly on the path of the prefetch it is starting.

A warm message now carries an account together with up to 32 of its slots, and any remaining slots for that account follow in further 32-slot messages. Besides cutting the number of sends, this hands one worker a run of slots that sit close together in the storage table. The batch is capped instead of being per-account so that a single account with a large read-set cannot serialize onto one worker, since `end_block` waits for the slowest queue. The `BeginBlock`/`EndBlock` broadcast and per-worker FIFO order are unchanged, so the provider still outlives every warm queued against it.

Also records `sync.prewarm.bal_slot_iteration_duration` around the dispatch loop; the histogram was declared but never observed.