### PR TITLE
refactor(net): reuse alloy bal hash validation

### DIFF
--- a/crates/net/downloaders/src/snap/block_access_list.rs
+++ b/crates/net/downloaders/src/snap/block_access_list.rs
@@ -246,16 +246,16 @@ impl BlockAccessListVerifier {
             // Hashing the raw bytes settles authenticity without decoding, so a peer cannot
             // charge us the decode of a list it was never able to serve.
             let raw = RawBal::new(raw);
-            if raw.hash() != commitment {
+            raw.ensure_hash(commitment).map_err(|error| {
                 debug!(
                     target: "downloaders::snap",
                     %block_hash,
-                    expected = %commitment,
-                    got = %raw.hash(),
+                    expected = %error.expected,
+                    got = %error.computed,
                     "Block access list does not match its header commitment"
                 );
-                return Err(RequestError::BadResponse)
-            }
+                RequestError::BadResponse
+            })?;
             let decoded = DecodedBal::from_raw_bal(raw).map_err(|error| {
                 debug!(target: "downloaders::snap", %block_hash, %error, "Invalid block access list");
                 RequestError::BadResponse

--- a/crates/net/p2p/src/full_block.rs
+++ b/crates/net/p2p/src/full_block.rs
@@ -1144,19 +1144,17 @@ fn seal_block_access_list_for_block<B: Block>(
     let (peer, bal) = bal.split();
     let Some(bal) = bal else { return Ok(None) };
     let raw_bal = RawBal::new(bal);
-    let computed = raw_bal.hash();
-    if computed == expected {
-        return Ok(Some(raw_bal))
-    }
-
-    debug!(
-        target: "downloaders",
-        block_hash = ?block.hash(),
-        ?computed,
-        ?expected,
-        "Received block access list with wrong hash",
-    );
-    Err(peer)
+    raw_bal.ensure_hash(expected).map_err(|error| {
+        debug!(
+            target: "downloaders",
+            block_hash = ?block.hash(),
+            computed = ?error.computed,
+            expected = ?error.expected,
+            "Received block access list with wrong hash",
+        );
+        peer
+    })?;
+    Ok(Some(raw_bal))
 }
 
 /// Wraps a block range with validated block access-list entries.


### PR DESCRIPTION
Use alloy’s `ensure_hash()` in snap and full-block downloaders, preserving existing errors and peer handling.
