### PR TITLE
chore(node-builder): remove unused builder and launch helpers

### DIFF
--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -16,12 +16,8 @@ use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
 use reth_exex::ExExContext;
 use reth_network::{
-    transactions::{
-        config::{AnnouncementFilteringPolicy, StrictEthAnnouncementFilter},
-        TransactionPropagationPolicy, TransactionsManagerConfig,
-    },
-    NetworkBuilder, NetworkConfig, NetworkConfigBuilder, NetworkHandle, NetworkManager,
-    NetworkPrimitives,
+    transactions::config::StrictEthAnnouncementFilter, NetworkBuilder, NetworkConfig,
+    NetworkConfigBuilder, NetworkHandle, NetworkManager, NetworkPrimitives,
 };
 use reth_node_api::{
     FullNodeTypes, FullNodeTypesAdapter, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter,
@@ -33,7 +29,7 @@ use reth_node_core::{
     primitives::Head,
 };
 use reth_provider::{
-    providers::{BlockchainProvider, NodeTypesForProvider, RocksDBProvider},
+    providers::{BlockchainProvider, NodeTypesForProvider},
     ChainSpecProvider, FullProvider,
 };
 use reth_tasks::TaskExecutor;
@@ -155,14 +151,12 @@ pub struct NodeBuilder<DB, ChainSpec> {
     config: NodeConfig<ChainSpec>,
     /// The configured database for the node.
     database: DB,
-    /// An optional [`RocksDBProvider`] to use instead of creating one during launch.
-    rocksdb_provider: Option<RocksDBProvider>,
 }
 
 impl<ChainSpec> NodeBuilder<(), ChainSpec> {
     /// Create a new [`NodeBuilder`].
     pub const fn new(config: NodeConfig<ChainSpec>) -> Self {
-        Self { config, database: (), rocksdb_provider: None }
+        Self { config, database: () }
     }
 }
 
@@ -172,41 +166,6 @@ impl<DB, ChainSpec> NodeBuilder<DB, ChainSpec> {
         &self.config
     }
 
-    /// Returns a mutable reference to the node builder's config.
-    pub const fn config_mut(&mut self) -> &mut NodeConfig<ChainSpec> {
-        &mut self.config
-    }
-
-    /// Returns a reference to the node's database
-    pub const fn db(&self) -> &DB {
-        &self.database
-    }
-
-    /// Returns a mutable reference to the node's database
-    pub const fn db_mut(&mut self) -> &mut DB {
-        &mut self.database
-    }
-
-    /// Applies a fallible function to the builder.
-    pub fn try_apply<F, R>(self, f: F) -> Result<Self, R>
-    where
-        F: FnOnce(Self) -> Result<Self, R>,
-    {
-        f(self)
-    }
-
-    /// Applies a fallible function to the builder, if the condition is `true`.
-    pub fn try_apply_if<F, R>(self, cond: bool, f: F) -> Result<Self, R>
-    where
-        F: FnOnce(Self) -> Result<Self, R>,
-    {
-        if cond {
-            f(self)
-        } else {
-            Ok(self)
-        }
-    }
-
     /// Apply a function to the builder
     pub fn apply<F>(self, f: F) -> Self
     where
@@ -214,30 +173,12 @@ impl<DB, ChainSpec> NodeBuilder<DB, ChainSpec> {
     {
         f(self)
     }
-
-    /// Apply a function to the builder, if the condition is `true`.
-    pub fn apply_if<F>(self, cond: bool, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        if cond {
-            f(self)
-        } else {
-            self
-        }
-    }
 }
 
 impl<DB, ChainSpec: EthChainSpec> NodeBuilder<DB, ChainSpec> {
     /// Configures the underlying database that the node will use.
     pub fn with_database<D>(self, database: D) -> NodeBuilder<D, ChainSpec> {
-        NodeBuilder { config: self.config, database, rocksdb_provider: self.rocksdb_provider }
-    }
-
-    /// Sets the [`RocksDBProvider`] to use instead of creating one during launch.
-    pub fn with_rocksdb_provider(mut self, rocksdb_provider: RocksDBProvider) -> Self {
-        self.rocksdb_provider = Some(rocksdb_provider);
-        self
+        NodeBuilder { config: self.config, database }
     }
 
     /// Preconfigure the builder with the context to launch the node.
@@ -283,33 +224,6 @@ impl<DB, ChainSpec: EthChainSpec> NodeBuilder<DB, ChainSpec> {
 
         WithLaunchContext { builder: self.with_database(db), task_executor }
     }
-
-    /// Creates a preconfigured test node whose datadir is preserved when the node is dropped.
-    ///
-    /// The caller owns cleanup of `datadir`. This is useful for tests that stop a node and launch
-    /// a new instance against the same database and static files.
-    #[cfg(feature = "test-utils")]
-    pub fn testing_node_with_persistent_datadir(
-        mut self,
-        task_executor: TaskExecutor,
-        datadir: impl Into<std::path::PathBuf>,
-    ) -> WithLaunchContext<NodeBuilder<Arc<reth_db::DatabaseEnv>, ChainSpec>> {
-        let path = reth_node_core::dirs::MaybePlatformPath::<DataDirPath>::from(datadir.into());
-        self.config = self.config.with_datadir_args(reth_node_core::args::DatadirArgs {
-            datadir: path.clone(),
-            ..Default::default()
-        });
-
-        let data_dir =
-            path.unwrap_or_chain_default(self.config.chain.chain(), self.config.datadir.clone());
-        let db_path = data_dir.data_dir().join("db");
-        let db = reth_db::init_db(&db_path, reth_db::mdbx::DatabaseArguments::test())
-            .unwrap_or_else(|error| {
-                panic!("could not create test database at {db_path:?}: {error}")
-            });
-
-        WithLaunchContext { builder: self.with_database(Arc::new(db)), task_executor }
-    }
 }
 
 impl<DB, ChainSpec> NodeBuilder<DB, ChainSpec>
@@ -333,7 +247,7 @@ where
         T: NodeTypesForProvider<ChainSpec = ChainSpec>,
         P: FullProvider<NodeTypesWithDBAdapter<T, DB>>,
     {
-        NodeBuilderWithTypes::new(self.config, self.database, self.rocksdb_provider)
+        NodeBuilderWithTypes::new(self.config, self.database)
     }
 
     /// Preconfigures the node with a specific node implementation.
@@ -371,11 +285,6 @@ impl<DB, ChainSpec> WithLaunchContext<NodeBuilder<DB, ChainSpec>> {
     pub const fn config(&self) -> &NodeConfig<ChainSpec> {
         self.builder.config()
     }
-
-    /// Returns a mutable reference to the node builder's config.
-    pub const fn config_mut(&mut self) -> &mut NodeConfig<ChainSpec> {
-        self.builder.config_mut()
-    }
 }
 
 impl<DB, ChainSpec> WithLaunchContext<NodeBuilder<DB, ChainSpec>>
@@ -383,12 +292,6 @@ where
     DB: Database + DatabaseMetrics + Clone + Unpin + 'static,
     ChainSpec: EthChainSpec + EthereumHardforks,
 {
-    /// Sets the [`RocksDBProvider`] to use instead of creating one during launch.
-    pub fn with_rocksdb_provider(mut self, rocksdb_provider: RocksDBProvider) -> Self {
-        self.builder.rocksdb_provider = Some(rocksdb_provider);
-        self
-    }
-
     /// Configures the types of the node.
     pub fn with_types<T>(self) -> WithLaunchContext<NodeBuilderWithTypes<RethFullAdapter<DB, T>>>
     where
@@ -503,39 +406,9 @@ where
         &self.builder.config
     }
 
-    /// Returns a mutable reference to the node builder's config.
-    pub const fn config_mut(&mut self) -> &mut NodeConfig<<T::Types as NodeTypes>::ChainSpec> {
-        &mut self.builder.config
-    }
-
     /// Returns a reference to node's database.
     pub const fn db(&self) -> &T::DB {
         &self.builder.adapter.database
-    }
-
-    /// Returns a mutable reference to node's database.
-    pub const fn db_mut(&mut self) -> &mut T::DB {
-        &mut self.builder.adapter.database
-    }
-
-    /// Applies a fallible function to the builder.
-    pub fn try_apply<F, R>(self, f: F) -> Result<Self, R>
-    where
-        F: FnOnce(Self) -> Result<Self, R>,
-    {
-        f(self)
-    }
-
-    /// Applies a fallible function to the builder, if the condition is `true`.
-    pub fn try_apply_if<F, R>(self, cond: bool, f: F) -> Result<Self, R>
-    where
-        F: FnOnce(Self) -> Result<Self, R>,
-    {
-        if cond {
-            f(self)
-        } else {
-            Ok(self)
-        }
     }
 
     /// Apply a function to the builder
@@ -544,18 +417,6 @@ where
         F: FnOnce(Self) -> Self,
     {
         f(self)
-    }
-
-    /// Apply a function to the builder, if the condition is `true`.
-    pub fn apply_if<F>(self, cond: bool, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        if cond {
-            f(self)
-        } else {
-            self
-        }
     }
 
     /// Sets the hook that is run once the node's components are initialized.
@@ -681,24 +542,6 @@ where
         }
     }
 
