### PR TITLE
test: index legacy proof reference nodes

### DIFF
--- a/crates/trie/trie/src/proof_v2/mod.rs
+++ b/crates/trie/trie/src/proof_v2/mod.rs
@@ -2094,10 +2094,23 @@ mod tests {
         legacy_nodes: &[ProofTrieNodeV2],
         targets: &[ProofV2Target],
     ) -> Vec<ProofTrieNodeV2> {
+        let max_path_len =
+            legacy_nodes.iter().map(|node| node.path.len()).max().unwrap_or_default();
+        let mut nodes_by_path = BTreeMap::new();
+        for node in legacy_nodes {
+            assert!(nodes_by_path.insert(node.path, node).is_none(), "duplicate legacy node path");
+        }
+
+        // Only ancestors of a target can contribute to its projection, including nodes whose
+        // compressed key crosses the requested parent boundary.
         let mut projected = targets
             .iter()
             .flat_map(|target| {
-                legacy_nodes.iter().filter_map(move |node| project_legacy_proof_node(node, target))
+                let nodes_by_path = &nodes_by_path;
+                (0..=max_path_len.min(target.key_nibbles.len())).filter_map(move |len| {
+                    let node = nodes_by_path.get(&target.key_nibbles.slice(..len))?;
+                    project_legacy_proof_node(node, target)
+                })
             })
             .collect::<Vec<_>>();
         projected.sort_unstable_by(|a, b| depth_first::cmp(&a.path, &b.path));
@@ -2602,6 +2615,31 @@ mod tests {
         assert_eq!(root_proof.len(), 1);
         assert!(matches!(root_proof[0].node, TrieNodeV2::EmptyRoot));
         assert_eq!(root, Some(EMPTY_ROOT_HASH));
+    }
+
+    #[test]
+    fn test_indexed_legacy_projection_matches_full_scan() {
+        let slots = [
+            B256::right_padding_from(&[0xae, 0xd4, 0x00]),
+            B256::right_padding_from(&[0xae, 0xd4, 0x10]),
+            B256::right_padding_from(&[0xf0]),
+        ];
+        let harness = ProofTestHarness::new(slots.map(|key| (key, U256::from(1))).into());
+        let (nodes, _) = harness.proof_v2(&mut slots.map(ProofV2Target::new));
+
+        for key in slots.into_iter().chain([B256::ZERO, B256::repeat_byte(0xae)]) {
+            for parent in std::iter::once(ProofV2TargetParent::NONE)
+                .chain((0..64).map(ProofV2TargetParent::new))
+            {
+                let target = ProofV2Target::new(key).with_parent(parent);
+                let mut expected = nodes
+                    .iter()
+                    .filter_map(|node| project_legacy_proof_node(node, &target))
+                    .collect::<Vec<_>>();
+                expected.sort_unstable_by(|a, b| depth_first::cmp(&a.path, &b.path));
+                assert_eq!(project_legacy_proof(&nodes, &[target]), expected);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Index legacy proof nodes by path so the test reference checker visits only ancestors of each target, preserving the projection and equality checks, the full 10,240-key fixture, and all 4,000 property cases. An added test compares indexed lookup with a full scan across present/absent keys and every parent depth.

`test_big_trie` fell from 14.837s on main to [8.281s in CI](https://github.com/paradigmxyz/reth/actions/runs/34050902571/job/101534221991), about 44% faster; the property test stayed essentially unchanged at 6.765s versus 6.816s. Serial local measurements also improved from 12.573s to 8.041s / 8.217s. All 3,252 unit tests passed, with one retry in an unrelated engine persistence test. Authored with Codex.
