### PR TITLE
fix(rpc): hold a blocking IO permit for eth_getLogs range scans

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -40,7 +40,7 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
     /// Returns handle to semaphore for blocking IO tasks.
     ///
     /// This semaphore is used to limit concurrent blocking IO operations like `eth_call`,
-    /// `eth_estimateGas`, and similar methods that require EVM execution.
+    /// `eth_estimateGas` and the `eth_getLogs` range scans.
     fn blocking_io_task_guard(&self) -> &Arc<Semaphore>;
 
     /// Acquires a permit from the tracing task semaphore.
@@ -80,8 +80,8 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
 
     /// Acquires a permit from the blocking IO request semaphore.
     ///
-    /// This should be used for operations like `eth_call`, `eth_estimateGas`, and similar methods
-    /// that require EVM execution and are spawned as blocking tasks.
+    /// This should be used for operations like `eth_call`, `eth_estimateGas` and the `eth_getLogs`
+    /// range scans, which are spawned as blocking tasks.
     ///
     /// See also [`Semaphore::acquire_owned`](`tokio::sync::Semaphore::acquire_owned`).
     fn acquire_owned_blocking_io(

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -655,9 +655,18 @@ where
             return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter))
         }
 
+        // The scan occupies a blocking thread until it completes, so it shares the budget for
+        // blocking IO requests with `eth_call` and friends instead of growing the pool unboundedly.
+        let permit = self
+            .eth_api
+            .acquire_owned_blocking_io()
+            .await
+            .map_err(|_| EthFilterError::InternalError)?;
+
         let (mut tx, rx) = oneshot::channel();
         let this = self.clone();
         self.task_spawner.spawn_blocking_task(async move {
+            let _permit = permit;
             let fut = this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits);
             tokio::pin!(fut);
             let res = tokio::select! {
@@ -2039,5 +2048,35 @@ mod tests {
         // Each block hash should be the hash of its own header, not derived from any other header
         assert_eq!(logs[0].block_hash, Some(expected_hashes[0])); // block 100
         assert_eq!(logs[1].block_hash, Some(expected_hashes[2])); // block 102
+    }
+
+    #[tokio::test]
+    async fn test_range_scan_waits_for_blocking_io_permit() {
+        use reth_rpc_eth_api::helpers::SpawnBlocking;
+
+        let provider = MockEthProvider::default();
+        provider.add_header(FixedBytes::random(), alloy_consensus::Header::default());
+        let eth_api = build_test_eth_api(provider);
+
+        // take every permit so the scan has to wait for one
+        let guard = eth_api.blocking_io_task_guard().clone();
+        let permits =
+            guard.clone().acquire_many_owned(guard.available_permits() as u32).await.unwrap();
+
+        let eth_filter = EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
+        let scan = eth_filter.inner.clone().get_logs_in_block_range(
+            Filter::default(),
+            0,
+            0,
+            QueryLimits::default(),
+        );
+        tokio::pin!(scan);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut scan).await.is_err(),
+            "scan must wait for a blocking IO permit"
+        );
+
+        drop(permits);
+        assert!(scan.await.unwrap().is_empty());
     }
 }

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -62,9 +62,7 @@ where
         limits: QueryLimits,
     ) -> impl Future<Output = RpcResult<Vec<RpcLog<Eth::NetworkTypes>>>> + Send {
         trace!(target: "rpc::eth", "Serving eth_getLogs");
-        // the authenticated endpoint serves a single trusted consumer, so its queries are not
-        // queued behind the public ones
-        self.inner.clone().logs_for_filter(filter, limits, false).map_err(|e| e.into())
+        self.logs_for_filter(filter, limits).map_err(|e| e.into())
     }
 }
 
@@ -301,7 +299,6 @@ where
                         from_block_number,
                         to_block_number,
                         self.inner.query_limits,
-                        true,
                     )
                     .await?;
                 Ok(FilterChanges::Logs(logs))
@@ -340,7 +337,7 @@ where
         filter: Filter,
         limits: QueryLimits,
     ) -> Result<Vec<RpcLog<Eth::NetworkTypes>>, EthFilterError> {
-        self.inner.clone().logs_for_filter(filter, limits, true).await
+        self.inner.clone().logs_for_filter(filter, limits).await
     }
 }
 
