### PR TITLE
chore: fix latest nightly clippy lints

### DIFF
--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -299,10 +299,7 @@ mod tests {
 
         for (id, entry) in collector.iter().unwrap().enumerate() {
             let expected = entries[id];
-            assert_eq!(
-                entry.unwrap(),
-                (expected.0.encode().to_vec(), expected.1.compress().clone())
-            );
+            assert_eq!(entry.unwrap(), (expected.0.encode().to_vec(), expected.1.compress()));
         }
 
         let temp_dir_path = collector.dir.as_ref().unwrap().path().to_path_buf();

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -27,7 +27,7 @@ use reth_network_types::{
 use std::{
     collections::VecDeque,
     fmt::Display,
-    io::{self},
+    io,
     net::{IpAddr, SocketAddr},
     pin::Pin,
     task::{Context, Poll},

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -512,7 +512,7 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                             total: total_stages,
                         },
                         stage_id,
-                        result: out.clone(),
+                        result: out,
                     });
                     if let Some(metrics_tx) = &mut self.metrics_tx {
                         let _ = metrics_tx.send(MetricEvent::StageCheckpoint {

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -1210,7 +1210,7 @@ mod tests {
             // Test Unwind
             provider = factory.database_provider_rw().unwrap();
             let mut stage = stage();
-            provider.set_prune_modes(mode.clone().unwrap_or_default());
+            provider.set_prune_modes(mode.unwrap_or_default());
 
             let result = stage
                 .unwind(

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -350,7 +350,7 @@ where
                 // Read the raw value, and let the rayon worker to decompress & decode.
                 let chunk = match static_file_provider.fetch_range_with_predicate(
                     StaticFileSegment::Transactions,
-                    chunk_range.clone(),
+                    chunk_range,
                     |cursor, number| {
                         Ok(cursor
                             .get_one::<TransactionMask<

--- a/crates/stages/stages/tests/pipeline.rs
+++ b/crates/stages/stages/tests/pipeline.rs
@@ -325,7 +325,7 @@ async fn run_pipeline_forward_and_unwind(
 
         let block_with_senders = RecoveredBlock::new_unhashed(
             Block::new(
-                temp_header.clone(),
+                temp_header,
                 BlockBody {
                     transactions: transactions.clone(),
                     ommers: Vec::new(),
@@ -377,7 +377,7 @@ async fn run_pipeline_forward_and_unwind(
         };
 
         let block: SealedBlock<Block> = SealedBlock::seal_parts(
-            header.clone(),
+            header,
             BlockBody { transactions, ommers: Vec::new(), withdrawals: None },
         );
 

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -752,7 +752,7 @@ mod tests {
                     })
                     .collect();
 
-                let changeset = generate_test_changesets(block_num, addresses.clone());
+                let changeset = generate_test_changesets(block_num, addresses);
 
                 writer.append_account_changeset(changeset, block_num).unwrap();
             }

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -3925,7 +3925,7 @@ mod tests {
         // insert a bunch of transactions into the queued pool
         for _ in 0..queued_limit.max_txs {
             let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
         }
@@ -3935,7 +3935,7 @@ mod tests {
 
         for _ in 0..queued_limit.max_txs {
             let tx = MockTransaction::eip1559().inc_price_by(10).inc_nonce();
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
@@ -3955,7 +3955,7 @@ mod tests {
         // insert a bunch of transactions into the queued pool
         for _ in 0..blob_limit.max_txs {
             let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
         }
@@ -3965,7 +3965,7 @@ mod tests {
 
         for _ in 0..blob_limit.max_txs {
             let tx = MockTransaction::eip4844().inc_price_by(100).with_blob_fee(100);
-            let validated = f.validated(tx.clone());
+            let validated = f.validated(tx);
             let _id = *validated.id();
             pool.add_transaction(validated, U256::from(1_000), 0, None).unwrap();
 
@@ -4408,8 +4408,7 @@ mod tests {
             tx6.clone(),
             tx7.clone(),
         ] {
-            pool.add_transaction(f.validated(tx.clone()), on_chain_balance, on_chain_nonce, None)
-                .unwrap();
+            pool.add_transaction(f.validated(tx), on_chain_balance, on_chain_nonce, None).unwrap();
         }
 
         let base_fee = base_fee as u64;

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -837,7 +837,7 @@ proptest! {
         let mut hashed_account_cursor = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();
 
         let mut state = BTreeMap::default();
-        for accounts in account_changes {
+        for mut accounts in account_changes {
             let should_generate_changeset = !state.is_empty();
             let mut changes = PrefixSetMut::default();
             for (hashed_address, balance) in accounts.clone() {
@@ -854,7 +854,7 @@ proptest! {
                     .unwrap()
             });
 
-            state.append(&mut accounts.clone());
+            state.append(&mut accounts);
             let expected_root = state_root_prehashed(
                 state.iter().map(|(&key, &balance)| (key, (Account { balance, ..Default::default() }, std::iter::empty())))
             );

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1124,8 +1124,7 @@ impl ArenaParallelSparseTrie {
             );
 
             let branch = arena[head_idx].branch_mut();
-            branch.state =
-                ArenaSparseNodeState::Cached { rlp_node: rlp_node.clone(), epoch: node_epoch };
+            branch.state = ArenaSparseNodeState::Cached { rlp_node, epoch: node_epoch };
             branch.branch_masks = new_branch_masks;
 
             // Record trie updates for dirty branches only.

--- a/testing/ef-tests/src/cases/blockchain_test.rs
+++ b/testing/ef-tests/src/cases/blockchain_test.rs
@@ -332,7 +332,7 @@ fn decode_blocks(
             .map_err(|err| Error::block_failed(block_number, err))?;
 
         let recovered_block =
-            decoded.clone().try_recover().map_err(|err| Error::block_failed(block_number, err))?;
+            decoded.try_recover().map_err(|err| Error::block_failed(block_number, err))?;
 
         blocks.push(recovered_block);
     }


### PR DESCRIPTION
Removes redundant clones and simplifies a self import that became errors with the September 2 nightly Clippy release.

This restores both Clippy jobs on main.