### PR TITLE
test(e2e): await payload builds instead of sleeping

### DIFF
--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -343,7 +343,10 @@ where
         let url = self.rpc_url();
         let beacon_handle = self.inner.add_ons_handle.beacon_engine_handle.clone();
 
-        Ok(crate::testsuite::NodeClient::new_with_beacon_engine(rpc, auth, url, beacon_handle))
+        let mut client =
+            crate::testsuite::NodeClient::new_with_beacon_engine(rpc, auth, url, beacon_handle);
+        client.payload_builder = Some(self.inner.payload_builder_handle.clone());
+        Ok(client)
     }
 
     /// Calls the `testing_buildBlockV1` RPC on this node.

--- a/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
+++ b/crates/e2e-test-utils/src/testsuite/actions/produce_blocks.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_eth::{Block, Header, Receipt, Transaction, TransactionReques
 use eyre::Result;
 use futures_util::future::BoxFuture;
 use reth_ethereum_primitives::TransactionSigned;
-use reth_node_api::{EngineTypes, PayloadTypes};
+use reth_node_api::{EngineTypes, PayloadKind, PayloadTypes};
 use reth_rpc_api::clients::{EngineApiClient, EthApiClient};
 use std::{collections::HashSet, marker::PhantomData, time::Duration};
 use tokio::time::sleep;
@@ -330,7 +330,18 @@ where
 
             env.active_node_state_mut()?.next_payload_id = Some(payload_id);
 
-            sleep(Duration::from_secs(1)).await;
+            if let Some(builder) = &env.node_clients[producer_idx].payload_builder {
+                // Wait for the pending build rather than racing it with an empty fallback payload.
+                tokio::time::timeout(
+                    Duration::from_secs(30),
+                    builder.resolve_kind(payload_id, PayloadKind::WaitForPending),
+                )
+                .await?
+                .ok_or_else(|| eyre::eyre!("Unknown payload {payload_id}"))??;
+            } else {
+                // RPC-only clients do not expose the local payload builder.
+                sleep(Duration::from_secs(1)).await;
+            }
 
             let built_payload_envelope = EngineApiClient::<Engine>::get_payload_v3(
                 &env.node_clients[producer_idx].engine.http_client(),

--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -8,7 +8,7 @@ use alloy_primitives::B256;
 use eyre::Result;
 use jsonrpsee::http_client::HttpClient;
 use reth_node_api::{EngineTypes, PayloadTypes};
-use reth_payload_builder::PayloadId;
+use reth_payload_builder::{PayloadBuilderHandle, PayloadId};
 use std::{collections::HashMap, marker::PhantomData};
 pub mod actions;
 pub mod setup;
@@ -32,6 +32,8 @@ where
     pub engine: AuthServerHandle,
     /// Beacon consensus engine handle for direct interaction with the consensus engine
     pub beacon_engine_handle: Option<ConsensusEngineHandle<Payload>>,
+    /// Local payload builder used to wait for an in-progress build before requesting it over RPC.
+    pub(crate) payload_builder: Option<PayloadBuilderHandle<Payload>>,
     /// Alloy provider for interacting with the node
     provider: Arc<dyn Provider + Send + Sync>,
 }
@@ -44,7 +46,7 @@ where
     pub fn new(rpc: HttpClient, engine: AuthServerHandle, url: Url) -> Self {
         let provider =
             Arc::new(ProviderBuilder::new().connect_http(url)) as Arc<dyn Provider + Send + Sync>;
-        Self { rpc, engine, beacon_engine_handle: None, provider }
+        Self { rpc, engine, beacon_engine_handle: None, payload_builder: None, provider }
     }
 
     /// Instantiates a new [`NodeClient`] with the given handles, RPC URL, and beacon engine handle
@@ -56,7 +58,13 @@ where
     ) -> Self {
         let provider =
             Arc::new(ProviderBuilder::new().connect_http(url)) as Arc<dyn Provider + Send + Sync>;
-        Self { rpc, engine, beacon_engine_handle: Some(beacon_engine_handle), provider }
+        Self {
+            rpc,
+            engine,
+            beacon_engine_handle: Some(beacon_engine_handle),
+            payload_builder: None,
+            provider,
+        }
     }
 
     /// Get a block by number using the alloy provider

--- a/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
+++ b/crates/e2e-test-utils/tests/e2e-testsuite/main.rs
@@ -192,7 +192,8 @@ async fn test_testsuite_produce_blocks() -> Result<()> {
     let test = TestBuilder::new()
         .with_setup(setup)
         .with_action(ProduceBlocks::<EthEngineTypes>::new(5))
-        .with_action(MakeCanonical::new());
+        .with_action(MakeCanonical::new())
+        .with_action(AssertChainTip::new(5));
 
     test.run::<EthereumNode>().await?;
 


### PR DESCRIPTION
Wait for the local pending payload build before fetching it over the Engine API, replacing the unconditional one-second-per-block sleep while preserving the delay for RPC-only clients. Using WaitForPending avoids racing the build with an empty fallback, and the block-production case now also asserts the final chain height.

The same 24 e2e tests took 18.6s on the repeat and [18.9s](https://github.com/paradigmxyz/reth/actions/runs/34040317018/job/101505757877) versus [81.7s on main](https://github.com/paradigmxyz/reth/actions/runs/34032239719/job/101483775890), with no retries on either run; the 43-block live-sync case fell from 49.5s to 6.4s.

Authored with Codex.
