### PR TITLE
perf(db): use FxHashMap for cached MDBX dbi lookups

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -22,8 +22,8 @@ use reth_libmdbx::{
 };
 use reth_storage_errors::db::LogLevel;
 use reth_tracing::tracing::error;
+use rustc_hash::FxHashMap;
 use std::{
-    collections::HashMap,
     ops::{Deref, Range},
     path::{Path, PathBuf},
     sync::Arc,
@@ -251,7 +251,7 @@ pub struct DatabaseEnv {
     /// More generally, do not dynamically create, re-open, or drop tables at
     /// runtime. It's better to perform table creation and migration only once
     /// at startup.
-    dbis: Arc<HashMap<&'static str, ffi::MDBX_dbi>>,
+    dbis: Arc<FxHashMap<&'static str, ffi::MDBX_dbi>>,
     /// Cache for metric handles. If `None`, metrics are not recorded.
     metrics: Option<Arc<DatabaseEnvMetrics>>,
     /// Write lock for when dealing with a read-write environment.

--- a/crates/storage/db/src/implementation/mdbx/tx.rs
+++ b/crates/storage/db/src/implementation/mdbx/tx.rs
@@ -12,9 +12,9 @@ use reth_db_api::{
 use reth_libmdbx::{ffi::MDBX_dbi, CommitLatency, Transaction, TransactionKind, WriteFlags, RW};
 use reth_storage_errors::db::{DatabaseWriteError, DatabaseWriteOperation};
 use reth_tracing::tracing::{debug, instrument, trace, warn};
+use rustc_hash::FxHashMap;
 use std::{
     backtrace::Backtrace,
-    collections::HashMap,
     marker::PhantomData,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -33,7 +33,7 @@ pub struct Tx<K: TransactionKind> {
     inner: Transaction<K>,
 
     /// Cached MDBX DBIs for reuse.
-    dbis: Arc<HashMap<&'static str, MDBX_dbi>>,
+    dbis: Arc<FxHashMap<&'static str, MDBX_dbi>>,
 
     /// Handler for metrics with its own [Drop] implementation for cases when the transaction isn't
     /// closed by [`Tx::commit`] or [`Tx::abort`], but we still need to report it in the metrics.
@@ -48,7 +48,7 @@ impl<K: TransactionKind> Tx<K> {
     #[track_caller]
     pub(crate) fn new(
         inner: Transaction<K>,
-        dbis: Arc<HashMap<&'static str, MDBX_dbi>>,
+        dbis: Arc<FxHashMap<&'static str, MDBX_dbi>>,
         env_metrics: Option<Arc<DatabaseEnvMetrics>>,
     ) -> reth_libmdbx::Result<Self> {
         let metrics_handler = env_metrics


### PR DESCRIPTION
Every table operation on an MDBX transaction resolves the table's dbi handle through `Tx::get_dbi_raw`, which looks the table name up in the cached `dbis` map. That map used the std default hasher, so each `get`, `put`, `delete`, `entries` and `new_cursor` call SipHashed a table name string (`"PlainAccountState"` is 17 bytes) before the probe.

Switches the map to `FxHashMap`. The keys are compile-time `&'static str` table names, never attacker-controlled, so the DoS resistance of SipHash buys nothing here. `rustc-hash` is already pulled in by the `mdbx` feature that gates this module, so there is no dependency change.

The map is private, populated once at startup in `create_tables` / `create_tables_for`, and only ever read afterwards, so the hasher swap is not observable outside the crate.

Not benchmarked: the lookup is a few tens of nanoseconds buried under the MDBX call it precedes, and the machine was too loaded to get a trustworthy isolated number.