### PR TITLE
perf(rpc): build txpool_contentFrom from the sender's transactions

### DIFF
--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc_api::TxPoolApiServer;
-use reth_rpc_convert::{RpcConvert, RpcTypes};
+use reth_rpc_convert::RpcConvert;
 use reth_rpc_eth_api::RpcTransaction;
 use reth_transaction_pool::{
     AllPoolTransactions, PoolConsensusTx, PoolTransaction, TransactionPool,
@@ -40,38 +40,46 @@ where
     Eth: RpcConvert<Primitives: NodePrimitives<SignedTx = PoolConsensusTx<Pool>>>,
 {
     fn content(&self) -> Result<TxpoolContent<RpcTransaction<Eth::Network>>, Eth::Error> {
-        #[inline]
-        fn insert<Tx, RpcTxB>(
-            tx: &Tx,
-            content: &mut BTreeMap<
-                Address,
-                BTreeMap<String, <RpcTxB::Network as RpcTypes>::TransactionResponse>,
-            >,
-            resp_builder: &RpcTxB,
-        ) -> Result<(), RpcTxB::Error>
-        where
-            Tx: PoolTransaction,
-            RpcTxB: RpcConvert<Primitives: NodePrimitives<SignedTx = Tx::Consensus>>,
-        {
-            content.entry(tx.sender()).or_default().insert(
-                tx.nonce().to_string(),
-                resp_builder.fill_pending(tx.clone_into_consensus())?,
-            );
-
-            Ok(())
-        }
-
         let AllPoolTransactions { pending, queued } = self.pool.all_transactions();
 
         let mut content = TxpoolContent::default();
-        for pending in pending {
-            insert::<_, Eth>(&pending.transaction, &mut content.pending, &self.converter)?;
+        for tx in pending {
+            let sender = tx.transaction.sender();
+            self.insert_by_nonce(&tx.transaction, content.pending.entry(sender).or_default())?;
         }
-        for queued in queued {
-            insert::<_, Eth>(&queued.transaction, &mut content.queued, &self.converter)?;
+        for tx in queued {
+            let sender = tx.transaction.sender();
+            self.insert_by_nonce(&tx.transaction, content.queued.entry(sender).or_default())?;
         }
 
         Ok(content)
+    }
+
+    fn content_from(
+        &self,
+        from: Address,
+    ) -> Result<TxpoolContentFrom<RpcTransaction<Eth::Network>>, Eth::Error> {
+        let mut content = TxpoolContentFrom::default();
+        for tx in self.pool.get_pending_transactions_by_sender(from) {
+            self.insert_by_nonce(&tx.transaction, &mut content.pending)?;
+        }
+        for tx in self.pool.get_queued_transactions_by_sender(from) {
+            self.insert_by_nonce(&tx.transaction, &mut content.queued)?;
+        }
+
+        Ok(content)
+    }
+
+    /// Converts the pool transaction and inserts it into the given map, keyed by its nonce.
+    #[inline]
+    fn insert_by_nonce(
+        &self,
+        tx: &Pool::Transaction,
+        txs: &mut BTreeMap<String, RpcTransaction<Eth::Network>>,
+    ) -> Result<(), Eth::Error> {
+        txs.insert(tx.nonce().to_string(), self.converter.fill_pending(tx.clone_into_consensus())?);
+
+        Ok(())
     }
 }
 
@@ -135,7 +143,7 @@ where
         from: Address,
     ) -> RpcResult<TxpoolContentFrom<RpcTransaction<Eth::Network>>> {
         trace!(target: "rpc::eth", ?from, "Serving txpool_contentFrom");
-        Ok(self.content().map_err(Into::into)?.remove_from(&from))
+        Ok(self.content_from(from).map_err(Into::into)?)
     }
 
     /// Returns the details of all transactions currently pending for inclusion in the next
@@ -152,5 +160,45 @@ where
 impl<Pool, Eth> fmt::Debug for TxPoolApi<Pool, Eth> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TxpoolApi").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eth::helpers::types::EthRpcConverter;
+    use reth_chainspec::MAINNET;
+    use reth_rpc_eth_types::receipt::EthReceiptConverter;
+    use reth_transaction_pool::{
+        test_utils::{testing_pool, MockTransaction},
+        TransactionOrigin,
+    };
+
+    #[tokio::test]
+    async fn content_from_matches_content() {
+        let senders = [Address::with_last_byte(1), Address::with_last_byte(2)];
+
+        let pool = testing_pool();
+        for sender in senders {
+            // nonces 0 and 1 end up in the pending sub-pool, the gapped nonce 9 in a parked one
+            for nonce in [0, 1, 9] {
+                let tx = MockTransaction::legacy()
+                    .with_sender(sender)
+                    .with_nonce(nonce)
+                    .with_gas_price(100);
+                pool.add_transaction(TransactionOrigin::External, tx).await.unwrap();
+            }
+        }
+
+        let api =
+            TxPoolApi::new(pool, EthRpcConverter::new(EthReceiptConverter::new(MAINNET.clone())));
+        let mut content = api.content().unwrap();
+        // guards the fixture: both sub-pools must be populated for the comparison to mean anything
+        assert_eq!((content.pending.len(), content.queued.len()), (senders.len(), senders.len()));
+
+        // the unknown sender must yield the same empty result as the whole-pool path
+        for sender in senders.into_iter().chain([Address::with_last_byte(3)]) {
+            assert_eq!(api.content_from(sender).unwrap(), content.remove_from(&sender));
+        }
     }
 }

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -62,8 +62,7 @@ where
         let mut content = TxpoolContentFrom::default();
         // one snapshot for both sides, so a transaction moving between sub-pools meanwhile is
         // reported on exactly one of them
-        let AllPoolTransactions { pending, queued } =
-            self.pool.get_pending_and_queued_transactions_by_sender(from);
+        let AllPoolTransactions { pending, queued } = self.pool.all_transactions_by_sender(from);
         for tx in pending {
             self.insert_by_nonce(&tx.transaction, &mut content.pending)?;
         }

--- a/crates/rpc/rpc/src/txpool.rs
+++ b/crates/rpc/rpc/src/txpool.rs
@@ -60,10 +60,14 @@ where
         from: Address,
     ) -> Result<TxpoolContentFrom<RpcTransaction<Eth::Network>>, Eth::Error> {
         let mut content = TxpoolContentFrom::default();
-        for tx in self.pool.get_pending_transactions_by_sender(from) {
+        // one snapshot for both sides, so a transaction moving between sub-pools meanwhile is
+        // reported on exactly one of them
+        let AllPoolTransactions { pending, queued } =
+            self.pool.get_pending_and_queued_transactions_by_sender(from);
+        for tx in pending {
             self.insert_by_nonce(&tx.transaction, &mut content.pending)?;
         }
-        for tx in self.pool.get_queued_transactions_by_sender(from) {
+        for tx in queued {
             self.insert_by_nonce(&tx.transaction, &mut content.queued)?;
         }
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -641,6 +641,13 @@ where
         self.pool.all_transactions()
     }
 
+    fn all_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<Self::Transaction> {
+        self.pool.all_transactions_by_sender(sender)
+    }
+
     fn all_transaction_hashes(&self) -> Vec<TxHash> {
         self.pool.all_transaction_hashes()
     }
@@ -725,13 +732,6 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.pool.get_queued_transactions_by_sender(sender)
-    }
-
-    fn get_pending_and_queued_transactions_by_sender(
-        &self,
-        sender: Address,
-    ) -> AllPoolTransactions<Self::Transaction> {
-        self.pool.get_pending_and_queued_transactions_by_sender(sender)
     }
 
     fn get_highest_transaction_by_sender(

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -727,6 +727,13 @@ where
         self.pool.get_queued_transactions_by_sender(sender)
     }
 
+    fn get_pending_and_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<Self::Transaction> {
+        self.pool.get_pending_and_queued_transactions_by_sender(sender)
+    }
+
     fn get_highest_transaction_by_sender(
         &self,
         sender: Address,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -302,6 +302,13 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         vec![]
     }
 
+    fn get_pending_and_queued_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> AllPoolTransactions<Self::Transaction> {
+        Default::default()
+    }
+
     fn get_highest_transaction_by_sender(
         &self,
         _sender: Address,

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -220,6 +220,13 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         AllPoolTransactions::default()
     }
 
+    fn all_transactions_by_sender(
+        &self,
+        _sender: Address,
+    ) -> AllPoolTransactions<Self::Transaction> {
+        AllPoolTransactions::default()
+    }
+
     fn all_transaction_hashes(&self) -> Vec<TxHash> {
         vec![]
     }
@@ -300,13 +307,6 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         _sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         vec![]
-    }
-
-    fn get_pending_and_queued_transactions_by_sender(
-        &self,
-        _sender: Address,
-    ) -> AllPoolTransactions<Self::Transaction> {
-        Default::default()
     }
 
     fn get_highest_transaction_by_sender(

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1200,6 +1200,20 @@ where
         self.get_pool_data().pending_txs_by_sender(sender_id)
     }
 
