### PR TITLE
perf(engine): batch BAL prewarm targets across accounts

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -19,10 +19,11 @@ use tracing::trace;
 /// generic over the provider factory; each worker builds its own per block.
 pub type BuildProviderFn = dyn Fn() -> ProviderResult<StateProviderBox> + Send + Sync;
 
-/// A single warm request: a whole account (basic account + its bytecode) or one storage slot.
+/// A single warm request: a whole account (basic account + its bytecode) followed by a batch of
+/// its storage slots, or a batch of storage slots on their own.
 enum PrewarmTarget {
-    Account(Address),
-    Storage(Address, StorageKey),
+    Account(Address, Box<[StorageKey]>),
+    Storage(Address, Box<[StorageKey]>),
 }
 
 /// A message in a worker's queue. The per-block lifecycle is explicit and ordered (the queue is
@@ -87,14 +88,23 @@ impl BalPrewarmPool {
         }
     }
 
-    /// Fire-and-forget: warm an account (basic account + bytecode) on some worker.
-    pub fn warm_account(&self, addr: Address) {
-        self.send_warm(PrewarmTarget::Account(addr));
-    }
+    /// Fire-and-forget: warm an account (basic account + bytecode) and its storage slots.
+    ///
+    /// The slots are dispatched in [`WARM_BATCH_SIZE`] chunks that are distributed independently,
+    /// so a single account with a large read-set does not serialize onto one worker;
+    /// [`end_block`](Self::end_block) waits for the slowest queue.
+    pub fn warm_account(&self, addr: Address, slots: impl IntoIterator<Item = StorageKey>) {
+        let mut slots = slots.into_iter();
+        let mut batch: Box<[StorageKey]> = slots.by_ref().take(WARM_BATCH_SIZE).collect();
+        self.send_warm(PrewarmTarget::Account(addr, batch));
 
-    /// Fire-and-forget: warm one storage slot on some worker.
-    pub fn warm_storage(&self, addr: Address, slot: StorageKey) {
-        self.send_warm(PrewarmTarget::Storage(addr, slot));
+        loop {
+            batch = slots.by_ref().take(WARM_BATCH_SIZE).collect();
+            if batch.is_empty() {
+                break
+            }
+            self.send_warm(PrewarmTarget::Storage(addr, batch));
+        }
     }
 
     /// Ends the block: every worker drops its provider (and read txn) once it has drained the warm
@@ -141,6 +151,13 @@ impl BalPrewarmPool {
 /// This should explain why this particular value is picked.
 pub const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
 
+/// Number of storage slots carried by one warm message.
+///
+/// Batching amortizes the send over many slots and hands the worker a run of slots that live
+/// close together in the storage table, while the cap keeps enough messages in flight to saturate
+/// the workers on blocks whose read-set is concentrated in a few accounts.
+const WARM_BATCH_SIZE: usize = 32;
+
 fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and
     // `EndBlock`. `None` while idle, so no read txn is pinned across the inter-block gap.
@@ -164,16 +181,17 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
             PrewarmMsg::Warm(target) => {
                 let Some(provider) = provider.as_ref() else { continue };
                 match target {
-                    PrewarmTarget::Account(addr) => {
+                    PrewarmTarget::Account(addr, slots) => {
                         if let Ok(Some(account)) = provider.basic_account(&addr) &&
                             let Some(code_hash) = account.bytecode_hash &&
                             code_hash != alloy_consensus::constants::KECCAK_EMPTY
                         {
                             let _ = provider.bytecode_by_hash(&code_hash);
                         }
+                        warm_slots(provider, addr, &slots);
                     }
-                    PrewarmTarget::Storage(addr, slot) => {
-                        let _ = provider.storage(addr, slot);
+                    PrewarmTarget::Storage(addr, slots) => {
+                        warm_slots(provider, addr, &slots);
                     }
                 }
             }
@@ -182,6 +200,16 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
                 drop(end_tx);
             }
         }
+    }
+}
+
+fn warm_slots(
+    provider: &CachedStateProvider<StateProviderBox>,
+    addr: Address,
+    slots: &[StorageKey],
+) {
+    for &slot in slots {
+        let _ = provider.storage(addr, slot);
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -156,7 +156,7 @@ pub const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
 /// Batching amortizes the send over many slots and hands the worker a run of slots that live
 /// close together in the storage table, while the cap keeps enough messages in flight to saturate
 /// the workers on blocks whose read-set is concentrated in a few accounts.
-const WARM_BATCH_SIZE: usize = 32;
+const WARM_BATCH_SIZE: usize = 8;
 
 fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -90,7 +90,7 @@ impl BalPrewarmPool {
 
     /// Fire-and-forget: warm an account (basic account + bytecode) and its storage slots.
     ///
-    /// The slots are dispatched in [`WARM_BATCH_SIZE`] chunks that are distributed independently,
+    /// The slots are dispatched in `WARM_BATCH_SIZE` chunks that are distributed independently,
     /// so a single account with a large read-set does not serialize onto one worker;
     /// [`end_block`](Self::end_block) waits for the slowest queue.
     pub fn warm_account(&self, addr: Address, slots: impl IntoIterator<Item = StorageKey>) {

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -21,6 +21,7 @@ pub type BuildProviderFn = dyn Fn() -> ProviderResult<StateProviderBox> + Send +
 
 /// A single warm request: a whole account (basic account + its bytecode) followed by a batch of
 /// its storage slots, or a batch of storage slots on their own.
+#[derive(Debug)]
 enum PrewarmTarget {
     Account(Address, Box<[StorageKey]>),
     Storage(Address, Box<[StorageKey]>),
@@ -35,8 +36,8 @@ enum PrewarmMsg {
         caches: ExecutionCache,
         txpool_snapshot: Option<TxPoolPrewarmCacheSnapshot>,
     },
-    /// Warm one target into the held provider's cache. Ignored if no provider is held.
-    Warm(PrewarmTarget),
+    /// Warm a batch of targets into the held provider's cache. Ignored if no provider is held.
+    Warm(Vec<PrewarmTarget>),
     /// Drop the held provider (and its read txn).
     EndBlock(Arc<SendOnDrop>),
 }
@@ -88,23 +89,10 @@ impl BalPrewarmPool {
         }
     }
 
-    /// Fire-and-forget: warm an account (basic account + bytecode) and its storage slots.
-    ///
-    /// The slots are dispatched in `WARM_BATCH_SIZE` chunks that are distributed independently,
-    /// so a single account with a large read-set does not serialize onto one worker;
-    /// [`end_block`](Self::end_block) waits for the slowest queue.
-    pub fn warm_account(&self, addr: Address, slots: impl IntoIterator<Item = StorageKey>) {
-        let mut slots = slots.into_iter();
-        let mut batch: Box<[StorageKey]> = slots.by_ref().take(WARM_BATCH_SIZE).collect();
-        self.send_warm(PrewarmTarget::Account(addr, batch));
-
-        loop {
-            batch = slots.by_ref().take(WARM_BATCH_SIZE).collect();
-            if batch.is_empty() {
-                break
-            }
-            self.send_warm(PrewarmTarget::Storage(addr, batch));
-        }
+    /// Returns a warmer that batches warm requests for the current block and hands each batch to
+    /// a worker. Drop it, or call [`BalPrewarmer::finish`], before [`end_block`](Self::end_block).
+    pub const fn warmer(&self) -> BalPrewarmer<'_> {
+        BalPrewarmer { pool: self, batch: Vec::new() }
     }
 
     /// Ends the block: every worker drops its provider (and read txn) once it has drained the warm
@@ -123,9 +111,68 @@ impl BalPrewarmPool {
         rx.blocking_recv().expect("BAL prewarm pool dropped without signaling completion");
     }
 
-    fn send_warm(&self, target: PrewarmTarget) {
+    fn send_warm(&self, batch: Vec<PrewarmTarget>) {
         let i = self.next.fetch_add(1, Ordering::Relaxed) % self.workers.len();
-        let _ = self.workers[i].send(PrewarmMsg::Warm(target));
+        let _ = self.workers[i].send(PrewarmMsg::Warm(batch));
+    }
+}
+
+/// Fire-and-forget warm requests for one block, batched across accounts.
+///
+/// Targets are collected until `WARM_BATCH_TARGETS` of them are pending, then sent to the next
+/// worker as one message, so neither a small account nor a single slot chunk costs a send of its
+/// own. The remainder is flushed by [`finish`](Self::finish) or on drop.
+#[derive(Debug)]
+pub struct BalPrewarmer<'a> {
+    pool: &'a BalPrewarmPool,
+    batch: Vec<PrewarmTarget>,
+}
+
+impl BalPrewarmer<'_> {
+    /// Warms an account (basic account + bytecode) and its storage slots.
+    ///
+    /// The slots are split into `WARM_BATCH_SIZE` chunks that can land on different workers, so a
+    /// single account with a large read-set does not serialize onto one worker;
+    /// [`BalPrewarmPool::end_block`] waits for the slowest queue.
+    pub fn warm_account(&mut self, addr: Address, slots: impl IntoIterator<Item = StorageKey>) {
+        let mut slots = slots.into_iter();
+        let mut chunk: Box<[StorageKey]> = slots.by_ref().take(WARM_BATCH_SIZE).collect();
+        self.push(PrewarmTarget::Account(addr, chunk));
+
+        loop {
+            chunk = slots.by_ref().take(WARM_BATCH_SIZE).collect();
+            if chunk.is_empty() {
+                break
+            }
+            self.push(PrewarmTarget::Storage(addr, chunk));
+        }
+    }
+
+    /// Sends the pending targets.
+    pub fn finish(mut self) {
+        self.flush();
+    }
+
+    fn push(&mut self, target: PrewarmTarget) {
+        if self.batch.is_empty() {
+            self.batch.reserve(WARM_BATCH_TARGETS);
+        }
+        self.batch.push(target);
+        if self.batch.len() >= WARM_BATCH_TARGETS {
+            self.flush();
+        }
+    }
+
+    fn flush(&mut self) {
+        if !self.batch.is_empty() {
+            self.pool.send_warm(std::mem::take(&mut self.batch));
+        }
+    }
+}
+
+impl Drop for BalPrewarmer<'_> {
+    fn drop(&mut self) {
+        self.flush();
     }
 }
 
