### PR TITLE
perf(rpc): update eth cache gauges once per drained batch

### DIFF
--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -429,7 +429,7 @@ where
         self.bal_cache.shrink_to(min_capacity);
     }
 
-    fn update_cached_metrics(&self) {
+    fn update_cached_metrics(&mut self) {
         self.full_block_cache.update_cached_metrics();
         self.receipts_cache.update_cached_metrics();
         self.bal_cache.update_cached_metrics();
@@ -449,7 +449,8 @@ where
             let Poll::Ready(action) = this.action_rx.poll_next_unpin(cx) else {
                 // shrink queues if we don't have any work to do
                 this.shrink_queues();
-                // gauges only need to be accurate once the batch of messages is drained
+                // gauges only need to be accurate once the batch of messages is drained, and only
+                // caches that changed during the batch republish theirs
                 this.update_cached_metrics();
                 return Poll::Pending;
             };

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -449,6 +449,8 @@ where
             let Poll::Ready(action) = this.action_rx.poll_next_unpin(cx) else {
                 // shrink queues if we don't have any work to do
                 this.shrink_queues();
+                // gauges only need to be accurate once the batch of messages is drained
+                this.update_cached_metrics();
                 return Poll::Pending;
             };
 
@@ -603,7 +605,6 @@ where
                             let _ = response_tx.send(result);
                         }
                     };
-                    this.update_cached_metrics();
                 }
             }
         }

--- a/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/multi_consumer.rs
@@ -24,6 +24,8 @@ where
     metrics: CacheMetrics,
     // Tracked heap usage
     memory_usage: usize,
+    /// Whether the cached count or memory usage changed since the gauges were last published.
+    metrics_dirty: bool,
 }
 
 impl<K, V, L, S> Debug for MultiConsumerLruCache<K, V, L, S>
@@ -68,9 +70,10 @@ where
     where
         V: InMemorySize,
     {
-        self.cache
-            .remove(key)
-            .inspect(|value| self.memory_usage = self.memory_usage.saturating_sub(value.size()));
+        self.cache.remove(key).inspect(|value| {
+            self.memory_usage = self.memory_usage.saturating_sub(value.size());
+            self.metrics_dirty = true;
+        });
         self.queued
             .remove(key)
             .inspect(|removed| self.metrics.queued_consumers_count.decrement(removed.len() as f64))
@@ -105,10 +108,12 @@ where
         {
             // update tracked memory with the evicted value
             self.memory_usage = self.memory_usage.saturating_sub(evicted.size());
+            self.metrics_dirty = true;
         }
 
         if self.cache.insert(key, value) {
             self.memory_usage = self.memory_usage.saturating_add(size);
+            self.metrics_dirty = true;
             true
         } else {
             false
@@ -121,11 +126,18 @@ where
         self.queued.shrink_to(min_capacity);
     }
 
-    /// Update metrics for the inner cache.
+    /// Publishes the cached count and memory usage gauges if either changed since the last call.
+    ///
+    /// Returns whether the gauges were written, so lookups that only hit the cache cost nothing.
     #[inline]
-    pub fn update_cached_metrics(&self) {
+    pub fn update_cached_metrics(&mut self) -> bool {
+        if !self.metrics_dirty {
+            return false
+        }
+        self.metrics_dirty = false;
         self.metrics.cached_count.set(self.cache.len() as f64);
         self.metrics.memory_usage.set(self.memory_usage as f64);
+        true
     }
 }
 
@@ -140,6 +152,32 @@ where
             queued: Default::default(),
             metrics: CacheMetrics::new_with_labels(&[("cache", cache_id.to_string())]),
             memory_usage: 0,
+            metrics_dirty: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn gauges_only_republished_after_cache_changes() {
+        let mut cache: MultiConsumerLruCache<B256, B256, ByLength, ()> =
+            MultiConsumerLruCache::new(2, "test");
+        assert!(!cache.update_cached_metrics());
+
+        assert!(cache.insert(B256::ZERO, B256::ZERO));
+        assert!(cache.update_cached_metrics());
+        assert!(!cache.update_cached_metrics());
+
+        // hits do not touch the gauges
+        assert!(cache.get(&B256::ZERO).is_some());
+        assert!(cache.get(&B256::with_last_byte(1)).is_none());
+        assert!(!cache.update_cached_metrics());
+
+        assert!(cache.remove(&B256::ZERO).is_none());
+        assert!(cache.update_cached_metrics());
     }
 }


### PR DESCRIPTION
`EthStateCacheService::poll` published the cached-count and memory-usage gauges of all three caches after every message it handled, six gauge stores per action on the single-task actor that funnels `eth_getBlockBy*`, `eth_getLogs`, `eth_getTransactionReceipt`, `eth_getBlockReceipts` and the gas oracle. A pure cache hit is otherwise an LRU lookup, an `Arc` clone and a oneshot send.

Each cache now tracks whether an insert, eviction or removal changed its count or memory usage since the gauges were last published, and the service republishes once per drained batch, right before returning `Poll::Pending`, only for caches that changed. Lookups that only hit the cache never touch the gauges, which they also skipped before via the `continue` branches, and a batch that only served hits costs nothing extra. The gauge values are unchanged; only their update cadence moves from per message to per batch.