+    /// Returns the pending and the queued transactions of the given sender from one read guard,
+    /// so both sides reflect the same pool state.
+    pub fn get_pending_and_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<T::Transaction> {
+        let Some(sender_id) = self.sender_id(&sender) else { return Default::default() };
+        let pool = self.get_pool_data();
+        AllPoolTransactions {
+            pending: pool.pending_txs_by_sender(sender_id),
+            queued: pool.queued_txs_by_sender(sender_id),
+        }
+    }
+
     /// Returns the highest transaction of the address
     pub fn get_highest_transaction_by_sender(
         &self,
@@ -1668,13 +1682,48 @@ mod tests {
     use crate::{
         blobstore::{BlobStore, InMemoryBlobStore, PooledBlobSidecar},
         identifier::SenderId,
-        test_utils::{MockTransaction, TestPoolBuilder},
+        test_utils::{testing_pool, MockTransaction, TestPoolBuilder},
         validate::ValidTransaction,
-        BlockInfo, PoolConfig, SubPoolLimit, TransactionOrigin, TransactionValidationOutcome, U256,
+        BlockInfo, PoolConfig, SubPoolLimit, TransactionOrigin, TransactionPool,
+        TransactionPoolExt, TransactionValidationOutcome, ValidPoolTransaction, U256,
     };
+    use alloy_consensus::Transaction;
     use alloy_eips::{eip4844::BlobTransactionSidecar, eip7594::BlobTransactionSidecarVariant};
     use alloy_primitives::Address;
-    use std::{fs, path::PathBuf};
+    use std::{fs, path::PathBuf, sync::Arc};
+
+    #[tokio::test]
+    async fn pending_and_queued_by_sender_share_one_snapshot() {
+        let pool = testing_pool();
+        let sender = Address::with_last_byte(1);
+        // nonces 0 and 1 are pending, the gapped nonce 9 is queued
+        for nonce in [0, 1, 9] {
+            let tx =
+                MockTransaction::legacy().with_sender(sender).with_nonce(nonce).with_gas_price(100);
+            pool.add_transaction(TransactionOrigin::External, tx).await.unwrap();
+        }
+        let nonces = |txs: &[Arc<ValidPoolTransaction<MockTransaction>>]| {
+            let mut nonces: Vec<_> = txs.iter().map(|tx| tx.transaction.nonce()).collect();
+            nonces.sort_unstable();
+            nonces
+        };
+
+        let txs = pool.get_pending_and_queued_transactions_by_sender(sender);
+        assert_eq!(nonces(&txs.pending), [0, 1]);
+        assert_eq!(nonces(&txs.queued), [9]);
+
+        // a higher base fee reclassifies the pending transactions as queued; the snapshot must
+        // report each of them on exactly one side
+        pool.set_block_info(BlockInfo {
+            pending_basefee: 200,
+            block_gas_limit: 30_000_000,
+            ..Default::default()
+        });
+        let txs = pool.get_pending_and_queued_transactions_by_sender(sender);
+        assert!(txs.pending.is_empty());
+        assert_eq!(nonces(&txs.queued), [0, 1, 9]);
+        assert_eq!(nonces(&pool.get_transactions_by_sender(sender)), [0, 1, 9]);
+    }
 
     #[test]
     fn test_discard_blobs_on_blob_tx_eviction() {

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1055,6 +1055,20 @@ where
         }
     }
 
+    /// Returns all transactions of the given sender, collected under a single read guard so that
+    /// both sides reflect the same pool state.
+    pub fn all_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<T::Transaction> {
+        let Some(sender_id) = self.sender_id(&sender) else { return Default::default() };
+        let pool = self.get_pool_data();
+        AllPoolTransactions {
+            pending: pool.pending_txs_by_sender(sender_id),
+            queued: pool.queued_txs_by_sender(sender_id),
+        }
+    }
+
     /// Returns _all_ transactions in the pool
     pub fn all_transaction_hashes(&self) -> Vec<TxHash> {
         self.get_pool_data().all().transactions_iter().map(|tx| *tx.hash()).collect()
@@ -1198,20 +1212,6 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         let Some(sender_id) = self.sender_id(&sender) else { return Vec::new() };
         self.get_pool_data().pending_txs_by_sender(sender_id)
-    }
-
-    /// Returns the pending and the queued transactions of the given sender from one read guard,
-    /// so both sides reflect the same pool state.
-    pub fn get_pending_and_queued_transactions_by_sender(
-        &self,
-        sender: Address,
-    ) -> AllPoolTransactions<T::Transaction> {
-        let Some(sender_id) = self.sender_id(&sender) else { return Default::default() };
-        let pool = self.get_pool_data();
-        AllPoolTransactions {
-            pending: pool.pending_txs_by_sender(sender_id),
-            queued: pool.queued_txs_by_sender(sender_id),
-        }
     }
 
     /// Returns the highest transaction of the address
@@ -1693,7 +1693,7 @@ mod tests {
     use std::{fs, path::PathBuf, sync::Arc};
 
     #[tokio::test]
-    async fn pending_and_queued_by_sender_share_one_snapshot() {
+    async fn all_transactions_by_sender_across_reclassification() {
         let pool = testing_pool();
         let sender = Address::with_last_byte(1);
         // nonces 0 and 1 are pending, the gapped nonce 9 is queued
@@ -1708,7 +1708,7 @@ mod tests {
             nonces
         };
 
-        let txs = pool.get_pending_and_queued_transactions_by_sender(sender);
+        let txs = pool.all_transactions_by_sender(sender);
         assert_eq!(nonces(&txs.pending), [0, 1]);
         assert_eq!(nonces(&txs.queued), [9]);
 
@@ -1719,7 +1719,7 @@ mod tests {
             block_gas_limit: 30_000_000,
             ..Default::default()
         });
-        let txs = pool.get_pending_and_queued_transactions_by_sender(sender);
+        let txs = pool.all_transactions_by_sender(sender);
         assert!(txs.pending.is_empty());
         assert_eq!(nonces(&txs.queued), [0, 1, 9]);
         assert_eq!(nonces(&pool.get_transactions_by_sender(sender)), [0, 1, 9]);

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -458,6 +458,16 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
     /// Consumer: RPC
     fn all_transactions(&self) -> AllPoolTransactions<Self::Transaction>;
 
+    /// Returns all transactions of the given sender that are currently in the pool, grouped by
+    /// whether they are ready for inclusion in the next block or not.
+    ///
+    /// Both groups are collected from one snapshot of the pool, so a transaction that is moved
+    /// between sub-pools concurrently shows up in exactly one of them.
+    ///
+    /// Consumer: RPC
+    fn all_transactions_by_sender(&self, sender: Address)
+        -> AllPoolTransactions<Self::Transaction>;
+
     /// Returns the _hashes_ of all transactions regardless of whether they can be propagated or
     /// not.
     ///
@@ -610,22 +620,6 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
         &self,
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
-
-    /// Returns the pending and the queued transactions of the given sender.
-    ///
-    /// Both sides are read from one consistent snapshot of the pool, so a transaction that moves
-    /// between the pending and the queued sub-pools while this runs shows up on exactly one side.
-    ///
-    /// The default implementation queries both sides separately and does not give that guarantee.
-    fn get_pending_and_queued_transactions_by_sender(
-        &self,
-        sender: Address,
-    ) -> AllPoolTransactions<Self::Transaction> {
-        AllPoolTransactions {
-            pending: self.get_pending_transactions_by_sender(sender),
-            queued: self.get_queued_transactions_by_sender(sender),
-        }
-    }
 
     /// Returns the highest transaction sent by a given user
     fn get_highest_transaction_by_sender(

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -611,6 +611,22 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>>;
 
+    /// Returns the pending and the queued transactions of the given sender.
+    ///
+    /// Both sides are read from one consistent snapshot of the pool, so a transaction that moves
+    /// between the pending and the queued sub-pools while this runs shows up on exactly one side.
+    ///
+    /// The default implementation queries both sides separately and does not give that guarantee.
+    fn get_pending_and_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<Self::Transaction> {
+        AllPoolTransactions {
+            pending: self.get_pending_transactions_by_sender(sender),
+            queued: self.get_queued_transactions_by_sender(sender),
+        }
+    }
+
     /// Returns the highest transaction sent by a given user
     fn get_highest_transaction_by_sender(
         &self,


### PR DESCRIPTION
`txpool_contentFrom` went through `content()`, which clones the Arc list of every pending and queued transaction in the pool, converts each of them to an RPC transaction with a freshly allocated nonce string, and then keeps a single sender. The cost per call scaled with the size of the pool rather than with the sender being asked about.

The endpoint now asks the pool for that sender only. `TransactionPool` gains a required `all_transactions_by_sender`, mirroring `all_transactions` for one sender; `Pool` serves it from a single read guard, so both sides come from one snapshot and a transaction that is being reclassified between sub-pools shows up on exactly one side, as it did with the old `all_transactions` path. The method deliberately has no default over the two existing per-sender getters, since that would reintroduce the split snapshot. The per-transaction conversion is shared with `content()` through `insert_by_nonce`, so the entries are identical to before. A pool test covers the snapshot across a base fee reclassification, and an rpc test compares the new path against `content().remove_from(..)`.