-    /// Installs an `ExEx` (Execution Extension) in the node if the condition is true.
-    ///
-    /// # Note
-    ///
-    /// The `ExEx` ID must be unique.
-    pub fn install_exex_if<F, R, E>(self, cond: bool, exex_id: impl Into<String>, exex: F) -> Self
-    where
-        F: FnOnce(ExExContext<NodeAdapter<T, CB::Components>>) -> R + Send + 'static,
-        R: Future<Output = eyre::Result<E>> + Send,
-        E: Future<Output = eyre::Result<()>> + Send,
-    {
-        if cond {
-            self.install_exex(exex_id, exex)
-        } else {
-            self
-        }
-    }
-
     /// Launches the node with the given launcher.
     pub async fn launch_with<L>(self, launcher: L) -> eyre::Result<L::Node>
     where
@@ -818,11 +661,6 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         &mut self.config_container.config
     }
 
-    /// Returns the loaded reh.toml config.
-    pub const fn reth_config(&self) -> &reth_config::Config {
-        &self.config_container.toml_config
-    }
-
     /// Returns the executor of the node.
     ///
     /// This can be used to execute async tasks or functions during the setup.
@@ -862,6 +700,9 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
 
     /// Convenience function to start the network tasks.
     ///
+    /// Uses the transaction manager config and propagation policy from the node config and the
+    /// default [`StrictEthAnnouncementFilter`] for announcement filtering.
+    ///
     /// Spawns the configured network and associated tasks and returns the [`NetworkHandle`]
     /// connected to that network.
     pub fn start_network<N, Pool>(
@@ -880,84 +721,12 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
             + 'static,
         Node::Provider: BlockReaderFor<N>,
     {
-        self.start_network_with(
-            builder,
-            pool,
-            self.config().network.transactions_manager_config(),
-            self.config().network.tx_propagation_policy,
-        )
-    }
-
-    /// Convenience function to start the network tasks.
-    ///
-    /// Accepts the config for the transaction task and the policy for propagation.
-    /// Uses the default [`StrictEthAnnouncementFilter`] for announcement filtering.
-    ///
-    /// Spawns the configured network and associated tasks and returns the [`NetworkHandle`]
-    /// connected to that network.
-    pub fn start_network_with<Pool, N, Policy>(
-        &self,
-        builder: NetworkBuilder<(), (), N>,
-        pool: Pool,
-        tx_config: TransactionsManagerConfig,
-        propagation_policy: Policy,
-    ) -> NetworkHandle<N>
-    where
-        N: NetworkPrimitives,
-        Pool: TransactionPool<
-                Transaction: PoolTransaction<
-                    Consensus = N::BroadcastedTransaction,
-                    Pooled = N::PooledTransaction,
-                >,
-            > + Unpin
-            + 'static,
-        Node::Provider: BlockReaderFor<N>,
-        Policy: TransactionPropagationPolicy<N>,
-    {
-        self.start_network_with_policies(
-            builder,
-            pool,
-            tx_config,
-            propagation_policy,
-            StrictEthAnnouncementFilter::default(),
-        )
-    }
-
-    /// Convenience function to start the network tasks with custom policies.
-    ///
-    /// Accepts the config for the transaction task, the policy for propagation,
-    /// and a custom announcement filter. This is useful for configuring which tx types are accepted
-    /// in announcements.
-    ///
-    /// Spawns the configured network and associated tasks and returns the [`NetworkHandle`]
-    /// connected to that network.
-    pub fn start_network_with_policies<Pool, N, PropPolicy, AnnPolicy>(
-        &self,
-        builder: NetworkBuilder<(), (), N>,
-        pool: Pool,
-        tx_config: TransactionsManagerConfig,
-        propagation_policy: PropPolicy,
-        announcement_policy: AnnPolicy,
-    ) -> NetworkHandle<N>
-    where
-        N: NetworkPrimitives,
-        Pool: TransactionPool<
-                Transaction: PoolTransaction<
-                    Consensus = N::BroadcastedTransaction,
-                    Pooled = N::PooledTransaction,
-                >,
-            > + Unpin
-            + 'static,
-        Node::Provider: BlockReaderFor<N>,
-        PropPolicy: TransactionPropagationPolicy<N>,
-        AnnPolicy: AnnouncementFilteringPolicy<N>,
-    {
         let (handle, network, txpool, eth) = builder
             .transactions_with_policies(
                 pool.clone(),
-                tx_config,
-                propagation_policy,
-                announcement_policy,
+                self.config().network.transactions_manager_config(),
+                self.config().network.tx_propagation_policy,
+                StrictEthAnnouncementFilter::default(),
             )
             .map_transactions(|transactions| {
                 if let Some(cache) = self.sender_recovery_cache.clone() {
@@ -1002,18 +771,6 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         let secret_key = self.config().network.secret_key(data_dir.p2p_secret())?;
         Ok(secret_key)
     }
-
-    /// Builds the [`NetworkConfig`].
-    pub fn build_network_config<N>(
-        &self,
-        network_builder: NetworkConfigBuilder<N>,
-    ) -> NetworkConfig<Node::Provider, N>
-    where
-        N: NetworkPrimitives,
-        Node::Types: NodeTypes<ChainSpec: Hardforks>,
-    {
-        network_builder.build(self.provider.clone())
-    }
 }
 
 impl<Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>> BuilderContext<Node> {
@@ -1032,8 +789,7 @@ impl<Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>> BuilderContext
     where
         N: NetworkPrimitives,
     {
-        let network_builder = self.network_config_builder();
-        Ok(self.build_network_config(network_builder?))
+        Ok(self.network_config_builder()?.build(self.provider.clone()))
     }
 
     /// Get the [`NetworkConfigBuilder`].
@@ -1047,7 +803,7 @@ impl<Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>> BuilderContext
             .config()
             .network
             .network_config(
-                self.reth_config(),
+                &self.config_container.toml_config,
                 self.config().chain.clone(),
                 secret_key,
                 default_peers_path,
@@ -1067,31 +823,5 @@ impl<Node: FullNodeTypes> std::fmt::Debug for BuilderContext<Node> {
             .field("executor", &self.executor)
             .field("config", &self.config())
             .finish()
-    }
-}
-
-#[cfg(all(test, feature = "test-utils"))]
-mod tests {
-    use super::*;
-    use reth_chainspec::ChainSpec;
-    use reth_tasks::Runtime;
-
-    #[test]
-    fn persistent_test_datadir_can_be_reopened() {
-        let root = tempfile::tempdir().unwrap();
-        let datadir = root.path().join("node");
-        let runtime = Runtime::test();
-
-        let config = || NodeConfig::new(Arc::new(ChainSpec::<alloy_consensus::Header>::default()));
-        let first = NodeBuilder::new(config())
-            .testing_node_with_persistent_datadir(runtime.clone(), datadir.clone());
-        assert!(datadir.join("db").exists());
-        drop(first);
-        assert!(datadir.join("db").exists());
-
-        let reopened = NodeBuilder::new(config())
-            .testing_node_with_persistent_datadir(runtime, datadir.clone());
-        drop(reopened);
-        assert!(datadir.join("db").exists());
     }
 }

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -16,7 +16,6 @@ use crate::{
 use reth_exex::ExExContext;
 use reth_node_api::{FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes};
 use reth_node_core::node_config::NodeConfig;
-use reth_provider::providers::RocksDBProvider;
 use reth_tasks::TaskExecutor;
 use std::{fmt, fmt::Debug, future::Future};
 
@@ -26,8 +25,6 @@ pub struct NodeBuilderWithTypes<T: FullNodeTypes> {
     config: NodeConfig<<T::Types as NodeTypes>::ChainSpec>,
     /// The configured database for the node.
     adapter: NodeTypesAdapter<T>,
-    /// An optional [`RocksDBProvider`] to use instead of creating one during launch.
-    rocksdb_provider: Option<RocksDBProvider>,
 }
 
 impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
@@ -35,9 +32,8 @@ impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
     pub const fn new(
         config: NodeConfig<<T::Types as NodeTypes>::ChainSpec>,
         database: T::DB,
-        rocksdb_provider: Option<RocksDBProvider>,
     ) -> Self {
-        Self { config, adapter: NodeTypesAdapter::new(database), rocksdb_provider }
+        Self { config, adapter: NodeTypesAdapter::new(database) }
     }
 
     /// Advances the state of the node builder to the next state where all components are configured
@@ -45,12 +41,11 @@ impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
     where
         CB: NodeComponentsBuilder<T>,
     {
-        let Self { config, adapter, rocksdb_provider } = self;
+        let Self { config, adapter } = self;
 
         NodeBuilderWithComponents {
             config,
             adapter,
-            rocksdb_provider,
             components_builder,
             add_ons: AddOns { hooks: NodeHooks::default(), exexs: Vec::new(), add_ons: () },
         }
@@ -155,8 +150,6 @@ pub struct NodeBuilderWithComponents<
     pub config: NodeConfig<<T::Types as NodeTypes>::ChainSpec>,
     /// Adapter for the underlying node types and database
     pub adapter: NodeTypesAdapter<T>,
-    /// An optional [`RocksDBProvider`] to use instead of creating one during launch.
-    pub rocksdb_provider: Option<RocksDBProvider>,
     /// container for type specific components
     pub components_builder: CB,
     /// Additional node extensions.
@@ -174,12 +167,11 @@ where
     where
         AO: NodeAddOns<NodeAdapter<T, CB::Components>>,
     {
-        let Self { config, adapter, rocksdb_provider, components_builder, .. } = self;
+        let Self { config, adapter, components_builder, .. } = self;
 
         NodeBuilderWithComponents {
             config,
             adapter,
-            rocksdb_provider,
             components_builder,
             add_ons: AddOns { hooks: NodeHooks::default(), exexs: Vec::new(), add_ons },
         }

--- a/crates/node/builder/src/components/builder.rs
+++ b/crates/node/builder/src/components/builder.rs
@@ -8,15 +8,11 @@ use crate::{
     BuilderContext, ConfigureEvm, FullNodeTypes,
 };
 use reth_chainspec::EthChainSpec;
-use reth_consensus::{noop::NoopConsensus, FullConsensus};
+use reth_consensus::FullConsensus;
 use reth_network::{types::NetPrimitivesFor, EthNetworkPrimitives, NetworkPrimitives};
 use reth_network_api::{noop::NoopNetwork, FullNetwork};
-use reth_node_api::{BlockTy, BodyTy, HeaderTy, NodeTypes, PrimitivesTy, ReceiptTy, TxTy};
-use reth_payload_builder::PayloadBuilderHandle;
-use reth_transaction_pool::{
-    noop::NoopTransactionPool, EthPoolTransaction, EthPooledTransaction, PoolPooledTx,
-    PoolTransaction, TransactionPool,
-};
+use reth_node_api::{BlockTy, BodyTy, HeaderTy, PrimitivesTy, ReceiptTy, TxTy};
+use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionPool};
 use std::{future::Future, marker::PhantomData};
 
 /// A generic, general purpose and customizable [`NodeComponentsBuilder`] implementation.
@@ -75,66 +71,6 @@ impl<Node, PoolB, PayloadB, NetworkB, ExecB, ConsB>
             _marker: Default::default(),
         }
     }
-
-    /// Apply a function to the pool builder.
-    pub fn map_pool(self, f: impl FnOnce(PoolB) -> PoolB) -> Self {
-        Self {
-            pool_builder: f(self.pool_builder),
-            payload_builder: self.payload_builder,
-            network_builder: self.network_builder,
-            executor_builder: self.executor_builder,
-            consensus_builder: self.consensus_builder,
-            _marker: self._marker,
-        }
-    }
-
-    /// Apply a function to the payload builder.
-    pub fn map_payload(self, f: impl FnOnce(PayloadB) -> PayloadB) -> Self {
-        Self {
-            pool_builder: self.pool_builder,
-            payload_builder: f(self.payload_builder),
-            network_builder: self.network_builder,
-            executor_builder: self.executor_builder,
-            consensus_builder: self.consensus_builder,
-            _marker: self._marker,
-        }
-    }
-
-    /// Apply a function to the network builder.
-    pub fn map_network(self, f: impl FnOnce(NetworkB) -> NetworkB) -> Self {
-        Self {
-            pool_builder: self.pool_builder,
-            payload_builder: self.payload_builder,
-            network_builder: f(self.network_builder),
-            executor_builder: self.executor_builder,
-            consensus_builder: self.consensus_builder,
-            _marker: self._marker,
-        }
-    }
-
-    /// Apply a function to the executor builder.
-    pub fn map_executor(self, f: impl FnOnce(ExecB) -> ExecB) -> Self {
-        Self {
-            pool_builder: self.pool_builder,
-            payload_builder: self.payload_builder,
-            network_builder: self.network_builder,
-            executor_builder: f(self.executor_builder),
-            consensus_builder: self.consensus_builder,
-            _marker: self._marker,
-        }
-    }
-
-    /// Apply a function to the consensus builder.
-    pub fn map_consensus(self, f: impl FnOnce(ConsB) -> ConsB) -> Self {
-        Self {
-            pool_builder: self.pool_builder,
-            payload_builder: self.payload_builder,
-            network_builder: self.network_builder,
-            executor_builder: self.executor_builder,
-            consensus_builder: f(self.consensus_builder),
-            _marker: self._marker,
-        }
-    }
 }
 
 impl<Node, PoolB, PayloadB, NetworkB, ExecB, ConsB>
@@ -165,21 +101,6 @@ where
             executor_builder,
             consensus_builder,
             _marker,
-        }
-    }
-
-    /// Sets [`NoopTransactionPoolBuilder`].
-    pub fn noop_pool<Tx>(
-        self,
-    ) -> ComponentsBuilder<Node, NoopTransactionPoolBuilder<Tx>, PayloadB, NetworkB, ExecB, ConsB>
-    {
-        ComponentsBuilder {
-            pool_builder: NoopTransactionPoolBuilder::<Tx>::default(),
-            payload_builder: self.payload_builder,
-            network_builder: self.network_builder,
-            executor_builder: self.executor_builder,
-            consensus_builder: self.consensus_builder,
-            _marker: self._marker,
         }
     }
 
@@ -320,34 +241,6 @@ where
             _marker: self._marker,
         }
     }
