### PR TITLE
feat(cli): add --authrpc.jwtsecret-hex

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -545,8 +545,21 @@ pub struct RpcServerArgs {
     /// If no path is provided, a secret will be generated and stored in the datadir under
     /// `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex`
     /// by default.
-    #[arg(long = "authrpc.jwtsecret", value_name = "PATH", global = true, required = false, default_value = Resettable::from(DefaultRpcServerArgs::get_global().auth_jwtsecret.as_ref().map(|v| v.to_string_lossy().into())))]
+    #[arg(long = "authrpc.jwtsecret", value_name = "PATH", global = true, required = false, conflicts_with = "auth_jwtsecret_hex", default_value = Resettable::from(DefaultRpcServerArgs::get_global().auth_jwtsecret.as_ref().map(|v| v.to_string_lossy().into())))]
     pub auth_jwtsecret: Option<PathBuf>,
+
+    /// Hex encoded JWT secret to use for the authenticated engine-API RPC server.
+    ///
+    /// This will enforce JWT authentication for all requests coming from the consensus layer.
+    /// Cannot be used together with `--authrpc.jwtsecret`.
+    #[arg(
+        long = "authrpc.jwtsecret-hex",
+        value_name = "HEX",
+        global = true,
+        required = false,
+        conflicts_with = "auth_jwtsecret"
+    )]
+    pub auth_jwtsecret_hex: Option<JwtSecret>,
 
     /// Enable auth engine API over IPC
     #[arg(long, default_value_t = DefaultRpcServerArgs::get_global().auth_ipc)]
@@ -949,6 +962,7 @@ impl Default for RpcServerArgs {
             auth_addr,
             auth_port,
             auth_jwtsecret,
+            auth_jwtsecret_hex: None,
             auth_ipc,
             auth_ipc_path,
             disable_auth_server,
@@ -1172,6 +1186,7 @@ mod tests {
             auth_addr: "127.0.0.1".parse().unwrap(),
             auth_port: 8551,
             auth_jwtsecret: Some(std::path::PathBuf::from("/tmp/jwt.hex")),
+            auth_jwtsecret_hex: None,
             auth_ipc: false,
             auth_ipc_path: "engine.ipc".to_string(),
             disable_auth_server: false,
@@ -1315,5 +1330,42 @@ mod tests {
         .args;
 
         assert_eq!(parsed_args, args);
+    }
+
+    #[test]
+    fn parse_auth_jwtsecret_hex() {
+        let hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let args =
+            CommandParser::<RpcServerArgs>::parse_from(["reth", "--authrpc.jwtsecret-hex", hex])
+                .args;
+
+        let expected = JwtSecret::from_hex(hex).unwrap();
+        assert_eq!(args.auth_jwtsecret_hex, Some(expected));
+        assert_eq!(args.auth_jwtsecret, None);
+    }
+
+    #[test]
+    fn parse_auth_jwtsecret_hex_with_0x_prefix() {
+        let hex = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let args =
+            CommandParser::<RpcServerArgs>::parse_from(["reth", "--authrpc.jwtsecret-hex", hex])
+                .args;
+
+        let expected = JwtSecret::from_hex(hex).unwrap();
+        assert_eq!(args.auth_jwtsecret_hex, Some(expected));
+        assert_eq!(args.auth_jwtsecret, None);
+    }
+
+    #[test]
+    fn test_auth_jwtsecret_and_hex_are_mutually_exclusive() {
+        let result = CommandParser::<RpcServerArgs>::try_parse_from([
+            "reth",
+            "--authrpc.jwtsecret",
+            "/tmp/jwt.hex",
+            "--authrpc.jwtsecret-hex",
+            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        ]);
+
+        assert!(result.is_err());
     }
 }

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -75,7 +75,7 @@ pub trait RethRpcServerConfig {
     /// the filesystem. This file can then be used to provision the counterpart client.
     ///
     /// The `default_jwt_path` provided as an argument will be used as the default location for the
-    /// jwt secret in case the `auth_jwtsecret` argument is not provided.
+    /// jwt secret in case neither `--authrpc.jwtsecret` nor `--authrpc.jwtsecret-hex` is provided.
     fn auth_jwt_secret(&self, default_jwt_path: PathBuf) -> Result<JwtSecret, JwtError>;
 
     /// Returns the configured jwt secret key for the regular rpc servers, if any.
@@ -254,12 +254,17 @@ impl RethRpcServerConfig for RpcServerArgs {
     }
 
     fn auth_jwt_secret(&self, default_jwt_path: PathBuf) -> Result<JwtSecret, JwtError> {
-        match self.auth_jwtsecret.as_ref() {
-            Some(fpath) => {
-                debug!(target: "reth::cli", user_path=?fpath, "Reading JWT auth secret file");
-                JwtSecret::from_file(fpath)
+        if let Some(secret) = self.auth_jwtsecret_hex {
+            debug!(target: "reth::cli", "Using JWT auth secret from hex");
+            Ok(secret)
+        } else {
+            match self.auth_jwtsecret.as_ref() {
+                Some(fpath) => {
+                    debug!(target: "reth::cli", user_path=?fpath, "Reading JWT auth secret file");
+                    JwtSecret::from_file(fpath)
+                }
+                None => get_or_create_jwt_secret_from_path(&default_jwt_path),
             }
-            None => get_or_create_jwt_secret_from_path(&default_jwt_path),
         }
     }
 
@@ -273,6 +278,7 @@ mod tests {
     use clap::{Args, Parser};
     use reth_node_core::args::RpcServerArgs;
     use reth_rpc_eth_types::RPC_DEFAULT_GAS_CAP;
+    use reth_rpc_layer::JwtSecret;
     use reth_rpc_server_types::{constants, RethRpcModule, RpcModuleSelection};
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
@@ -425,5 +431,16 @@ mod tests {
         let config = args.eth_config().filter_config();
         assert_eq!(config.max_blocks_per_filter, Some(100));
         assert_eq!(config.max_logs_per_response, Some(200));
+    }
+
+    #[test]
+    fn test_auth_jwt_secret_from_hex() {
+        let hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let args =
+            CommandParser::<RpcServerArgs>::parse_from(["reth", "--authrpc.jwtsecret-hex", hex])
+                .args;
+
+        let secret = args.auth_jwt_secret(std::env::temp_dir().join("unused.jwt")).unwrap();
+        assert_eq!(secret, JwtSecret::from_hex(hex).unwrap());
     }
 }

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -407,6 +407,11 @@ RPC:
 
           If no path is provided, a secret will be generated and stored in the datadir under `<DIR>/<CHAIN_ID>/jwt.hex`. For mainnet this would be `~/.local/share/reth/mainnet/jwt.hex` by default.
 
+      --authrpc.jwtsecret-hex <HEX>
+          Hex encoded JWT secret to use for the authenticated engine-API RPC server.
+
+          This will enforce JWT authentication for all requests coming from the consensus layer. Cannot be used together with `--authrpc.jwtsecret`.
+
       --auth-ipc
           Enable auth engine API over IPC
 


### PR DESCRIPTION
Adds `--authrpc.jwtsecret-hex <HEX>` as an inline alternative to `--authrpc.jwtsecret <PATH>`, matching `--p2p-secret-key-hex`.

The two flags are mutually exclusive. If neither is set, the JWT is still generated or loaded from the datadir.

## Test plan
- [x] Parse hex with and without `0x`
- [x] Reject using both `--authrpc.jwtsecret` and `--authrpc.jwtsecret-hex`
- [x] `auth_jwt_secret()` uses the hex value when provided
- [ ] `reth node --help` shows the new flag