### PR TITLE
refactor(db): use FastInstant alias for metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8076,7 +8076,6 @@ dependencies = [
  "page_size",
  "parking_lot",
  "proptest",
- "quanta",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,7 +513,6 @@ notify = { version = "8.0.0", default-features = false, features = ["macos_fseve
 nybbles = { version = "0.4.8", default-features = false }
 once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
 parking_lot = "0.12"
-quanta = "0.12"
 paste = "1.0"
 rand = "0.9"
 rayon = "1.7"

--- a/crates/storage/db/Cargo.toml
+++ b/crates/storage/db/Cargo.toml
@@ -20,6 +20,7 @@ reth-nippy-jar.workspace = true
 reth-tracing.workspace = true
 tracing.workspace = true
 reth-static-file-types.workspace = true
+reth-primitives-traits = { workspace = true, optional = true, features = ["quanta"] }
 
 # ethereum
 alloy-primitives.workspace = true
@@ -31,7 +32,6 @@ eyre = { workspace = true, optional = true }
 # metrics
 reth-metrics = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
-quanta = { workspace = true, optional = true }
 
 # misc
 page_size = { workspace = true, optional = true }
@@ -73,7 +73,7 @@ mdbx = [
     "dep:reth-libmdbx",
     "dep:eyre",
     "dep:page_size",
-    "dep:quanta",
+    "dep:reth-primitives-traits",
     "reth-metrics",
     "dep:metrics",
     "dep:strum",

--- a/crates/storage/db/src/metrics.rs
+++ b/crates/storage/db/src/metrics.rs
@@ -1,7 +1,7 @@
 use crate::Tables;
 use metrics::Histogram;
-use quanta::Instant;
 use reth_metrics::{metrics::Counter, Metrics};
+use reth_primitives_traits::FastInstant as Instant;
 use rustc_hash::FxHashMap;
 use std::{array, sync::Arc, time::Duration};
 use strum::{EnumCount, EnumIter, IntoEnumIterator};


### PR DESCRIPTION
Route database metrics timing through `reth_primitives_traits::FastInstant` and remove the direct `quanta` dependency from Reth.

Prompted by: @DaniPopes