-
-    /// Sets [`NoopPayloadBuilder`].
-    pub fn noop_payload(
-        self,
-    ) -> ComponentsBuilder<Node, PoolB, NoopPayloadBuilder, NetworkB, ExecB, ConsB> {
-        ComponentsBuilder {
-            pool_builder: self.pool_builder,
-            payload_builder: NoopPayloadBuilder,
-            network_builder: self.network_builder,
-            executor_builder: self.executor_builder,
-            consensus_builder: self.consensus_builder,
-            _marker: self._marker,
-        }
-    }
-
-    /// Sets [`NoopConsensusBuilder`].
-    pub fn noop_consensus(
-        self,
-    ) -> ComponentsBuilder<Node, PoolB, PayloadB, NetworkB, ExecB, NoopConsensusBuilder> {
-        ComponentsBuilder {
-            pool_builder: self.pool_builder,
-            payload_builder: self.payload_builder,
-            network_builder: self.network_builder,
-            executor_builder: self.executor_builder,
-            consensus_builder: NoopConsensusBuilder,
-            _marker: self._marker,
-        }
-    }
 }
 
 impl<Node, PoolB, PayloadB, NetworkB, ExecB, ConsB> NodeComponentsBuilder<Node>
@@ -463,33 +356,6 @@ where
     }
 }
 
-/// Builds [`NoopTransactionPool`].
-#[derive(Debug, Clone)]
-pub struct NoopTransactionPoolBuilder<Tx = EthPooledTransaction>(PhantomData<Tx>);
-
-impl<N, Tx, Evm> PoolBuilder<N, Evm> for NoopTransactionPoolBuilder<Tx>
-where
-    N: FullNodeTypes,
-    Tx: EthPoolTransaction<Consensus = TxTy<N::Types>> + Unpin,
-    Evm: Send,
-{
-    type Pool = NoopTransactionPool<Tx>;
-
-    async fn build_pool(
-        self,
-        _ctx: &BuilderContext<N>,
-        _evm_config: Evm,
-    ) -> eyre::Result<Self::Pool> {
-        Ok(NoopTransactionPool::<Tx>::new())
-    }
-}
-
-impl<Tx> Default for NoopTransactionPoolBuilder<Tx> {
-    fn default() -> Self {
-        Self(PhantomData)
-    }
-}
-
 /// Builds [`NoopNetwork`].
 #[derive(Debug, Clone)]
 pub struct NoopNetworkBuilder<Net = EthNetworkPrimitives>(PhantomData<Net>);
@@ -526,40 +392,5 @@ where
 impl<Net> Default for NoopNetworkBuilder<Net> {
     fn default() -> Self {
         Self(PhantomData)
-    }
-}
-
-/// Builds [`NoopConsensus`].
-#[derive(Debug, Clone, Default)]
-pub struct NoopConsensusBuilder;
-
-impl<N> ConsensusBuilder<N> for NoopConsensusBuilder
-where
-    N: FullNodeTypes,
-{
-    type Consensus = NoopConsensus;
-
-    async fn build_consensus(self, _ctx: &BuilderContext<N>) -> eyre::Result<Self::Consensus> {
-        Ok(NoopConsensus::default())
-    }
-}
-
-/// Builds [`PayloadBuilderHandle::noop`].
-#[derive(Debug, Clone, Default)]
-pub struct NoopPayloadBuilder;
-
-impl<N, Pool, EVM> PayloadServiceBuilder<N, Pool, EVM> for NoopPayloadBuilder
-where
-    N: FullNodeTypes,
-    Pool: TransactionPool,
-    EVM: ConfigureEvm<Primitives = PrimitivesTy<N::Types>> + 'static,
-{
-    async fn spawn_payload_builder_service(
-        self,
-        _ctx: &BuilderContext<N>,
-        _pool: Pool,
-        _evm_config: EVM,
-    ) -> eyre::Result<PayloadBuilderHandle<<N::Types as NodeTypes>::Payload>> {
-        Ok(PayloadBuilderHandle::<<N::Types as NodeTypes>::Payload>::noop())
     }
 }

