### PR TITLE
chore(ci): cache test dependency artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,8 @@ jobs:
           tool: nextest
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          cache-targets: false
+          prefix-key: v1-rust-e2e-targets
+          cache-bin: false
           cache-on-failure: true
       - name: Run e2e tests
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          cache-targets: false
+          prefix-key: v1-rust-integration-targets
+          cache-bin: false
           cache-on-failure: true
       - name: Run tests
         run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -45,7 +45,8 @@ jobs:
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          cache-targets: false
+          prefix-key: v1-rust-unit-targets
+          cache-bin: false
           cache-on-failure: true
       - uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
         with:


### PR DESCRIPTION
Cache dependency artifacts for unit, integration, and e2e tests under separate keys, preserving all commands, filters, features, and runner sizes. Whole-job durations fell from recent medians of 507/544/466s to [430](https://github.com/paradigmxyz/reth/actions/runs/34040102281/attempts/2)/[458](https://github.com/paradigmxyz/reth/actions/runs/34040102235/attempts/2)/[393s](https://github.com/paradigmxyz/reth/actions/runs/34040102262/attempts/2) with warm caches, about 15–16% each and four runner-minutes combined; those figures include 17–21s restores.

Initial cold population took 548/595/525s, including 35–52s cache saves, so cache misses pay an upfront cost; archives are approximately 1.6–1.8GB each. Authored with Codex.
