### PR TITLE
fix(engine): finalize pipeline sync target after backfill

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1885,6 +1885,13 @@ where
 
             // update the tracked canonical head
             self.canonical_in_memory_state.set_canonical_head(new_head);
+
+            // If the pipeline reached the head of the syncing FCU, apply its safe and finalized
+            // blocks now that the head is canonical. An unwind must wait for a new FCU because the
+            // supplied sync target may have been invalidated.
+            if !ctrl.is_unwind() {
+                self.on_canonicalized_sync_target(backfill_num_hash.hash);
+            }
         }
 
         // check if we need to run backfill again by comparing the most recent backfill target

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -2853,6 +2853,51 @@ fn test_canonicalizing_downloaded_sync_target_head_updates_finalized() {
     assert!(test_harness.tree.state.forkchoice_state_tracker.sync_target_state().is_none());
 }
 
+/// Tests that pipeline backfill reaching a syncing FCU with `head == finalized` applies the
+/// finalized block without waiting for another FCU.
+#[test]
+fn test_backfill_reaching_sync_target_head_updates_finalized() {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = MAINNET.clone();
+    let mut test_harness = TestHarness::new(chain_spec);
+
+    let blocks: Vec<_> = test_harness.block_builder.get_executed_blocks(0..3).collect();
+    let initial_head = blocks[0].recovered_block().num_hash();
+    let sync_target = blocks[2].recovered_block().num_hash();
+    test_harness = test_harness.with_blocks(blocks);
+    test_harness.tree.state.tree_state.set_canonical_head(initial_head);
+
+    let fcu_state = ForkchoiceState {
+        head_block_hash: sync_target.hash,
+        safe_block_hash: sync_target.hash,
+        finalized_block_hash: sync_target.hash,
+    };
+    test_harness
+        .tree
+        .state
+        .forkchoice_state_tracker
+        .set_latest(fcu_state, ForkchoiceStatus::Syncing);
+
+    test_harness
+        .tree
+        .on_backfill_sync_finished(ControlFlow::Continue { block_number: sync_target.number })
+        .unwrap();
+
+    assert_eq!(test_harness.tree.state.tree_state.current_canonical_head, sync_target);
+    assert_eq!(
+        test_harness.tree.canonical_in_memory_state.get_finalized_num_hash(),
+        Some(sync_target)
+    );
+    assert_eq!(test_harness.tree.canonical_in_memory_state.get_safe_num_hash(), Some(sync_target));
+    assert_eq!(
+        test_harness.tree.state.forkchoice_state_tracker.last_valid_state(),
+        Some(fcu_state)
+    );
+    assert!(test_harness.tree.state.forkchoice_state_tracker.sync_target_state().is_none());
+    assert!(test_harness.from_tree_rx.try_recv().is_err());
+}
+
 // --- Backfill target selection tests ---
 //
 // Cover `backfill_target_hash` and its consumer `backfill_sync_target`, exercised end-to-end

--- a/crates/ethereum/node/tests/e2e/p2p.rs
+++ b/crates/ethereum/node/tests/e2e/p2p.rs
@@ -2,7 +2,7 @@ use crate::utils::{
     advance_with_random_transactions, eth_payload_attributes, eth_payload_attributes_amsterdam,
 };
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
-use alloy_eips::Encodable2718;
+use alloy_eips::{BlockNumberOrTag, Encodable2718};
 use alloy_network::TxSignerSync;
 use alloy_primitives::B256;
 use alloy_provider::{Provider, ProviderBuilder};
