### PR TITLE
perf(provider): avoid hash map for dense sender range

### DIFF
--- a/crates/storage/provider/src/either_writer.rs
+++ b/crates/storage/provider/src/either_writer.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     StaticFileProviderFactory,
 };
-use alloy_primitives::{map::HashMap, Address, BlockNumber, TxHash, TxNumber, B256};
+use alloy_primitives::{Address, BlockNumber, TxHash, TxNumber, B256};
 use rayon::slice::ParallelSliceMut;
 use reth_db::{
     cursor::{DbCursorRO, DbDupCursorRW},
@@ -787,29 +787,36 @@ where
     CURSOR: DbCursorRO<tables::TransactionSenders>,
 {
     /// Fetches the senders for a range of transactions.
+    ///
+    /// The returned vector has one entry per transaction in `range`: entry `i` holds the sender of
+    /// transaction `range.start + i`, or `None` if no sender is recorded for it.
     pub fn senders_by_tx_range(
         &mut self,
         range: Range<TxNumber>,
-    ) -> ProviderResult<HashMap<TxNumber, Address>> {
+    ) -> ProviderResult<Vec<Option<Address>>> {
+        let start = range.start;
+        let mut senders = vec![None; range.end.saturating_sub(start) as usize];
         match self {
-            Self::Database(cursor, _) => cursor
-                .walk_range(range)?
-                .map(|result| result.map_err(ProviderError::from))
-                .collect::<ProviderResult<HashMap<_, _>>>(),
-            Self::StaticFile(provider, _) => range
-                .clone()
-                .zip(provider.fetch_range_iter(
+            Self::Database(cursor, _) => {
+                for entry in cursor.walk_range(range)? {
+                    let (tx_num, sender) = entry?;
+                    senders[(tx_num - start) as usize] = Some(sender);
+                }
+            }
+            Self::StaticFile(provider, _) => {
+                let iter = provider.fetch_range_iter(
                     StaticFileSegment::TransactionSenders,
                     range,
                     |cursor, number| cursor.get_one::<TransactionSenderMask>(number.into()),
-                )?)
-                .filter_map(|(tx_num, sender)| {
-                    let result = sender.transpose()?;
-                    Some(result.map(|sender| (tx_num, sender)))
-                })
-                .collect::<ProviderResult<HashMap<_, _>>>(),
-            Self::RocksDB(_) => Err(ProviderError::UnsupportedProvider),
+                )?;
+                for (slot, sender) in senders.iter_mut().zip(iter) {
+                    *slot = sender?;
+                }
+            }
+            Self::RocksDB(_) => return Err(ProviderError::UnsupportedProvider),
         }
+
+        Ok(senders)
     }
 }
 
@@ -1128,11 +1135,11 @@ mod tests {
                 assert!(matches!(reader, EitherReader::Database(_, _)));
             }
 
-            assert_eq!(
-                reader.senders_by_tx_range(0..6).unwrap(),
-                senders.iter().copied().collect::<HashMap<_, _>>(),
-                "{reader}"
-            );
+            let mut expected = vec![None; 6];
+            for (tx_num, sender) in senders {
+                expected[tx_num as usize] = Some(sender);
+            }
+            assert_eq!(reader.senders_by_tx_range(0..6).unwrap(), expected, "{reader}");
         }
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -1209,17 +1209,16 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
         let senders = if tx_range.is_empty() {
             vec![]
         } else {
-            let known_senders: HashMap<TxNumber, Address> =
-                EitherReader::new_senders(self)?.senders_by_tx_range(tx_range.clone())?;
+            let known_senders = EitherReader::new_senders(self)?.senders_by_tx_range(tx_range)?;
 
             let mut senders = Vec::with_capacity(body.transactions().len());
-            for (tx_num, tx) in tx_range.zip(body.transactions()) {
-                match known_senders.get(&tx_num) {
+            for (known_sender, tx) in known_senders.into_iter().zip(body.transactions()) {
+                match known_sender {
                     None => {
                         let sender = tx.recover_signer_unchecked()?;
                         senders.push(sender);
                     }
-                    Some(sender) => senders.push(*sender),
+                    Some(sender) => senders.push(sender),
                 }
             }
             senders
@@ -1314,18 +1313,18 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
             let senders = if tx_range.is_empty() {
                 Vec::new()
             } else {
-                let known_senders: HashMap<TxNumber, Address> =
-                    EitherReader::new_senders(self)?.senders_by_tx_range(tx_range.clone())?;
+                let known_senders =
+                    EitherReader::new_senders(self)?.senders_by_tx_range(tx_range)?;
 
                 let mut senders = Vec::with_capacity(body.transactions().len());
-                for (tx_num, tx) in tx_range.zip(body.transactions()) {
-                    match known_senders.get(&tx_num) {
+                for (known_sender, tx) in known_senders.into_iter().zip(body.transactions()) {
+                    match known_sender {
                         None => {
                             // recover the sender from the transaction if not found
                             let sender = tx.recover_signer_unchecked()?;
                             senders.push(sender);
                         }
-                        Some(sender) => senders.push(*sender),
+                        Some(sender) => senders.push(sender),
                     }
                 }
 


### PR DESCRIPTION
`EitherReader::senders_by_tx_range` collected into a `HashMap<TxNumber, Address>`, but it is only called with a single block's contiguous transaction range, and both callers immediately walk that range in order and probe the map once per transaction. So for every block we built a SipHash map of N entries and then did N lookups over dense, already-ordered keys.

It now returns a `Vec<Option<Address>>` with one slot per transaction in the range, indexed by `tx_num - range.start`. The callers zip it with the block body instead of looking keys up, which keeps the existing behaviour for transactions with no recorded sender: the slot stays `None` and the sender is recovered from the signature as before. Sparse ranges still work, since both the database walk and the static file iterator only fill the slots they actually have.