### PR TITLE
fix(rpc): return -32000 for unknown filter ids

### DIFF
--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -1050,8 +1050,9 @@ pub enum EthFilterError {
 impl From<EthFilterError> for jsonrpsee::types::error::ErrorObject<'static> {
     fn from(err: EthFilterError) -> Self {
         match err {
+            // geth and Nethermind answer -32000 for unknown filter ids
             EthFilterError::FilterNotFound(_) => rpc_error_with_code(
-                jsonrpsee::types::error::INVALID_PARAMS_CODE,
+                jsonrpsee::types::error::CALL_EXECUTION_FAILED_CODE,
                 "filter not found",
             ),
             err @ EthFilterError::InternalError => {


### PR DESCRIPTION
`eth_getFilterChanges` and `eth_getFilterLogs` returned -32602 (invalid params) for an unknown filter id, while geth and Nethermind answer -32000 for `eth_getFilterChanges` with an unknown id. This maps `EthFilterError::FilterNotFound` to -32000 so clients keying on the error code get the same answer from reth. The message stays "filter not found" and `eth_uninstallFilter` still returns `false`.