### PR TITLE
feat(download): allow retry delay overrides

### DIFF
--- a/bin/reth/tests/it/download/mod.rs
+++ b/bin/reth/tests/it/download/mod.rs
@@ -205,9 +205,20 @@ async fn bad_output_checksum_prevents_finalization() {
         json!(blake3::hash(b"wrong").to_hex().to_string());
     let server = snapshot.serve(true).await;
     let dir = tempfile::tempdir().unwrap();
-    let output = download(&server, dir.path(), &["--with-txs-since", "20"]);
+    let output =
+        download(&server, dir.path(), &["--with-txs-since", "20", "--retry-backoff", "0ms"]);
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("Failed integrity validation"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("after 10 attempts"));
+    assert_eq!(
+        server
+            .requests()
+            .iter()
+            .filter(|(path, range)| { path == "/snapshot/state.tar.zst" && range.is_none() })
+            .count(),
+        10,
+        "each checksum failure must fetch a fresh archive"
+    );
     assert!(!dir.path().join("reth.toml").exists());
     assert!(!dir.path().join("db/mdbx.dat").exists());
 }

--- a/crates/cli/commands/src/download/archive.rs
+++ b/crates/cli/commands/src/download/archive.rs
@@ -31,6 +31,7 @@ pub(crate) async fn run_modular_downloads(
     target_dir: &Path,
     download_concurrency: usize,
     cancel_token: CancellationToken,
+    retry_backoff: Option<Duration>,
 ) -> Result<()> {
     let download_cache_dir = target_dir.join(DOWNLOAD_CACHE_DIR);
     fs::create_dir_all(&download_cache_dir)?;
@@ -45,7 +46,8 @@ pub(crate) async fn run_modular_downloads(
         Some(Arc::clone(&shared)),
         Some(DownloadRequestLimiter::new(download_concurrency)),
         cancel_token,
-    );
+    )
+    .with_retry_backoff(retry_backoff);
     let ctx =
         ArchiveProcessContext::new(target_dir.to_path_buf(), Some(download_cache_dir), session);
 
@@ -185,7 +187,9 @@ impl ArchiveProcessor {
                     if attempt >= MAX_DOWNLOAD_RETRIES {
                         state = ArchiveAttemptState::Fail;
                     } else {
-                        std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));
+                        std::thread::sleep(
+                            self.ctx.session().retry_delay(Duration::from_secs(RETRY_BACKOFF_SECS)),
+                        );
                         attempt += 1;
                         state = ArchiveAttemptState::RunAttempt;
                     }

--- a/crates/cli/commands/src/download/extract.rs
+++ b/crates/cli/commands/src/download/extract.rs
@@ -300,7 +300,9 @@ pub(crate) fn streaming_download_and_extract(
                 }
                 last_error = Some(err);
                 if attempt < MAX_DOWNLOAD_RETRIES {
-                    std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));
+                    std::thread::sleep(
+                        session.retry_delay(Duration::from_secs(RETRY_BACKOFF_SECS)),
+                    );
                 }
                 continue;
             }
@@ -342,7 +344,9 @@ pub(crate) fn streaming_download_and_extract(
                 }
                 last_error = Some(error);
                 if attempt < MAX_DOWNLOAD_RETRIES {
-                    std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));
+                    std::thread::sleep(
+                        session.retry_delay(Duration::from_secs(RETRY_BACKOFF_SECS)),
+                    );
                 }
             }
         }
@@ -417,13 +421,15 @@ fn blocking_download_and_extract(
     resumable: bool,
     request_limiter: Option<Arc<DownloadRequestLimiter>>,
     cancel_token: CancellationToken,
+    retry_backoff: Option<Duration>,
 ) -> Result<()> {
     let format = CompressionFormat::from_url(url)?;
 
     if let Ok(parsed_url) = Url::parse(url) &&
         parsed_url.scheme() == "file"
     {
-        let session = DownloadSession::new(shared, request_limiter, cancel_token);
+        let session = DownloadSession::new(shared, request_limiter, cancel_token)
+            .with_retry_backoff(retry_backoff);
         let file_path = parsed_url
             .to_file_path()
             .map_err(|_| eyre::eyre!("Invalid file:// URL path: {}", url))?;
@@ -437,14 +443,17 @@ fn blocking_download_and_extract(
             url,
             format,
             target_dir,
-            DownloadSession::new(shared, Some(request_limiter), cancel_token),
+            DownloadSession::new(shared, Some(request_limiter), cancel_token)
+                .with_retry_backoff(retry_backoff),
         )
     } else if resumable {
         let session =
-            DownloadSession::new(shared, Some(DownloadRequestLimiter::new(1)), cancel_token);
+            DownloadSession::new(shared, Some(DownloadRequestLimiter::new(1)), cancel_token)
+                .with_retry_backoff(retry_backoff);
         download_and_extract(url, format, target_dir, session)
     } else {
-        let session = DownloadSession::new(shared, None, cancel_token);
+        let session =
+            DownloadSession::new(shared, None, cancel_token).with_retry_backoff(retry_backoff);
         let result = streaming_download_and_extract(url, format, target_dir, &session);
         if result.is_ok() {
             session.record_archive_output_complete(0);
@@ -465,6 +474,7 @@ pub(crate) async fn stream_and_extract(
     resumable: bool,
     request_limiter: Option<Arc<DownloadRequestLimiter>>,
     cancel_token: CancellationToken,
+    retry_backoff: Option<Duration>,
 ) -> Result<()> {
     let target_dir = target_dir.to_path_buf();
     let url = url.to_string();
@@ -476,6 +486,7 @@ pub(crate) async fn stream_and_extract(
             resumable,
             request_limiter,
             cancel_token,
+            retry_backoff,
         )
     })
     .await??;

--- a/crates/cli/commands/src/download/fetch.rs
+++ b/crates/cli/commands/src/download/fetch.rs
@@ -247,9 +247,12 @@ impl ArchiveFetcher {
                     if attempt < max_download_retries {
                         info!(target: "reth::cli",
                             file = %self.paths.file_name(),
-                            "Download failed, retrying in {RETRY_BACKOFF_SECS}s..."
+                            retry_delay = ?self.session.retry_delay(Duration::from_secs(RETRY_BACKOFF_SECS)),
+                            "Download failed, retrying"
                         );
-                        std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));
+                        std::thread::sleep(
+                            self.session.retry_delay(Duration::from_secs(RETRY_BACKOFF_SECS)),
+                        );
                     }
                     continue;
                 }