@@ -485,7 +482,6 @@ where
         self: Arc<Self>,
         filter: Filter,
         limits: QueryLimits,
-        gated: bool,
     ) -> Result<Vec<RpcLog<Eth::NetworkTypes>>, EthFilterError> {
         match filter.block_option {
             FilterBlockOption::AtBlockHash(block_hash) => {
@@ -604,14 +600,8 @@ where
                     .into());
                 }
 
-                self.get_logs_in_block_range(
-                    filter,
-                    from_block_number,
-                    to_block_number,
-                    limits,
-                    gated,
-                )
-                .await
+                self.get_logs_in_block_range(filter, from_block_number, to_block_number, limits)
+                    .await
             }
         }
     }
@@ -651,7 +641,6 @@ where
         from_block: u64,
         to_block: u64,
         limits: QueryLimits,
-        gated: bool,
     ) -> Result<Vec<RpcLog<Eth::NetworkTypes>>, EthFilterError> {
         trace!(target: "rpc::eth::filter", from=from_block, to=to_block, ?filter, "finding logs in range");
 
@@ -669,16 +658,11 @@ where
         // The scan occupies a blocking thread until it completes, so it shares the budget for
         // blocking IO requests with `eth_call` and friends instead of pinning an unbounded number
         // of pool threads.
-        let permit = if gated {
-            Some(
-                self.eth_api
-                    .acquire_owned_blocking_io()
-                    .await
-                    .map_err(|_| EthFilterError::InternalError)?,
-            )
-        } else {
-            None
-        };
+        let permit = self
+            .eth_api
+            .acquire_owned_blocking_io()
+            .await
+            .map_err(|_| EthFilterError::InternalError)?;
 
         let (mut tx, rx) = oneshot::channel();
         let this = self.clone();
@@ -1461,8 +1445,7 @@ mod tests {
             super::EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
 
         let filter = Filter::new().from_block(100u64).to_block(BlockNumberOrTag::Latest);
-        let result =
-            eth_filter.inner.clone().logs_for_filter(filter, QueryLimits::default(), true).await;
+        let result = eth_filter.inner.clone().logs_for_filter(filter, QueryLimits::default()).await;
         assert!(matches!(result, Err(EthFilterError::InvalidBlockRangeParams)), "{result:?}");
     }
 
@@ -1950,7 +1933,6 @@ mod tests {
                 100,
                 102,
                 QueryLimits { max_blocks_per_filter: None, max_logs_per_response: Some(2) },
-                true,
             )
             .await
             .expect_err("range should exceed max logs");
@@ -2054,7 +2036,7 @@ mod tests {
         let logs = eth_filter
             .inner
             .clone()
-            .get_logs_in_block_range(filter, 100, 103, QueryLimits::default(), true)
+            .get_logs_in_block_range(filter, 100, 103, QueryLimits::default())
             .await
             .expect("should succeed");
 
@@ -2088,7 +2070,6 @@ mod tests {
             0,
             0,
             QueryLimits::default(),
-            true,
         );
         tokio::pin!(scan);
         assert!(

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -62,7 +62,9 @@ where
         limits: QueryLimits,
     ) -> impl Future<Output = RpcResult<Vec<RpcLog<Eth::NetworkTypes>>>> + Send {
         trace!(target: "rpc::eth", "Serving eth_getLogs");
-        self.logs_for_filter(filter, limits).map_err(|e| e.into())
+        // the authenticated endpoint serves a single trusted consumer, so its queries are not
+        // queued behind the public ones
+        self.inner.clone().logs_for_filter(filter, limits, false).map_err(|e| e.into())
     }
 }
 
@@ -299,6 +301,7 @@ where
                         from_block_number,
                         to_block_number,
                         self.inner.query_limits,
+                        true,
                     )
                     .await?;
                 Ok(FilterChanges::Logs(logs))
