### PR TITLE
fix(txpool): park pending blob txs when the blob fee rises and the base fee falls

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -230,48 +230,49 @@ impl<T: TransactionOrdering> TxPool<T> {
         F: FnMut(&Arc<ValidPoolTransaction<T::Transaction>>),
     {
         std::mem::swap(&mut self.all_transactions.pending_fees.blob_fee, &mut pending_blob_fee);
-        match (self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee), base_fee_update)
-        {
-            (Ordering::Equal, Ordering::Equal | Ordering::Greater) => {
-                // fee unchanged, nothing to update
+        let blob_fee_update = self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee);
+
+        // A rise in the blob fee parks pending blob transactions, a fall in either fee can make
+        // parked ones valid again, and a single update can need both: the blob fee and the base
+        // fee are derived from different gas counters, so a block can raise one while lowering the
+        // other. They are therefore checked independently rather than as one combined match.
+        if blob_fee_update.is_gt() {
+            // increased blob fee: recheck pending pool and remove all that are no longer valid
+            let removed =
+                self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
+            for tx in removed {
+                let to = {
+                    let tx = self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+
+                    // the blob fee is too high now, unset the blob fee cap block flag
+                    tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                    tx.subpool = tx.state.into();
+                    tx.subpool
+                };
+                self.add_transaction_to_subpool(to, tx);
             }
-            (Ordering::Greater, Ordering::Equal | Ordering::Greater) => {
-                // increased blob fee: recheck pending pool and remove all that are no longer valid
-                let removed =
-                    self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
-                for tx in removed {
-                    let to = {
-                        let tx =
-                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+        }
 
-                        // the blob fee is too high now, unset the blob fee cap block flag
-                        tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
-                        tx.subpool = tx.state.into();
-                        tx.subpool
-                    };
-                    self.add_transaction_to_subpool(to, tx);
+        if blob_fee_update.is_lt() || base_fee_update.is_lt() {
+            // decreased blob/base fee: recheck blob pool and promote all that are now valid.
+            // `satisfy_pending_fee_ids` requires both fees to be satisfied, so this cannot promote
+            // a transaction the block above just parked.
+            let removed = self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
+            for tx in removed {
+                let subpool = {
+                    let tx_meta =
+                        self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+                    tx_meta.state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                    tx_meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+                    tx_meta.subpool = tx_meta.state.into();
+                    tx_meta.subpool
+                };
+
+                if subpool == SubPool::Pending {
+                    on_promoted(&tx);
                 }
-            }
-            (Ordering::Less, _) | (_, Ordering::Less) => {
-                // decreased blob/base fee: recheck blob pool and promote all that are now valid
-                let removed =
-                    self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
-                for tx in removed {
-                    let subpool = {
-                        let tx_meta =
-                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
-                        tx_meta.state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
-                        tx_meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
-                        tx_meta.subpool = tx_meta.state.into();
-                        tx_meta.subpool
-                    };
 
-                    if subpool == SubPool::Pending {
-                        on_promoted(&tx);
-                    }
-
-                    self.add_transaction_to_subpool(subpool, tx);
-                }
+                self.add_transaction_to_subpool(subpool, tx);
             }
         }
     }
@@ -3583,6 +3584,42 @@ mod tests {
         let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
         assert_eq!(tx_meta.subpool, SubPool::Pending);
         assert!(tx_meta.state.contains(TxState::ENOUGH_FEE_CAP_BLOCK));
+    }
+
+    #[test]
+    fn update_blob_fee_parks_pending_when_base_fee_falls_in_the_same_block() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let initial_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+        let initial_base_fee = 100u64;
+        pool.all_transactions.pending_fees.base_fee = initial_base_fee;
+
+        // comfortably satisfies both fees, so it starts out pending
+        let tx = MockTransaction::eip4844()
+            .with_max_fee(500)
+            .with_priority_fee(1)
+            .with_blob_fee(initial_blob_fee + 100);
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+        assert_eq!(pool.pending_pool.len(), 1);
+
+        // the blob fee rises past its cap while the base fee falls, which is what a blob heavy
+        // but gas light block produces. The rise still has to park it.
+        let raised_blob_fee = tx.max_fee_per_blob_gas().unwrap() + 1;
+        pool.all_transactions.pending_fees.base_fee = initial_base_fee - 1;
+        pool.update_blob_fee(raised_blob_fee, Ordering::Less, |_| {});
+
+        assert!(pool.pending_pool.is_empty(), "transaction was left in the pending pool");
+        assert_eq!(pool.blob_pool.len(), 1);
+
+        let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
+        assert!(
+            !tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK),
+            "blob fee cap flag was not cleared"
+        );
+        assert_eq!(tx_meta.subpool, SubPool::Blob);
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -230,22 +230,67 @@ impl<T: TransactionOrdering> TxPool<T> {
         F: FnMut(&Arc<ValidPoolTransaction<T::Transaction>>),
     {
         std::mem::swap(&mut self.all_transactions.pending_fees.blob_fee, &mut pending_blob_fee);
-        let blob_fee_update = self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee);
-        match (blob_fee_update, base_fee_update) {
+        match (self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee), base_fee_update)
+        {
             (Ordering::Equal, Ordering::Equal | Ordering::Greater) => {
                 // fee unchanged, nothing to update
             }
             (Ordering::Greater, Ordering::Equal | Ordering::Greater) => {
                 // increased blob fee: recheck pending pool and remove all that are no longer valid
-                self.demote_pending_by_blob_fee();
+                let removed =
+                    self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
+                for tx in removed {
+                    let to = {
+                        let tx =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+
+                        // the blob fee is too high now, unset the blob fee cap block flag
+                        tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                        tx.subpool = tx.state.into();
+                        tx.subpool
+                    };
+                    self.add_transaction_to_subpool(to, tx);
+                }
             }
-            (Ordering::Less, _) | (_, Ordering::Less) => {
-                if blob_fee_update.is_gt() {
-                    // increased blob fee while the base fee decreased: park pending transactions
-                    // that no longer cover the blob fee before promoting from the blob pool
-                    self.demote_pending_by_blob_fee();
+            (Ordering::Greater, Ordering::Less) => {
+                // The blob fee increased while the base fee decreased, so this update must both
+                // park transactions that no longer cover the blob fee and promote transactions
+                // that now cover both fees. Demote first so the promotion check sees the final
+                // fee state.
+                let removed =
+                    self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
+                for tx in removed {
+                    let to = {
+                        let tx =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+
+                        tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                        tx.subpool = tx.state.into();
+                        tx.subpool
+                    };
+                    self.add_transaction_to_subpool(to, tx);
                 }
 
+                let removed =
+                    self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
+                for tx in removed {
+                    let subpool = {
+                        let tx_meta =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+                        tx_meta.state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                        tx_meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+                        tx_meta.subpool = tx_meta.state.into();
+                        tx_meta.subpool
+                    };
+
+                    if subpool == SubPool::Pending {
+                        on_promoted(&tx);
+                    }
+
+                    self.add_transaction_to_subpool(subpool, tx);
+                }
+            }
+            (Ordering::Less, _) | (Ordering::Equal, Ordering::Less) => {
                 // decreased blob/base fee: recheck blob pool and promote all that are now valid
                 let removed =
                     self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
@@ -266,24 +311,6 @@ impl<T: TransactionOrdering> TxPool<T> {
                     self.add_transaction_to_subpool(subpool, tx);
                 }
             }
-        }
-    }
-
-    /// Moves all pending transactions that no longer satisfy the tracked blob fee to the sub-pool
-    /// they now belong to.
-    fn demote_pending_by_blob_fee(&mut self) {
-        let removed =
-            self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
-        for tx in removed {
-            let to = {
-                let tx = self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
-
-                // the blob fee is too high now, unset the blob fee cap block flag
-                tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
-                tx.subpool = tx.state.into();
-                tx.subpool
-            };
-            self.add_transaction_to_subpool(to, tx);
         }
     }
 
@@ -705,12 +732,6 @@ impl<T: TransactionOrdering> TxPool<T> {
         // Apply subpool updates based on fee changes
         // This will record any additional promotions based on fee movements
         self.apply_fee_updates(prev_base_fee, prev_blob_fee, &mut outcome);
-
-        // The account update only rechecks the base fee, so a blob transaction it moved to pending
-        // on a stale blob fee flag was parked again by the fee update if the blob fee rose.
-        if self.all_transactions.pending_fees.blob_fee > prev_blob_fee {
-            outcome.promoted.retain(|tx| self.pending_pool.contains(tx.id()));
-        }
 
         // Update the rest of block info (without triggering fee updates again)
         self.all_transactions.set_block_info(block_info);
@@ -3639,44 +3660,46 @@ mod tests {
     }
 
     #[test]
-    fn canonical_state_change_does_not_report_blob_tx_parked_by_blob_fee_rise() {
+    fn update_blob_fee_demotes_and_promotes_when_base_fee_falls() {
         let mut f = MockTransactionFactory::default();
         let mut pool = TxPool::new(MockOrdering::default(), Default::default());
 
         let initial_blob_fee = pool.all_transactions.pending_fees.blob_fee;
-        let mut block_info = pool.block_info();
-        block_info.pending_basefee = 600;
-        pool.set_block_info(block_info);
+        let initial_base_fee = 600;
+        pool.all_transactions.pending_fees.base_fee = initial_base_fee;
 
-        // parked in the blob pool only because its fee cap is below the base fee
-        let tx = MockTransaction::eip4844()
-            .with_max_fee(500)
+        let tx_to_demote = MockTransaction::eip4844()
+            .with_max_fee(700)
             .with_priority_fee(1)
             .with_blob_fee(initial_blob_fee + 100);
-        let validated = f.validated(tx.clone());
-        let id = *validated.id();
+        let validated = f.validated(tx_to_demote);
+        let demoted_id = *validated.id();
         pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+
+        let tx_to_promote = MockTransaction::eip4844()
+            .with_max_fee(500)
+            .with_priority_fee(1)
+            .with_blob_fee(initial_blob_fee + 300);
+        let validated = f.validated(tx_to_promote);
+        let promoted_id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+
+        assert_eq!(pool.pending_pool.len(), 1);
         assert_eq!(pool.blob_pool.len(), 1);
 
-        // The base fee falls below its cap while the blob fee rises above it. The account update
-        // runs first and moves it to pending on its stale blob fee flag, then the fee update parks
-        // it again, so it must not end up in the promoted set.
-        block_info.pending_basefee = 400;
-        block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap() + 1);
-        let outcome = pool.on_canonical_state_change(
-            block_info,
-            vec![],
-            FxHashMap::default(),
-            PoolUpdateKind::Commit,
-        );
+        // The lower base fee makes one transaction affordable while the higher blob fee makes the
+        // other unaffordable, so the same update must both promote and demote.
+        let raised_blob_fee = initial_blob_fee + 200;
+        pool.all_transactions.pending_fees.base_fee = 400;
+        let mut promoted = Vec::new();
+        pool.update_blob_fee(raised_blob_fee, Ordering::Less, |tx| promoted.push(*tx.id()));
 
-        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.pending_pool.len(), 1);
         assert_eq!(pool.blob_pool.len(), 1);
-        assert!(outcome.promoted.is_empty(), "parked transaction was reported as promoted");
+        assert_eq!(promoted, vec![promoted_id]);
 
-        let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
-        assert_eq!(tx_meta.subpool, SubPool::Blob);
-        assert!(!tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
+        assert_eq!(pool.all_transactions.txs.get(&demoted_id).unwrap().subpool, SubPool::Blob);
+        assert_eq!(pool.all_transactions.txs.get(&promoted_id).unwrap().subpool, SubPool::Pending);
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -706,6 +706,12 @@ impl<T: TransactionOrdering> TxPool<T> {
         // This will record any additional promotions based on fee movements
         self.apply_fee_updates(prev_base_fee, prev_blob_fee, &mut outcome);
 
+        // The account update only rechecks the base fee, so a blob transaction it moved to pending
+        // on a stale blob fee flag was parked again by the fee update if the blob fee rose.
+        if self.all_transactions.pending_fees.blob_fee > prev_blob_fee {
+            outcome.promoted.retain(|tx| self.pending_pool.contains(tx.id()));
+        }
+
         // Update the rest of block info (without triggering fee updates again)
         self.all_transactions.set_block_info(block_info);
 
@@ -3630,6 +3636,47 @@ mod tests {
             "blob fee cap flag was not cleared"
         );
         assert_eq!(tx_meta.subpool, SubPool::Blob);
+    }
+
+    #[test]
+    fn canonical_state_change_does_not_report_blob_tx_parked_by_blob_fee_rise() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = TxPool::new(MockOrdering::default(), Default::default());
+
+        let initial_blob_fee = pool.all_transactions.pending_fees.blob_fee;
+        let mut block_info = pool.block_info();
+        block_info.pending_basefee = 600;
+        pool.set_block_info(block_info);
+
+        // parked in the blob pool only because its fee cap is below the base fee
+        let tx = MockTransaction::eip4844()
+            .with_max_fee(500)
+            .with_priority_fee(1)
+            .with_blob_fee(initial_blob_fee + 100);
+        let validated = f.validated(tx.clone());
+        let id = *validated.id();
+        pool.add_transaction(validated, U256::from(1_000_000), 0, None).unwrap();
+        assert_eq!(pool.blob_pool.len(), 1);
+
+        // The base fee falls below its cap while the blob fee rises above it. The account update
+        // runs first and moves it to pending on its stale blob fee flag, then the fee update parks
+        // it again, so it must not end up in the promoted set.
+        block_info.pending_basefee = 400;
+        block_info.pending_blob_fee = Some(tx.max_fee_per_blob_gas().unwrap() + 1);
+        let outcome = pool.on_canonical_state_change(
+            block_info,
+            vec![],
+            FxHashMap::default(),
+            PoolUpdateKind::Commit,
+        );
+
+        assert!(pool.pending_pool.is_empty());
+        assert_eq!(pool.blob_pool.len(), 1);
+        assert!(outcome.promoted.is_empty(), "parked transaction was reported as promoted");
+
+        let tx_meta = pool.all_transactions.txs.get(&id).unwrap();
+        assert_eq!(tx_meta.subpool, SubPool::Blob);
+        assert!(!tx_meta.state.contains(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK));
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -231,49 +231,59 @@ impl<T: TransactionOrdering> TxPool<T> {
     {
         std::mem::swap(&mut self.all_transactions.pending_fees.blob_fee, &mut pending_blob_fee);
         let blob_fee_update = self.all_transactions.pending_fees.blob_fee.cmp(&pending_blob_fee);
-
-        // A rise in the blob fee parks pending blob transactions, a fall in either fee can make
-        // parked ones valid again, and a single update can need both: the blob fee and the base
-        // fee are derived from different gas counters, so a block can raise one while lowering the
-        // other. They are therefore checked independently rather than as one combined match.
-        if blob_fee_update.is_gt() {
-            // increased blob fee: recheck pending pool and remove all that are no longer valid
-            let removed =
-                self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
-            for tx in removed {
-                let to = {
-                    let tx = self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
-
-                    // the blob fee is too high now, unset the blob fee cap block flag
-                    tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
-                    tx.subpool = tx.state.into();
-                    tx.subpool
-                };
-                self.add_transaction_to_subpool(to, tx);
+        match (blob_fee_update, base_fee_update) {
+            (Ordering::Equal, Ordering::Equal | Ordering::Greater) => {
+                // fee unchanged, nothing to update
             }
-        }
-
-        if blob_fee_update.is_lt() || base_fee_update.is_lt() {
-            // decreased blob/base fee: recheck blob pool and promote all that are now valid.
-            // `satisfy_pending_fee_ids` requires both fees to be satisfied, so this cannot promote
-            // a transaction the block above just parked.
-            let removed = self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
-            for tx in removed {
-                let subpool = {
-                    let tx_meta =
-                        self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
-                    tx_meta.state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
-                    tx_meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
-                    tx_meta.subpool = tx_meta.state.into();
-                    tx_meta.subpool
-                };
-
-                if subpool == SubPool::Pending {
-                    on_promoted(&tx);
+            (Ordering::Greater, Ordering::Equal | Ordering::Greater) => {
+                // increased blob fee: recheck pending pool and remove all that are no longer valid
+                self.demote_pending_by_blob_fee();
+            }
+            (Ordering::Less, _) | (_, Ordering::Less) => {
+                if blob_fee_update.is_gt() {
+                    // increased blob fee while the base fee decreased: park pending transactions
+                    // that no longer cover the blob fee before promoting from the blob pool
+                    self.demote_pending_by_blob_fee();
                 }
 
-                self.add_transaction_to_subpool(subpool, tx);
+                // decreased blob/base fee: recheck blob pool and promote all that are now valid
+                let removed =
+                    self.blob_pool.enforce_pending_fees(&self.all_transactions.pending_fees);
+                for tx in removed {
+                    let subpool = {
+                        let tx_meta =
+                            self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+                        tx_meta.state.insert(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                        tx_meta.state.insert(TxState::ENOUGH_FEE_CAP_BLOCK);
+                        tx_meta.subpool = tx_meta.state.into();
+                        tx_meta.subpool
+                    };
+
+                    if subpool == SubPool::Pending {
+                        on_promoted(&tx);
+                    }
+
+                    self.add_transaction_to_subpool(subpool, tx);
+                }
             }
+        }
+    }
+
+    /// Moves all pending transactions that no longer satisfy the tracked blob fee to the sub-pool
+    /// they now belong to.
+    fn demote_pending_by_blob_fee(&mut self) {
+        let removed =
+            self.pending_pool.update_blob_fee(self.all_transactions.pending_fees.blob_fee);
+        for tx in removed {
+            let to = {
+                let tx = self.all_transactions.txs.get_mut(tx.id()).expect("tx exists in set");
+
+                // the blob fee is too high now, unset the blob fee cap block flag
+                tx.state.remove(TxState::ENOUGH_BLOB_FEE_CAP_BLOCK);
+                tx.subpool = tx.state.into();
+                tx.subpool
+            };
+            self.add_transaction_to_subpool(to, tx);
         }
     }
 


### PR DESCRIPTION
Closes #26959

Adds an explicit `(blob fee rises, base fee falls)` match arm that first parks pending transactions which no longer cover the blob fee, then promotes transactions which now cover both fees. This covers blob-heavy but execution-gas-light blocks and includes regression tests for demotion alone and simultaneous demotion and promotion.