### PR TITLE
chore(ci): cancel superseded PR lint runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
 
+# Supersede PR runs without cancelling independent main or merge-queue runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Cancel superseded PR lint runs, matching the test workflows; key by PR number to keep fork branches distinct and by run ID elsewhere to preserve independent main and merge-queue runs. Two recent obsolete runs continued for over seven minutes, spending [23](https://github.com/paradigmxyz/reth/actions/runs/33977836414) and [28](https://github.com/paradigmxyz/reth/actions/runs/33970210087) runner-minutes after newer commits started, and a new commit on this PR correctly [cancelled its predecessor](https://github.com/paradigmxyz/reth/actions/runs/34040432703).

Authored with Codex.
