### PR TITLE
fix(provider): use memory overlay for in-memory block state

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1,3 +1,4 @@
+use super::state::latest::LatestStateProvider;
 use crate::{
     providers::{
         ConsistentProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider,
@@ -17,7 +18,7 @@ use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, TxHash, TxNumber,
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
-    PersistedBlockNotifications, PersistedBlockSubscriptions,
+    MemoryOverlayStateProvider, PersistedBlockNotifications, PersistedBlockSubscriptions,
 };
 use reth_chainspec::ChainInfo;
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
@@ -32,10 +33,13 @@ use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{
     BlockBodyIndicesProvider, DatabaseProviderROFactory, NodePrimitivesProvider, RangeEnd,
     RangeResponse, RangeResult, StateRangeProvider, StateRangeProviderFactory, StateRangeView,
-    StorageChangeSetReader, StorageRangeResult,
+    StorageChangeSetReader, StorageRangeResult, TryIntoHistoricalStateProvider,
 };
 use reth_storage_errors::provider::ProviderResult;
-use reth_storage_overlay::{OverlayStateProvider, OverlayStateProviderFactory, OwnedProvider};
+use reth_storage_overlay::{
+    anchor_for_parent, AnchorForParent, OverlayStateProvider, OverlayStateProviderFactory,
+    OwnedProvider,
+};
 use reth_trie::{
     hashed_cursor::{HashedCursor, HashedCursorFactory},
     metrics::TrieRootMetrics,
@@ -154,11 +158,22 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
         &self,
         state: &BlockState<N::Primitives>,
     ) -> ProviderResult<StateProviderBox> {
-        let state_provider_factory = OverlayStateProviderFactory::new(
-            self.database.clone(),
-            self.database.overlay_manager().overlay_builder(state.hash()),
-        );
-        Ok(Box::new(state_provider_factory.database_provider_ro()?))
+        let provider = self.database.provider()?;
+        let mut overlay = Vec::new();
+        let anchor = anchor_for_parent(
+            state.hash(),
+            state.chain().map(|state| state.block()).inspect(|block| overlay.push(block.clone())),
+            &provider,
+        )?;
+
+        let historical: StateProviderBox = match anchor {
+            AnchorForParent::NoReverts { .. } => Box::new(LatestStateProvider::new(provider)),
+            AnchorForParent::RevertsRequired { anchor, .. } => {
+                provider.try_into_history_at_block(anchor.number)?
+            }
+        };
+
+        Ok(Box::new(MemoryOverlayStateProvider::new(historical, overlay)))
     }
 
     /// Returns a cursor-backed state view for a state root still only in canonical in-memory

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -294,14 +294,22 @@ where
             return Ok((&overlay.overlay, overlay.historical_fallback.as_ref()))
         }
 
+        let initialization_start = Instant::now();
+        let frontiers_start = Instant::now();
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
+        self.metrics.execution_overlay_frontiers_duration.record(frontiers_start.elapsed());
+        let cache_access_start = Instant::now();
         let overlay = match self
             .execution_overlay_cache
             .entry((state_trie_tip_block.hash, finish_tip_block.hash))
         {
-            dashmap::Entry::Occupied(entry) => entry.get().clone(),
+            dashmap::Entry::Occupied(entry) => {
+                self.metrics.execution_overlay_cache_hits.increment(1);
+                entry.get().clone()
+            }
             dashmap::Entry::Vacant(entry) => {
                 self.metrics.execution_overlay_cache_misses.increment(1);
+                let build_start = Instant::now();
                 let (overlay, fallback_block_number) = self
                     .overlay_builder
                     .as_ref()
@@ -341,11 +349,16 @@ where
                     })
                     .transpose()?;
                 let overlay = CachedExecutionOverlay { overlay, historical_fallback };
+                self.metrics.execution_overlay_build_duration.record(build_start.elapsed());
                 entry.insert(overlay.clone());
                 overlay
             }
         };
+        self.metrics.execution_overlay_cache_access_duration.record(cache_access_start.elapsed());
         let _ = self.execution_overlay.set(overlay);
+        self.metrics
+            .execution_overlay_initialization_duration
+            .record(initialization_start.elapsed());
         let overlay = self.execution_overlay.get().expect("execution overlay was just initialized");
         Ok((&overlay.overlay, overlay.historical_fallback.as_ref()))
     }
