### PR TITLE
perf(rocksdb): stop keeping flushed memtables as write history

### DIFF
--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -148,6 +148,17 @@ const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 << 20;
 /// memtable arena usage exceeds the budget.
 const DEFAULT_WRITE_BUFFER_MANAGER_SIZE: usize = 4 * 1024 * 1024 * 1024;
 
+/// Bytes of flushed memtables kept in memory as write history for `OptimisticTransactionDB`
+/// conflict checks.
+///
+/// Left unset, `OptimisticTransactionDB` defaults this to `max_write_buffer_number *
+/// write_buffer_size`, pinning two flushed memtables per column family for conflict checks that
+/// only [`RocksTx`] commits perform; the production write path writes batches directly and reads
+/// go through snapshots. Zero is not usable because `OptimisticTransactionDB::Open` maps it back
+/// to that default, so 1 byte is the smallest value that lets `RocksDB` free a flushed memtable on
+/// the next writes to the column family.
+const DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN: i64 = 1;
+
 /// Default buffer capacity for compression in batches.
 /// 4 KiB matches common block/page sizes and comfortably holds typical history values,
 /// reducing the first few reallocations without over-allocating.
@@ -271,6 +282,7 @@ impl RocksDBBuilder {
         // Only use Zstd compression, disable dictionary training
         cf_options.set_bottommost_zstd_max_train_bytes(0, true);
         cf_options.set_write_buffer_size(DEFAULT_WRITE_BUFFER_SIZE);
+        cf_options.set_max_write_buffer_size_to_maintain(DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN);
 
         cf_options
     }
@@ -307,6 +319,7 @@ impl RocksDBBuilder {
         // varint-encoded u64 (a few bytes). Compression wastes CPU cycles for zero space savings.
         cf_options.set_compression_type(DBCompressionType::None);
         cf_options.set_bottommost_compression_type(DBCompressionType::None);
+        cf_options.set_max_write_buffer_size_to_maintain(DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN);
 
         cf_options
     }
@@ -835,8 +848,10 @@ impl RocksDBProvider {
 
     /// Creates a new transaction with MDBX-like semantics (read-your-writes, rollback).
     ///
-    /// Note: With `OptimisticTransactionDB`, commits may fail if there are conflicts.
-    /// Conflict detection happens at commit time, not at write time.
+    /// Note: With `OptimisticTransactionDB`, commits may fail if there are conflicts, or if the
+    /// column family was flushed since the transaction's first write: flushed memtables are not
+    /// kept as write history (see `DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN`). Conflict
+    /// detection happens at commit time, not at write time.
     ///
     /// # Panics
     /// Panics if the provider is in read-only mode.
@@ -2956,6 +2971,28 @@ mod tests {
         tables,
     };
     use tempfile::TempDir;
+
+    #[test]
+    fn flushed_memtables_are_not_kept_as_write_history() {
+        let temp_dir = TempDir::new().unwrap();
+        let provider =
+            RocksDBBuilder::new(temp_dir.path()).with_table::<TestTable>().build().unwrap();
+        let db = provider.0.db_rw();
+        let cf = db.cf_handle(TestTable::NAME).unwrap();
+
+        provider.put::<TestTable>(1, &b"a".to_vec()).unwrap();
+        provider.flush(&[TestTable::NAME]).unwrap();
+        // RocksDB trims write history lazily: the first write after a flush schedules the trim
+        // and the next write runs it.
+        provider.put::<TestTable>(2, &b"b".to_vec()).unwrap();
+        provider.put::<TestTable>(3, &b"c".to_vec()).unwrap();
+
+        let retained = db
+            .property_int_value_cf(cf, rocksdb::properties::NUM_IMMUTABLE_MEM_TABLE_FLUSHED)
+            .unwrap()
+            .unwrap();
+        assert_eq!(retained, 0, "flushed memtable kept in memory as write history");
+    }
 
     #[test]
     fn max_open_files_adapts_to_file_descriptor_limit() {


### PR DESCRIPTION
`OptimisticTransactionDB` defaults `max_write_buffer_size_to_maintain` to `max_write_buffer_number * write_buffer_size`, so RocksDB keeps two flushed memtables per column family in memory as write history for optimistic conflict checks: 128 MiB for `TransactionHashNumbers` and 256 MiB each for `AccountsHistory` and `StoragesHistory` (`max_write_buffer_size_to_maintain=134217728` / `268435456` in a node's `rocksdb/OPTIONS-*`). Only `RocksTx::commit` runs those checks and nothing in production calls `tx()`; batches go through `write_opt` and reads through snapshots. This sets the target to 1 byte (`OptimisticTransactionDB::Open` maps 0 back to the default), so flushed memtables are freed on the next writes to the column family.

Same ingest before/after (three default column families, five commit+flush rounds of ~65 MiB each, debug test binary):

| | retained history (`size-all-mem-tables` − `cur-size-all-mem-tables`) | `num-immutable-mem-table-flushed` | VmRSS |
|---|---|---|---|
| before | 687 MB (137 + 274 + 277) | 2 / 4 / 4 | 819 MB |
| after | 0 | 0 / 0 / 0 | 351 MB |

The ceiling is arithmetic from the OPTIONS dump: 128 + 256 + 256 = 640 MiB across the three column families that take writes; 687 MB is the harness reading. Five rounds fill the history to its target, which is also the steady state of a node at tip, since it writes and flushes continuously.

The `default` column family is left alone: rust-rocksdb opens it with plain `Options::default()` when no descriptor names it, and reth never writes to it, so it holds no memtables.

`RocksTx` commits can now hit `TryAgain` when the column family was flushed after the transaction's first write; its doc comment says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)