@@ -328,9 +331,12 @@ impl ArchiveFetcher {
                 if attempt < max_download_retries {
                     info!(target: "reth::cli",
                         file = %self.paths.file_name(),
-                        "Download interrupted, retrying in {RETRY_BACKOFF_SECS}s..."
+                        retry_delay = ?self.session.retry_delay(Duration::from_secs(RETRY_BACKOFF_SECS)),
+                        "Download interrupted, retrying"
                     );
-                    std::thread::sleep(Duration::from_secs(RETRY_BACKOFF_SECS));
+                    std::thread::sleep(
+                        self.session.retry_delay(Duration::from_secs(RETRY_BACKOFF_SECS)),
+                    );
                 }
                 continue;
             }
@@ -550,6 +556,8 @@ struct SegmentedWorkerContext<'a> {
     request_limiter: &'a DownloadRequestLimiter,
     /// Cancellation token shared by the whole command.
     cancel_token: &'a CancellationToken,
+    /// Session carrying the retry-delay override.
+    session: &'a DownloadSession,
 }
 
 impl SegmentedDownload {
@@ -588,6 +596,7 @@ impl SegmentedDownload {
         let worker_context = SegmentedWorkerContext {
             url,
             part_path: paths.part_path(),
+            session: &session,
             shared,
             request_limiter: request_limiter.as_ref(),
             cancel_token,
@@ -669,6 +678,7 @@ impl SegmentedDownload {
                 &piece_progress_bytes,
                 context.request_limiter,
                 context.cancel_token,
+                context.session,
             ) {
                 state.note_terminal_failure();
                 terminal_failure.record(error);
@@ -691,6 +701,7 @@ impl SegmentedDownload {
         piece_progress_bytes: &AtomicU64,
         request_limiter: &DownloadRequestLimiter,
         cancel_token: &CancellationToken,
+        session: &DownloadSession,
     ) -> Result<()> {
         for attempt in 1..=SEGMENT_RETRY_ATTEMPTS {
             if cancel_token.is_cancelled() {
@@ -711,7 +722,9 @@ impl SegmentedDownload {
                 Err(PieceAttemptFailure::Retryable { error: _, throttled })
                     if attempt < SEGMENT_RETRY_ATTEMPTS =>
                 {
-                    std::thread::sleep(piece_retry_backoff(attempt, throttled));
+                    std::thread::sleep(
+                        session.retry_delay(piece_retry_backoff(attempt, throttled)),
+                    );
                 }
                 Err(PieceAttemptFailure::Retryable { error, .. }) => return Err(error),
                 Err(PieceAttemptFailure::Terminal(error)) => return Err(error),

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -118,6 +118,7 @@ use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
     sync::{Arc, OnceLock},
+    time::Duration,
 };
 use tracing::info;
 use tui::{run_selector, SelectorOutput};
@@ -442,6 +443,14 @@ pub struct DownloadCommand<C: ChainSpecParser> {
     #[arg(long, default_value_t = MAX_CONCURRENT_DOWNLOADS)]
     download_concurrency: usize,
 
+    /// Override the delay between retry attempts (for example, 500ms or 5s).
+    ///
+    /// Applies to requests, extraction, output verification, and segmented downloads.
+    /// By default, retries wait five seconds; segmented requests use adaptive backoff.
+    /// This does not change the number of attempts.
+    #[arg(long, value_name = "DURATION", value_parser = reth_cli_util::parse_duration_from_secs_or_ms)]
+    retry_backoff: Option<Duration>,
+
     /// List available snapshots and exit.
     ///
     /// Queries the snapshots API and prints all available snapshots for the selected chain,
@@ -491,6 +500,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
                 self.resumable,
                 Some(request_limiter),
                 cancel_token.clone(),
+                self.retry_backoff,
             )
             .await?;
             info!(target: "reth::cli", "Snapshot downloaded and extracted successfully");
@@ -534,6 +544,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             target_dir,
             self.download_concurrency.max(1),
             cancel_token.clone(),
+            self.retry_backoff,
         )
         .await?;
 
@@ -1226,6 +1237,26 @@ mod tests {
         assert_eq!(defaults.default_base_url, "https://custom.example.com");
         assert_eq!(defaults.available_snapshots.len(), 4); // 2 defaults + 2 added
         assert_eq!(defaults.long_help, Some("Custom help for snapshots".to_string()));
+    }
+
+    #[test]
+    fn test_download_retry_backoff() {
+        let parse = |args: Vec<&str>| {
+            CommandParser::<DownloadCommand<EthereumChainSpecParser>>::try_parse_from(args)
+        };
+        assert_eq!(parse(vec!["reth"]).unwrap().args.retry_backoff, None);
+        for (value, expected) in [
+            ("0ms", Duration::ZERO),
+            ("250ms", Duration::from_millis(250)),
+            ("2s", Duration::from_secs(2)),
+        ] {
+            assert_eq!(
+                parse(vec!["reth", "--retry-backoff", value]).unwrap().args.retry_backoff,
+                Some(expected)
+            );
+        }
+        assert!(parse(vec!["reth", "--retry-backoff=-1s"]).is_err());
+        assert!(parse(vec!["reth", "--retry-backoff", "invalid"]).is_err());
     }
 
     #[test]

--- a/crates/cli/commands/src/download/session.rs
+++ b/crates/cli/commands/src/download/session.rs
@@ -4,6 +4,7 @@ use reth_cli_util::cancellation::CancellationToken;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
+    time::Duration,
 };
 
 /// Shared state for one run of `reth download`.
@@ -15,6 +16,8 @@ pub(crate) struct DownloadSession {
     request_limiter: Option<Arc<DownloadRequestLimiter>>,
     /// Cancellation token shared by the whole command.
     cancel_token: CancellationToken,
+    /// Optional fixed delay overriding the default retry backoff.
+    retry_backoff: Option<Duration>,
 }
 
 impl DownloadSession {
@@ -24,7 +27,18 @@ impl DownloadSession {
         request_limiter: Option<Arc<DownloadRequestLimiter>>,
         cancel_token: CancellationToken,
     ) -> Self {
-        Self { progress, request_limiter, cancel_token }
+        Self { progress, request_limiter, cancel_token, retry_backoff: None }
+    }
+
+    /// Overrides the delay between retry attempts for this download.
+    pub(crate) const fn with_retry_backoff(mut self, retry_backoff: Option<Duration>) -> Self {
+        self.retry_backoff = retry_backoff;
+        self
+    }
+
+    /// Returns the configured delay, preserving the caller's default when no override is set.
+    pub(crate) fn retry_delay(&self, default: Duration) -> Duration {
+        self.retry_backoff.unwrap_or(default)
     }
 
     /// Returns the shared progress tracker, if this flow uses one.
@@ -96,5 +110,24 @@ impl ArchiveProcessContext {
     /// Returns the shared download session.
     pub(crate) fn session(&self) -> &DownloadSession {
         &self.session
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_delay_preserves_defaults_or_uses_override() {
+        let session = DownloadSession::new(None, None, CancellationToken::new());
+        for default in [Duration::from_secs(2), Duration::from_secs(5), Duration::from_secs(40)] {
+            assert_eq!(session.retry_delay(default), default);
+            for delay in [Duration::ZERO, Duration::from_millis(250)] {
+                assert_eq!(
+                    session.clone().with_retry_backoff(Some(delay)).retry_delay(default),
+                    delay
+                );
+            }
+        }
     }
 }

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -223,6 +223,11 @@ Storage:
 
           [default: 8]
 
+      --retry-backoff <DURATION>
+          Override the delay between retry attempts (for example, 500ms or 5s).
+
+          Applies to requests, extraction, output verification, and segmented downloads. By default, retries wait five seconds; segmented requests use adaptive backoff. This does not change the number of attempts.
+
       --list
           List available snapshots and exit.
 


### PR DESCRIPTION
Add `reth download --retry-backoff <DURATION>` to override retry delays while preserving the existing defaults and attempt counts. The checksum-failure test uses zero delay and now explicitly checks ten fresh archive downloads and exhausted integrity validation, alongside the failed exit status and absent final database/configuration.

The test fell from 48.147s to [3.181s in CI](https://github.com/paradigmxyz/reth/actions/runs/34058764889/job/101555390074), about 93% faster; locally, the same assertions took 48.633s without the option and 3.685s / 3.634s with zero delay. The checksum mismatch is intentional, and no integrity check is bypassed. All 580 integration tests passed, with two unrelated tests retrying. Authored with Codex.
