### PR TITLE
feat: scalffold new `snap-sync` crate with minimal pivot module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10264,11 +10264,12 @@ version = "2.5.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
+ "alloy-eips",
  "alloy-primitives",
  "reth-primitives-traits",
  "reth-provider",
- "reth-static-file-types",
  "reth-storage-api",
+ "reth-storage-errors",
  "thiserror 2.0.18",
  "tokio-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10259,6 +10259,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-snap-sync"
+version = "2.5.2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-static-file-types",
+ "reth-storage-api",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-stages"
 version = "2.5.2"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10270,6 +10270,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "thiserror 2.0.18",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "crates/rpc/rpc-e2e-tests/",
     "crates/rpc/rpc-convert/",
     "crates/rpc/rpc/",
+    "crates/snap-sync/",
     "crates/stages/api/",
     "crates/stages/stages/",
     "crates/stages/types/",
@@ -409,6 +410,7 @@ reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
 reth-rpc-traits = { version = "0.7.0", default-features = false }
+reth-snap-sync = { path = "crates/snap-sync" }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }

--- a/crates/snap-sync/Cargo.toml
+++ b/crates/snap-sync/Cargo.toml
@@ -22,6 +22,7 @@ alloy-primitives.workspace = true
 
 # misc
 thiserror.workspace = true
+tokio-util.workspace = true
 
 [dev-dependencies]
 alloy-consensus.workspace = true

--- a/crates/snap-sync/Cargo.toml
+++ b/crates/snap-sync/Cargo.toml
@@ -15,9 +15,11 @@ workspace = true
 # reth
 reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
+reth-storage-errors.workspace = true
 
 # alloy
 alloy-eip7928.workspace = true
+alloy-eips.workspace = true
 alloy-primitives.workspace = true
 
 # misc
@@ -27,4 +29,3 @@ tokio-util.workspace = true
 [dev-dependencies]
 alloy-consensus.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-static-file-types.workspace = true

--- a/crates/snap-sync/Cargo.toml
+++ b/crates/snap-sync/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "reth-snap-sync"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "snap/2 state synchronization"
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-primitives-traits.workspace = true
+reth-storage-api.workspace = true
+
+# alloy
+alloy-eip7928.workspace = true
+alloy-primitives.workspace = true
+
+# misc
+thiserror.workspace = true
+
+[dev-dependencies]
+alloy-consensus.workspace = true
+reth-provider = { workspace = true, features = ["test-utils"] }
+reth-static-file-types.workspace = true

--- a/crates/snap-sync/src/error.rs
+++ b/crates/snap-sync/src/error.rs
@@ -1,14 +1,11 @@
 //! Failures raised while assembling a snap state generation.
 
+use reth_storage_errors::provider::ProviderError;
+
 /// Error returned while assembling a snap state generation.
 #[derive(Debug, thiserror::Error)]
 pub enum SnapSyncError {
-    /// The provider rejected a database operation.
-    #[error("snap database operation failed: {0}")]
-    Database(String),
-}
-
-// Erasing provider error types keeps the session's public bounds small.
-pub(crate) fn db_error(error: impl core::fmt::Display) -> SnapSyncError {
-    SnapSyncError::Database(error.to_string())
+    /// A header lookup failed.
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
 }

--- a/crates/snap-sync/src/error.rs
+++ b/crates/snap-sync/src/error.rs
@@ -1,0 +1,14 @@
+//! Failures raised while assembling a snap state generation.
+
+/// Error returned while assembling a snap state generation.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapSyncError {
+    /// The provider rejected a database operation.
+    #[error("snap database operation failed: {0}")]
+    Database(String),
+}
+
+// Erasing provider error types keeps the session's public bounds small.
+pub(crate) fn db_error(error: impl core::fmt::Display) -> SnapSyncError {
+    SnapSyncError::Database(error.to_string())
+}

--- a/crates/snap-sync/src/generation.rs
+++ b/crates/snap-sync/src/generation.rs
@@ -10,15 +10,15 @@ use reth_storage_api::HeaderProvider;
 /// still on the canonical chain, and the root is what downloaded ranges authenticate against.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SnapGeneration {
-    /// Pivot block number.
+    // Pivot block number.
     target_block: u64,
-    /// Pivot block hash.
+    // Pivot block hash.
     target_hash: B256,
-    /// State root that downloaded ranges authenticate against.
+    // Root downloaded ranges authenticate against.
     state_root: B256,
-    /// Stage reached so far.
+    // Stage reached so far.
     phase: SnapPhase,
-    /// First block whose block access list has not been applied.
+    // First block whose block access list has not been applied.
     next_block: u64,
 }
 
