### PR TITLE
test: signal background metrics hook completion

### DIFF
--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -494,7 +494,10 @@ mod tests {
     use socket2::{Domain, Socket, Type};
     use std::{
         net::{SocketAddr, TcpListener},
-        sync::atomic::{AtomicUsize, Ordering},
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            mpsc, Mutex,
+        },
     };
 
     fn get_random_available_addr() -> SocketAddr {
@@ -569,14 +572,22 @@ mod tests {
         install_prometheus_recorder();
 
         let collections = Arc::new(AtomicUsize::new(0));
+        let (release, wait_for_release) = mpsc::channel();
+        let wait_for_release = Mutex::new(wait_for_release);
+        let completed = Arc::new(tokio::sync::Notify::new());
         let hooks = Hooks::builder()
             .with_background_interval(Duration::from_secs(60))
             .with_background_hook({
                 let collections = collections.clone();
+                let completed = completed.clone();
                 move || {
-                    std::thread::sleep(Duration::from_secs(2));
+                    // Dropping the sender also unblocks the hook if a scrape assertion fails.
+                    if wait_for_release.lock().unwrap().recv().is_err() {
+                        return
+                    }
                     let collections = collections.fetch_add(1, Ordering::Relaxed) + 1;
                     metrics::gauge!("test_background_hook_collections").set(collections as f64);
+                    completed.notify_one();
                 }
             })
             .build();
@@ -611,9 +622,8 @@ mod tests {
         assert_eq!(collections.load(Ordering::Relaxed), 0);
 
         // once it completes, its values are rendered by the following scrape
-        while collections.load(Ordering::Relaxed) == 0 {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        release.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(10), completed.notified()).await.unwrap();
         let body = Client::new().get(&url).send().await.unwrap().text().await.unwrap();
         assert!(
             body.contains("test_background_hook_collections"),

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -573,7 +573,7 @@ mod tests {
 
         let collections = Arc::new(AtomicUsize::new(0));
         let (release, wait_for_release) = mpsc::channel();
-        let wait_for_release = Mutex::new(wait_for_release);
+        let wait_for_release = Mutex::new(Some(wait_for_release));
         let completed = Arc::new(tokio::sync::Notify::new());
         let hooks = Hooks::builder()
             .with_background_interval(Duration::from_secs(60))
@@ -582,7 +582,9 @@ mod tests {
                 let completed = completed.clone();
                 move || {
                     // Dropping the sender also unblocks the hook if a scrape assertion fails.
-                    if wait_for_release.lock().unwrap().recv().is_err() {
+                    if let Some(wait_for_release) = wait_for_release.lock().unwrap().take() &&
+                        wait_for_release.recv().is_err()
+                    {
                         return
                     }
                     let collections = collections.fetch_add(1, Ordering::Relaxed) + 1;


### PR DESCRIPTION
Hold the first background metrics hook until its scrape returns, then release it explicitly and await notification after publishing the gauge. Preserve the nonblocking-scrape, metric-output, and collection-count assertions; dropping the sender unblocks the hook on assertion failure, and later invocations remain observable.

The test fell from 2.047s on main (2.050s in the contemporary control) to [0.042s in CI](https://github.com/paradigmxyz/reth/actions/runs/34051104031/job/101534824295), removing the two-second sleep and polling loop. All 3,251 unit tests passed without retries. Authored with Codex.
