### PR TITLE
perf(trie): reuse ready ancestor overlays

### DIFF
--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -470,9 +470,6 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
         span.record("cache_reused", false);
 
-        // Resolve the block path and any cached parent overlay before locking the child entry.
-        let mut blocks = Self::blocks_from_parent_state(parent_state, anchor_hash)?;
-        span.record("block_count", blocks.len());
         enum CacheAction<T> {
             Ready(Arc<T>),
             Wait(Arc<OverlayWaiter<T>>),
@@ -502,21 +499,14 @@ impl<N: NodePrimitives> OverlayManager<N> {
             CacheAction::Ready(input) => Ok(Some(input)),
             CacheAction::Wait(waiter) => Ok(Some(waiter.wait())),
             CacheAction::Compute(waiter) => {
-                let parent_input = blocks.first().and_then(|block| {
-                    let parent_hash = block.recovered_block().parent_hash();
-                    (parent_hash != anchor_hash)
-                        .then(|| {
-                            cache
-                                .take_ready(&OverlayCacheKey { anchor_hash, tip_hash: parent_hash })
-                        })
-                        .flatten()
-                });
+                let (blocks, parent_input) =
+                    Self::blocks_from_parent_state(parent_state, anchor_hash, cache)?;
+                span.record("block_count", blocks.len());
                 span.record("parent_overlay_reused", parent_input.is_some());
                 let compute_input = match parent_input {
-                    Some(parent_input) => ComputeOverlayInput::ExtendCached {
-                        block: blocks.swap_remove(0),
-                        parent_input,
-                    },
+                    Some(parent_input) => {
+                        ComputeOverlayInput::ExtendCached { blocks, parent_input }
+                    }
                     None => ComputeOverlayInput::MergeBlocks(blocks),
                 };
                 let input = Arc::new(compute(compute_input, span));
@@ -539,10 +529,11 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
     }
 
-    fn blocks_from_parent_state(
+    fn blocks_from_parent_state<T>(
         parent_state: &BlockState<N>,
         anchor_hash: B256,
-    ) -> Result<Vec<ExecutedBlock<N>>, StateTrieOverlayError> {
+        cache: &OverlayCache<T>,
+    ) -> Result<BlocksAndParentOverlay<N, T>, StateTrieOverlayError> {
         let tip_hash = parent_state.hash();
         let mut hash = tip_hash;
         let mut blocks = Vec::new();
@@ -554,7 +545,12 @@ impl<N: NodePrimitives> OverlayManager<N> {
             hash = block.recovered_block().parent_hash();
             blocks.push(block);
             if hash == anchor_hash {
-                return Ok(blocks)
+                return Ok((blocks, None))
+            }
+            if let Some(parent_input) =
+                cache.take_ready(&OverlayCacheKey { anchor_hash, tip_hash: hash })
+            {
+                return Ok((blocks, Some(parent_input)))
             }
         }
         Err(StateTrieOverlayError { tip_hash, anchor_hash })
@@ -728,9 +724,11 @@ impl<T> OverlayWaiter<T> {
 }
 
 enum ComputeOverlayInput<N: NodePrimitives, T> {
-    ExtendCached { block: ExecutedBlock<N>, parent_input: Arc<T> },
+    ExtendCached { blocks: Vec<ExecutedBlock<N>>, parent_input: Arc<T> },
     MergeBlocks(Vec<ExecutedBlock<N>>),
 }
+
+type BlocksAndParentOverlay<N, T> = (Vec<ExecutedBlock<N>>, Option<Arc<T>>);
 
 #[tracing::instrument(
     level = "trace",
@@ -750,7 +748,7 @@ fn compute_overlay<N: NodePrimitives>(
 ) -> TrieInputSorted {
     let started_at = Instant::now();
     let block_count = match &input {
-        ComputeOverlayInput::ExtendCached { .. } => 1,
+        ComputeOverlayInput::ExtendCached { blocks, .. } |
         ComputeOverlayInput::MergeBlocks(blocks) => blocks.len(),
     };
     let parent_overlay = matches!(&input, ComputeOverlayInput::ExtendCached { .. });
@@ -758,22 +756,22 @@ fn compute_overlay<N: NodePrimitives>(
     tracing::Span::current().record("parent_overlay", parent_overlay);
 
     let overlay = match input {
-        ComputeOverlayInput::ExtendCached { block, parent_input } => {
-            let trie_data = block.trie_data();
-
+        ComputeOverlayInput::ExtendCached { blocks, parent_input } => {
+            let head = blocks
+                .first()
+                .expect("cached parent requires a child block")
+                .recovered_block()
+                .hash();
             trace!(
                 target: "storage::overlay::manager",
                 %anchor_hash,
-                head = %block.recovered_block().hash(),
+                %head,
                 "extending cached parent state trie overlay"
             );
 
             let mut parent_input = parent_input;
-            extend_overlay(
-                Arc::make_mut(&mut parent_input),
-                &trie_data.sorted.hashed_state,
-                &trie_data.sorted.trie_updates,
-            );
+            let extension = merge_blocks(blocks);
+            extend_overlay(Arc::make_mut(&mut parent_input), &extension.state, &extension.nodes);
             Arc::try_unwrap(parent_input).expect("Arc::make_mut leaves the child overlay unique")
         }
         ComputeOverlayInput::MergeBlocks(blocks) => merge_blocks(blocks),
@@ -863,7 +861,7 @@ fn compute_execution_overlay_inner<N: NodePrimitives>(
 ) -> ExecutionOverlay {
     let started_at = Instant::now();
     let block_count = match &input {
-        ComputeOverlayInput::ExtendCached { .. } => 1,
+        ComputeOverlayInput::ExtendCached { blocks, .. } |
         ComputeOverlayInput::MergeBlocks(blocks) => blocks.len(),
     };
     let parent_overlay = matches!(&input, ComputeOverlayInput::ExtendCached { .. });
@@ -871,9 +869,12 @@ fn compute_execution_overlay_inner<N: NodePrimitives>(
     tracing::Span::current().record("parent_overlay", parent_overlay);
 
     let overlay = match input {
-        ComputeOverlayInput::ExtendCached { block, parent_input } => {
+        ComputeOverlayInput::ExtendCached { blocks, parent_input } => {
             let mut parent_input = parent_input;
-            Arc::make_mut(&mut parent_input).extend_block(&block);
+            let overlay = Arc::make_mut(&mut parent_input);
+            for block in blocks.iter().rev() {
+                overlay.extend_block(block);
+            }
             Arc::try_unwrap(parent_input).expect("Arc::make_mut leaves the child overlay unique")
         }
         ComputeOverlayInput::MergeBlocks(blocks) => {
@@ -961,8 +962,12 @@ mod tests {
     }
 
     fn test_blocks() -> Vec<ExecutedBlock<EthPrimitives>> {
+        test_blocks_with_count(3)
+    }
+
+    fn test_blocks_with_count(count: u64) -> Vec<ExecutedBlock<EthPrimitives>> {
         TestBlockBuilder::eth()
-            .get_executed_blocks(1..4)
+            .get_executed_blocks(1..count + 1)
             .enumerate()
             .map(|(index, block)| with_unique_state(&block, index as u8 + 1))
             .collect()
@@ -1148,6 +1153,72 @@ mod tests {
             .values()
             .flatten()
             .all(|account| account.account_id.is_none()));
+    }
+
+    #[test]
+    fn reuses_nearest_ready_ancestor_overlay() {
+        let manager = OverlayManager::default();
+        let blocks = test_blocks();
+        for block in &blocks {
+            manager.insert_block(block.clone());
+        }
+
+        let anchor_hash = blocks[0].recovered_block().parent_hash();
+        let ancestor_hash = blocks[0].recovered_block().hash();
+        let child_hash = blocks[2].recovered_block().hash();
+        let ancestor_key = OverlayCacheKey { anchor_hash, tip_hash: ancestor_hash };
+
+        overlay_for_parent(&manager, ancestor_hash, anchor_hash).unwrap();
+        manager.execution_overlay_for_parent(ancestor_hash, anchor_hash).unwrap();
+
+        let (_, child_state) = overlay_for_parent(&manager, child_hash, anchor_hash).unwrap();
+        let child_execution =
+            manager.execution_overlay_for_parent(child_hash, anchor_hash).unwrap();
+
+        assert!(!manager.state_trie_overlays.entries.contains_key(&ancestor_key));
+        assert!(!manager.execution_overlays.entries.contains_key(&ancestor_key));
+        assert_eq!(child_state.accounts.len(), 3);
+        assert_eq!(child_execution.accounts().len(), 3);
+    }
+
+    #[test]
+    #[ignore = "manual performance benchmark"]
+    fn benchmark_parent_overlay_reuse() {
+        const DEPTH: u64 = 128;
+        const ITERATIONS: usize = 20;
+
+        let manager = OverlayManager::default();
+        let blocks = test_blocks_with_count(DEPTH);
+        for block in &blocks {
+            manager.insert_block(block.clone());
+        }
+
+        let anchor_hash = blocks[0].recovered_block().parent_hash();
+        let tip_hash = blocks.last().unwrap().recovered_block().hash();
+        let parent_hash = blocks[blocks.len() - 2].recovered_block().hash();
+
+        let mut uncached = Duration::ZERO;
+        for _ in 0..ITERATIONS {
+            manager.state_trie_overlays.entries.clear();
+            let start = Instant::now();
+            std::hint::black_box(overlay_for_parent(&manager, tip_hash, anchor_hash).unwrap());
+            uncached += start.elapsed();
+        }
+
+        let mut parent_ready = Duration::ZERO;
+        for _ in 0..ITERATIONS {
+            manager.state_trie_overlays.entries.clear();
+            overlay_for_parent(&manager, parent_hash, anchor_hash).unwrap();
+            let start = Instant::now();
+            std::hint::black_box(overlay_for_parent(&manager, tip_hash, anchor_hash).unwrap());
+            parent_ready += start.elapsed();
+        }
+
+        eprintln!(
+            "depth={DEPTH}, iterations={ITERATIONS}, uncached_avg={:?}, parent_ready_avg={:?}",
+            uncached / ITERATIONS as u32,
+            parent_ready / ITERATIONS as u32,
+        );
     }
 
     #[cfg(feature = "rayon")]


### PR DESCRIPTION
Avoid walking and cloning the full ancestor path before checking for a reusable overlay.

On an exact cache miss, look up ready overlays while walking toward the anchor, then extend the nearest ready ancestor with only the remaining suffix. Reusing an overlay transfers its cache entry to the child, so this does not increase cache residency.

Release-mode microbenchmark, 128-block in-memory chain (20 iterations, warmed):

- Full-path rebuild: 34.9–37.2 µs/request
- Reuse ready direct parent: 9.8–10.5 µs/request
- Targeted overlay-build reduction: ~71–74%

This benchmark isolates overlay construction; end-to-end production benefit depends on retained-chain depth and overlay-cache hit rate.