@@ -978,6 +991,16 @@ pub(crate) struct OverlayStateProviderFactoryMetrics {
     state_trie_overlay_cache_misses: Counter,
     /// Number of cache misses when fetching execution overlays.
     execution_overlay_cache_misses: Counter,
+    /// Number of cache hits when fetching execution overlays.
+    execution_overlay_cache_hits: Counter,
+    /// Duration of resolving durable frontiers for a cold execution overlay.
+    execution_overlay_frontiers_duration: Histogram,
+    /// Duration of accessing the execution overlay cache.
+    execution_overlay_cache_access_duration: Histogram,
+    /// Duration of constructing an execution overlay on a cache miss.
+    execution_overlay_build_duration: Histogram,
+    /// Overall duration of initializing a provider's execution overlay.
+    execution_overlay_initialization_duration: Histogram,
 }
 
 type StateTrieOverlayCache = Arc<DashMap<(BlockHash, BlockHash), StateTrieOverlay>>;


### PR DESCRIPTION
## Summary

- Restore `MemoryOverlayStateProvider` for `BlockchainProvider` state over in-memory blocks while retaining `OverlayStateProvider` for engine validation and trie work.
- The public E2E regression bisected to `f0166c32`: TPS fell 7.32%, builder gas throughput fell 13.57%, and fill-idle p50 rose 55.68%.
- A three-pair, unprofiled instrumented A/B shows the mechanism: factory-local execution-overlay cache misses fall from 12.42M to 641. Samply caller stacks attribute the repeated cold initialization primarily to transaction-pool validation, not payload prewarming.

## Instrumented A/B

The control and feature use identical instrumentation; the only behavioral difference is `OverlayStateProvider` versus `MemoryOverlayStateProvider` in `block_state_provider`. Across both nodes and three measured 120-second run pairs, with profiling disabled:

| Metric | Overlay control | Memory-overlay fix | Delta |
|---|---:|---:|---:|
| Factory-local execution-overlay initializations | 12,426,735 | 11,564 | -99.91% |
| Factory-local execution-overlay cache hits | 11,145 | 10,924 | -2.0% |
| Factory-local execution-overlay cache misses | 12,415,490 | 641 | -99.99% |
| `OverlayManager` execution-overlay cache reuses | 12,413,548 | 274 | -99.998% |
| Prewarm state-provider setup, mean | 38.2 us | 17.0 us | -55.4% |
| Prewarm blocking receives / payload, mean | 143.4 | 97.1 | -32.3% |
| Empty prewarm results / payload, mean | 163.7 | 121.0 | -26.1% |
| Prewarm blocking time / payload, mean | 2.740 ms | 2.139 ms | -21.9% |
| Fill-idle / payload, mean | 128.7 ms | 91.6 ms | -28.8% |

The factory-local miss does not mean the overlay was fully recomputed: the baseline reused `OverlayManager` entries 12.41M times. `block_state_provider` created a new `OverlayStateProviderFactory` and therefore a fresh outer cache on every call; it then missed that cache and fell through to the shared manager cache. The fix removes this repeated factory/provider/frontier/outer-cache path. Remaining feature-side overlay initialization comes from validation/trie paths that intentionally retain the overlay provider.

The same run measured TPS at 20,532 -> 22,602 (+10.08%, significant), builder gas throughput at 1,602.3 -> 1,932.1 Mgas/s (+20.58%, significant), and fill-idle p50 at 130 -> 90 ms (-30.77%). The workflow verdict is `Mixed Results`: block time mean regressed 1.80%, validator gas throughput regressed 2.05%, and validator latency p50 regressed 14.32%.

## Profile

Across the two 600-second Samply node profiles, inclusive `block_state_provider` CPU samples fall from 41.9/44.8k to 20.1/23.5k, while the cold `execution_overlay` path falls from 51.8/55.7k to 0.3/0.3k. Of the baseline node A `execution_overlay` samples, 51.5k of 51.8k are entered from `storage`, and 51.2k are under Tempo transaction-pool `StateCacheDb` storage reads. Similarly, 41.6k of 41.9k `block_state_provider` samples are under transaction-pool validation; only 312 are under payload prewarming.

The flattened state lookup is not itself the measured bottleneck. The transaction validator obtains a short-lived latest state provider, and its first storage read pays for frontier resolution, the fresh factory-local cache miss, the `OverlayManager` lookup, and local cache insertion. Each initialization averages only 7 us, but it occurred 12.4M times in the three-pair run, so the setup was never amortized. The lower prewarm-empty and fill-idle metrics are downstream effects of faster pool validation.

## Verification

- `cargo +nightly fmt --all --check`
- `cargo check -p reth-provider`
- `cargo test -p reth-provider test_state_provider_factory --lib`
- `cargo +nightly clippy -p reth-storage-overlay --lib --all-features -- -D warnings`
- [Instrumented Tempo public E2E benchmark](https://github.com/tempoxyz/tempo/actions/runs/33746488533) (3 x 120 s pairs, 100 GiB state, 50k target TPS, profiling disabled)

Prompted by: @shekhirin