@@ -327,6 +327,70 @@ async fn test_long_reorg() -> eyre::Result<()> {
     // Ensure that it works the other way around too.
     advance_with_random_transactions(&mut first_node, 20, &mut rng, true).await?;
     second_node.sync_to(first_node.block_hash(100)).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pipeline_sync_target_head_becomes_finalized() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    const TARGET_BLOCK: u64 = 100;
+
+    let seed: [u8; 32] = rand::rng().random();
+    let mut rng = StdRng::from_seed(seed);
+    println!("Seed: {seed:?}");
+
+    let chain_spec = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+            .cancun_activated()
+            .prague_activated()
+            .build(),
+    );
+
+    let (mut nodes, _) = setup_engine::<EthereumNode>(
+        2,
+        chain_spec.clone(),
+        false,
+        Default::default(),
+        eth_payload_attributes,
+    )
+    .await?;
+
+    let mut first_node = nodes.pop().unwrap();
+    let second_node = nodes.pop().unwrap();
+
+    let first_provider = ProviderBuilder::new().connect_http(first_node.rpc_url());
+    let second_provider = ProviderBuilder::new().connect_http(second_node.rpc_url());
+
+    advance_with_random_transactions(&mut first_node, TARGET_BLOCK as usize, &mut rng, false)
+        .await?;
+
+    assert_eq!(second_provider.get_block_number().await?, 0);
+
+    let target = first_provider.get_block_by_number(TARGET_BLOCK.into()).await?.unwrap();
+
+    // Send exactly one FCU with an unknown head == safe == finalized. The node must promote this
+    // FCU when pipeline sync completes, without relying on another FCU.
+    second_node.update_forkchoice(target.header.hash, target.header.hash).await?;
+
+    tokio::time::timeout(Duration::from_secs(40), async {
+        while second_provider.get_block_number().await? != TARGET_BLOCK {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        eyre::Ok(())
+    })
+    .await
+    .map_err(|_| eyre::eyre!("timed out waiting for pipeline sync to block {TARGET_BLOCK}"))??;
+
+    let finalized = second_provider
+        .get_block_by_number(BlockNumberOrTag::Finalized)
+        .await?
+        .ok_or_else(|| eyre::eyre!("finalized block not found"))?;
+    assert_eq!(finalized.header.number, TARGET_BLOCK);
+    assert_eq!(finalized.header.hash, target.header.hash);
 
     Ok(())
 }

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -299,10 +299,7 @@ mod tests {
 
         for (id, entry) in collector.iter().unwrap().enumerate() {
             let expected = entries[id];
-            assert_eq!(
-                entry.unwrap(),
-                (expected.0.encode().to_vec(), expected.1.compress().clone())
-            );
+            assert_eq!(entry.unwrap(), (expected.0.encode().to_vec(), expected.1.compress()));
         }
 
         let temp_dir_path = collector.dir.as_ref().unwrap().path().to_path_buf();

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -27,7 +27,7 @@ use reth_network_types::{
 use std::{
     collections::VecDeque,
     fmt::Display,
-    io::{self},
+    io,
     net::{IpAddr, SocketAddr},
     pin::Pin,
     task::{Context, Poll},

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -512,7 +512,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             total: total_stages,
                         },
                         stage_id,
-                        result: out.clone(),
+                        result: out,
                     });
                     if let Some(metrics_tx) = &mut self.metrics_tx {
                         let _ = metrics_tx.send(MetricEvent::StageCheckpoint {

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -1210,7 +1210,7 @@ mod tests {
             // Test Unwind
             provider = factory.database_provider_rw().unwrap();
             let mut stage = stage();
-            provider.set_prune_modes(mode.clone().unwrap_or_default());
+            provider.set_prune_modes(mode.unwrap_or_default());
 
             let result = stage
                 .unwind(

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -350,7 +350,7 @@ where
                 // Read the raw value, and let the rayon worker to decompress & decode.
                 let chunk = match static_file_provider.fetch_range_with_predicate(
                     StaticFileSegment::Transactions,
-                    chunk_range.clone(),
+                    chunk_range,
                     |cursor, number| {
                         Ok(cursor
                             .get_one::<TransactionMask<

--- a/crates/stages/stages/tests/pipeline.rs
+++ b/crates/stages/stages/tests/pipeline.rs
@@ -325,7 +325,7 @@ async fn run_pipeline_forward_and_unwind(
 
         let block_with_senders = RecoveredBlock::new_unhashed(
             Block::new(
-                temp_header.clone(),
+                temp_header,
                 BlockBody {
                     transactions: transactions.clone(),
                     ommers: Vec::new(),
@@ -377,7 +377,7 @@ async fn run_pipeline_forward_and_unwind(
         };
 
         let block: SealedBlock<Block> = SealedBlock::seal_parts(
-            header.clone(),
+            header,
             BlockBody { transactions, ommers: Vec::new(), withdrawals: None },
         );
 

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -752,7 +752,7 @@ mod tests {
                     })
                     .collect();
 
-                let changeset = generate_test_changesets(block_num, addresses.clone());
+                let changeset = generate_test_changesets(block_num, addresses);
 
                 writer.append_account_changeset(changeset, block_num).unwrap();
             }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3925,7 +3925,7 @@ mod tests {
         // insert a bunch of transactions into the queued pool
         for _ in 0..queued_limit.max_txs {
             let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
         }
@@ -3935,7 +3935,7 @@ mod tests {
 
         for _ in 0..queued_limit.max_txs {
             let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
@@ -3955,7 +3955,7 @@ mod tests {
         // insert a bunch of transactions into the queued pool
         for _ in 0..blob_limit.max_txs {
             let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
         }
@@ -3965,7 +3965,7 @@ mod tests {
 
         for _ in 0..blob_limit.max_txs {
             let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
@@ -4408,8 +4408,7 @@ mod tests {
             tx6.clone(),
             tx7.clone(),
         ] {
-            pool.add_transaction(f.validated(tx.clone()), on_chain_balance, on_chain_nonce, None)
-                .unwrap();
+            pool.add_transaction(f.validated(tx), on_chain_balance, on_chain_nonce, None).unwrap();
         }
 
         let base_fee = base_fee as u64;

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -837,7 +837,7 @@ proptest! {
         let mut hashed_account_cursor = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
 
         let mut state = BTreeMap::default();
-        for accounts in account_changes {
+        for mut accounts in account_changes {
             let should_generate_changeset = !state.is_empty();
             let mut changes = PrefixSetMut::default();
             for (hashed_address, balance) in accounts.clone() {
@@ -854,7 +854,7 @@ proptest! {
                     .unwrap()
             });
 
-            state.append(&mut accounts.clone());
+            state.append(&mut accounts);
             let expected_root = state_root_prehashed(
                 state.iter().map(|(&key, &balance)| (key, (Account { balance, ..Default::default() }, std::iter::empty())))
             );

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1124,8 +1124,7 @@ impl ArenaParallelSparseTrie {
             );
 
             let branch = arena[head_idx].branch_mut();
-            branch.state =
-                ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone(), epoch: node_epoch };
+            branch.state = ArenaSparseNodeState::Cached { rlp_node, epoch: node_epoch };
             branch.branch_masks = new_branch_masks;
 
             // Record trie updates for dirty branches only.

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -332,7 +332,7 @@ fn decode_blocks(
             .map_err(|err| Error::block_failed(block_number, err))?;
 
         let recovered_block =
-            decoded.clone().try_recover().map_err(|err| Error::block_failed(block_number, err))?;
+            decoded.try_recover().map_err(|err| Error::block_failed(block_number, err))?;
 
         blocks.push(recovered_block);
     }


### PR DESCRIPTION
Applies the syncing forkchoice state when pipeline backfill reaches its requested head, so its safe and finalized blocks are tracked without requiring another FCU.

Adds focused engine-tree coverage and a two-node E2E regression test for an unknown head equal to the finalized block.