### PR TITLE
perf(trie): preallocate branch node hashes vec

### DIFF
--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -139,7 +139,7 @@ impl ArenaSparseNodeBranch {
 
     /// Returns a [`BranchNodeCompact`] from this branch's masks and children hashes.
     pub(super) fn branch_node_compact(&self, arena: &NodeArena) -> BranchNodeCompact {
-        let mut hashes = Vec::new();
+        let mut hashes = Vec::with_capacity(self.branch_masks.hash_mask.count_bits() as usize);
         for (nibble, child) in self.child_iter() {
             if self.branch_masks.hash_mask.is_bit_set(nibble) {
                 let hash = match child {


### PR DESCRIPTION
`ArenaSparseNodeBranch::branch_node_compact` built the child hash vector with `Vec::new()` and pushed one 32-byte `B256` per bit set in the hash mask, so a branch with many hashed children grew the allocation several times before settling. The exact length is already known from `hash_mask.count_bits()` — `BranchNodeCompact::new` asserts the two match — so the vector can be sized up front.

This runs once per dirty branch that produces a trie update on every `root()` call, for the upper trie and each dirty subtrie.