--- a/crates/node/builder/src/components/payload.rs
+++ b/crates/node/builder/src/components/payload.rs
@@ -4,11 +4,9 @@ use crate::{BuilderContext, FullNodeTypes};
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_chain_state::CanonStateSubscriptions;
 use reth_node_api::{NodeTypes, PayloadBuilderFor};
-use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService, PayloadServiceCommand};
+use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_transaction_pool::TransactionPool;
 use std::future::Future;
-use tokio::sync::{broadcast, mpsc};
-use tracing::warn;
 
 /// A type that knows how to spawn the payload service.
 pub trait PayloadServiceBuilder<Node: FullNodeTypes, Pool: TransactionPool, EvmConfig>:
@@ -69,20 +67,12 @@ pub trait PayloadBuilderBuilder<Node: FullNodeTypes, Pool: TransactionPool, EvmC
 pub struct BasicPayloadServiceBuilder<PB> {
     /// Builds the payload builder used by generated payload jobs.
     payload_builder_builder: PB,
-    /// Whether to pre-cache changed state from canonical state notifications.
-    pre_cache_state: bool,
 }
 
 impl<PB> BasicPayloadServiceBuilder<PB> {
     /// Create a new [`BasicPayloadServiceBuilder`].
     pub const fn new(payload_builder_builder: PB) -> Self {
-        Self { payload_builder_builder, pre_cache_state: true }
-    }
-
-    /// Sets whether to pre-cache changed state from canonical state notifications.
-    pub const fn with_pre_cache_state(mut self, pre_cache_state: bool) -> Self {
-        self.pre_cache_state = pre_cache_state;
-        self
+        Self { payload_builder_builder }
     }
 }
 
@@ -109,7 +99,7 @@ where
         pool: Pool,
         evm_config: EvmConfig,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
-        let Self { payload_builder_builder, pre_cache_state } = self;
+        let Self { payload_builder_builder } = self;
         let payload_builder =
             payload_builder_builder.build_payload_builder(ctx, pool, evm_config).await?;
 
@@ -119,7 +109,7 @@ where
             .interval(conf.interval)
             .deadline(conf.deadline)
             .max_payload_tasks(conf.max_payload_tasks)
-            .pre_cache_state(pre_cache_state);
+            .pre_cache_state(true);
 
         let payload_generator = BasicPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
@@ -140,50 +130,5 @@ where
         );
 
         Ok(payload_service_handle)
-    }
-}
-
-/// A `NoopPayloadServiceBuilder` useful for node implementations that are not implementing
-/// validating/sequencing logic.
-#[derive(Debug, Clone, Copy, Default)]
-#[non_exhaustive]
-pub struct NoopPayloadServiceBuilder;
-
-impl<Node, Pool, Evm> PayloadServiceBuilder<Node, Pool, Evm> for NoopPayloadServiceBuilder
-where
-    Node: FullNodeTypes,
-    Pool: TransactionPool,
-    Evm: Send,
-{
-    async fn spawn_payload_builder_service(
-        self,
-        ctx: &BuilderContext<Node>,
-        _pool: Pool,
-        _evm_config: Evm,
-    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
-        let (tx, mut rx) = mpsc::unbounded_channel();
-
-        ctx.task_executor().spawn_critical_os_thread(
-            "payload-service",
-            "payload builder service",
-            async move {
-                #[expect(clippy::collection_is_never_read)]
-                let mut subscriptions = Vec::new();
-
-                while let Some(message) = rx.recv().await {
-                    match message {
-                        PayloadServiceCommand::Subscribe(tx) => {
-                            let (events_tx, events_rx) = broadcast::channel(100);
-                            // Retain senders to make sure that channels are not getting closed
-                            subscriptions.push(events_tx);
-                            let _ = tx.send(events_rx);
-                        }
-                        message => warn!(?message, "Noop payload service received a message"),
-                    }
-                }
-            },
-        );
-
-        Ok(PayloadBuilderHandle::new(tx))
     }
 }

--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -7,8 +7,7 @@ use reth_chainspec::EthereumHardforks;
 use reth_node_api::{BlockTy, NodeTypes, TxTy};
 use reth_transaction_pool::{
     blobstore::DiskFileBlobStore, BlobStore, CoinbaseTipOrdering, PoolConfig, PoolTransaction,
-    SubPoolLimit, TransactionOrdering, TransactionPool, TransactionValidationTaskExecutor,
-    TransactionValidator,
+    SubPoolLimit, TransactionPool, TransactionValidationTaskExecutor, TransactionValidator,
 };
 use std::future::Future;
 
@@ -175,42 +174,20 @@ where
     where
         BS: BlobStore + Clone,
     {
-        self.build_with_ordering_and_spawn_maintenance_task(
-            CoinbaseTipOrdering::default(),
-            blob_store,
-            pool_config,
-        )
-    }
-
-    /// Build the transaction pool with a custom [`TransactionOrdering`] and spawn its maintenance
-    /// tasks.
-    pub fn build_with_ordering_and_spawn_maintenance_task<BS, O>(
-        self,
-        ordering: O,
-        blob_store: BS,
-        pool_config: PoolConfig,
-    ) -> eyre::Result<reth_transaction_pool::Pool<TransactionValidationTaskExecutor<V>, O, BS>>
-    where
-        BS: BlobStore + Clone,
-        O: TransactionOrdering<Transaction = V::Transaction>,
-    {
         let TxPoolBuilder { ctx, validator, .. } = self;
 
-        let transaction_pool =
-            reth_transaction_pool::Pool::new(validator, ordering, blob_store, pool_config.clone());
+        let transaction_pool = reth_transaction_pool::Pool::new(
+            validator,
+            CoinbaseTipOrdering::default(),
+            blob_store,
+            pool_config.clone(),
+        );
 
-        spawn_maintenance_tasks(ctx, transaction_pool.clone(), &pool_config)?;
+        spawn_local_backup_task(ctx, transaction_pool.clone())?;
+        spawn_pool_maintenance_task(ctx, transaction_pool.clone(), &pool_config)?;
 
         Ok(transaction_pool)
     }
-}
-
-/// Create blob store with default configuration.
-pub fn create_blob_store<Node: FullNodeTypes>(
-    ctx: &BuilderContext<Node>,
-) -> eyre::Result<DiskFileBlobStore> {
-    let cache_size = Some(ctx.config().txpool.max_cached_entries);
-    create_blob_store_with_cache(ctx, cache_size)
 }
 
 /// Create blob store with custom cache size configuration for how many blobs should be cached in
@@ -293,22 +270,6 @@ where
         ),
     );
 
-    Ok(())
-}
-
-/// Spawn all maintenance tasks for a transaction pool (backup + main maintenance).
-pub fn spawn_maintenance_tasks<Node, Pool>(
-    ctx: &BuilderContext<Node>,
-    pool: Pool,
-    pool_config: &PoolConfig,
-) -> eyre::Result<()>
-where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec: EthereumHardforks>>,
-    Pool: reth_transaction_pool::TransactionPoolExt<Block = BlockTy<Node::Types>> + Clone + 'static,
-    Pool::Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>,
-{
-    spawn_local_backup_task(ctx, pool.clone())?;
-    spawn_pool_maintenance_task(ctx, pool, pool_config)?;
     Ok(())
 }
 

--- a/crates/node/builder/src/hooks.rs
+++ b/crates/node/builder/src/hooks.rs
@@ -34,32 +34,12 @@ where
         self
     }
 
-    /// Sets the hook that is run once the node's components are initialized.
-    #[expect(unused)]
-    pub(crate) fn on_component_initialized<F>(mut self, hook: F) -> Self
-    where
-        F: OnComponentInitializedHook<Node> + 'static,
-    {
-        self.set_on_component_initialized(hook);
-        self
-    }
-
     /// Sets the hook that is run once the node has started.
     pub(crate) fn set_on_node_started<F>(&mut self, hook: F) -> &mut Self
     where
         F: OnNodeStartedHook<Node, AddOns> + 'static,
     {
         self.on_node_started = Box::new(hook);
-        self
-    }
-
-    /// Sets the hook that is run once the node has started.
-    #[expect(unused)]
-    pub(crate) fn on_node_started<F>(mut self, hook: F) -> Self
-    where
-        F: OnNodeStartedHook<Node, AddOns> + 'static,
-    {
-        self.set_on_node_started(hook);
         self
     }
 }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -44,11 +44,8 @@ use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{
     database::Database, database_metrics::DatabaseMetrics, models::PartialStateTrieUnwindMarker,
 };
