### PR TITLE
test: skip wall-clock waits in peer tick test

### DIFF
--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -2903,8 +2903,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_tick() {
+    #[tokio::test]
+    async fn test_tick() {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
         let config = PeersConfig::test();
@@ -2913,7 +2913,6 @@ mod tests {
         peer_manager.add_peer(peer_id, PeerAddr::from_tcp(socket_addr), None);
 
         // Age the last tick directly so each reputation update sees a full elapsed second.
-
         peer_manager.last_tick -= Duration::from_secs(1);
         peer_manager.tick();
 

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -2903,8 +2903,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_tick() {
+    #[test]
+    fn test_tick() {
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2));
         let socket_addr = SocketAddr::new(ip, 8008);
         let config = PeersConfig::test();
@@ -2912,7 +2912,9 @@ mod tests {
         let peer_id = PeerId::random();
         peer_manager.add_peer(peer_id, PeerAddr::from_tcp(socket_addr), None);
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        // Age the last tick directly so each reputation update sees a full elapsed second.
+
+        peer_manager.last_tick -= Duration::from_secs(1);
         peer_manager.tick();
 
         // still unconnected
@@ -2921,7 +2923,7 @@ mod tests {
         // mark as connected
         peer_manager.peers.get_mut(&peer_id).unwrap().state = PeerConnectionState::Out;
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        peer_manager.last_tick -= Duration::from_secs(1);
         peer_manager.tick();
 
         // still at default reputation
@@ -2929,7 +2931,7 @@ mod tests {
 
         peer_manager.peers.get_mut(&peer_id).unwrap().reputation -= 1;
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        peer_manager.last_tick -= Duration::from_secs(1);
         peer_manager.tick();
 
         // tick applied


### PR DESCRIPTION
Age the peer manager's last tick directly instead of sleeping for three real seconds, preserving the Tokio runtime, all three reputation assertions, and the elapsed-time calculation. The test fell from 3.013s on main and a contemporary control to [0.007s in CI](https://github.com/paradigmxyz/reth/actions/runs/34051065377/job/101534731154); all 3,251 unit tests passed without retries. Authored with Codex.
