### PR TITLE
refactor(overlay): reduce execution overlay setup overhead

### DIFF
--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -506,6 +506,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Returns the in-memory execution overlay and the block for historical fallback reads.
+    #[instrument(level = "trace", target = "storage::overlay", skip_all)]
     pub fn execution_overlay<Provider>(
         &self,
         provider: &Provider,
@@ -523,6 +524,12 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Returns the in-memory execution overlay using frontiers already read from the provider.
+    #[instrument(
+        level = "trace",
+        target = "storage::overlay",
+        skip_all,
+        fields(?state_trie_tip_block, ?finish_tip_block, parent_hash = ?self.parent_hash)
+    )]
     pub fn execution_overlay_at_frontiers<Provider>(
         &self,
         provider: &Provider,

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -319,14 +319,14 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         match &self.overlay_source {
             Some(OverlaySource::Managed) => anchor_for_parent_with_frontiers(
                 self.parent_hash,
-                self.parent_state.iter().flat_map(|state| state.chain()).map(BlockState::block),
+                self.parent_state.iter().flat_map(|state| state.chain()).map(BlockState::block_ref),
                 partial_state_trie,
                 finish,
                 provider,
             ),
             _ => anchor_for_parent_with_frontiers(
                 self.parent_hash,
-                std::iter::empty::<ExecutedBlock<N>>(),
+                std::iter::empty::<&ExecutedBlock<N>>(),
                 partial_state_trie,
                 finish,
                 provider,
@@ -506,7 +506,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Returns the in-memory execution overlay and the block for historical fallback reads.
-    #[instrument(level = "debug", target = "storage::overlay", skip_all)]
     pub fn execution_overlay<Provider>(
         &self,
         provider: &Provider,
@@ -524,12 +523,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Returns the in-memory execution overlay using frontiers already read from the provider.
-    #[instrument(
-        level = "debug",
-        target = "storage::overlay",
-        skip_all,
-        fields(?state_trie_tip_block, ?finish_tip_block, parent_hash = ?self.parent_hash)
-    )]
     pub fn execution_overlay_at_frontiers<Provider>(
         &self,
         provider: &Provider,
@@ -715,26 +708,27 @@ struct OverlayBuilderMetrics {
     sparse_trie_overlay_skips: Counter,
 }
 
-fn anchor_for_parent_in<N: NodePrimitives>(
+fn anchor_for_parent_in<'a, N: NodePrimitives + 'a>(
     parent_hash: B256,
-    mut in_mem_chain: impl Iterator<Item = ExecutedBlock<N>>,
-    preferred_anchor: B256,
-) -> B256 {
-    if parent_hash == preferred_anchor {
-        return parent_hash
+    in_mem_chain: impl Iterator<Item = &'a ExecutedBlock<N>>,
+    preferred_anchor: BlockNumHash,
+) -> Option<BlockNumHash> {
+    if parent_hash == preferred_anchor.hash {
+        return Some(preferred_anchor)
     }
 
-    let mut hash = parent_hash;
+    let mut anchor = None;
 
-    loop {
-        let Some(block) = in_mem_chain.next() else { return hash };
-        let block_parent_hash = block.recovered_block().parent_hash();
+    for block in in_mem_chain {
+        let block_parent = block.recovered_block().parent_num_hash();
 
-        if block_parent_hash == preferred_anchor {
-            return block_parent_hash
+        if block_parent.hash == preferred_anchor.hash {
+            return Some(preferred_anchor)
         }
-        hash = block_parent_hash;
+        anchor = Some(block_parent);
     }
+
+    anchor
 }
 
 /// Describes whether an overlay must revert the database before using its anchor.
@@ -769,13 +763,13 @@ impl AnchorForParent {
 /// * `parent`: The block whose post-state is being targeted.
 /// * `in_mem_chain`: Yields the in-memory blocks in the chain, starting at `parent_hash`.
 /// * `provider`: Used to resolve the durable frontiers and check changeset availability.
-pub fn anchor_for_parent<N, Provider>(
+pub fn anchor_for_parent<'a, N, Provider>(
     parent_hash: B256,
-    in_mem_chain: impl Iterator<Item = ExecutedBlock<N>>,
+    in_mem_chain: impl Iterator<Item = &'a ExecutedBlock<N>>,
     provider: &Provider,
 ) -> ProviderResult<AnchorForParent>
 where
-    N: NodePrimitives,
+    N: NodePrimitives + 'a,
     Provider: StageCheckpointReader + BlockNumReader + PruneCheckpointReader,
 {
     let (partial_state_trie, finish) = database_state_frontiers(provider)?;
@@ -797,22 +791,43 @@ where
 /// * `partial_state_trie`: The durable state/trie frontier.
 /// * `finish`: The durable Finish frontier.
 /// * `provider`: Used to resolve the parent and check changeset availability.
-pub fn anchor_for_parent_with_frontiers<N, Provider>(
+pub fn anchor_for_parent_with_frontiers<'a, N, Provider>(
     parent_hash: B256,
-    in_mem_chain: impl Iterator<Item = ExecutedBlock<N>>,
+    in_mem_chain: impl Iterator<Item = &'a ExecutedBlock<N>>,
     partial_state_trie: BlockNumHash,
     finish: BlockNumHash,
     provider: &Provider,
 ) -> ProviderResult<AnchorForParent>
 where
-    N: NodePrimitives,
+    N: NodePrimitives + 'a,
     Provider: BlockNumReader + PruneCheckpointReader,
 {
     use std::io::Error;
 
-    let persisted_parent = provider
-        .block_number(parent_hash)?
-        .filter(|&parent_number| parent_number <= partial_state_trie.number);
+    let mut in_mem_chain = in_mem_chain.peekable();
+    let managed_parent_number = in_mem_chain
+        .peek()
+        .filter(|block| block.recovered_block().hash() == parent_hash)
+        .map(|block| block.recovered_block().number());
+    // Managed blocks already carry their number. Blocks above the state trie frontier cannot be a
+    // persisted anchor; for older blocks, verify canonicality with a number-to-hash lookup.
+    let persisted_parent = if let Some(parent_number) = managed_parent_number {
+        if parent_number > partial_state_trie.number {
+            None
+        } else if parent_number == partial_state_trie.number &&
+            parent_hash == partial_state_trie.hash
+        {
+            Some(parent_number)
+        } else {
+            (provider.block_hash(parent_number)? == Some(parent_hash)).then_some(parent_number)
+        }
+    } else if parent_hash == partial_state_trie.hash {
+        Some(partial_state_trie.number)
+    } else {
+        provider
+            .block_number(parent_hash)?
+            .filter(|&parent_number| parent_number <= partial_state_trie.number)
+    };
 
     let mut finish_seen = parent_hash == finish.hash;
     let anchor = if let Some(parent_number) = persisted_parent {
@@ -822,11 +837,12 @@ where
             finish_seen |= block.recovered_block().hash() == finish.hash;
         });
 
-        let anchor_hash =
-            anchor_for_parent_in(parent_hash, &mut in_mem_chain, partial_state_trie.hash);
-        if anchor_hash == partial_state_trie.hash {
-            BlockNumHash::new(partial_state_trie.number, anchor_hash)
+        if let Some(anchor) =
+            anchor_for_parent_in(parent_hash, &mut in_mem_chain, partial_state_trie)
+        {
+            anchor
         } else {
+            let anchor_hash = parent_hash;
             let anchor_number = provider
                 .convert_hash_or_number(anchor_hash.into())?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -812,29 +812,12 @@ where
     use std::io::Error;
 
     let mut in_mem_chain = in_mem_chain.peekable();
-    let managed_parent_number = in_mem_chain
-        .peek()
-        .filter(|block| block.recovered_block().hash() == parent_hash)
-        .map(|block| block.recovered_block().number());
-    // Managed blocks already carry their number. Blocks above the state trie frontier cannot be a
-    // persisted anchor; for older blocks, verify canonicality with a number-to-hash lookup.
-    let persisted_parent = if let Some(parent_number) = managed_parent_number {
-        if parent_number > partial_state_trie.number {
-            None
-        } else if parent_number == partial_state_trie.number &&
-            parent_hash == partial_state_trie.hash
-        {
-            Some(parent_number)
-        } else {
-            (provider.block_hash(parent_number)? == Some(parent_hash)).then_some(parent_number)
-        }
-    } else if parent_hash == partial_state_trie.hash {
-        Some(partial_state_trie.number)
-    } else {
-        provider
-            .block_number(parent_hash)?
-            .filter(|&parent_number| parent_number <= partial_state_trie.number)
-    };
+    let persisted_parent = persisted_parent_number(
+        parent_hash,
+        in_mem_chain.peek().copied(),
+        partial_state_trie,
+        provider,
+    )?;
 
     let mut finish_seen = parent_hash == finish.hash;
     let anchor = if let Some(parent_number) = persisted_parent {
@@ -897,6 +880,44 @@ where
     }
 
     Ok(AnchorForParent::RevertsRequired { anchor, finish })
+}
+
+/// Returns the parent number when `parent_hash` is a durable anchor.
+fn persisted_parent_number<N, Provider>(
+    parent_hash: B256,
+    managed_parent: Option<&ExecutedBlock<N>>,
+    partial_state_trie: BlockNumHash,
+    provider: &Provider,
+) -> ProviderResult<Option<BlockNumber>>
+where
+    N: NodePrimitives,
+    Provider: BlockNumReader,
+{
+    let managed_parent_number = managed_parent
+        .filter(|block| block.recovered_block().hash() == parent_hash)
+        .map(|block| block.recovered_block().number());
+
+    // Managed blocks already carry their number. Blocks above the state trie frontier cannot be a
+    // persisted anchor; for older blocks, verify canonicality with a number-to-hash lookup.
+    if let Some(parent_number) = managed_parent_number {
+        if parent_number > partial_state_trie.number {
+            return Ok(None)
+        }
+        if parent_number == partial_state_trie.number && parent_hash == partial_state_trie.hash {
+            return Ok(Some(parent_number))
+        }
+        return Ok(
+            (provider.block_hash(parent_number)? == Some(parent_hash)).then_some(parent_number)
+        )
+    }
+
+    if parent_hash == partial_state_trie.hash {
+        Ok(Some(partial_state_trie.number))
+    } else {
+        provider.block_number(parent_hash).map(|parent_number| {
+            parent_number.filter(|&number| number <= partial_state_trie.number)
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -57,8 +57,6 @@ pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
     /// Under partial persistence the overlay depends on both durable frontiers, so both hashes are
     /// part of the cache key.
     state_trie_overlay_cache: StateTrieOverlayCache,
-    /// A cache which maps durable frontier pairs to [`ExecutionOverlay`]s.
-    execution_overlay_cache: ExecutionOverlayCache,
     /// Metrics for provider factory operations.
     metrics: OverlayStateProviderFactoryMetrics,
 }
@@ -70,7 +68,6 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
             factory,
             overlay_builder,
             state_trie_overlay_cache: Default::default(),
-            execution_overlay_cache: Default::default(),
             metrics: Default::default(),
         }
     }
@@ -81,7 +78,6 @@ impl<F, N: NodePrimitives> OverlayStateProviderFactory<F, N> {
         self.overlay_builder =
             self.overlay_builder.with_skip_overlay_for_reused_sparse_trie(anchor_hash);
         self.state_trie_overlay_cache = Default::default();
-        self.execution_overlay_cache = Default::default();
         self
     }
 }
@@ -120,7 +116,6 @@ where
             provider,
             self.overlay_builder.clone(),
             Arc::clone(&self.state_trie_overlay_cache),
-            Arc::clone(&self.execution_overlay_cache),
             self.metrics.clone(),
             is_v2,
         ))
@@ -132,7 +127,6 @@ pub struct OverlayStateProvider<Provider, N: NodePrimitives = EthPrimitives> {
     provider: Provider,
     overlay_builder: Option<OverlayBuilder<N>>,
     state_trie_overlay_cache: StateTrieOverlayCache,
-    execution_overlay_cache: ExecutionOverlayCache,
     metrics: OverlayStateProviderFactoryMetrics,
     state_trie_overlay: OnceCell<StateTrieOverlay>,
     execution_overlay: OnceCell<CachedExecutionOverlay>,
@@ -144,7 +138,6 @@ impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, 
         provider: Provider,
         overlay_builder: OverlayBuilder<N>,
         state_trie_overlay_cache: StateTrieOverlayCache,
-        execution_overlay_cache: ExecutionOverlayCache,
         metrics: OverlayStateProviderFactoryMetrics,
         is_v2: bool,
     ) -> Self {
@@ -152,7 +145,6 @@ impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, 
             provider: OwnedProvider(provider),
             overlay_builder: Some(overlay_builder),
             state_trie_overlay_cache,
-            execution_overlay_cache,
             metrics,
             state_trie_overlay: OnceCell::new(),
             execution_overlay: OnceCell::new(),
@@ -170,7 +162,6 @@ impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, 
             provider: OwnedProvider(provider),
             overlay_builder: None,
             state_trie_overlay_cache: Default::default(),
-            execution_overlay_cache: Default::default(),
             metrics: Default::default(),
             state_trie_overlay: OnceCell::new(),
             execution_overlay: OnceCell::from(CachedExecutionOverlay {
@@ -192,7 +183,6 @@ impl<'a, Provider, N: NodePrimitives> OverlayStateProvider<&'a Provider, N> {
             provider,
             overlay_builder: None,
             state_trie_overlay_cache: Default::default(),
-            execution_overlay_cache: Default::default(),
             metrics: Default::default(),
             state_trie_overlay: OnceCell::from(state_trie_overlay),
             execution_overlay: OnceCell::new(),
@@ -295,56 +285,43 @@ where
         }
 
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
-        let overlay = match self
-            .execution_overlay_cache
-            .entry((state_trie_tip_block.hash, finish_tip_block.hash))
-        {
-            dashmap::Entry::Occupied(entry) => entry.get().clone(),
-            dashmap::Entry::Vacant(entry) => {
-                self.metrics.execution_overlay_cache_misses.increment(1);
-                let (overlay, fallback_block_number) = self
-                    .overlay_builder
-                    .as_ref()
-                    .expect("execution overlay must be initialized or lazily resolvable")
-                    .execution_overlay_at_frontiers(
-                        self.provider(),
-                        state_trie_tip_block,
-                        finish_tip_block,
-                    )?;
-                let historical_fallback = fallback_block_number
-                    .map(|block_number| {
-                        let account_history_block_number = self
-                            .provider()
-                            .get_prune_checkpoint(PruneSegment::AccountHistory)?
-                            .and_then(|checkpoint| checkpoint.block_number)
-                            .map(|block_number| block_number + 1);
-                        if account_history_block_number.is_some_and(|lowest| block_number < lowest)
-                        {
-                            return Err(ProviderError::StateAtBlockPruned(block_number))
-                        }
+        let (overlay, fallback_block_number) = self
+            .overlay_builder
+            .as_ref()
+            .expect("execution overlay must be initialized or lazily resolvable")
+            .execution_overlay_at_frontiers(
+                self.provider(),
+                state_trie_tip_block,
+                finish_tip_block,
+            )?;
+        let historical_fallback = fallback_block_number
+            .map(|block_number| {
+                let account_history_block_number = self
+                    .provider()
+                    .get_prune_checkpoint(PruneSegment::AccountHistory)?
+                    .and_then(|checkpoint| checkpoint.block_number)
+                    .map(|block_number| block_number + 1);
+                if account_history_block_number.is_some_and(|lowest| block_number < lowest) {
+                    return Err(ProviderError::StateAtBlockPruned(block_number))
+                }
 
-                        let storage_history_block_number = self
-                            .provider()
-                            .get_prune_checkpoint(PruneSegment::StorageHistory)?
-                            .and_then(|checkpoint| checkpoint.block_number)
-                            .map(|block_number| block_number + 1);
-                        if storage_history_block_number.is_some_and(|lowest| block_number < lowest)
-                        {
-                            return Err(ProviderError::StateAtBlockPruned(block_number))
-                        }
+                let storage_history_block_number = self
+                    .provider()
+                    .get_prune_checkpoint(PruneSegment::StorageHistory)?
+                    .and_then(|checkpoint| checkpoint.block_number)
+                    .map(|block_number| block_number + 1);
+                if storage_history_block_number.is_some_and(|lowest| block_number < lowest) {
+                    return Err(ProviderError::StateAtBlockPruned(block_number))
+                }
 
-                        Ok(HistoricalFallback {
-                            block_number,
-                            account_history_block_number,
-                            storage_history_block_number,
-                        })
-                    })
-                    .transpose()?;
-                let overlay = CachedExecutionOverlay { overlay, historical_fallback };
-                entry.insert(overlay.clone());
-                overlay
-            }
-        };
+                Ok(HistoricalFallback {
+                    block_number,
+                    account_history_block_number,
+                    storage_history_block_number,
+                })
+            })
+            .transpose()?;
+        let overlay = CachedExecutionOverlay { overlay, historical_fallback };
         let _ = self.execution_overlay.set(overlay);
         let overlay = self.execution_overlay.get().expect("execution overlay was just initialized");
         Ok((&overlay.overlay, overlay.historical_fallback.as_ref()))
@@ -976,12 +953,9 @@ pub(crate) struct OverlayStateProviderFactoryMetrics {
     database_provider_ro_duration: Histogram,
     /// Number of cache misses when fetching state trie overlays.
     state_trie_overlay_cache_misses: Counter,
-    /// Number of cache misses when fetching execution overlays.
-    execution_overlay_cache_misses: Counter,
 }
 
 type StateTrieOverlayCache = Arc<DashMap<(BlockHash, BlockHash), StateTrieOverlay>>;
-type ExecutionOverlayCache = Arc<DashMap<(BlockHash, BlockHash), CachedExecutionOverlay>>;
 
 #[derive(Clone, Debug)]
 struct CachedExecutionOverlay {
@@ -1175,20 +1149,14 @@ mod tests {
         assert!(provider.state_trie_overlay.get().is_none());
         assert!(provider.execution_overlay.get().is_none());
         assert!(state_provider_factory.state_trie_overlay_cache.is_empty());
-        assert!(state_provider_factory.execution_overlay_cache.is_empty());
 
         provider.basic_account(&Address::ZERO).unwrap();
-        let execution_overlay = Arc::clone(&provider.execution_overlay.get().unwrap().overlay);
         assert!(provider.state_trie_overlay.get().is_none());
         assert!(provider.execution_overlay.get().is_some());
         assert!(state_provider_factory.state_trie_overlay_cache.is_empty());
-        assert_eq!(state_provider_factory.execution_overlay_cache.len(), 1);
-        let cached_overlay = state_provider_factory.execution_overlay_cache.iter().next().unwrap();
-        assert!(Arc::ptr_eq(&execution_overlay, &cached_overlay.value().overlay));
 
         provider.account_trie_cursor().unwrap();
         assert_eq!(state_provider_factory.state_trie_overlay_cache.len(), 1);
-        assert_eq!(state_provider_factory.execution_overlay_cache.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Scan managed execution blocks by reference and carry `BlockNumHash` through anchor selection.
- Source managed parent numbers from in-memory block metadata when possible, avoiding hash-to-number DB lookups on the normal in-memory path.
- Remove the per-factory execution-overlay cache and its cache-miss metric; the per-provider lazy cell and manager cache remain.
- Move `execution_overlay` and `execution_overlay_at_frontiers` spans from DEBUG to TRACE; no metrics are added.

## Profile
- Samply attributed the hot setup path to execution-overlay span construction, repeated factory-cache misses, anchor DB resolution, and cloned `ExecutedBlock` drop/refcount work.
- This change removes those sources of repeated work while preserving opt-in TRACE diagnostics and canonicality checks for retained or forked blocks.

## Verification
- `cargo test -p reth-storage-overlay` (46 passed)
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p reth-storage-overlay --all-targets -- -D warnings`
- [End-to-end benchmark](https://github.com/paradigmxyz/reth/actions/runs/33768664418): infrastructure failed to fetch the snapshot manifest before any benchmark runs executed

Prompted by: @mediocregopher