-use reth_db_common::init::{
-    init_genesis_with_settings, init_genesis_with_settings_and_validate, InitStorageError,
-};
+use reth_db_common::init::{init_genesis_with_settings_and_validate, InitStorageError};
 use reth_downloaders::{bodies::noop::NoopBodiesDownloader, headers::noop::NoopHeaderDownloader};
-use reth_engine_local::MiningMode;
 use reth_evm::{noop::NoopEvmConfig, ConfigureEvm};
 use reth_exex::ExExManagerHandle;
 use reth_fs_util as fs;
@@ -70,7 +67,7 @@ use reth_node_metrics::{
     version::VersionInfo,
 };
 use reth_provider::{
-    providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
+    providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider},
     BalConfig, BalStoreHandle, BlockHashReader, BlockNumReader, DBProvider,
     DatabaseProviderFactory, InMemoryBalStore, MetadataProvider, MetadataWriter, ProviderError,
     ProviderFactory, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
@@ -88,7 +85,6 @@ use reth_static_file::{blocks_per_file_for_prune_distance, StaticFileProducer, S
 use reth_storage_overlay::OverlayManager;
 use reth_tasks::TaskExecutor;
 use reth_tracing::tracing::{debug, error, info, warn};
-use reth_transaction_pool::TransactionPool;
 use std::{num::NonZeroUsize, sync::Arc, thread::available_parallelism, time::Duration};
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender},
@@ -266,14 +262,6 @@ pub struct LaunchContextWith<T> {
 }
 
 impl<T> LaunchContextWith<T> {
-    /// Configure global settings this includes:
-    ///
-    /// - Raising the file descriptor limit
-    /// - Configuring the global rayon thread pool
-    pub fn configure_globals(&self, reserved_cpu_cores: u64) {
-        self.inner.configure_globals(reserved_cpu_cores.try_into().unwrap());
-    }
-
     /// Returns the data directory.
     pub const fn data_dir(&self) -> &ChainPath<DataDirPath> {
         &self.inner.data_dir
@@ -456,14 +444,6 @@ impl<R, ChainSpec: EthChainSpec> LaunchContextWith<Attached<WithConfigs<ChainSpe
         let secret = self.node_config().rpc.auth_jwt_secret(default_jwt_path)?;
         Ok(secret)
     }
-
-    /// Returns the [`MiningMode`] intended for --dev mode.
-    pub fn dev_mining_mode<Pool>(&self, pool: Pool) -> MiningMode<Pool>
-    where
-        Pool: TransactionPool + Unpin,
-    {
-        self.node_config().dev_mining_mode(pool)
-    }
 }
 
 impl<DB, ChainSpec> LaunchContextWith<Attached<WithConfigs<ChainSpec>, DB>>
@@ -477,7 +457,6 @@ where
     pub async fn create_provider_factory<N, Evm>(
         &self,
         overlay_manager: OverlayManager<N::Primitives>,
-        rocksdb_provider: Option<RocksDBProvider>,
         disabled_stages: &[StageId],
     ) -> eyre::Result<ProviderFactory<N>>
     where
@@ -510,16 +489,11 @@ where
                 .with_genesis_block_number(self.chain_spec().genesis().number.unwrap_or_default())
                 .build()?;
 
-        // Use the provided RocksDB provider or create a new one
-        let rocksdb_provider = if let Some(provider) = rocksdb_provider {
-            provider
-        } else {
-            RocksDBProvider::builder(self.data_dir().rocksdb())
-                .with_default_tables()
-                .with_metrics()
-                .with_statistics()
-                .build()?
-        };
+        let rocksdb_provider = RocksDBProvider::builder(self.data_dir().rocksdb())
+            .with_default_tables()
+            .with_metrics()
+            .with_statistics()
+            .build()?;
 
         let balstore_cache_size = self
             .node_config()
@@ -670,16 +644,14 @@ where
     pub async fn with_provider_factory<N, Evm>(
         self,
         overlay_manager: OverlayManager<N::Primitives>,
-        rocksdb_provider: Option<RocksDBProvider>,
         disabled_stages: &[StageId],
     ) -> eyre::Result<LaunchContextWith<Attached<WithConfigs<ChainSpec>, ProviderFactory<N>>>>
     where
         N: ProviderNodeTypes<DB = DB, ChainSpec = ChainSpec>,
         Evm: ConfigureEvm<Primitives = N::Primitives> + 'static,
     {
-        let factory = self
-            .create_provider_factory::<N, Evm>(overlay_manager, rocksdb_provider, disabled_stages)
-            .await?;
+        let factory =
+            self.create_provider_factory::<N, Evm>(overlay_manager, disabled_stages).await?;
         let ctx = LaunchContextWith {
             inner: self.inner,
             attachment: self.attachment.map_right(|_| factory),
@@ -693,19 +665,9 @@ impl<T> LaunchContextWith<Attached<WithConfigs<T::ChainSpec>, ProviderFactory<T>
 where
     T: ProviderNodeTypes,
 {
-    /// Returns access to the underlying database.
-    pub const fn database(&self) -> &T::DB {
-        self.right().db_ref()
-    }
-
     /// Returns the configured `ProviderFactory`.
     pub const fn provider_factory(&self) -> &ProviderFactory<T> {
         self.right()
-    }
-
-    /// Returns the static file provider to interact with the static files.
-    pub fn static_file_provider(&self) -> StaticFileProvider<T::Primitives> {
-        self.right().static_file_provider()
     }
 
     /// This launches the prometheus endpoint.
@@ -773,7 +735,7 @@ where
         Ok(())
     }
 
-    /// Convenience function to [`Self::init_genesis`]
+    /// Writes the genesis block and state if it has not already been written and validates it.
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
         init_genesis_with_settings_and_validate(
             self.provider_factory(),
@@ -781,11 +743,6 @@ where
             !self.node_config().debug.skip_genesis_validation,
         )?;
         Ok(self)
-    }
-
-    /// Write the genesis block and state if it has not already been written
-    pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
-        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())
     }
 
     /// Creates a new `WithMeteredProvider` container and attaches it to the
@@ -867,11 +824,6 @@ impl<T>
 where
     T: FullNodeTypes<Types: NodeTypesForProvider>,
 {
-    /// Returns access to the underlying database.
-    pub const fn database(&self) -> &T::DB {
-        self.provider_factory().db_ref()
-    }
-
     /// Returns the configured `ProviderFactory`.
     pub const fn provider_factory(
         &self,
@@ -979,11 +931,6 @@ where
         self.node_config().max_block(client, self.provider_factory().clone()).await
     }
 
-    /// Returns the static file provider to interact with the static files.
-    pub fn static_file_provider(&self) -> StaticFileProvider<<T::Types as NodeTypes>::Primitives> {
-        self.provider_factory().static_file_provider()
-    }
-
     /// Creates a new [`StaticFileProducer`] with the attached database.
     pub fn static_file_producer(
         &self,
@@ -999,11 +946,6 @@ where
     /// Returns the configured `NodeAdapter`.
     pub const fn node_adapter(&self) -> &NodeAdapter<T, CB::Components> {
         &self.right().node_adapter
-    }
-
-    /// Returns mutable reference to the configured `NodeAdapter`.
-    pub const fn node_adapter_mut(&mut self) -> &mut NodeAdapter<T, CB::Components> {
-        &mut self.right_mut().node_adapter
     }
 
     /// Returns a reference to the blockchain provider.
@@ -1147,34 +1089,14 @@ where
             Box<dyn crate::exex::BoxedLaunchExEx<NodeAdapter<T, CB::Components>>>,
         )>,
     ) -> eyre::Result<Option<ExExManagerHandle<PrimitivesTy<T::Types>>>> {
-        self.exex_launcher(installed_exex).launch().await
-    }
-
-    /// Creates an [`ExExLauncher`] for the installed ExExes.
-    ///
-    /// This returns the launcher before calling `.launch()`, allowing custom configuration
-    /// such as setting the WAL blocks warning threshold for L2 chains with faster block times:
-    ///
-    /// ```ignore
-    /// ctx.exex_launcher(exexes)
-    ///     .with_wal_blocks_warning(768)  // For 2-second block times
-    ///     .launch()
-    ///     .await
-    /// ```
-    #[expect(clippy::type_complexity)]
-    pub fn exex_launcher(
-        &self,
-        installed_exex: Vec<(
-            String,
-            Box<dyn crate::exex::BoxedLaunchExEx<NodeAdapter<T, CB::Components>>>,
-        )>,
-    ) -> ExExLauncher<NodeAdapter<T, CB::Components>> {
         ExExLauncher::new(
             self.head(),
             self.node_adapter().clone(),
             installed_exex,
             self.configs().clone(),
         )
+        .launch()
+        .await
     }
 
     /// Creates the ERA import source based on node configuration.
