### PR TITLE
refactor(storage): disable Linux MDBX write prefaulting

### DIFF
--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -409,6 +409,10 @@ impl DatabaseEnv {
             DatabaseEnvKind::RW => {
                 // enable writemap mode in RW mode
                 inner_env.write_map();
+                // Sparse page reuse makes MDBX's mincore residency probes expensive on Linux.
+                // Let the kernel fault pages in on demand instead of pre-faulting reclaimed pages.
+                #[cfg(target_os = "linux")]
+                inner_env.set_prefault_write(false);
                 Mode::ReadWrite { sync_mode: args.sync_mode }
             }
         };

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -45,6 +45,7 @@ impl Environment {
             sync_bytes: None,
             sync_period: None,
             rp_augment_limit: None,
+            prefault_write: None,
             loose_limit: None,
             dp_reserve_limit: None,
             txn_dp_limit: None,
@@ -613,6 +614,7 @@ pub struct EnvironmentBuilder {
     sync_bytes: Option<u64>,
     sync_period: Option<u64>,
     rp_augment_limit: Option<u64>,
+    prefault_write: Option<u64>,
     loose_limit: Option<u64>,
     dp_reserve_limit: Option<u64>,
     txn_dp_limit: Option<u64>,
@@ -686,6 +688,7 @@ impl EnvironmentBuilder {
                 for (opt, v) in [
                     (ffi::MDBX_opt_max_db, self.max_dbs),
                     (ffi::MDBX_opt_rp_augment_limit, self.rp_augment_limit),
+                    (ffi::MDBX_opt_prefault_write_enable, self.prefault_write),
                     (ffi::MDBX_opt_loose_limit, self.loose_limit),
                     (ffi::MDBX_opt_dp_reserve_limit, self.dp_reserve_limit),
                     (ffi::MDBX_opt_txn_dp_limit, self.txn_dp_limit),
@@ -845,6 +848,15 @@ impl EnvironmentBuilder {
 
     pub const fn set_rp_augment_limit(&mut self, v: u64) -> &mut Self {
         self.rp_augment_limit = Some(v);
+        self
+    }
+
+    /// Controls whether reclaimed and allocated pages are pre-faulted through file writes before
+    /// being touched in WRITEMAP mode. If unset, MDBX chooses its default behavior.
+    ///
+    /// Disabling this leaves page faults to the operating system and does not change the sync mode.
+    pub const fn set_prefault_write(&mut self, enabled: bool) -> &mut Self {
+        self.prefault_write = Some(enabled as u64);
         self
     }
 

--- a/crates/storage/libmdbx-rs/tests/environment.rs
+++ b/crates/storage/libmdbx-rs/tests/environment.rs
@@ -18,6 +18,47 @@ fn test_open() {
 }
 
 #[test]
+fn test_writemap_without_prefault_commit_abort_and_reopen() {
+    let dir = tempdir().unwrap();
+    {
+        let env =
+            Environment::builder().write_map().set_prefault_write(false).open(dir.path()).unwrap();
+        assert!(matches!(
+            env.info().unwrap().mode(),
+            Mode::ReadWrite { sync_mode: SyncMode::Durable }
+        ));
+
+        // Repeatedly replace overflow values so later transactions reuse freed pages.
+        for round in 0..4u8 {
+            let txn = env.begin_rw_txn().unwrap();
+            let dbi = txn.open_db(None).unwrap().dbi();
+            for key in 0..64u32 {
+                txn.put(dbi, key.to_be_bytes(), vec![round; 8192], WriteFlags::UPSERT).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+
+        {
+            let txn = env.begin_rw_txn().unwrap();
+            let dbi = txn.open_db(None).unwrap().dbi();
+            txn.put(dbi, 0u32.to_be_bytes(), b"uncommitted", WriteFlags::UPSERT).unwrap();
+            // Dropping the transaction must preserve the previously committed value.
+        }
+
+        let ops = env.info().unwrap().page_ops();
+        assert_eq!(ops.prefault, 0);
+        assert_eq!(ops.mincore, 0);
+    }
+
+    let env = Environment::builder().set_flags(Mode::ReadOnly.into()).open(dir.path()).unwrap();
+    let txn = env.begin_ro_txn().unwrap();
+    let dbi = txn.open_db(None).unwrap().dbi();
+    for key in 0..64u32 {
+        assert_eq!(txn.get::<Vec<u8>>(dbi, &key.to_be_bytes()).unwrap(), Some(vec![3; 8192]));
+    }
+}
+
+#[test]
 fn test_begin_txn() {
     let dir = tempdir().unwrap();
 


### PR DESCRIPTION
## Summary

Disable MDBX write pre-faulting for Linux RW environments, retaining WRITEMAP and the configured sync mode. **Experimental draft: persistence improves on this replay, but the overall result is mixed—not ready to merge as a default.**

The [six-pair benchmark](https://github.com/paradigmxyz/reth/actions/runs/33927848156) uses 500 blocks, 125 warmup blocks, and profiling:

| Metric | Baseline | Feature | `summary.json` verdict |
|---|---:|---:|---|
| Persistence wait/block | 28.40 ms | 18.81 ms | **33.8% better** |
| MDBX write/block | 31.68 ms | 21.99 ms | **30.6% better** |
| Execution mean | 27.64 ms | 28.30 ms | **2.4% worse** |
| Execution P90 | 44.15 ms | 45.65 ms | **3.4% worse** |

Raw elapsed replay duration averaged 29.49s → 25.08s; this is supporting evidence, not a summary verdict. The summary's execution-oriented “Wall Clock” metric regressed 2.4% and excludes the persistence wait under investigation.

## Profile and risk

The [baseline profile](https://share.firefox.dev/3VeWV4j) spends 31.5% of persistence-thread CPU in `mincore`; the [feature profile](https://share.firefox.dev/4cuCaYo) removes that work but spends 35% in page-fault handling. Profiles include warmup.

This revisits [#25805](https://github.com/paradigmxyz/reth/pull/25805), where the same setting regressed persistence wait by 592% on an earlier workload. Page-residency sensitivity and the current execution regression require investigation before merging. Durability, schema, and commit ordering are unchanged; tests cover commit, abort, reopening, and reclaimed-page writes.

## Verification

- [Main/main control](https://github.com/paradigmxyz/reth/actions/runs/33925619080): all headline verdicts neutral; persistence +1.3%, versus a 5% significance floor.
- Other iterations: [cursor replacement](https://github.com/paradigmxyz/reth/actions/runs/33926149423) and [identical trie-node skipping](https://github.com/paradigmxyz/reth/actions/runs/33928366051) were neutral and are excluded.
- Final source tree is identical to benchmarked commit [4b5d5ab68c](https://github.com/paradigmxyz/reth/commit/4b5d5ab68c4903d4e63ba1992af662e0adec645a).
- Passed: 317 tests, 4 doctests, formatting, and workspace Clippy.

```sh
cargo test -p reth-libmdbx -p reth-db -p reth-provider -j 8
cargo +nightly fmt --all --check
cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features -j 8 -- -D warnings
```

Prompted by: @shekhirin
