### PR TITLE
perf(txpool): use next_back to find the highest remaining nonce

### DIFF
--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -340,7 +340,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                             id.sender.start_bound(),
                             std::ops::Bound::Included(TransactionId::new(id.sender, u64::MAX)),
                         ))
-                        .last()
+                        .next_back()
                     {
                         // insert the new highest nonce for this sender
                         entry.insert(new_highest.clone());


### PR DESCRIPTION
When `PendingPool::remove_transaction` drops the highest-nonce transaction of a sender it looks up the new highest by taking the last entry of that sender's range in `by_id`. `by_id` is an `imbl::OrdMap`, and its `RangedIter` implements `DoubleEndedIterator` but does not override `Iterator::last`, so the default forward-consuming implementation walks every remaining transaction of that sender instead of stepping to the end once.

Switching to `next_back()` yields the same element in one step. This path runs for every transaction pruned from the pending pool on a new block, every eviction in `remove_to_limit` and every demotion, so the walk is up to `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER` node steps each time. Not benchmarked: the range is bounded at 16 entries, so the win is too small to isolate reliably.

The `.last()` calls in `txpool.rs` are left alone; those iterators are `TakeWhile`, which is not double-ended.