@@ -1285,14 +1207,6 @@ impl<L, R> Attached<L, R> {
     /// Creates a new `Attached` with the given values.
     pub const fn new(left: L, right: R) -> Self {
         Self { left, right }
-    }
-
-    /// Maps the left value to a new value.
-    pub fn map_left<F, T>(self, f: F) -> Attached<T, R>
-    where
-        F: FnOnce(L) -> T,
-    {
-        Attached::new(f(self.left), self.right)
     }
 
     /// Maps the right value to a new value.

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -4,13 +4,11 @@ use alloy_consensus::transaction::Either;
 use alloy_provider::network::AnyNetwork;
 use jsonrpsee::core::{DeserializeOwned, Serialize};
 use reth_chainspec::EthChainSpec;
-use reth_consensus_debug_client::{
-    DebugConsensusClient, EtherscanBlockProvider, PayloadProvider, RpcBlockProvider,
-};
-use reth_engine_local::{LocalMiner, MiningMode};
+use reth_consensus_debug_client::{DebugConsensusClient, EtherscanBlockProvider, RpcBlockProvider};
+use reth_engine_local::LocalMiner;
 use reth_node_api::{
-    BlockTy, FullNodeComponents, FullNodeTypes, HeaderTy, NodeTypes, PayloadAttrTy,
-    PayloadAttributesBuilder, PayloadTypes,
+    BlockTy, FullNodeComponents, HeaderTy, NodeTypes, PayloadAttrTy, PayloadAttributesBuilder,
+    PayloadTypes,
 };
 use reth_primitives_traits::SealedBlock;
 use std::{
@@ -19,9 +17,6 @@ use std::{
     sync::Arc,
 };
 use tracing::info;
-
-/// Helper adapter type for accessing [`PayloadTypes::ExecutionData`] on [`NodeTypes`].
-pub(crate) type PayloadDataTy<N> = <<N as NodeTypes>::Payload as PayloadTypes>::ExecutionData;
 
 /// [`Node`] extension with support for debugging utilities.
 ///
@@ -118,125 +113,40 @@ impl<L> DebugNodeLauncher<L> {
     }
 }
 
-/// Type alias for the default debug block provider. We use etherscan provider to satisfy the
-/// bounds.
-pub type DefaultDebugBlockProvider<N> = EtherscanBlockProvider<
-    <<N as FullNodeTypes>::Types as DebugNode<N>>::RpcBlock,
-    PayloadDataTy<<N as FullNodeTypes>::Types>,
->;
-
 /// Future for the [`DebugNodeLauncher`].
 #[expect(missing_debug_implementations, clippy::type_complexity)]
-pub struct DebugNodeLauncherFuture<L, Target, N, B = DefaultDebugBlockProvider<N>>
+pub struct DebugNodeLauncherFuture<L, Target, N>
 where
     N: FullNodeComponents<Types: DebugNode<N>>,
 {
     inner: L,
     target: Target,
-    local_payload_attributes_builder:
-        Option<Box<dyn PayloadAttributesBuilder<PayloadAttrTy<N::Types>, HeaderTy<N::Types>>>>,
     map_attributes:
         Option<Box<dyn Fn(PayloadAttrTy<N::Types>) -> PayloadAttrTy<N::Types> + Send + Sync>>,
-    debug_block_provider: Option<B>,
-    mining_mode: Option<MiningMode<N::Pool>>,
 }
 
-impl<L, Target, N, AddOns, B> DebugNodeLauncherFuture<L, Target, N, B>
+impl<L, Target, N, AddOns> DebugNodeLauncherFuture<L, Target, N>
 where
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N>,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>>,
-    B: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone,
 {
-    /// Sets a custom payload attributes builder for local mining in dev mode.
-    pub fn with_payload_attributes_builder(
-        self,
-        builder: impl PayloadAttributesBuilder<PayloadAttrTy<N::Types>, HeaderTy<N::Types>>,
-    ) -> Self {
-        Self {
-            inner: self.inner,
-            target: self.target,
-            local_payload_attributes_builder: Some(Box::new(builder)),
-            map_attributes: None,
-            debug_block_provider: self.debug_block_provider,
-            mining_mode: self.mining_mode,
-        }
-    }
-
     /// Sets a function to map payload attributes before building.
     pub fn map_debug_payload_attributes(
         self,
         f: impl Fn(PayloadAttrTy<N::Types>) -> PayloadAttrTy<N::Types> + Send + Sync + 'static,
     ) -> Self {
-        Self {
-            inner: self.inner,
-            target: self.target,
-            local_payload_attributes_builder: None,
-            map_attributes: Some(Box::new(f)),
-            debug_block_provider: self.debug_block_provider,
-            mining_mode: self.mining_mode,
-        }
-    }
-
-    /// Sets a custom [`MiningMode`] for the local miner in dev mode.
-    ///
-    /// This overrides the default mining mode that is derived from the node configuration
-    /// (instant or interval). This can be used to provide a custom trigger-based mining mode.
-    pub fn with_mining_mode(mut self, mode: MiningMode<N::Pool>) -> Self {
-        self.mining_mode = Some(mode);
-        self
-    }
-
-    /// Sets a custom payload provider for the debug consensus client.
-    ///
-    /// When set, this provider will be used instead of creating an `EtherscanBlockProvider`
-    /// or `RpcBlockProvider` from CLI arguments.
-    pub fn with_debug_block_provider<B2>(
-        self,
-        provider: B2,
-    ) -> DebugNodeLauncherFuture<L, Target, N, B2>
-    where
-        B2: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone,
-    {
-        DebugNodeLauncherFuture {
-            inner: self.inner,
-            target: self.target,
-            local_payload_attributes_builder: self.local_payload_attributes_builder,
-            map_attributes: self.map_attributes,
-            debug_block_provider: Some(provider),
-            mining_mode: self.mining_mode,
-        }
+        Self { inner: self.inner, target: self.target, map_attributes: Some(Box::new(f)) }
     }
 
     async fn launch_node(self) -> eyre::Result<NodeHandle<N, AddOns>> {
-        let Self {
-            inner,
-            target,
-            local_payload_attributes_builder,
-            map_attributes,
-            debug_block_provider,
-            mining_mode,
-        } = self;
+        let Self { inner, target, map_attributes } = self;
 
         let handle = inner.launch_node(target).await?;
 
         let config = &handle.node.config;
 
-        if let Some(provider) = debug_block_provider {
-            info!(target: "reth::cli", "Using custom debug block provider");
-
-            let rpc_consensus_client = DebugConsensusClient::new(
-                handle.node.add_ons_handle.beacon_engine_handle.clone(),
-                Arc::new(provider),
-            );
-
-            handle
-                .node
-                .task_executor
-                .spawn_critical_task("custom debug block provider consensus client", async move {
-                    rpc_consensus_client.run().await
-                });
-        } else if let Some(url) = config.debug.rpc_consensus_url.clone() {
+        if let Some(url) = config.debug.rpc_consensus_url.clone() {
             info!(target: "reth::cli", "Using RPC consensus client: {}", url);
 
             let block_provider =
@@ -309,20 +219,14 @@ where
             let pool = handle.node.pool.clone();
             let payload_builder_handle = handle.node.payload_builder_handle.clone();
 
-            let builder = if let Some(builder) = local_payload_attributes_builder {
-                Either::Left(builder)
+            let local = N::Types::local_payload_attributes_builder(&chain_spec);
+            let builder = if let Some(f) = map_attributes {
+                Either::Left(move |parent| f(local.build(&parent)))
             } else {
-                let local = N::Types::local_payload_attributes_builder(&chain_spec);
-                let builder = if let Some(f) = map_attributes {
-                    Either::Left(move |parent| f(local.build(&parent)))
-                } else {
-                    Either::Right(local)
-                };
-                Either::Right(builder)
+                Either::Right(local)
             };
 
-            let dev_mining_mode =
-                mining_mode.unwrap_or_else(|| handle.node.config.dev_mining_mode(pool));
+            let dev_mining_mode = handle.node.config.dev_mining_mode(pool);
             let finality_depth = config.dev.finality_depth;
             let payload_wait_time = config.dev.payload_wait_time;
             if let (Some(wait_time), Some(block_time)) = (payload_wait_time, config.dev.block_time)
@@ -351,13 +255,12 @@ where
     }
 }
 
-impl<L, Target, N, AddOns, B> IntoFuture for DebugNodeLauncherFuture<L, Target, N, B>
+impl<L, Target, N, AddOns> IntoFuture for DebugNodeLauncherFuture<L, Target, N>
 where
     Target: Send + 'static,
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N> + 'static,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>> + 'static,
-    B: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone + 'static,
 {
     type Output = eyre::Result<NodeHandle<N, AddOns>>;
     type IntoFuture = Pin<Box<dyn Future<Output = eyre::Result<NodeHandle<N, AddOns>>> + Send>>;
@@ -373,19 +276,11 @@ where
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N> + 'static,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>> + 'static,
-    DefaultDebugBlockProvider<N>: PayloadProvider<ExecutionData = PayloadDataTy<N::Types>> + Clone,
 {
     type Node = NodeHandle<N, AddOns>;
     type Future = DebugNodeLauncherFuture<L, Target, N>;
 
     fn launch_node(self, target: Target) -> Self::Future {
-        DebugNodeLauncherFuture {
-            inner: self.inner,
-            target,
-            local_payload_attributes_builder: None,
-            map_attributes: None,
-            debug_block_provider: None,
-            mining_mode: None,
-        }
+        DebugNodeLauncherFuture { inner: self.inner, target, map_attributes: None }
     }
 }

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -85,12 +85,11 @@ impl EngineNodeLauncher {
         let Self { ctx, engine_tree_config } = self;
         let NodeBuilderWithComponents {
             adapter: NodeTypesAdapter { database },
-            rocksdb_provider,
             components_builder,
             add_ons: AddOns { hooks, exexs: installed_exex, add_ons },
             config,
         } = target;
-        let NodeHooks { on_component_initialized, on_node_started, .. } = hooks;
+        let NodeHooks { on_component_initialized, on_node_started } = hooks;
 
         // Create the overlay manager that will be shared across the provider and engine.
         let overlay_manager = OverlayManager::<N::Primitives>::new(
@@ -112,7 +111,6 @@ impl EngineNodeLauncher {
             // Create the provider factory with the shared overlay manager
             .with_provider_factory::<_, <CB::Components as NodeComponents<T>>::Evm>(
                 overlay_manager.clone(),
-                rocksdb_provider,
                 disabled_stages,
             )
             .await?

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -22,10 +22,6 @@ pub struct ExExLauncher<Node: FullNodeComponents> {
     extensions: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
     components: Node,
     config_container: WithConfigs<<Node::Types as NodeTypes>::ChainSpec>,
-    /// The threshold for the number of blocks in the WAL before emitting a warning.
-    wal_blocks_warning: usize,
-    /// The max notification buffer capacity for the ExEx manager.
-    capacity: usize,
 }
 
 impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
@@ -36,30 +32,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
         extensions: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
         config_container: WithConfigs<<Node::Types as NodeTypes>::ChainSpec>,
     ) -> Self {
-        Self {
-            head,
-            extensions,
-            components,
-            config_container,
-            wal_blocks_warning: DEFAULT_WAL_BLOCKS_WARNING,
-            capacity: DEFAULT_EXEX_MANAGER_CAPACITY,
-        }
-    }
-
-    /// Sets the threshold for the number of blocks in the WAL before emitting a warning.
-    ///
-    /// For L2 chains with faster block times, this value should be increased proportionally
-    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
-    /// a value 6x higher than the default (768 instead of 128).
-    pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
-        self.wal_blocks_warning = threshold;
-        self
-    }
-
-    /// Sets the max notification buffer capacity for the [`ExExManager`].
-    pub const fn with_capacity(mut self, capacity: usize) -> Self {
-        self.capacity = capacity;
-        self
+        Self { head, extensions, components, config_container }
     }
 
     /// Launches all execution extensions.
@@ -69,8 +42,7 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
     pub async fn launch(
         self,
     ) -> eyre::Result<Option<ExExManagerHandle<PrimitivesTy<Node::Types>>>> {
-        let Self { head, extensions, components, config_container, wal_blocks_warning, capacity } =
-            self;
+        let Self { head, extensions, components, config_container } = self;
         let head = BlockNumHash::new(head.number, head.hash);
 
         if extensions.is_empty() {
@@ -144,11 +116,11 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
         let exex_manager = ExExManager::new(
             components.provider().clone(),
             exex_handles,
-            capacity,
+            DEFAULT_EXEX_MANAGER_CAPACITY,
             exex_wal,
             components.provider().finalized_block_stream(),
         )
-        .with_wal_blocks_warning(wal_blocks_warning);
+        .with_wal_blocks_warning(DEFAULT_WAL_BLOCKS_WARNING);
         let exex_manager_handle = exex_manager.handle();
         components.task_executor().spawn_critical_task("exex manager", async move {
             exex_manager.await.expect("exex manager crashed");
@@ -182,7 +154,6 @@ impl<Node: FullNodeComponents> Debug for ExExLauncher<Node> {
             .field("extensions", &self.extensions.iter().map(|(id, _)| id).collect::<Vec<_>>())
             .field("components", &"...")
             .field("config_container", &self.config_container)
-            .field("wal_blocks_warning", &self.wal_blocks_warning)
             .finish()
     }
 }

--- a/crates/node/builder/src/lib.rs
+++ b/crates/node/builder/src/lib.rs
@@ -31,7 +31,7 @@ pub use builder::{add_ons::AddOns, *};
 
 mod launch;
 pub use launch::{
-    debug::{DebugNode, DebugNodeLauncher, DebugNodeLauncherFuture, DefaultDebugBlockProvider},
+    debug::{DebugNode, DebugNodeLauncher, DebugNodeLauncherFuture},
     engine::EngineNodeLauncher,
     *,
 };

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -17,8 +17,6 @@ use reth_rpc_api::EngineApiClient;
 use reth_rpc_builder::{auth::AuthServerHandle, RpcServerHandle};
 use reth_tasks::TaskExecutor;
 use std::{
-    fmt::Debug,
-    marker::PhantomData,
     ops::{Deref, DerefMut},
     sync::Arc,
 };
@@ -48,60 +46,6 @@ pub trait Node<N: FullNodeTypes>: NodeTypes + Clone {
     /// Returns the stages that should be disabled for this node.
     fn disabled_stages() -> &'static [reth_stages::StageId] {
         &[]
-    }
-}
-
-/// A [`Node`] type builder
-#[derive(Clone, Default, Debug)]
-pub struct AnyNode<N = (), C = (), AO = ()>(PhantomData<N>, C, AO);
-
-impl<N, C, AO> AnyNode<N, C, AO> {
-    /// Configures the types of the node.
-    pub fn types<T>(self) -> AnyNode<T, C, AO> {
-        AnyNode(PhantomData, self.1, self.2)
-    }
-
-    /// Sets the node components builder.
-    pub fn components_builder<T>(self, value: T) -> AnyNode<N, T, AO> {
-        AnyNode(PhantomData, value, self.2)
-    }
-
-    /// Sets the node add-ons.
-    pub fn add_ons<T>(self, value: T) -> AnyNode<N, C, T> {
-        AnyNode(PhantomData, self.1, value)
-    }
-}
-
-impl<N, C, AO> NodeTypes for AnyNode<N, C, AO>
-where
-    N: FullNodeTypes,
-    C: Clone + Debug + Send + Sync + Unpin + 'static,
-    AO: Clone + Debug + Send + Sync + Unpin + 'static,
-{
-    type Primitives = <N::Types as NodeTypes>::Primitives;
-
-    type ChainSpec = <N::Types as NodeTypes>::ChainSpec;
-
-    type Storage = <N::Types as NodeTypes>::Storage;
-
-    type Payload = <N::Types as NodeTypes>::Payload;
-}
-
-impl<N, C, AO> Node<N> for AnyNode<N, C, AO>
-where
-    N: FullNodeTypes + Clone,
-    C: NodeComponentsBuilder<N> + Clone + Debug + Sync + Unpin + 'static,
-    AO: NodeAddOns<NodeAdapter<N, C::Components>> + Clone + Debug + Sync + Unpin + 'static,
-{
-    type ComponentsBuilder = C;
-    type AddOns = AO;
-
-    fn components_builder(&self) -> Self::ComponentsBuilder {
-        self.1.clone()
-    }
-
-    fn add_ons(&self) -> Self::AddOns {
-        self.2.clone()
     }
 }
 
@@ -181,22 +125,6 @@ where
     Node: FullNodeComponents<Types: NodeTypes<Payload = Engine>>,
     AddOns: RethRpcAddOns<Node>,
 {
-    /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
-    ///
-    /// This will send authenticated http requests to the node's auth server.
-    pub fn engine_http_client(&self) -> impl EngineApiClient<Engine> + use<Engine, Node, AddOns> {
-        self.auth_server_handle().http_client()
-    }
-
-    /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
-    ///
-    /// This will send authenticated ws requests to the node's auth server.
-    pub async fn engine_ws_client(
-        &self,
-    ) -> impl EngineApiClient<Engine> + use<Engine, Node, AddOns> {
-        self.auth_server_handle().ws_client().await
-    }
-
     /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
     ///
     /// This will send not authenticated IPC requests to the node's auth server.

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -97,32 +97,12 @@ where
         self
     }
 
-    /// Sets the hook that is run once the rpc server is started.
-    #[expect(unused)]
-    pub(crate) fn on_rpc_started<F>(mut self, hook: F) -> Self
-    where
-        F: OnRpcStarted<Node, EthApi> + 'static,
-    {
-        self.set_on_rpc_started(hook);
-        self
-    }
-
     /// Sets the hook that is run to configure the rpc modules.
     pub(crate) fn set_extend_rpc_modules<F>(&mut self, hook: F) -> &mut Self
     where
         F: ExtendRpcModules<Node, EthApi> + 'static,
     {
         self.extend_rpc_modules = Box::new(hook);
-        self
-    }
-
-    /// Sets the hook that is run to configure the rpc modules.
-    #[expect(unused)]
-    pub(crate) fn extend_rpc_modules<F>(mut self, hook: F) -> Self
-    where
-        F: ExtendRpcModules<Node, EthApi> + 'static,
-    {
-        self.set_extend_rpc_modules(hook);
         self
     }
 }
@@ -418,46 +398,6 @@ impl<Node: FullNodeComponents, EthApi: EthApiTypes> RpcHandle<Node, EthApi> {
     }
 }
 
-/// Handle returned when only the regular RPC server (HTTP/WS/IPC) is launched.
-///
-/// This handle provides access to the RPC server endpoints and registry, but does not
-/// include an authenticated Engine API server. Use this when you only need regular
-/// RPC functionality.
-#[derive(Debug, Clone)]
-pub struct RpcServerOnlyHandle<Node: FullNodeComponents, EthApi: EthApiTypes> {
-    /// Handle to the RPC server
-    pub rpc_server_handle: RpcServerHandle,
-    /// Configured RPC modules.
-    pub rpc_registry: RpcRegistry<Node, EthApi>,
-    /// Notification channel for engine API events
-    pub engine_events: EventSender<ConsensusEngineEvent<<Node::Types as NodeTypes>::Primitives>>,
-    /// Handle to the consensus engine.
-    pub engine_handle: ConsensusEngineHandle<<Node::Types as NodeTypes>::Payload>,
-}
-
-impl<Node: FullNodeComponents, EthApi: EthApiTypes> RpcServerOnlyHandle<Node, EthApi> {
-    /// Returns the RPC server handle.
-    pub const fn rpc_server_handle(&self) -> &RpcServerHandle {
-        &self.rpc_server_handle
-    }
-
-    /// Returns the consensus engine handle.
-    ///
-    /// This handle can be used to interact with the engine service directly.
-    pub const fn consensus_engine_handle(
-        &self,
-    ) -> &ConsensusEngineHandle<<Node::Types as NodeTypes>::Payload> {
-        &self.engine_handle
-    }
-
-    /// Returns the consensus engine events sender.
-    pub const fn consensus_engine_events(
-        &self,
-    ) -> &EventSender<ConsensusEngineEvent<<Node::Types as NodeTypes>::Primitives>> {
-        &self.engine_events
-    }
-}
-
 /// Handle returned when only the authenticated Engine API server is launched.
 ///
 /// This handle provides access to the Engine API server and registry, but does not
@@ -651,33 +591,6 @@ where
         }
     }
 
-    /// Maps the [`EngineValidatorBuilder`] builder type.
-    pub fn with_engine_validator<T>(
-        self,
-        engine_validator_builder: T,
-    ) -> RpcAddOns<Node, EthB, PVB, EB, T, RpcMiddleware, AuthHttpMiddleware> {
-        let Self {
-            hooks,
-            eth_api_builder,
-            payload_validator_builder,
-            engine_api_builder,
-            rpc_middleware,
-            auth_http_middleware,
-            tokio_runtime,
-            ..
-        } = self;
-        RpcAddOns {
-            hooks,
-            eth_api_builder,
-            payload_validator_builder,
-            engine_api_builder,
-            engine_validator_builder,
-            rpc_middleware,
-            auth_http_middleware,
-            tokio_runtime,
-        }
-    }
-
     /// Sets the RPC middleware stack for processing RPC requests.
     ///
     /// This method configures a custom middleware stack that will be applied to all RPC requests
@@ -844,52 +757,6 @@ where
         }
     }
 
-    /// Add a new layer `T` to the configured [`RpcServiceBuilder`].
-    pub fn layer_rpc_middleware<T>(
-        self,
-        layer: T,
-    ) -> RpcAddOns<Node, EthB, PVB, EB, EVB, Stack<RpcMiddleware, T>, AuthHttpMiddleware> {
-        let Self {
-            hooks,
-            eth_api_builder,
-            payload_validator_builder,
-            engine_api_builder,
-            engine_validator_builder,
-            rpc_middleware,
-            auth_http_middleware,
-            tokio_runtime,
-        } = self;
-        let rpc_middleware = Stack::new(rpc_middleware, layer);
-        RpcAddOns {
-            hooks,
-            eth_api_builder,
-            payload_validator_builder,
-            engine_api_builder,
-            engine_validator_builder,
-            rpc_middleware,
-            auth_http_middleware,
-            tokio_runtime,
-        }
-    }
-
-    /// Optionally adds a new layer `T` to the configured [`RpcServiceBuilder`].
-    #[expect(clippy::type_complexity)]
-    pub fn option_layer_rpc_middleware<T>(
-        self,
-        layer: Option<T>,
-    ) -> RpcAddOns<
-        Node,
-        EthB,
-        PVB,
-        EB,
-        EVB,
-        Stack<RpcMiddleware, Either<T, Identity>>,
-        AuthHttpMiddleware,
-    > {
-        let layer = layer.map(Either::Left).unwrap_or(Either::Right(Identity::new()));
-        self.layer_rpc_middleware(layer)
-    }
-
     /// Sets the hook that is run once the rpc server is started.
     pub fn on_rpc_started<F>(mut self, hook: F) -> Self
     where
@@ -943,63 +810,11 @@ where
     RpcMiddleware: RethRpcMiddleware,
     AuthHttpMiddleware: RethAuthHttpMiddleware<Identity>,
 {
-    /// Launches only the regular RPC server (HTTP/WS/IPC), without the authenticated Engine API
-    /// server.
-    ///
-    /// This is useful when you only need the regular RPC functionality and want to avoid
-    /// starting the auth server.
-    pub async fn launch_rpc_server<F>(
-        self,
-        ctx: AddOnsContext<'_, N>,
-        ext: F,
-    ) -> eyre::Result<RpcServerOnlyHandle<N, EthB::EthApi>>
-    where
-        F: FnOnce(RpcModuleContainer<'_, N, EthB::EthApi>) -> eyre::Result<()>,
-    {
-        let rpc_middleware = self.rpc_middleware.clone();
-        let tokio_runtime = self.tokio_runtime.clone();
-        let setup_ctx = self.setup_rpc_components(ctx, ext).await?;
-        let RpcSetupContext {
-            node,
-            config,
-            mut modules,
-            mut auth_module,
-            auth_config: _,
-            mut registry,
-            on_rpc_started,
-            engine_events,
-            engine_handle,
-        } = setup_ctx;
-
-        let server_config = config
-            .rpc
-            .rpc_server_config()
-            .set_rpc_middleware(rpc_middleware)
-            .with_tokio_runtime(tokio_runtime);
-        let rpc_server_handle = Self::launch_rpc_server_internal(server_config, &modules).await?;
-
-        let handles =
-            RethRpcServerHandles { rpc: rpc_server_handle.clone(), auth: AuthServerHandle::noop() };
-        Self::finalize_rpc_setup(
-            &mut registry,
-            &mut modules,
-            &mut auth_module,
-            &node,
-            config,
-            on_rpc_started,
-            handles,
-        )?;
-
-        Ok(RpcServerOnlyHandle {
-            rpc_server_handle,
-            rpc_registry: registry,
-            engine_events,
-            engine_handle,
-        })
-    }
-
     /// Launches the RPC servers with the given context and an additional hook for extending
     /// modules. Whether the auth server is launched depends on the CLI configuration.
+    ///
+    /// When the auth server is disabled, it will not be started and a noop handle will be used
+    /// instead.
     pub async fn launch_add_ons_with<F>(
         self,
         ctx: AddOnsContext<'_, N>,
@@ -1008,25 +823,7 @@ where
     where
         F: FnOnce(RpcModuleContainer<'_, N, EthB::EthApi>) -> eyre::Result<()>,
     {
-        // Check CLI config to determine if auth server should be disabled
         let disable_auth = ctx.config.rpc.disable_auth_server;
-        self.launch_add_ons_with_opt_engine(ctx, ext, disable_auth).await
-    }
-
-    /// Launches the RPC servers with the given context and an additional hook for extending
-    /// modules. Optionally disables the auth server based on the `disable_auth` parameter.
-    ///
-    /// When `disable_auth` is true, the auth server will not be started and a noop handle
-    /// will be used instead.
-    pub async fn launch_add_ons_with_opt_engine<F>(
-        self,
-        ctx: AddOnsContext<'_, N>,
-        ext: F,
-        disable_auth: bool,
-    ) -> eyre::Result<RpcHandle<N, EthB::EthApi>>
-    where
-        F: FnOnce(RpcModuleContainer<'_, N, EthB::EthApi>) -> eyre::Result<()>,
-    {
         let rpc_middleware = self.rpc_middleware.clone();
         let auth_http_middleware = self.auth_http_middleware.clone();
         let tokio_runtime = self.tokio_runtime.clone();


### PR DESCRIPTION
Removes pub helpers and combinators in `reth-node-builder` that have no callers anywhere in the workspace, including the never-set `rocksdb_provider` builder field (its `Some` branch was unreachable), the unused `AnyNode` type, and the `DebugNodeLauncherFuture` block-provider/mining-mode overrides that nothing could set. Behaviour of the remaining launch path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)