### PR TITLE
refactor(engine): reuse alloy bal state and index helpers

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -92,7 +92,10 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let signer = *tx.signer();
                 let tx_gas_limit = tx.tx().gas_limit();
 
-                executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
+                executor
+                    .evm_mut()
+                    .db_mut()
+                    .set_bal_index(BlockAccessIndex::from_tx_index(index as u64));
                 let result = executor
                     .execute_transaction_without_commit(tx)
                     .map_err(BalWorkerError::Execution)?;

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -692,14 +692,11 @@ where
         // changes to start processing them before potentially hitting the db in the next step.
         if !account_changes.storage_changes.is_empty() {
             let hashed_address = *hashed_address.get_or_insert_with(|| keccak256(address));
-            let mut storage_map = reth_trie::HashedStorage::default();
-
-            for slot_changes in &account_changes.storage_changes {
-                let hashed_slot = keccak256(slot_changes.slot.to_be_bytes::<32>());
-                if let Some(last_change) = slot_changes.changes.last() {
-                    storage_map.storage.insert(hashed_slot, last_change.new_value);
-                }
-            }
+            let storage_map = reth_trie::HashedStorage::from_iter(
+                account_changes
+                    .storage_post_states()
+                    .map(|(slot, value)| (keccak256(slot.to_be_bytes::<32>()), value)),
+            );
 
             let mut hashed_state = reth_trie::HashedPostState::default();
             hashed_state.storages.insert(hashed_address, storage_map);


### PR DESCRIPTION
Use `storage_post_states()` for prewarming and `from_tx_index()` in bal workers.
