### PR TITLE
perf(nippy-jar): allocate cursor scratch buffer lazily

### DIFF
--- a/crates/storage/nippy-jar/src/cursor.rs
+++ b/crates/storage/nippy-jar/src/cursor.rs
@@ -12,7 +12,8 @@ pub struct NippyJarCursor<'a, H = ()> {
     jar: &'a NippyJar<H>,
     /// Data and offset reader.
     reader: Arc<DataReader>,
-    /// Internal buffer to unload data to without reallocating memory on each retrieval.
+    /// Internal buffer to unload data to without reallocating memory on each retrieval. Only
+    /// compressed jars decompress into it, so it is sized on first use.
     internal_buffer: Vec<u8>,
     /// Cursor row position.
     row: u64,
@@ -27,30 +28,21 @@ impl<H: NippyJarHeader> std::fmt::Debug for NippyJarCursor<'_, H> {
 impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
     /// Creates a new instance of [`NippyJarCursor`] for the given [`NippyJar`].
     pub fn new(jar: &'a NippyJar<H>) -> Result<Self, NippyJarError> {
-        let max_row_size = jar.max_row_size;
         Ok(Self {
             jar,
             reader: Arc::new(jar.open_data_reader()?),
-            // Makes sure that we have enough buffer capacity to decompress any row of data.
-            internal_buffer: Vec::with_capacity(max_row_size),
+            internal_buffer: Vec::new(),
             row: 0,
         })
     }
 
     /// Creates a new instance of [`NippyJarCursor`] with the specified [`NippyJar`] and data
     /// reader.
-    pub fn with_reader(
+    pub const fn with_reader(
         jar: &'a NippyJar<H>,
         reader: Arc<DataReader>,
     ) -> Result<Self, NippyJarError> {
-        let max_row_size = jar.max_row_size;
-        Ok(Self {
-            jar,
-            reader,
-            // Makes sure that we have enough buffer capacity to decompress any row of data.
-            internal_buffer: Vec::with_capacity(max_row_size),
-            row: 0,
-        })
+        Ok(Self { jar, reader, internal_buffer: Vec::new(), row: 0 })
     }
 
     /// Returns a reference to the related [`NippyJar`]
@@ -162,6 +154,12 @@ impl<'a, H: NippyJarHeader> NippyJarCursor<'a, H> {
         };
 
         if let Some(compression) = self.jar.compressor() {
+            // The decompressors write into the spare capacity of the buffer, so it has to fit any
+            // row of data. The buffer is only cleared between rows, so this reserves once.
+            if self.internal_buffer.capacity() < self.jar.max_row_size {
+                self.internal_buffer.reserve(self.jar.max_row_size - self.internal_buffer.len());
+            }
+
             let from = self.internal_buffer.len();
             match compression {
                 Compressors::Zstd(z) if z.use_dict => {


### PR DESCRIPTION
`NippyJarCursor::new` and `with_reader` allocated `internal_buffer` with `max_row_size` capacity on every construction, but that buffer is only ever written by the decompression branch of `read_value`. In reth only the headers segment is compressed with lz4; transaction, receipt and sender jars have no compressor, so those cursors allocated and freed the buffer without ever touching it. Cursors are constructed per single-row read (`transaction_by_id`, `receipt`, `transaction_sender`, ...) and per element in `fetch_range_iter`, so that was one malloc/free per static-file read.

The buffer now starts empty and is sized at the point of first decompression. It is cleared but not shrunk between rows, so compressed jars reserve once per cursor and behave exactly as before: the lz4 and zstd-dictionary decompressors write into spare capacity, which is still at least `max_row_size` before any row is decoded. `with_reader` became `const` as a side effect of dropping the allocation.

Counting allocations over 1000 single-row reads of a 3-column jar with 100-byte values, each read constructing its own cursor: uncompressed goes from 5000 allocations / 563000 bytes to 4000 / 263000, and the lz4 jar is unchanged at 5000 / 563000.