### PR TITLE
fix(download): reject zero blocks_per_file in snapshot manifest

### DIFF
--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -268,6 +268,19 @@ impl SnapshotManifest {
         self.base_url.as_deref().unwrap_or("")
     }
 
+    /// Validates the internal consistency and required fields of the snapshot manifest.
+    pub fn validate(&self) -> Result<()> {
+        for (key, component) in &self.components {
+            if let ComponentManifest::Chunked(chunked) = component {
+                eyre::ensure!(
+                    chunked.blocks_per_file > 0,
+                    "Invalid modular manifest: component '{key}' has blocks_per_file = 0; must be greater than zero"
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Look up a component by type.
     pub fn component(&self, ty: SnapshotComponentType) -> Option<&ComponentManifest> {
         self.components.get(ty.key())
@@ -473,6 +486,9 @@ impl ComponentManifest {
 impl ChunkedArchive {
     /// Returns the number of chunks.
     pub fn num_chunks(&self) -> u64 {
+        if self.blocks_per_file == 0 {
+            return 0;
+        }
         self.total_blocks.div_ceil(self.blocks_per_file)
     }
 
@@ -480,7 +496,7 @@ impl ChunkedArchive {
     /// tip.
     pub fn tail_chunks_for_distance(&self, distance: u64) -> u64 {
         let needed = distance.min(self.total_blocks);
-        if needed == 0 {
+        if needed == 0 || self.blocks_per_file == 0 {
             return 0;
         }
 
@@ -505,7 +521,7 @@ impl ChunkedArchive {
             return path.clone();
         }
         let start = index * self.blocks_per_file;
-        let end = (index + 1) * self.blocks_per_file - 1;
+        let end = (index + 1).saturating_mul(self.blocks_per_file).saturating_sub(1);
         format!("{key}-{start}-{end}.tar.zst")
     }
 
@@ -1589,5 +1605,47 @@ mod tests {
             "mismatched chunk_files must not partially apply"
         );
         assert_eq!(urls[1], "https://example.com/mainnet/headers-500000-999999.tar.zst");
+    }
+
+    #[test]
+    fn manifest_rejects_zero_blocks_per_file() {
+        let manifest: SnapshotManifest = serde_json::from_value(serde_json::json!({
+            "block": 9,
+            "chain_id": 1,
+            "storage_version": 2,
+            "timestamp": 0,
+            "base_url": "http://127.0.0.1:9/",
+            "components": {
+                "headers": {
+                    "blocks_per_file": 0,
+                    "total_blocks": 10,
+                    "chunk_sizes": [10],
+                    "chunk_output_files": [[{
+                        "path": "static_files/static_file_headers_0_9",
+                        "size": 1,
+                        "blake3": "0".repeat(64)
+                    }]]
+                }
+            }
+        }))
+        .unwrap();
+
+        let err = manifest.validate().unwrap_err();
+        assert!(err.to_string().contains("blocks_per_file = 0"));
+    }
+
+    #[test]
+    fn chunked_archive_zero_blocks_per_file_does_not_panic() {
+        let chunked = ChunkedArchive {
+            blocks_per_file: 0,
+            total_blocks: 10,
+            chunk_sizes: vec![],
+            chunk_decompressed_sizes: vec![],
+            chunk_files: vec![],
+            chunk_output_files: vec![],
+        };
+        assert_eq!(chunked.num_chunks(), 0);
+        assert_eq!(chunked.tail_chunks_for_distance(5), 0);
+        assert_eq!(chunked.chunk_relative_path("headers", 0), "headers-0-0.tar.zst");
     }
 }

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -584,6 +584,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             "Snapshot chain ID {} does not match selected chain ID {chain_id}",
             manifest.chain_id
         );
+        manifest.validate()?;
         manifest.base_url = Some(resolve_manifest_base_url(&manifest, &manifest_source)?);
 
         info!(target: "reth::cli",

--- a/crates/cli/commands/src/download/planning.rs
+++ b/crates/cli/commands/src/download/planning.rs
@@ -205,15 +205,20 @@ pub(crate) fn collect_planned_archives(
             continue;
         };
 
-        if let Some(ComponentManifest::Chunked(chunked)) = manifest.component(*ty) &&
-            !chunked.chunk_files_are_consistent()
-        {
-            eyre::bail!(
-                "Invalid modular manifest: {} chunk_files length ({}) does not match chunk count ({})",
-                ty.key(),
-                chunked.chunk_files.len(),
-                chunked.num_chunks()
+        if let Some(ComponentManifest::Chunked(chunked)) = manifest.component(*ty) {
+            eyre::ensure!(
+                chunked.blocks_per_file > 0,
+                "Invalid modular manifest: component '{}' has blocks_per_file = 0; must be greater than zero",
+                ty.key()
             );
+            if !chunked.chunk_files_are_consistent() {
+                eyre::bail!(
+                    "Invalid modular manifest: {} chunk_files length ({}) does not match chunk count ({})",
+                    ty.key(),
+                    chunked.chunk_files.len(),
+                    chunked.num_chunks()
+                );
+            }
         }
 
         total_download_size += manifest.size_for_distance(*ty, distance);


### PR DESCRIPTION
<!-- Thanks for contributing to Reth! By opening this PR, you agree to the terms of the CLA (https://reth.rs/cla). -->

## Description

Resolves #27030

A modular snapshot manifest with `blocks_per_file: 0` triggers a divide-by-zero panic in `ChunkedArchive::num_chunks()` (`self.total_blocks.div_ceil(self.blocks_per_file)`) when calculating chunk counts and expanding snapshot archives.

This PR addresses this by:
1. Adding `SnapshotManifest::validate(&self)` to check that any chunked component specifies `blocks_per_file > 0`.
2. Calling `manifest.validate()?` early in `DownloadCommand::load_manifest()` right after verifying `chain_id`.
3. Adding an explicit guard in `collect_planned_archives()` before chunk consistency verification.
4. Adding defensive zero guards in `ChunkedArchive::num_chunks()` and `ChunkedArchive::tail_chunks_for_distance()`, plus saturating arithmetic in `ChunkedArchive::chunk_relative_path()`.
5. Adding unit tests for manifest validation and non-panicking `ChunkedArchive` behavior.