@@ -158,6 +205,12 @@ pub const DEFAULT_BAL_PREWARM_THREADS: usize = 128;
 /// the workers on blocks whose read-set is concentrated in a few accounts.
 const WARM_BATCH_SIZE: usize = 8;
 
+/// Number of warm targets (accounts or slot chunks) carried by one message.
+///
+/// Consecutive BAL accounts are small on average, so sending them one per message left the send
+/// itself as the dominant per-account cost of the dispatch loop.
+const WARM_BATCH_TARGETS: usize = 8;
+
 fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and
     // `EndBlock`. `None` while idle, so no read txn is pinned across the inter-block gap.
@@ -178,23 +231,25 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
                     }
                 };
             }
-            PrewarmMsg::Warm(target) => {
+            PrewarmMsg::Warm(targets) => {
                 let Some(provider) = provider.as_ref() else { continue };
-                match target {
-                    PrewarmTarget::Account(addr, slots) => {
-                        if let Ok(Some(account)) = provider.basic_account(&addr) &&
-                            let Some(code_hash) = account.bytecode_hash &&
-                            code_hash != alloy_consensus::constants::KECCAK_EMPTY
-                        {
-                            let _ = provider.bytecode_by_hash(&code_hash);
+                for target in targets {
+                    match target {
+                        PrewarmTarget::Account(addr, slots) => {
+                            if let Ok(Some(account)) = provider.basic_account(&addr) &&
+                                let Some(code_hash) = account.bytecode_hash &&
+                                code_hash != alloy_consensus::constants::KECCAK_EMPTY
+                            {
+                                let _ = provider.bytecode_by_hash(&code_hash);
+                            }
+                            for &slot in &slots {
+                                let _ = provider.storage(addr, slot);
+                            }
                         }
-                        for &slot in &slots {
-                            let _ = provider.storage(addr, slot);
-                        }
-                    }
-                    PrewarmTarget::Storage(addr, slots) => {
-                        for &slot in &slots {
-                            let _ = provider.storage(addr, slot);
+                        PrewarmTarget::Storage(addr, slots) => {
+                            for &slot in &slots {
+                                let _ = provider.storage(addr, slot);
+                            }
                         }
                     }
                 }

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -188,10 +188,14 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
                         {
                             let _ = provider.bytecode_by_hash(&code_hash);
                         }
-                        warm_slots(provider, addr, &slots);
+                        for &slot in &slots {
+                            let _ = provider.storage(addr, slot);
+                        }
                     }
                     PrewarmTarget::Storage(addr, slots) => {
-                        warm_slots(provider, addr, &slots);
+                        for &slot in &slots {
+                            let _ = provider.storage(addr, slot);
+                        }
                     }
                 }
             }
@@ -202,17 +206,6 @@ fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
         }
     }
 }
