### PR TITLE
refactor(engine): reuse alloy helpers for bal prewarming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,8 +252,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.8"
-source = "git+https://github.com/lean-apple/alloy-eips?rev=b05480a7bb8dd4581184f32c69ee112e2f7b42f0#b05480a7bb8dd4581184f32c69ee112e2f7b42f0"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd59d7221d384c46771ffbf6f18f70aa7753326351277857016bed5127b888f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,8 +253,7 @@ dependencies = [
 [[package]]
 name = "alloy-eip7928"
 version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
+source = "git+https://github.com/lean-apple/alloy-eips?rev=b05480a7bb8dd4581184f32c69ee112e2f7b42f0#b05480a7bb8dd4581184f32c69ee112e2f7b42f0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -694,3 +694,6 @@ vergen-git2 = "10.0.1"
 
 # networking
 ipnet = "2.11"
+
+[patch.crates-io]
+alloy-eip7928 = { git = "https://github.com/lean-apple/alloy-eips", rev = "b05480a7bb8dd4581184f32c69ee112e2f7b42f0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,7 +442,7 @@ alloy-sol-types = { version = "1.6.1", default-features = false }
 
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-eip2124 = { version = "0.2.0", default-features = false }
-alloy-eip7928 = { version = "0.4.8", default-features = false, features = ["rlp"] }
+alloy-eip7928 = { version = "0.4.9", default-features = false, features = ["rlp"] }
 alloy-evm = { version = "0.39.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false, features = ["core-net"] }
 alloy-trie = { version = "0.9.4", default-features = false }
@@ -694,6 +694,3 @@ vergen-git2 = "10.0.1"
 
 # networking
 ipnet = "2.11"
-
-[patch.crates-io]
-alloy-eip7928 = { git = "https://github.com/lean-apple/alloy-eips", rev = "b05480a7bb8dd4581184f32c69ee112e2f7b42f0" }

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -431,14 +431,7 @@ where
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
             let dispatch_start = Instant::now();
             for account in prefetch_bal.as_bal() {
-                pool.warm_account(
-                    account.address,
-                    account
-                        .storage_changes
-                        .iter()
-                        .map(|change| change.slot.into())
-                        .chain(account.storage_reads.iter().map(|&slot| slot.into())),
-                );
+                pool.warm_account(account.address, account.storage_slots().map(Into::into));
             }
             ctx.metrics.bal_slot_iteration_duration.record(dispatch_start.elapsed());
             pool.end_block();
@@ -778,13 +771,13 @@ struct BalAccountStateFields {
 impl BalAccountStateFields {
     fn from_changes(account_changes: &alloy_eip7928::AccountChanges) -> Self {
         Self {
-            balance: account_changes.balance_changes.last().map(|change| change.post_balance),
-            nonce: account_changes.nonce_changes.last().map(|change| change.new_nonce),
-            code_hash: account_changes.code_changes.last().map(|code_change| {
-                if code_change.new_code.is_empty() {
+            balance: account_changes.balance_post_state(),
+            nonce: account_changes.nonce_post_state(),
+            code_hash: account_changes.code_post_state().map(|code| {
+                if code.is_empty() {
                     alloy_consensus::constants::KECCAK_EMPTY
                 } else {
-                    keccak256(&code_change.new_code)
+                    keccak256(code)
                 }
             }),
         }


### PR DESCRIPTION
- Use released `alloy-eip7928` 0.4.9, which includes the merged [alloy-rs/eips#126](https://github.com/alloy-rs/eips/pull/126).
- Use `storage_slots()` for changed and read slots in bal prewarming.
- Use the account post-state accessors, preserving empty-code hashing and account merging.
