### PR TITLE
perf(txpool): track highest nonce per sender on fee rebuild

### DIFF
--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -178,7 +178,9 @@ impl<T: TransactionOrdering> PendingPool<T> {
 
         // Drain and iterate over all transactions.
         let mut transactions_iter = self.clear_transactions().into_iter().peekable();
+        let mut highest: Option<TransactionId> = None;
         while let Some((id, tx)) = transactions_iter.next() {
+            self.flush_highest_nonce(&mut highest, Some(id.sender));
             if tx.transaction.is_eip4844() && tx.transaction.max_fee_per_blob_gas() < Some(blob_fee)
             {
                 // Add this tx to the removed collection since it no longer satisfies the blob fee
@@ -195,10 +197,15 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 }
             } else {
                 self.size_of += tx.transaction.size();
-                self.update_independents_and_highest_nonces(&tx);
+                if highest.is_none() {
+                    // first kept transaction of this sender, hence the independent one
+                    self.independent_transactions.insert(id.sender, tx.clone());
+                }
+                highest = Some(id);
                 self.by_id.insert(id, tx);
             }
         }
+        self.flush_highest_nonce(&mut highest, None);
 
         removed
     }
@@ -221,7 +228,9 @@ impl<T: TransactionOrdering> PendingPool<T> {
 
         // Drain and iterate over all transactions.
         let mut transactions_iter = self.clear_transactions().into_iter().peekable();
+        let mut highest: Option<TransactionId> = None;
         while let Some((id, mut tx)) = transactions_iter.next() {
+            self.flush_highest_nonce(&mut highest, Some(id.sender));
             if tx.transaction.max_fee_per_gas() < base_fee as u128 {
                 // Add this tx to the removed collection since it no longer satisfies the base fee
                 // condition. Decrease the total pool size.
@@ -240,12 +249,34 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 tx.priority = self.ordering.priority(&tx.transaction.transaction, base_fee);
 
                 self.size_of += tx.transaction.size();
-                self.update_independents_and_highest_nonces(&tx);
+                if highest.is_none() {
+                    // first kept transaction of this sender, hence the independent one
+                    self.independent_transactions.insert(id.sender, tx.clone());
+                }
+                highest = Some(id);
                 self.by_id.insert(id, tx);
             }
         }
+        self.flush_highest_nonce(&mut highest, None);
 
         removed
+    }
+
+    /// Writes the transaction tracked by a rebuild loop (`update_base_fee`, `update_blob_fee`) to
+    /// `highest_nonces` if the loop has moved on to `next_sender`.
+    ///
+    /// The pool is drained in ascending `(sender, nonce)` order, so the highest kept nonce of a
+    /// sender is only known once the drain reaches the next sender or the end of the pool.
+    fn flush_highest_nonce(
+        &mut self,
+        tracked: &mut Option<TransactionId>,
+        next_sender: Option<SenderId>,
+    ) {
+        if let Some(id) = tracked.take_if(|id| Some(id.sender) != next_sender) &&
+            let Some(tx) = self.by_id.get(&id).cloned()
+        {
+            self.highest_nonces.insert(id.sender, tx);
+        }
     }
 
     /// Updates the independent transaction and highest nonces set, assuming the given transaction
@@ -745,6 +776,35 @@ mod tests {
         assert_eq!(removed.len(), 2);
         assert!(pool.is_empty());
         pool.assert_invariants();
+    }
+
+    #[test]
+    fn test_enforce_basefee_tracks_highest_nonce_of_partially_removed_sender() {
+        let mut f = MockTransactionFactory::default();
+        let mut pool = PendingPool::new(MockOrdering::default());
+
+        // sender a keeps its first transaction but its descendant is priced out
+        let a = MockTransaction::eip1559().inc_price_by(20);
+        let a0 = f.validated_arc(a.clone());
+        let a1 = f.validated_arc(a.inc_nonce().rng_hash().decr_price_by(15));
+        // sender b keeps both of its transactions
+        let b = MockTransaction::eip1559().inc_price_by(20);
+        let b0 = f.validated_arc(b.clone());
+        let b1 = f.validated_arc(b.inc_nonce().rng_hash());
+
+        for tx in [&a0, &a1, &b0, &b1] {
+            pool.add_transaction(tx.clone(), 0);
+        }
+
+        let removed = pool.update_base_fee((a1.max_fee_per_gas() + 1) as u64);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].hash(), a1.hash());
+
+        pool.assert_invariants();
+        assert_eq!(pool.highest_nonces[&a0.sender_id()].transaction.nonce(), a0.nonce());
+        assert_eq!(pool.independent_transactions[&a0.sender_id()].transaction.nonce(), a0.nonce());
+        assert_eq!(pool.highest_nonces[&b1.sender_id()].transaction.nonce(), b1.nonce());
+        assert_eq!(pool.independent_transactions[&b0.sender_id()].transaction.nonce(), b0.nonce());
     }
 
     #[test]


### PR DESCRIPTION
`update_base_fee` and `update_blob_fee` drain the pending pool and re-insert every surviving transaction through the same helper the normal add path uses. That helper has to consider each transaction a candidate for `highest_nonces`, so for a pool of 2000 transactions across 200 senders the rebuild performed 2200 `PendingTransaction` clones (an `Arc` bump plus a priority clone) and dropped 1800 superseded entries again, plus two hash lookups per transaction. This runs on roughly every other block, whenever the base fee rises.

The drain yields transactions in ascending `(sender, nonce)` order, so the first kept transaction of a sender is already the independent one and the last kept one is already the highest nonce. Tracking the current sender and writing `highest_nonces` when the drain moves past it brings the same pool down to 400 clones. Measured with a temporary counter in `PendingTransaction::clone`; the machine was too loaded for meaningful wall-clock numbers.

The subtle case is a sender whose later nonces are priced out mid-drain: the removal branch also drops all of that sender's remaining transactions, so the tracked entry is still the highest kept nonce and gets flushed at the sender boundary. The added test covers that, and it fails without the flush.