### PR TITLE
chore(ci): build only e2e test targets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
           cargo nextest run \
             --no-fail-fast \
             --locked --features "asm-keccak" \
-            --workspace \
+            --workspace --test e2e_testsuite \
             --exclude 'example-*' \
             --exclude 'exex-subscription' \
             --exclude 'ef-tests' \


### PR DESCRIPTION
Compile only the `e2e_testsuite` Cargo targets instead of building unrelated workspace test binaries before filtering execution. Package exclusions, features, runner size, and the existing nextest filter remain unchanged, and the candidate ran the identical set of 24 tests.

Compilation fell from 5m55s on main (6m00s in the contemporary control) to 3m16s. The complete job took [5m08s](https://github.com/paradigmxyz/reth/actions/runs/34040945456/job/101507470872), versus a 7m46s median across three recent runs: approximately 34% faster in this measurement. The candidate included one successful retry of `test_apply_with_import` after an unexpected FCU `Syncing` response; suite execution remained about 84s. Authored with Codex.
