### PR TITLE
perf(ipc): avoid copying IPC subscription payloads

### DIFF
--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -536,7 +536,7 @@ async fn to_ipc_service<S, T>(
             }
             item = rx_item.next() => {
                 let Some(item) = item else { break };
-                conn.push_back(item.to_string());
+                conn.push_back(String::from(Box::<str>::from(item)));
             }
             _ = &mut stopped => {
                 // shutdown

--- a/crates/rpc/ipc/src/stream_codec.rs
+++ b/crates/rpc/ipc/src/stream_codec.rs
@@ -27,7 +27,7 @@
 // This basis of this file has been taken from the deprecated jsonrpc codebase:
 // https://github.com/paritytech/jsonrpc
 
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use std::{io, str};
 
 /// Separator for enveloping messages in streaming codecs
@@ -162,11 +162,14 @@ impl tokio_util::codec::Encoder<String> for StreamCodec {
     type Error = io::Error;
 
     fn encode(&mut self, msg: String, buf: &mut BytesMut) -> io::Result<()> {
-        let mut payload = msg.into_bytes();
-        if let Separator::Byte(separator) = self.outgoing_separator {
-            payload.push(separator);
+        match self.outgoing_separator {
+            Separator::Byte(separator) => {
+                buf.reserve(msg.len() + 1);
+                buf.extend_from_slice(msg.as_bytes());
+                buf.put_u8(separator);
+            }
+            Separator::Empty => buf.extend_from_slice(msg.as_bytes()),
         }
-        buf.extend_from_slice(&payload);
         Ok(())
     }
 }


### PR DESCRIPTION
Every subscription notification pushed to an IPC connection was going through `item.to_string()`, which allocates a second buffer and copies the whole payload out of the `Box<RawValue>` it already owns. serde_json converts `Box<RawValue>` to `Box<str>` by transmute, so the existing allocation can be handed to the connection unchanged. With `newPendingTransactions` or `logs` this runs hundreds of times per second per connection.

The second commit removes the intermediate `Vec<u8>` in the stream codec's encoder. It moved the message into a vector, pushed the separator byte onto it (reallocating and copying the whole payload whenever capacity equalled length, which is now always the case for notifications since `Box<str>` has no spare capacity), and then copied that vector into the output buffer. It now reserves once on the output buffer and writes the payload and separator straight into it. The `Separator::Empty` branch is unchanged apart from skipping the vector.