@@ -337,7 +340,7 @@ where
         filter: Filter,
         limits: QueryLimits,
     ) -> Result<Vec<RpcLog<Eth::NetworkTypes>>, EthFilterError> {
-        self.inner.clone().logs_for_filter(filter, limits).await
+        self.inner.clone().logs_for_filter(filter, limits, true).await
     }
 }
 
@@ -482,6 +485,7 @@ where
         self: Arc<Self>,
         filter: Filter,
         limits: QueryLimits,
+        gated: bool,
     ) -> Result<Vec<RpcLog<Eth::NetworkTypes>>, EthFilterError> {
         match filter.block_option {
             FilterBlockOption::AtBlockHash(block_hash) => {
@@ -600,8 +604,14 @@ where
                     .into());
                 }
 
-                self.get_logs_in_block_range(filter, from_block_number, to_block_number, limits)
-                    .await
+                self.get_logs_in_block_range(
+                    filter,
+                    from_block_number,
+                    to_block_number,
+                    limits,
+                    gated,
+                )
+                .await
             }
         }
     }
@@ -641,6 +651,7 @@ where
         from_block: u64,
         to_block: u64,
         limits: QueryLimits,
+        gated: bool,
     ) -> Result<Vec<RpcLog<Eth::NetworkTypes>>, EthFilterError> {
         trace!(target: "rpc::eth::filter", from=from_block, to=to_block, ?filter, "finding logs in range");
 
@@ -656,12 +667,18 @@ where
         }
 
         // The scan occupies a blocking thread until it completes, so it shares the budget for
-        // blocking IO requests with `eth_call` and friends instead of growing the pool unboundedly.
-        let permit = self
-            .eth_api
-            .acquire_owned_blocking_io()
-            .await
-            .map_err(|_| EthFilterError::InternalError)?;
+        // blocking IO requests with `eth_call` and friends instead of pinning an unbounded number
+        // of pool threads.
+        let permit = if gated {
+            Some(
+                self.eth_api
+                    .acquire_owned_blocking_io()
+                    .await
+                    .map_err(|_| EthFilterError::InternalError)?,
+            )
+        } else {
+            None
+        };
 
         let (mut tx, rx) = oneshot::channel();
         let this = self.clone();
@@ -1444,7 +1461,8 @@ mod tests {
             super::EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
 
         let filter = Filter::new().from_block(100u64).to_block(BlockNumberOrTag::Latest);
-        let result = eth_filter.inner.clone().logs_for_filter(filter, QueryLimits::default()).await;
+        let result =
+            eth_filter.inner.clone().logs_for_filter(filter, QueryLimits::default(), true).await;
         assert!(matches!(result, Err(EthFilterError::InvalidBlockRangeParams)), "{result:?}");
     }
 
@@ -1932,6 +1950,7 @@ mod tests {
                 100,
                 102,
                 QueryLimits { max_blocks_per_filter: None, max_logs_per_response: Some(2) },
+                true,
             )
             .await
             .expect_err("range should exceed max logs");
@@ -2035,7 +2054,7 @@ mod tests {
         let logs = eth_filter
             .inner
             .clone()
-            .get_logs_in_block_range(filter, 100, 103, QueryLimits::default())
+            .get_logs_in_block_range(filter, 100, 103, QueryLimits::default(), true)
             .await
             .expect("should succeed");
 
@@ -2069,6 +2088,7 @@ mod tests {
             0,
             0,
             QueryLimits::default(),
+            true,
         );
         tokio::pin!(scan);
         assert!(


### PR DESCRIPTION
Range scans in `eth_getLogs` and the log filter polls occupy a blocking pool thread for their whole duration without holding any permit, unlike `eth_call` and the other blocking IO requests which go through the blocking IO semaphore. Enough concurrent scans take the whole pool and stall every other blocking task, including the state cache fills that the rest of the `eth_` API depends on.

Every range scan now holds a blocking IO permit (`--rpc.max-blocking-io-requests`) for its lifetime, so it shares the same bounded budget as the other blocking IO requests. The permit is taken before the task is spawned, so waiting for one does not occupy a thread, and it is released when the client disconnects, once the scan reaches its first await point.

The receipt fetching inside a scan can spawn further blocking tasks, which #27000 puts under the same budget.