@@ -66,8 +66,8 @@ impl SnapGeneration {
 
     /// Returns whether the block this generation is anchored to is still canonical.
     ///
-    /// A generation whose anchor was orphaned can still be recovered from the block access lists
-    /// of the abandoned branch, so this is reported separately from whether it is worth finishing.
+    /// Separate from whether it is worth finishing: an orphaned anchor is recoverable from the
+    /// abandoned branch's lists.
     pub fn is_canonical(&self, provider: &impl HeaderProvider) -> Result<bool, SnapSyncError> {
         let header = provider.sealed_header(self.target_block).map_err(db_error)?;
         Ok(header.is_some_and(|header| header.hash() == self.target_hash))

--- a/crates/snap-sync/src/generation.rs
+++ b/crates/snap-sync/src/generation.rs
@@ -1,47 +1,34 @@
 //! Identifies one attempt at downloading state, and how far it has progressed.
 
-use crate::{error::db_error, SnapSyncError};
+use crate::SnapSyncError;
+use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use reth_storage_api::HeaderProvider;
 
 /// One attempt at downloading state, anchored to the pivot block it targets.
 ///
-/// The anchor is kept as both a hash and a state root: the hash decides whether the attempt is
-/// still on the canonical chain, and the root is what downloaded ranges authenticate against.
+/// The anchor is kept as both a number-hash pair and a state root: the hash decides whether the
+/// attempt is still on the canonical chain, and the root is what downloaded ranges authenticate
+/// against.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SnapGeneration {
-    // Pivot block number.
-    target_block: u64,
-    // Pivot block hash.
-    target_hash: B256,
+    // Pivot block this attempt is anchored to.
+    target: BlockNumHash,
     // Root downloaded ranges authenticate against.
     state_root: B256,
     // Stage reached so far.
     phase: SnapPhase,
-    // First block whose block access list has not been applied.
-    next_block: u64,
 }
 
 impl SnapGeneration {
     /// Creates a generation anchored to the given pivot, before any range is downloaded.
-    pub const fn new(target_block: u64, target_hash: B256, state_root: B256) -> Self {
-        Self {
-            target_block,
-            target_hash,
-            state_root,
-            phase: SnapPhase::Accounts,
-            next_block: target_block.saturating_add(1),
-        }
+    pub const fn new(target: BlockNumHash, state_root: B256) -> Self {
+        Self { target, state_root, phase: SnapPhase::Accounts }
     }
 
-    /// Pivot block number.
-    pub const fn target_block(&self) -> u64 {
-        self.target_block
-    }
-
-    /// Pivot block hash.
-    pub const fn target_hash(&self) -> B256 {
-        self.target_hash
+    /// Pivot block this generation is anchored to.
+    pub const fn target(&self) -> BlockNumHash {
+        self.target
     }
 
     /// State root that downloaded ranges authenticate against.
@@ -54,14 +41,9 @@ impl SnapGeneration {
         self.phase
     }
 
-    /// First block whose block access list has not been applied.
-    pub const fn next_block(&self) -> u64 {
-        self.next_block
-    }
-
     /// Returns how far the canonical head has moved past this generation's anchor.
     pub const fn lag(&self, head: u64) -> u64 {
-        head.saturating_sub(self.target_block)
+        head.saturating_sub(self.target.number)
     }
 
     /// Returns whether the block this generation is anchored to is still canonical.
@@ -69,8 +51,8 @@ impl SnapGeneration {
     /// Separate from whether it is worth finishing: an orphaned anchor is recoverable from the
     /// abandoned branch's lists.
     pub fn is_canonical(&self, provider: &impl HeaderProvider) -> Result<bool, SnapSyncError> {
-        let header = provider.sealed_header(self.target_block).map_err(db_error)?;
-        Ok(header.is_some_and(|header| header.hash() == self.target_hash))
+        let header = provider.sealed_header(self.target.number)?;
+        Ok(header.is_some_and(|header| header.hash() == self.target.hash))
     }
 
     /// Returns this generation moved to `phase`.

--- a/crates/snap-sync/src/generation.rs
+++ b/crates/snap-sync/src/generation.rs
@@ -1,0 +1,93 @@
+//! Identifies one attempt at downloading state, and how far it has progressed.
+
+use crate::{error::db_error, SnapSyncError};
+use alloy_primitives::B256;
+use reth_storage_api::HeaderProvider;
+
+/// One attempt at downloading state, anchored to the pivot block it targets.
+///
+/// The anchor is kept as both a hash and a state root: the hash decides whether the attempt is
+/// still on the canonical chain, and the root is what downloaded ranges authenticate against.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SnapGeneration {
+    /// Pivot block number.
+    target_block: u64,
+    /// Pivot block hash.
+    target_hash: B256,
+    /// State root that downloaded ranges authenticate against.
+    state_root: B256,
+    /// Stage reached so far.
+    phase: SnapPhase,
+    /// First block whose block access list has not been applied.
+    next_block: u64,
+}
+
+impl SnapGeneration {
+    /// Creates a generation anchored to the given pivot, before any range is downloaded.
+    pub const fn new(target_block: u64, target_hash: B256, state_root: B256) -> Self {
+        Self {
+            target_block,
+            target_hash,
+            state_root,
+            phase: SnapPhase::Accounts,
+            next_block: target_block.saturating_add(1),
+        }
+    }
+
+    /// Pivot block number.
+    pub const fn target_block(&self) -> u64 {
+        self.target_block
+    }
+
+    /// Pivot block hash.
+    pub const fn target_hash(&self) -> B256 {
+        self.target_hash
+    }
+
+    /// State root that downloaded ranges authenticate against.
+    pub const fn state_root(&self) -> B256 {
+        self.state_root
+    }
+
+    /// Stage this generation has reached.
+    pub const fn phase(&self) -> SnapPhase {
+        self.phase
+    }
+
+    /// First block whose block access list has not been applied.
+    pub const fn next_block(&self) -> u64 {
+        self.next_block
+    }
+
+    /// Returns how far the canonical head has moved past this generation's anchor.
+    pub const fn lag(&self, head: u64) -> u64 {
+        head.saturating_sub(self.target_block)
+    }
+
+    /// Returns whether the block this generation is anchored to is still canonical.
+    ///
+    /// A generation whose anchor was orphaned can still be recovered from the block access lists
+    /// of the abandoned branch, so this is reported separately from whether it is worth finishing.
+    pub fn is_canonical(&self, provider: &impl HeaderProvider) -> Result<bool, SnapSyncError> {
+        let header = provider.sealed_header(self.target_block).map_err(db_error)?;
+        Ok(header.is_some_and(|header| header.hash() == self.target_hash))
+    }
+
+    /// Returns this generation moved to `phase`.
+    #[cfg(test)]
+    pub(crate) const fn with_phase(mut self, phase: SnapPhase) -> Self {
+        self.phase = phase;
+        self
+    }
+}
+
+/// The stage a [`SnapGeneration`] has reached.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SnapPhase {
+    /// Account, storage and bytecode ranges are being downloaded.
+    Accounts,
+    /// Authenticated block access lists are being applied.
+    BlockAccessLists,
+    /// The final state trie is being rebuilt and checked.
+    Trie,
+}

--- a/crates/snap-sync/src/lib.rs
+++ b/crates/snap-sync/src/lib.rs
@@ -41,4 +41,4 @@ mod test_utils;
 pub use error::SnapSyncError;
 pub use generation::{SnapGeneration, SnapPhase};
 pub use pivot::SnapPivotPolicy;
-pub use session::{SnapSession, SnapSessionState};
+pub use session::{SnapSyncSession, SnapSyncSessionState};

--- a/crates/snap-sync/src/lib.rs
+++ b/crates/snap-sync/src/lib.rs
@@ -33,7 +33,12 @@
 mod error;
 mod generation;
 mod pivot;
+mod session;
+
+#[cfg(test)]
+mod test_utils;
 
 pub use error::SnapSyncError;
 pub use generation::{SnapGeneration, SnapPhase};
 pub use pivot::SnapPivotPolicy;
+pub use session::{SnapSession, SnapSessionState};

--- a/crates/snap-sync/src/lib.rs
+++ b/crates/snap-sync/src/lib.rs
@@ -1,0 +1,39 @@
+//! snap/2 state synchronization for [EIP-8189](https://eips.ethereum.org/EIPS/eip-8189).
+//!
+//! Coordinates a state bootstrap that starts from a recent pivot block, downloads accounts, storage
+//! and bytecode authenticated against that pivot's state root, and advances the pivot with
+//! [EIP-7928 block access lists](https://eips.ethereum.org/EIPS/eip-7928) as the chain moves past
+//! it.
+//!
+//! This crate owns download progress only. Authenticated downloads come from
+//! `reth-downloaders`, and verified state is handed back to node integration once its trie root
+//! matches the target header.
+//!
+//! ```
+//! use reth_snap_sync::SnapPivotPolicy;
+//!
+//! let policy = SnapPivotPolicy::default();
+//! // Without a finalized block, anchor at the EIP's example distance.
+//! assert_eq!(policy.pivot_block(1_000, None), Some(936));
+//! // A recent finalized block is anchored to directly.
+//! assert_eq!(policy.pivot_block(1_000, Some(950)), Some(950));
+//! // Stalled finality falls back to the example distance.
+//! assert_eq!(policy.pivot_block(1_000, Some(500)), Some(936));
+//! // A chain shorter than the head distance has no pivot yet.
+//! assert_eq!(policy.pivot_block(4, None), None);
+//! ```
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/paradigmxyz/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod error;
+mod generation;
+mod pivot;
+
+pub use error::SnapSyncError;
+pub use generation::{SnapGeneration, SnapPhase};
+pub use pivot::SnapPivotPolicy;

--- a/crates/snap-sync/src/pivot.rs
+++ b/crates/snap-sync/src/pivot.rs
@@ -30,11 +30,11 @@ const DEFAULT_ADVANCE_AFTER: u64 = SERVED_STATE_WINDOW - DEFAULT_HEAD_DISTANCE /
 /// Distance and history bounds that decide where a generation is anchored.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SnapPivotPolicy {
-    /// Blocks behind the head to anchor at when no finalized block is available.
+    // Blocks behind the head to anchor at when no finalized block is available.
     head_distance: u64,
-    /// Pivot lag that triggers re-anchoring while ranges are still downloading.
+    // Pivot lag that triggers re-anchoring while ranges are still downloading.
     advance_after: u64,
-    /// Blocks of block access list history a peer is assumed to still serve.
+    // Blocks of block access list history a peer is assumed to still serve.
     history: u64,
 }
 
@@ -63,8 +63,8 @@ impl SnapPivotPolicy {
 
     /// Returns this policy assuming `history` blocks of block access lists remain servable.
     ///
-    /// Applying that many lists is cheaper than downloading the state again, so the default is the
-    /// full EIP-7928 retention period rather than a shorter catch-up bound.
+    /// Defaults to the full EIP-7928 retention period, since applying lists beats downloading the
+    /// state again.
     pub const fn with_history(mut self, history: u64) -> Self {
         self.history = history;
         self
@@ -72,9 +72,8 @@ impl SnapPivotPolicy {
 
     /// Returns the block a pivot anchored under `head` targets.
     ///
-    /// Prefers a `finalized` block that peers should still be serving, since it cannot be reorged
-    /// at all. Falls back to `head_distance` before the first forkchoice update, and whenever
-    /// finality has stalled past the point where its state is served.
+    /// Prefers a finalized block that peers still serve state for, since it cannot be reorged, and
+    /// falls back to the head distance.
     pub const fn pivot_block(&self, head: u64, finalized: Option<u64>) -> Option<u64> {
         if let Some(finalized) = finalized &&
             head.saturating_sub(finalized) <= self.advance_after
@@ -86,46 +85,50 @@ impl SnapPivotPolicy {
 
     /// Returns whether `generation` should be re-anchored under `head`.
     ///
-    /// Advancing costs one block access list per intervening block, which stays far cheaper than
-    /// restarting the download, so this triggers well before peers stop serving the old root.
+    /// Advancing stays far cheaper than restarting, so this triggers well before peers stop
+    /// serving the old root.
     pub const fn needs_advance(&self, generation: SnapGeneration, head: u64) -> bool {
         generation.lag(head) > self.advance_after
     }
 
     /// Returns whether the block access lists `generation` still needs remain servable.
     ///
-    /// Once they are not, the downloaded state can no longer be carried forward and the attempt
-    /// has to be restarted from a fresh pivot.
+    /// Once they are not, its state cannot be carried forward and the attempt has to restart.
     pub const fn is_catchable(&self, generation: SnapGeneration, head: u64) -> bool {
         generation.lag(head) <= self.history
     }
 
     /// Returns a fresh generation for the canonical pivot under `head`.
     ///
-    /// `None` means the chain is not ready to be pivoted on: it is shorter than the head distance,
-    /// its pivot header is not downloaded yet, or EIP-7928 is not active at the pivot, so no block
-    /// access list can carry that state forward.
+    /// A candidate that is not eligible falls back to the head distance; `None` means no candidate
+    /// can anchor a sync yet.
     pub fn select(
         &self,
         provider: &impl HeaderProvider,
         head: u64,
         finalized: Option<u64>,
     ) -> Result<Option<SnapGeneration>, SnapSyncError> {
-        let Some(block_number) = self.pivot_block(head, finalized) else { return Ok(None) };
-        let Some(header) = provider.sealed_header(block_number).map_err(db_error)? else {
-            return Ok(None)
-        };
-        if header.block_access_list_hash().is_none() {
-            return Ok(None)
+        let preferred = self.pivot_block(head, finalized);
+        let fallback =
+            head.checked_sub(self.head_distance).filter(|block| Some(*block) != preferred);
+        for block_number in preferred.into_iter().chain(fallback) {
+            let Some(header) = provider.sealed_header(block_number).map_err(db_error)? else {
+                continue
+            };
+            if header.block_access_list_hash().is_some() {
+                return Ok(Some(SnapGeneration::new(
+                    block_number,
+                    header.hash(),
+                    header.state_root(),
+                )))
+            }
         }
-        Ok(Some(SnapGeneration::new(block_number, header.hash(), header.state_root())))
+        Ok(None)
     }
 
     /// Returns whether an interrupted generation is still worth finishing under `head`.
     ///
-    /// A fully downloaded generation only needs its trie rebuilt, so it stays worth finishing
-    /// however far the head has moved on. Whether its anchor is still canonical is reported
-    /// separately by [`SnapGeneration::is_canonical`].
+    /// A fully downloaded generation only needs its trie rebuilt, so it always is.
     pub const fn is_finishable(&self, generation: SnapGeneration, head: u64) -> bool {
         matches!(generation.phase(), SnapPhase::Trie) || self.is_catchable(generation, head)
     }
@@ -229,10 +232,26 @@ mod tests {
     }
 
     #[test]
+    fn an_ineligible_finalized_pivot_falls_back_to_the_head_distance() {
+        // Block access lists only start at block 2, so the finalized block predates activation.
+        let headers = chain(Some(2));
+        let fallback = headers[2].clone();
+        let provider = provider_with(headers);
+
+        let generation = policy().select(&provider, 3, Some(1)).unwrap().unwrap();
+
+        // HEAD-1, rather than waiting for finality to reach activation.
+        assert_eq!(generation.target_block(), 2);
+        assert_eq!(generation.target_hash(), fallback.hash_slow());
+    }
+
+    #[test]
     fn pivot_without_a_bal_commitment_is_not_selectable() {
         let provider = provider_with(chain(Some(3)));
 
         assert_eq!(policy().select(&provider, 3, None).unwrap(), None);
+        // Neither the finalized anchor nor the fallback carries a commitment.
+        assert_eq!(policy().select(&provider, 3, Some(1)).unwrap(), None);
     }
 
     #[test]

--- a/crates/snap-sync/src/pivot.rs
+++ b/crates/snap-sync/src/pivot.rs
@@ -10,7 +10,7 @@
 //! is available, and re-anchoring starts once a pivot lags by 96 blocks rather than at the edge of
 //! the window peers still serve state for.
 
-use crate::{error::db_error, SnapGeneration, SnapPhase, SnapSyncError};
+use crate::{SnapGeneration, SnapPhase, SnapSyncError};
 use alloy_eip7928::BAL_RETENTION_PERIOD_SLOTS;
 use reth_primitives_traits::AlloyBlockHeader;
 use reth_storage_api::HeaderProvider;
@@ -111,15 +111,9 @@ impl SnapPivotPolicy {
         let fallback =
             head.checked_sub(self.head_distance).filter(|block| Some(*block) != preferred);
         for block_number in preferred.into_iter().chain(fallback) {
-            let Some(header) = provider.sealed_header(block_number).map_err(db_error)? else {
-                continue
-            };
+            let Some(header) = provider.sealed_header(block_number)? else { continue };
             if header.block_access_list_hash().is_some() {
-                return Ok(Some(SnapGeneration::new(
-                    block_number,
-                    header.hash(),
-                    header.state_root(),
-                )))
+                return Ok(Some(SnapGeneration::new(header.num_hash(), header.state_root())))
             }
         }
         Ok(None)
@@ -137,6 +131,7 @@ impl SnapPivotPolicy {
 mod tests {
     use super::*;
     use crate::test_utils::{chain, policy, provider_with};
+    use alloy_eips::BlockNumHash;
     use alloy_primitives::B256;
 
     #[test]
@@ -147,11 +142,10 @@ mod tests {
 
         let generation = policy().select(&provider, 3, None).unwrap().unwrap();
 
-        assert_eq!(generation.target_block(), 2);
-        assert_eq!(generation.target_hash(), expected.hash_slow());
+        assert_eq!(generation.target().number, 2);
+        assert_eq!(generation.target().hash, expected.hash_slow());
         assert_eq!(generation.state_root(), expected.state_root);
         assert_eq!(generation.phase(), SnapPhase::Accounts);
-        assert_eq!(generation.next_block(), 3);
     }
 
     #[test]
@@ -162,8 +156,8 @@ mod tests {
 
         let generation = policy().select(&provider, 3, Some(1)).unwrap().unwrap();
 
-        assert_eq!(generation.target_block(), 1);
-        assert_eq!(generation.target_hash(), expected.hash_slow());
+        assert_eq!(generation.target().number, 1);
+        assert_eq!(generation.target().hash, expected.hash_slow());
     }
 
     #[test]
@@ -177,8 +171,8 @@ mod tests {
         let generation = policy.select(&provider, 3, Some(1)).unwrap().unwrap();
 
         // HEAD-1, not the stale finalized block 1.
-        assert_eq!(generation.target_block(), 2);
-        assert_eq!(generation.target_hash(), fallback.hash_slow());
+        assert_eq!(generation.target().number, 2);
+        assert_eq!(generation.target().hash, fallback.hash_slow());
     }
 
     #[test]
@@ -191,8 +185,8 @@ mod tests {
         let generation = policy().select(&provider, 3, Some(1)).unwrap().unwrap();
 
         // HEAD-1, rather than waiting for finality to reach activation.
-        assert_eq!(generation.target_block(), 2);
-        assert_eq!(generation.target_hash(), fallback.hash_slow());
+        assert_eq!(generation.target().number, 2);
+        assert_eq!(generation.target().hash, fallback.hash_slow());
     }
 
     #[test]
@@ -221,7 +215,7 @@ mod tests {
     #[test]
     fn a_pivot_lagging_past_the_advance_window_is_re_anchored() {
         let policy = policy();
-        let generation = SnapGeneration::new(0, B256::ZERO, B256::ZERO);
+        let generation = SnapGeneration::new(BlockNumHash::new(0, B256::ZERO), B256::ZERO);
 
         assert!(!policy.needs_advance(generation, 4));
         assert!(policy.needs_advance(generation, 5));
@@ -232,7 +226,8 @@ mod tests {
         let headers = chain(Some(0));
         let anchor = headers[1].clone();
         let provider = provider_with(headers);
-        let generation = SnapGeneration::new(1, anchor.hash_slow(), anchor.state_root);
+        let generation =
+            SnapGeneration::new(BlockNumHash::new(1, anchor.hash_slow()), anchor.state_root);
         let policy = policy();
 
         assert!(generation.is_canonical(&provider).unwrap());
@@ -243,8 +238,9 @@ mod tests {
     #[test]
     fn downloaded_state_finishes_outside_the_bal_window() {
         let anchor = chain(Some(0))[1].clone();
-        let generation = SnapGeneration::new(1, anchor.hash_slow(), anchor.state_root)
-            .with_phase(SnapPhase::Trie);
+        let generation =
+            SnapGeneration::new(BlockNumHash::new(1, anchor.hash_slow()), anchor.state_root)
+                .with_phase(SnapPhase::Trie);
 
         assert!(policy().is_finishable(generation, 1_000));
     }
@@ -252,7 +248,8 @@ mod tests {
     #[test]
     fn reorged_anchor_is_not_canonical() {
         let provider = provider_with(chain(Some(0)));
-        let generation = SnapGeneration::new(1, B256::repeat_byte(0xff), B256::ZERO);
+        let generation =
+            SnapGeneration::new(BlockNumHash::new(1, B256::repeat_byte(0xff)), B256::ZERO);
 
         assert!(!generation.is_canonical(&provider).unwrap());
     }

--- a/crates/snap-sync/src/pivot.rs
+++ b/crates/snap-sync/src/pivot.rs
@@ -137,57 +137,8 @@ impl SnapPivotPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::Header;
+    use crate::test_utils::{chain, policy, provider_with};
     use alloy_primitives::B256;
-    use reth_provider::{
-        test_utils::create_test_provider_factory, DatabaseProviderFactory,
-        StaticFileProviderFactory, StaticFileWriter,
-    };
-    use reth_static_file_types::StaticFileSegment;
-
-    // Small bounds keep header fixtures short without changing the policy's decisions.
-    fn policy() -> SnapPivotPolicy {
-        SnapPivotPolicy::default().with_head_distance(1).with_advance_after(4).with_history(8)
-    }
-
-    fn header(number: u64, parent_hash: B256, block_access_list_hash: Option<B256>) -> Header {
-        Header {
-            number,
-            parent_hash,
-            state_root: B256::repeat_byte(number as u8),
-            block_access_list_hash,
-            ..Default::default()
-        }
-    }
-
-    fn provider_with(
-        headers: impl IntoIterator<Item = Header>,
-    ) -> impl HeaderProvider<Header = Header> {
-        let factory = create_test_provider_factory();
-        let static_files = factory.static_file_provider();
-        let mut writer = static_files.latest_writer(StaticFileSegment::Headers).unwrap();
-        for header in headers {
-            let hash = header.hash_slow();
-            writer.append_header(&header, &hash).unwrap();
-        }
-        writer.commit().unwrap();
-        drop(writer);
-        drop(static_files);
-        factory.database_provider_ro().unwrap()
-    }
-
-    fn chain(bal_from: Option<u64>) -> Vec<Header> {
-        let mut headers = Vec::new();
-        let mut parent = B256::ZERO;
-        for number in 0..=3 {
-            let bal =
-                bal_from.filter(|from| number >= *from).map(|_| B256::with_last_byte(number as u8));
-            let header = header(number, parent, bal);
-            parent = header.hash_slow();
-            headers.push(header);
-        }
-        headers
-    }
 
     #[test]
     fn selects_the_bal_capable_pivot_behind_the_head() {

--- a/crates/snap-sync/src/pivot.rs
+++ b/crates/snap-sync/src/pivot.rs
@@ -1,0 +1,290 @@
+//! Chooses the canonical block a snap generation is anchored to.
+//!
+//! [EIP-8189](https://eips.ethereum.org/EIPS/eip-8189#synchronization-algorithm) pivot selection
+//! anchors synchronization at a block "sufficiently behind the chain head [...] to reduce the
+//! likelihood of P being reorged while remaining recent enough that serving peers still hold its
+//! state in memory". Those two pressures are what this policy balances: too close to the head and
+//! the anchor is reorged, too far and no peer will serve its state.
+//!
+//! Two choices depart from the EIP's example: a finalized block is preferred as the anchor when one
+//! is available, and re-anchoring starts once a pivot lags by 96 blocks rather than at the edge of
+//! the window peers still serve state for.
+
+use crate::{error::db_error, SnapGeneration, SnapPhase, SnapSyncError};
+use alloy_eip7928::BAL_RETENTION_PERIOD_SLOTS;
+use reth_primitives_traits::AlloyBlockHeader;
+use reth_storage_api::HeaderProvider;
+
+// EIP-8189 gives HEAD-64 as its example anchor, matching go-ethereum's `fsMinFullBlocks`.
+const DEFAULT_HEAD_DISTANCE: u64 = 64;
+
+// Blocks of state history a serving peer is assumed to still hold. Mirrors reth's own
+// `SNAPSHOT_STATE_RETENTION`, which bounds the roots it will answer range requests for.
+const SERVED_STATE_WINDOW: u64 = 128;
+
+// Re-anchor before the pivot reaches the edge of the served window, so ranges already in flight do
+// not fail against a root peers have just dropped. go-ethereum re-anchors at
+// `2 * fsMinFullBlocks` minus a reorg-protection delay for the same reason.
+const DEFAULT_ADVANCE_AFTER: u64 = SERVED_STATE_WINDOW - DEFAULT_HEAD_DISTANCE / 2;
+
+/// Distance and history bounds that decide where a generation is anchored.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SnapPivotPolicy {
+    /// Blocks behind the head to anchor at when no finalized block is available.
+    head_distance: u64,
+    /// Pivot lag that triggers re-anchoring while ranges are still downloading.
+    advance_after: u64,
+    /// Blocks of block access list history a peer is assumed to still serve.
+    history: u64,
+}
+
+impl Default for SnapPivotPolicy {
+    fn default() -> Self {
+        Self {
+            head_distance: DEFAULT_HEAD_DISTANCE,
+            advance_after: DEFAULT_ADVANCE_AFTER,
+            history: BAL_RETENTION_PERIOD_SLOTS,
+        }
+    }
+}
+
+impl SnapPivotPolicy {
+    /// Returns this policy anchoring `head_distance` blocks behind the head.
+    pub const fn with_head_distance(mut self, head_distance: u64) -> Self {
+        self.head_distance = head_distance;
+        self
+    }
+
+    /// Returns this policy re-anchoring once a pivot lags by `advance_after` blocks.
+    pub const fn with_advance_after(mut self, advance_after: u64) -> Self {
+        self.advance_after = advance_after;
+        self
+    }
+
+    /// Returns this policy assuming `history` blocks of block access lists remain servable.
+    ///
+    /// Applying that many lists is cheaper than downloading the state again, so the default is the
+    /// full EIP-7928 retention period rather than a shorter catch-up bound.
+    pub const fn with_history(mut self, history: u64) -> Self {
+        self.history = history;
+        self
+    }
+
+    /// Returns the block a pivot anchored under `head` targets.
+    ///
+    /// Prefers a `finalized` block that peers should still be serving, since it cannot be reorged
+    /// at all. Falls back to `head_distance` before the first forkchoice update, and whenever
+    /// finality has stalled past the point where its state is served.
+    pub const fn pivot_block(&self, head: u64, finalized: Option<u64>) -> Option<u64> {
+        if let Some(finalized) = finalized &&
+            head.saturating_sub(finalized) <= self.advance_after
+        {
+            return Some(finalized)
+        }
+        head.checked_sub(self.head_distance)
+    }
+
+    /// Returns whether `generation` should be re-anchored under `head`.
+    ///
+    /// Advancing costs one block access list per intervening block, which stays far cheaper than
+    /// restarting the download, so this triggers well before peers stop serving the old root.
+    pub const fn needs_advance(&self, generation: SnapGeneration, head: u64) -> bool {
+        generation.lag(head) > self.advance_after
+    }
+
+    /// Returns whether the block access lists `generation` still needs remain servable.
+    ///
+    /// Once they are not, the downloaded state can no longer be carried forward and the attempt
+    /// has to be restarted from a fresh pivot.
+    pub const fn is_catchable(&self, generation: SnapGeneration, head: u64) -> bool {
+        generation.lag(head) <= self.history
+    }
+
+    /// Returns a fresh generation for the canonical pivot under `head`.
+    ///
+    /// `None` means the chain is not ready to be pivoted on: it is shorter than the head distance,
+    /// its pivot header is not downloaded yet, or EIP-7928 is not active at the pivot, so no block
+    /// access list can carry that state forward.
+    pub fn select(
+        &self,
+        provider: &impl HeaderProvider,
+        head: u64,
+        finalized: Option<u64>,
+    ) -> Result<Option<SnapGeneration>, SnapSyncError> {
+        let Some(block_number) = self.pivot_block(head, finalized) else { return Ok(None) };
+        let Some(header) = provider.sealed_header(block_number).map_err(db_error)? else {
+            return Ok(None)
+        };
+        if header.block_access_list_hash().is_none() {
+            return Ok(None)
+        }
+        Ok(Some(SnapGeneration::new(block_number, header.hash(), header.state_root())))
+    }
+
+    /// Returns whether an interrupted generation is still worth finishing under `head`.
+    ///
+    /// A fully downloaded generation only needs its trie rebuilt, so it stays worth finishing
+    /// however far the head has moved on. Whether its anchor is still canonical is reported
+    /// separately by [`SnapGeneration::is_canonical`].
+    pub const fn is_finishable(&self, generation: SnapGeneration, head: u64) -> bool {
+        matches!(generation.phase(), SnapPhase::Trie) || self.is_catchable(generation, head)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_primitives::B256;
+    use reth_provider::{
+        test_utils::create_test_provider_factory, DatabaseProviderFactory,
+        StaticFileProviderFactory, StaticFileWriter,
+    };
+    use reth_static_file_types::StaticFileSegment;
+
+    // Small bounds keep header fixtures short without changing the policy's decisions.
+    fn policy() -> SnapPivotPolicy {
+        SnapPivotPolicy::default().with_head_distance(1).with_advance_after(4).with_history(8)
+    }
+
+    fn header(number: u64, parent_hash: B256, block_access_list_hash: Option<B256>) -> Header {
+        Header {
+            number,
+            parent_hash,
+            state_root: B256::repeat_byte(number as u8),
+            block_access_list_hash,
+            ..Default::default()
+        }
+    }
+
+    fn provider_with(
+        headers: impl IntoIterator<Item = Header>,
+    ) -> impl HeaderProvider<Header = Header> {
+        let factory = create_test_provider_factory();
+        let static_files = factory.static_file_provider();
+        let mut writer = static_files.latest_writer(StaticFileSegment::Headers).unwrap();
+        for header in headers {
+            let hash = header.hash_slow();
+            writer.append_header(&header, &hash).unwrap();
+        }
+        writer.commit().unwrap();
+        drop(writer);
+        drop(static_files);
+        factory.database_provider_ro().unwrap()
+    }
+
+    fn chain(bal_from: Option<u64>) -> Vec<Header> {
+        let mut headers = Vec::new();
+        let mut parent = B256::ZERO;
+        for number in 0..=3 {
+            let bal =
+                bal_from.filter(|from| number >= *from).map(|_| B256::with_last_byte(number as u8));
+            let header = header(number, parent, bal);
+            parent = header.hash_slow();
+            headers.push(header);
+        }
+        headers
+    }
+
+    #[test]
+    fn selects_the_bal_capable_pivot_behind_the_head() {
+        let headers = chain(Some(0));
+        let expected = headers[2].clone();
+        let provider = provider_with(headers);
+
+        let generation = policy().select(&provider, 3, None).unwrap().unwrap();
+
+        assert_eq!(generation.target_block(), 2);
+        assert_eq!(generation.target_hash(), expected.hash_slow());
+        assert_eq!(generation.state_root(), expected.state_root);
+        assert_eq!(generation.phase(), SnapPhase::Accounts);
+        assert_eq!(generation.next_block(), 3);
+    }
+
+    #[test]
+    fn a_recent_finalized_block_is_anchored_to_instead_of_the_head_distance() {
+        let headers = chain(Some(0));
+        let expected = headers[1].clone();
+        let provider = provider_with(headers);
+
+        let generation = policy().select(&provider, 3, Some(1)).unwrap().unwrap();
+
+        assert_eq!(generation.target_block(), 1);
+        assert_eq!(generation.target_hash(), expected.hash_slow());
+    }
+
+    #[test]
+    fn finality_stalled_outside_the_advance_window_falls_back_to_the_head_distance() {
+        let headers = chain(Some(0));
+        let fallback = headers[2].clone();
+        let provider = provider_with(headers);
+        // A finalized block two behind the head is outside this policy's advance window.
+        let policy = policy().with_advance_after(1);
+
+        let generation = policy.select(&provider, 3, Some(1)).unwrap().unwrap();
+
+        // HEAD-1, not the stale finalized block 1.
+        assert_eq!(generation.target_block(), 2);
+        assert_eq!(generation.target_hash(), fallback.hash_slow());
+    }
+
+    #[test]
+    fn pivot_without_a_bal_commitment_is_not_selectable() {
+        let provider = provider_with(chain(Some(3)));
+
+        assert_eq!(policy().select(&provider, 3, None).unwrap(), None);
+    }
+
+    #[test]
+    fn pivot_beyond_downloaded_headers_is_not_selectable() {
+        let provider = provider_with(chain(Some(0)));
+
+        assert_eq!(policy().select(&provider, 9, None).unwrap(), None);
+    }
+
+    #[test]
+    fn chain_shorter_than_the_head_distance_has_no_pivot() {
+        let provider = provider_with(chain(Some(0)));
+
+        assert_eq!(policy().with_head_distance(4).select(&provider, 0, None).unwrap(), None);
+    }
+
+    #[test]
+    fn a_pivot_lagging_past_the_advance_window_is_re_anchored() {
+        let policy = policy();
+        let generation = SnapGeneration::new(0, B256::ZERO, B256::ZERO);
+
+        assert!(!policy.needs_advance(generation, 4));
+        assert!(policy.needs_advance(generation, 5));
+    }
+
+    #[test]
+    fn generation_outside_the_bal_window_is_not_finishable() {
+        let headers = chain(Some(0));
+        let anchor = headers[1].clone();
+        let provider = provider_with(headers);
+        let generation = SnapGeneration::new(1, anchor.hash_slow(), anchor.state_root);
+        let policy = policy();
+
+        assert!(generation.is_canonical(&provider).unwrap());
+        assert!(policy.is_finishable(generation, 9));
+        assert!(!policy.is_finishable(generation, 10));
+    }
+
+    #[test]
+    fn downloaded_state_finishes_outside_the_bal_window() {
+        let anchor = chain(Some(0))[1].clone();
+        let generation = SnapGeneration::new(1, anchor.hash_slow(), anchor.state_root)
+            .with_phase(SnapPhase::Trie);
+
+        assert!(policy().is_finishable(generation, 1_000));
+    }
+
+    #[test]
+    fn reorged_anchor_is_not_canonical() {
+        let provider = provider_with(chain(Some(0)));
+        let generation = SnapGeneration::new(1, B256::repeat_byte(0xff), B256::ZERO);
+
+        assert!(!generation.is_canonical(&provider).unwrap());
+    }
+}

--- a/crates/snap-sync/src/pivot.rs
+++ b/crates/snap-sync/src/pivot.rs
@@ -15,16 +15,15 @@ use alloy_eip7928::BAL_RETENTION_PERIOD_SLOTS;
 use reth_primitives_traits::AlloyBlockHeader;
 use reth_storage_api::HeaderProvider;
 
-// EIP-8189 gives HEAD-64 as its example anchor, matching go-ethereum's `fsMinFullBlocks`.
+// EIP-8189's example anchor, matching go-ethereum's `fsMinFullBlocks`.
 const DEFAULT_HEAD_DISTANCE: u64 = 64;
 
-// Blocks of state history a serving peer is assumed to still hold. Mirrors reth's own
-// `SNAPSHOT_STATE_RETENTION`, which bounds the roots it will answer range requests for.
+// Blocks of state history a serving peer is assumed to still hold, mirroring reth's own
+// `SNAPSHOT_STATE_RETENTION`.
 const SERVED_STATE_WINDOW: u64 = 128;
 
-// Re-anchor before the pivot reaches the edge of the served window, so ranges already in flight do
-// not fail against a root peers have just dropped. go-ethereum re-anchors at
-// `2 * fsMinFullBlocks` minus a reorg-protection delay for the same reason.
+// Re-anchor before the pivot reaches the edge of that window, so ranges in flight do not fail
+// against a root peers just dropped.
 const DEFAULT_ADVANCE_AFTER: u64 = SERVED_STATE_WINDOW - DEFAULT_HEAD_DISTANCE / 2;
 
 /// Distance and history bounds that decide where a generation is anchored.

--- a/crates/snap-sync/src/session.rs
+++ b/crates/snap-sync/src/session.rs
@@ -9,23 +9,27 @@ use tokio_util::sync::CancellationToken;
 /// Targets come from the local chain, never from a peer: peers only supply state, which is
 /// authenticated against the target's state root.
 #[derive(Debug)]
-pub struct SnapSession {
+pub struct SnapSyncSession {
     // Decides which blocks are eligible targets.
     policy: SnapPivotPolicy,
     // How far the attempt has got.
-    state: SnapSessionState,
+    state: SnapSyncSessionState,
     // Cancelled once, watched by whatever took the target.
     cancellation: CancellationToken,
 }
 
-impl SnapSession {
+impl SnapSyncSession {
     /// Creates a session waiting for its first eligible target.
     pub fn new(policy: SnapPivotPolicy) -> Self {
-        Self { policy, state: SnapSessionState::Waiting, cancellation: CancellationToken::new() }
+        Self {
+            policy,
+            state: SnapSyncSessionState::Waiting,
+            cancellation: CancellationToken::new(),
+        }
     }
 
     /// What the session is doing.
-    pub const fn state(&self) -> &SnapSessionState {
+    pub const fn state(&self) -> &SnapSyncSessionState {
         &self.state
     }
 
@@ -49,11 +53,11 @@ impl SnapSession {
         provider: &impl HeaderProvider,
         head: u64,
         finalized: Option<u64>,
-    ) -> Result<&SnapSessionState, SnapSyncError> {
-        if matches!(self.state, SnapSessionState::Waiting | SnapSessionState::Selected(_)) {
+    ) -> Result<&SnapSyncSessionState, SnapSyncError> {
+        if matches!(self.state, SnapSyncSessionState::Waiting | SnapSyncSessionState::Selected(_)) {
             self.state = match self.policy.select(provider, head, finalized)? {
-                Some(generation) => SnapSessionState::Selected(generation),
-                None => SnapSessionState::Waiting,
+                Some(generation) => SnapSyncSessionState::Selected(generation),
+                None => SnapSyncSessionState::Waiting,
             };
         }
         Ok(&self.state)
@@ -64,8 +68,8 @@ impl SnapSession {
     /// Taking the target is what starts it, so only the first caller gets one: a target already
     /// being downloaded has an owner, and a waiting or cancelled session has nothing to hand out.
     pub fn start(&mut self) -> Option<(SnapGeneration, CancellationToken)> {
-        let SnapSessionState::Selected(generation) = self.state else { return None };
-        self.state = SnapSessionState::Downloading(generation);
+        let SnapSyncSessionState::Selected(generation) = self.state else { return None };
+        self.state = SnapSyncSessionState::Downloading(generation);
         Some((generation, self.cancellation.clone()))
     }
 
@@ -74,13 +78,13 @@ impl SnapSession {
     /// Terminal: a later attempt needs a new session.
     pub fn cancel(&mut self) {
         self.cancellation.cancel();
-        self.state = SnapSessionState::Cancelled;
+        self.state = SnapSyncSessionState::Cancelled;
     }
 }
 
-/// What a [`SnapSession`] is doing.
+/// What a [`SnapSyncSession`] is doing.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SnapSessionState {
+pub enum SnapSyncSessionState {
     /// No block is eligible yet, so the session holds no target.
     Waiting,
     /// A target is selected, but no work has taken it yet.
@@ -91,7 +95,7 @@ pub enum SnapSessionState {
     Cancelled,
 }
 
-impl SnapSessionState {
+impl SnapSyncSessionState {
     /// Target of this state, if it has one.
     pub const fn target(&self) -> Option<&SnapGeneration> {
         match self {
@@ -106,8 +110,8 @@ mod tests {
     use super::*;
     use crate::test_utils::{chain, policy, provider_with};
 
-    fn session() -> SnapSession {
-        SnapSession::new(policy())
+    fn session() -> SnapSyncSession {
+        SnapSyncSession::new(policy())
     }
 
     #[test]
@@ -116,7 +120,7 @@ mod tests {
         let provider = provider_with(chain(Some(3)));
         let mut session = session();
 
-        assert_eq!(session.select(&provider, 3, None).unwrap(), &SnapSessionState::Waiting);
+        assert_eq!(session.select(&provider, 3, None).unwrap(), &SnapSyncSessionState::Waiting);
         assert_eq!(session.target(), None);
         assert!(session.start().is_none());
     }
@@ -156,7 +160,7 @@ mod tests {
         // The head has run past the downloaded headers, so no candidate confirms the old target.
         session.select(&provider, 9, None).unwrap();
 
-        assert_eq!(session.state(), &SnapSessionState::Waiting);
+        assert_eq!(session.state(), &SnapSyncSessionState::Waiting);
         assert!(session.start().is_none());
     }
 
@@ -169,7 +173,7 @@ mod tests {
 
         session.select(&provider, 3, None).unwrap();
 
-        assert_eq!(session.state(), &SnapSessionState::Downloading(started));
+        assert_eq!(session.state(), &SnapSyncSessionState::Downloading(started));
     }
 
     #[test]
@@ -193,7 +197,7 @@ mod tests {
 
         assert!(outstanding.is_cancelled());
         assert!(session.is_cancelled());
-        assert_eq!(session.state(), &SnapSessionState::Cancelled);
+        assert_eq!(session.state(), &SnapSyncSessionState::Cancelled);
         assert_eq!(session.target(), None);
     }
 
@@ -203,7 +207,7 @@ mod tests {
         let mut session = session();
         session.cancel();
 
-        assert_eq!(session.select(&provider, 3, None).unwrap(), &SnapSessionState::Cancelled);
+        assert_eq!(session.select(&provider, 3, None).unwrap(), &SnapSyncSessionState::Cancelled);
         assert!(session.start().is_none());
     }
 }

--- a/crates/snap-sync/src/session.rs
+++ b/crates/snap-sync/src/session.rs
@@ -135,8 +135,8 @@ mod tests {
         session.select(&provider, 3, None).unwrap();
 
         let target = session.target().unwrap();
-        assert_eq!(target.target_block(), 2);
-        assert_eq!(target.target_hash(), expected.hash_slow());
+        assert_eq!(target.target().number, 2);
+        assert_eq!(target.target().hash, expected.hash_slow());
     }
 
     #[test]
@@ -145,10 +145,10 @@ mod tests {
         let mut session = session();
 
         session.select(&provider, 2, None).unwrap();
-        assert_eq!(session.target().unwrap().target_block(), 1);
+        assert_eq!(session.target().unwrap().target().number, 1);
 
         session.select(&provider, 3, None).unwrap();
-        assert_eq!(session.target().unwrap().target_block(), 2);
+        assert_eq!(session.target().unwrap().target().number, 2);
     }
 
     #[test]

--- a/crates/snap-sync/src/session.rs
+++ b/crates/snap-sync/src/session.rs
@@ -1,0 +1,209 @@
+//! Drives one snap synchronization attempt: what it targets, and when it stops.
+
+use crate::{SnapGeneration, SnapPivotPolicy, SnapSyncError};
+use reth_storage_api::HeaderProvider;
+use tokio_util::sync::CancellationToken;
+
+/// One snap synchronization attempt, from the pivot it targets to the work it owns.
+///
+/// Targets come from the local chain, never from a peer: peers only supply state, which is
+/// authenticated against the target's state root.
+#[derive(Debug)]
+pub struct SnapSession {
+    // Decides which blocks are eligible targets.
+    policy: SnapPivotPolicy,
+    // How far the attempt has got.
+    state: SnapSessionState,
+    // Cancelled once, watched by whatever took the target.
+    cancellation: CancellationToken,
+}
+
+impl SnapSession {
+    /// Creates a session waiting for its first eligible target.
+    pub fn new(policy: SnapPivotPolicy) -> Self {
+        Self { policy, state: SnapSessionState::Waiting, cancellation: CancellationToken::new() }
+    }
+
+    /// What the session is doing.
+    pub const fn state(&self) -> &SnapSessionState {
+        &self.state
+    }
+
+    /// Pivot this session is anchored to, if it has one.
+    pub const fn target(&self) -> Option<&SnapGeneration> {
+        self.state.target()
+    }
+
+    /// Returns whether this session has been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancellation.is_cancelled()
+    }
+
+    /// Selects a target under `head`, or waits while no block is eligible.
+    ///
+    /// A target no work has taken yet is replaced by a newer eligible one and dropped when none is
+    /// eligible, since nothing authenticates against its root so far. Moving a target that work
+    /// has taken is instead pivot advancement, which has to carry the downloaded state forward.
+    pub fn select(
+        &mut self,
+        provider: &impl HeaderProvider,
+        head: u64,
+        finalized: Option<u64>,
+    ) -> Result<&SnapSessionState, SnapSyncError> {
+        if matches!(self.state, SnapSessionState::Waiting | SnapSessionState::Selected(_)) {
+            self.state = match self.policy.select(provider, head, finalized)? {
+                Some(generation) => SnapSessionState::Selected(generation),
+                None => SnapSessionState::Waiting,
+            };
+        }
+        Ok(&self.state)
+    }
+
+    /// Hands the selected target, and the token to watch, to the work downloading against it.
+    ///
+    /// Taking the target is what starts it, so only the first caller gets one: a target already
+    /// being downloaded has an owner, and a waiting or cancelled session has nothing to hand out.
+    pub fn start(&mut self) -> Option<(SnapGeneration, CancellationToken)> {
+        let SnapSessionState::Selected(generation) = self.state else { return None };
+        self.state = SnapSessionState::Downloading(generation);
+        Some((generation, self.cancellation.clone()))
+    }
+
+    /// Signals outstanding work to stop and ends the session.
+    ///
+    /// Terminal: a later attempt needs a new session.
+    pub fn cancel(&mut self) {
+        self.cancellation.cancel();
+        self.state = SnapSessionState::Cancelled;
+    }
+}
+
+/// What a [`SnapSession`] is doing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SnapSessionState {
+    /// No block is eligible yet, so the session holds no target.
+    Waiting,
+    /// A target is selected, but no work has taken it yet.
+    Selected(SnapGeneration),
+    /// Work is outstanding against the target.
+    Downloading(SnapGeneration),
+    /// The session was cancelled and its outstanding work signalled to stop.
+    Cancelled,
+}
+
+impl SnapSessionState {
+    /// Target of this state, if it has one.
+    pub const fn target(&self) -> Option<&SnapGeneration> {
+        match self {
+            Self::Selected(generation) | Self::Downloading(generation) => Some(generation),
+            Self::Waiting | Self::Cancelled => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{chain, policy, provider_with};
+
+    fn session() -> SnapSession {
+        SnapSession::new(policy())
+    }
+
+    #[test]
+    fn waits_while_no_block_is_eligible() {
+        // The only block access list commitment is at the head, past the head distance.
+        let provider = provider_with(chain(Some(3)));
+        let mut session = session();
+
+        assert_eq!(session.select(&provider, 3, None).unwrap(), &SnapSessionState::Waiting);
+        assert_eq!(session.target(), None);
+        assert!(session.start().is_none());
+    }
+
+    #[test]
+    fn selects_an_eligible_target() {
+        let headers = chain(Some(0));
+        let expected = headers[2].clone();
+        let provider = provider_with(headers);
+        let mut session = session();
+
+        session.select(&provider, 3, None).unwrap();
+
+        let target = session.target().unwrap();
+        assert_eq!(target.target_block(), 2);
+        assert_eq!(target.target_hash(), expected.hash_slow());
+    }
+
+    #[test]
+    fn a_target_no_work_took_is_replaced_as_the_head_advances() {
+        let provider = provider_with(chain(Some(0)));
+        let mut session = session();
+
+        session.select(&provider, 2, None).unwrap();
+        assert_eq!(session.target().unwrap().target_block(), 1);
+
+        session.select(&provider, 3, None).unwrap();
+        assert_eq!(session.target().unwrap().target_block(), 2);
+    }
+
+    #[test]
+    fn a_target_no_work_took_is_dropped_once_it_is_no_longer_eligible() {
+        let provider = provider_with(chain(Some(0)));
+        let mut session = session();
+        session.select(&provider, 3, None).unwrap();
+
+        // The head has run past the downloaded headers, so no candidate confirms the old target.
+        session.select(&provider, 9, None).unwrap();
+
+        assert_eq!(session.state(), &SnapSessionState::Waiting);
+        assert!(session.start().is_none());
+    }
+
+    #[test]
+    fn a_target_work_took_is_kept() {
+        let provider = provider_with(chain(Some(0)));
+        let mut session = session();
+        session.select(&provider, 2, None).unwrap();
+        let (started, _) = session.start().unwrap();
+
+        session.select(&provider, 3, None).unwrap();
+
+        assert_eq!(session.state(), &SnapSessionState::Downloading(started));
+    }
+
+    #[test]
+    fn only_one_worker_takes_a_target() {
+        let provider = provider_with(chain(Some(0)));
+        let mut session = session();
+        session.select(&provider, 3, None).unwrap();
+
+        assert!(session.start().is_some());
+        assert!(session.start().is_none());
+    }
+
+    #[test]
+    fn cancellation_stops_outstanding_work() {
+        let provider = provider_with(chain(Some(0)));
+        let mut session = session();
+        session.select(&provider, 3, None).unwrap();
+        let (_, outstanding) = session.start().unwrap();
+
+        session.cancel();
+
+        assert!(outstanding.is_cancelled());
+        assert!(session.is_cancelled());
+        assert_eq!(session.state(), &SnapSessionState::Cancelled);
+        assert_eq!(session.target(), None);
+    }
+
+    #[test]
+    fn a_cancelled_session_selects_nothing() {
+        let provider = provider_with(chain(Some(0)));
+        let mut session = session();
+        session.cancel();
+
+        assert_eq!(session.select(&provider, 3, None).unwrap(), &SnapSessionState::Cancelled);
+        assert!(session.start().is_none());
+    }
+}

--- a/crates/snap-sync/src/test_utils.rs
+++ b/crates/snap-sync/src/test_utils.rs
@@ -1,0 +1,61 @@
+//! Header fixtures shared by the crate's tests.
+
+use crate::SnapPivotPolicy;
+use alloy_consensus::Header;
+use alloy_primitives::B256;
+use reth_provider::{
+    test_utils::create_test_provider_factory, DatabaseProviderFactory, StaticFileProviderFactory,
+    StaticFileWriter,
+};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::HeaderProvider;
+
+/// Small bounds keep header fixtures short without changing the policy's decisions.
+pub(crate) fn policy() -> SnapPivotPolicy {
+    SnapPivotPolicy::default().with_head_distance(1).with_advance_after(4).with_history(8)
+}
+
+/// A header with a state root distinctive to its number, and a commitment when one is given.
+pub(crate) fn header(
+    number: u64,
+    parent_hash: B256,
+    block_access_list_hash: Option<B256>,
+) -> Header {
+    Header {
+        number,
+        parent_hash,
+        state_root: B256::repeat_byte(number as u8),
+        block_access_list_hash,
+        ..Default::default()
+    }
+}
+
+/// Blocks `0..=3`, carrying a block access list commitment from `bal_from` onwards.
+pub(crate) fn chain(bal_from: Option<u64>) -> Vec<Header> {
+    let mut headers = Vec::new();
+    let mut parent = B256::ZERO;
+    for number in 0..=3 {
+        let bal =
+            bal_from.filter(|from| number >= *from).map(|_| B256::with_last_byte(number as u8));
+        let header = header(number, parent, bal);
+        parent = header.hash_slow();
+        headers.push(header);
+    }
+    headers
+}
+
+pub(crate) fn provider_with(
+    headers: impl IntoIterator<Item = Header>,
+) -> impl HeaderProvider<Header = Header> {
+    let factory = create_test_provider_factory();
+    let static_files = factory.static_file_provider();
+    let mut writer = static_files.latest_writer(StaticFileSegment::Headers).unwrap();
+    for header in headers {
+        let hash = header.hash_slow();
+        writer.append_header(&header, &hash).unwrap();
+    }
+    writer.commit().unwrap();
+    drop(writer);
+    drop(static_files);
+    factory.database_provider_ro().unwrap()
+}

--- a/crates/snap-sync/src/test_utils.rs
+++ b/crates/snap-sync/src/test_utils.rs
@@ -3,12 +3,7 @@
 use crate::SnapPivotPolicy;
 use alloy_consensus::Header;
 use alloy_primitives::B256;
-use reth_provider::{
-    test_utils::create_test_provider_factory, DatabaseProviderFactory, StaticFileProviderFactory,
-    StaticFileWriter,
-};
-use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::HeaderProvider;
+use reth_provider::test_utils::MockEthProvider;
 
 /// Small bounds keep header fixtures short without changing the policy's decisions.
 pub(crate) fn policy() -> SnapPivotPolicy {
@@ -44,18 +39,8 @@ pub(crate) fn chain(bal_from: Option<u64>) -> Vec<Header> {
     headers
 }
 
-pub(crate) fn provider_with(
-    headers: impl IntoIterator<Item = Header>,
-) -> impl HeaderProvider<Header = Header> {
-    let factory = create_test_provider_factory();
-    let static_files = factory.static_file_provider();
-    let mut writer = static_files.latest_writer(StaticFileSegment::Headers).unwrap();
-    for header in headers {
-        let hash = header.hash_slow();
-        writer.append_header(&header, &hash).unwrap();
-    }
-    writer.commit().unwrap();
-    drop(writer);
-    drop(static_files);
-    factory.database_provider_ro().unwrap()
+pub(crate) fn provider_with(headers: impl IntoIterator<Item = Header>) -> MockEthProvider {
+    let provider = MockEthProvider::default();
+    provider.extend_headers(headers.into_iter().map(|header| (header.hash_slow(), header)));
+    provider
 }


### PR DESCRIPTION
Related to [OSS-744](https://linear.app/tempoxyz/issue/OSS-744).

Adds `reth-snap-sync` with pivot selection and a session that identifies each attempt by its pivot hash and state root. Prefers a recent finalized block, falling back to 64 blocks behind the head when needed.

The session waits when no eligible pivot is available, replaces or clears an unstarted target as the chain changes, and signals cancellation to outstanding work.