-
-fn warm_slots(
-    provider: &CachedStateProvider<StateProviderBox>,
-    addr: Address,
-    slots: &[StorageKey],
-) {
-    for &slot in slots {
-        let _ = provider.storage(addr, slot);
-    }
-}
-
 struct SendOnDrop {
     sender: Option<oneshot::Sender<()>>,
 }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -429,15 +429,18 @@ where
             });
 
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
+            let dispatch_start = Instant::now();
             for account in prefetch_bal.as_bal() {
-                pool.warm_account(account.address);
-                for change in &account.storage_changes {
-                    pool.warm_storage(account.address, change.slot.into());
-                }
-                for &slot in &account.storage_reads {
-                    pool.warm_storage(account.address, slot.into());
-                }
+                pool.warm_account(
+                    account.address,
+                    account
+                        .storage_changes
+                        .iter()
+                        .map(|change| change.slot.into())
+                        .chain(account.storage_reads.iter().map(|&slot| slot.into())),
+                );
             }
+            ctx.metrics.bal_slot_iteration_duration.record(dispatch_start.elapsed());
             pool.end_block();
         }
 

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -430,8 +430,9 @@ where
 
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
             let dispatch_start = Instant::now();
+            let mut warmer = pool.warmer();
             for account in prefetch_bal.as_bal() {
-                pool.warm_account(
+                warmer.warm_account(
                     account.address,
                     account
                         .storage_changes
@@ -440,6 +441,7 @@ where
                         .chain(account.storage_reads.iter().map(|&slot| slot.into())),
                 );
             }
+            warmer.finish();
             ctx.metrics.bal_slot_iteration_duration.record(dispatch_start.elapsed());
             pool.end_block();
         }


### PR DESCRIPTION
Stacked on #26955. After that change the BAL prewarm dispatch loop still sent one message per account plus one per extra slot chunk, so on a big block the per-account send was the dominant remaining cost of the serial loop that runs ahead of `end_block`.

Warm requests now go through a `BalPrewarmer` that collects targets, accounts and slot chunks alike, and hands them to the next worker eight at a time as one message; the remainder is flushed by `finish` (and on drop). Workers iterate the batch with the same per-target logic as before, so the `BeginBlock`/`EndBlock` broadcast and the per-worker FIFO ordering are untouched, and a large account still spreads over several workers because its slot chunks can land in different batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)