### PR TITLE
perf(rpc): bound getLogs range header capacity by remaining headers

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -1220,7 +1220,7 @@ impl<
                 return Ok(None);
             };
 
-            let mut range_headers = Vec::with_capacity(self.max_range);
+            let mut range_headers = Vec::with_capacity(self.max_range.min(self.iter.len() + 1));
             range_headers.push(next_header);
 
             // Collect consecutive blocks up to max_range size


### PR DESCRIPTION
`RangeBlockMode::next` reserved `max_range` entries for every group of consecutive headers it collects. `max_range` is fixed at `MAX_HEADERS_RANGE` (1000) when the filter is constructed, so each group reserved room for 1000 `SealedHeader`s regardless of how many were actually available. At the ~530 bytes per header the file's own comment cites, that is a ~500 KB reservation. The collection loop stops at the first non-consecutive header, so a selective filter over a wide block range, where bloom hits are sparse, mostly produces single-header groups: one large allocation and free per matching block.

Capacity is now bounded by what the iterator can actually supply, `self.max_range.min(self.iter.len() + 1)`. The `+ 1` accounts for the header already pulled off the iterator and pushed before the loop. `self.iter` is a `Peekable<vec::IntoIter<_>>`, whose `len()` already includes a peeked-but-unconsumed element, and the same `len()` is read a few lines below for the parallel processing threshold. Only the reservation changes; group contents and control flow are unchanged.