### PR TITLE
test: run native reth node under hermit

### DIFF
--- a/crates/ethereum/node/tests/it/hermit.rs
+++ b/crates/ethereum/node/tests/it/hermit.rs
@@ -1,0 +1,192 @@
+//! A native node workload for running the test executable under Hermit's scheduler.
+
+use alloy_network::eip2718::Encodable2718;
+use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionRequest};
+use jsonrpsee_core::client::ClientT;
+use reth_chainspec::{ChainSpecBuilder, MAINNET};
+use reth_db::test_utils::create_test_rw_db;
+use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet};
+use reth_ethereum_engine_primitives::EthPayloadAttributes;
+use reth_node_builder::{NodeBuilder, NodeConfig};
+use reth_node_core::{
+    args::{DatadirArgs, RpcServerArgs},
+    dirs::{DataDirPath, MaybePlatformPath},
+};
+use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_provider::{BlockNumReader, DatabaseProviderFactory};
+use reth_rpc_server_types::{RethRpcModule, RpcModuleSelection};
+use reth_tasks::Runtime;
+use reth_transaction_pool::TransactionPool;
+use serde_json::{json, Value};
+use std::{str::FromStr, sync::Arc, time::Duration};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "native node guest for the Hermit determinism demonstration"]
+async fn hermit_native_node_transfers() -> eyre::Result<()> {
+    let runtime = Runtime::test();
+    let directory = tempfile::tempdir()?;
+    let chain = Arc::new(
+        ChainSpecBuilder::default()
+            .chain(MAINNET.chain)
+            .genesis(serde_json::from_str(include_str!("../assets/genesis.json"))?)
+            .cancun_activated()
+            .build(),
+    );
+    let mut rpc = RpcServerArgs::default().with_http();
+    rpc.http_api =
+        Some(RpcModuleSelection::from_iter([RethRpcModule::Eth, RethRpcModule::Testing]));
+    rpc.ipcdisable = true;
+    let mut config = NodeConfig::test()
+        .with_chain(chain.clone())
+        .with_datadir_args(DatadirArgs {
+            datadir: MaybePlatformPath::<DataDirPath>::from_str(
+                directory.path().to_str().unwrap(),
+            )?,
+            static_files_path: Some(directory.path().join("static")),
+            rocksdb_path: Some(directory.path().join("rocksdb")),
+            pprof_dumps_path: Some(directory.path().join("pprof")),
+        })
+        .with_rpc(rpc)
+        .with_unused_ports()
+        .with_disabled_discovery();
+    config.network.bootnodes = Some(vec![]);
+    config.network.max_outbound_peers = Some(0);
+    config.network.max_inbound_peers = Some(0);
+    config.network.nat = "none".parse()?;
+    config.network.p2p_secret_key_hex = Some(B256::repeat_byte(1));
+    config.engine.persistence_threshold = 1;
+    config.engine.memory_block_buffer_target = Some(0);
+    config.engine.num_state_masking_blocks = 0;
+    let builder = NodeBuilder::new(config)
+        .with_database(create_test_rw_db())
+        .with_launch_context(runtime.clone())
+        .with_types::<EthereumNode>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default());
+    let launcher = builder.engine_api_launcher();
+    let node = builder.launch_with(launcher).await?;
+    let client = node.node.rpc_server_handle().http_client().expect("HTTP enabled");
+    let wallet = Wallet::default();
+    let sender = wallet.inner.address();
+    let recipient = Address::repeat_byte(0x42);
+    let initial_balance: U256 =
+        client.request("eth_getBalance", (sender, BlockNumberOrTag::Latest)).await?;
+    let mut parent = chain.genesis_hash();
+    let mut total_fees = U256::ZERO;
+    let mut transcript = Vec::new();
+
+    // Fixed inputs keep the chain invariant while Hermit varies native thread scheduling.
+    // Five transactions also reach the engine's speculative prewarming threshold.
+    for height in 1..=3u64 {
+        let mut hashes = Vec::new();
+        for nonce in (height - 1) * 5..height * 5 {
+            let transaction = TransactionTestContext::sign_tx(
+                wallet.inner.clone(),
+                TransactionRequest {
+                    chain_id: Some(1),
+                    nonce: Some(nonce),
+                    gas: Some(21_000),
+                    max_fee_per_gas: Some(1_000_000_000_000),
+                    max_priority_fee_per_gas: Some(20_000_000_000),
+                    to: Some(recipient.into()),
+                    value: Some(U256::from(100)),
+                    ..Default::default()
+                },
+            )
+            .await;
+            let encoded = Bytes::from(transaction.encoded_2718());
+            let hash: B256 = client.request("eth_sendRawTransaction", (encoded,)).await?;
+            hashes.push(hash);
+        }
+        let attributes = EthPayloadAttributes {
+            timestamp: height * 12,
+            prev_randao: B256::repeat_byte(2),
+            suggested_fee_recipient: Address::repeat_byte(3),
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
+            ..Default::default()
+        };
+        let hash: B256 = client
+            .request(
+                "testing_commitBlockV1",
+                (attributes, Option::<Vec<Bytes>>::None, Some(Bytes::from_static(b"hermit"))),
+            )
+            .await?;
+        let block: Value =
+            client.request("eth_getBlockByNumber", (BlockNumberOrTag::Latest, false)).await?;
+        assert_eq!(block["hash"], json!(hash));
+        assert_eq!(block["parentHash"], json!(parent));
+        assert_eq!(block["number"], json!(format!("{height:#x}")));
+        assert_eq!(block["transactions"], json!(hashes));
+        assert_eq!(block["gasUsed"], json!(format!("{:#x}", 5 * 21_000)));
+        for (index, tx_hash) in hashes.iter().enumerate() {
+            let receipt: Value = client.request("eth_getTransactionReceipt", (tx_hash,)).await?;
+            assert_eq!(receipt["blockHash"], json!(hash));
+            assert_eq!(receipt["transactionIndex"], json!(format!("{index:#x}")));
+            assert_eq!(receipt["status"], json!("0x1"));
+            let gas: U256 = serde_json::from_value(receipt["gasUsed"].clone())?;
+            assert_eq!(gas, U256::from(21_000));
+            let price: U256 = serde_json::from_value(receipt["effectiveGasPrice"].clone())?;
+            total_fees += gas * price;
+        }
+        transcript.push(json!({
+            "number": height,
+            "hash": hash,
+            "stateRoot": block["stateRoot"],
+            "receiptsRoot": block["receiptsRoot"],
+            "transactions": hashes,
+        }));
+        parent = hash;
+        // The next batch depends on the production pool maintenance actor observing this head.
+        tokio::time::timeout(Duration::from_secs(30), async {
+            while node.node.pool.block_info().last_seen_block_hash != hash {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await?;
+    }
+
+    let nonce: U256 =
+        client.request("eth_getTransactionCount", (sender, BlockNumberOrTag::Latest)).await?;
+    let sender_balance: U256 =
+        client.request("eth_getBalance", (sender, BlockNumberOrTag::Latest)).await?;
+    let recipient_balance: U256 =
+        client.request("eth_getBalance", (recipient, BlockNumberOrTag::Latest)).await?;
+    assert_eq!(nonce, U256::from(15));
+    assert_eq!(recipient_balance, U256::from(1_500));
+    assert_eq!(sender_balance, initial_balance - total_fees - recipient_balance);
+
+    // Observe a real background commit, including the memory-to-disk provider boundary.
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if node.node.provider.database_provider_ro()?.best_block_number()? >= 2 {
+                return eyre::Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await??;
+    for (index, expected) in transcript.iter().enumerate() {
+        let block: Value =
+            client.request("eth_getBlockByNumber", (format!("{:#x}", index + 1), false)).await?;
+        assert_eq!(block["hash"], expected["hash"]);
+        assert_eq!(block["stateRoot"], expected["stateRoot"]);
+    }
+    println!(
+        "RETH_HERMIT_RESULT {}",
+        json!({
+            "blocks": transcript,
+            "senderNonce": nonce,
+            "senderBalance": sender_balance,
+            "recipientBalance": recipient_balance,
+        })
+    );
+    let shutdown_runtime = runtime.clone();
+    let stopped = tokio::task::spawn_blocking(move || {
+        shutdown_runtime.graceful_shutdown_with_timeout(Duration::from_secs(30))
+    })
+    .await?;
+    assert!(stopped, "native node did not drain its graceful tasks");
+    Ok(())
+}

--- a/crates/ethereum/node/tests/it/main.rs
+++ b/crates/ethereum/node/tests/it/main.rs
@@ -2,6 +2,7 @@
 
 mod builder;
 mod exex;
+mod hermit;
 mod testing;
 
 const fn main() {}

--- a/docs/design/deterministic-testing.md
+++ b/docs/design/deterministic-testing.md
@@ -6,6 +6,9 @@ building, EVM validation, forkchoice, live block download, and persistence under
 Production and simulation share their application drivers. Separate Loom and real-database crash
 tests cover properties that the cooperative executor cannot establish.
 
+For a native node experiment that controls OS threads and syscalls with Hermit,
+see [Running a native Reth node under Hermit](hermit-dst.md).
+
 ## Running and replaying
 
 Run the simulation campaigns with:

--- a/docs/design/hermit-dst.md
+++ b/docs/design/hermit-dst.md
@@ -1,0 +1,192 @@
+# Running a native Reth node under Hermit
+
+This experiment runs Reth's ordinary node launcher, Tokio/Rayon workers, HTTP RPC,
+transaction pool, engine, and database under [Hermit](https://github.com/facebookexperimental/hermit).
+Hermit controls execution at the operating-system boundary. The guest does not use
+the cooperative Commonware executor described in [deterministic-testing.md](deterministic-testing.md).
+
+The checkout is based on [PR #27017](https://github.com/paradigmxyz/reth/pull/27017),
+commit `1be64bcdaf641fdfdec8429d45f87e43b3e0dbc9`. The workload follows that branch's
+use of fixed signed transactions, explicit block timestamps, and checks across the
+memory-to-disk boundary.
+
+## Observed result
+
+The initial campaign, using `--no-pmu`, passed on September 7, 2026. All three seeds completed the real node
+workload and matched the native control's chain transcript. For each seed,
+Hermit's standard verifier passed and two independent runs had byte-identical
+stdout/stderr and identical ordered thread/operation events.
+
+| Scheduler seed | Native threads | Scheduler turns | Recorded events | Schedule SHA-256 prefix |
+| --- | ---: | ---: | ---: | --- |
+| 1 | 61 | 3,318 | 28,830 | `9443327a7a51` |
+| 2 | 61 | 3,265 | 28,758 | `3e40c1efaa2c` |
+| 3 | 61 | 3,257 | 28,886 | `ed0af8dcd99e` |
+
+Each seed executes four times: two ordinary runs plus the verifier's two runs.
+The 12 node executions and probes took about 44 seconds wall time. All result
+JSON files had SHA-256
+`1b320abc7f78e46046c19bea5b7aa0ab2b9ebe650c718f6e6b72a77d5c58276a`.
+The local evidence is in `target/hermit-dst/calibrated-campaign/`, including
+`results.json`, `commands.json`, and per-seed output/schedule files.
+
+The guest was compiled with Rust 1.96.1, `CARGO_PROFILE_DEV_DEBUG=0`,
+`CARGO_PROFILE_DEV_SPLIT_DEBUGINFO=off`, and `CARGO_INCREMENTAL=0`. Its binary hash
+was `874c42a67a7fdcb744652737958119df18d4191c41f2ae420a359623ab96e366`;
+the Hermit binary hash was
+`f72d73bc5b251df0784a27a6f9b97fd82808d8767f345bf24ad7979008abad9f`.
+Changing binaries can change the recorded schedules.
+
+## PMU enablement follow-up
+
+After applying the host's rr Zen workaround, the same Hermit binary passed PMU
+startup validation. A CPU-only loop of 10 million iterations completed with 100
+`inbound timer preemption event` log entries at a 1 ms virtual maximum timeslice;
+99 completed slices had zero syscalls and zero signals. The expected sum was
+`49999995000000`. Local source, executable, and diagnostic evidence are retained
+in `target/hermit-dst/pmu-probe/`.
+
+The PMU-enabled node workload then passed twice with scheduler seed 1, matching
+the native chain transcript. Both runs had byte-identical stdout/stderr and
+identical complete schedule JSON: 63,323 events, 675,270,496 conditional branches,
+2,572 scheduler turns, and 62 threads. The first execution took 197.7 seconds.
+`target/hermit-dst/pmu-campaign/pmu-repeat-verification.json` records the independent
+comparison. Hermit's separate two-run verifier exceeded the old 300-second host
+limit during its second execution, so the three-seed campaign remains incomplete;
+its `status.json` correctly records failure. The runner now defaults to 900 seconds
+per invocation to accommodate PMU overhead. This follow-up establishes exact
+seed-1 repeatability, but does not claim built-in verifier success or a completed
+three-seed PMU campaign.
+
+## Workload
+
+The ignored integration test `hermit::hermit_native_node_transfers` starts a node
+and a loopback HTTP client in the same process. It submits 15 signed transfers via
+`eth_sendRawTransaction`, commits three blocks through `testing_commitBlockV1`, and
+checks transaction order, canonical parents, receipts, gas usage, fees, balances,
+and the sender nonce. It waits for the background database worker to persist at
+least two blocks, rereads the chain, and drains graceful shutdown tasks.
+
+Each run emits a `RETH_HERMIT_RESULT` JSON transcript containing block hashes,
+state roots, receipt roots, transaction hashes, and final balances. Inputs are
+fixed while Hermit varies scheduling. Matching chain results across seeds is the
+application invariant; repeated-run verification separately checks reproducibility.
+
+Discovery, bootnodes, NAT, IPC, and inbound/outbound peer slots are disabled. All
+mutable guest data belongs in Hermit's fresh `/tmp`. Running the client outside
+Hermit, sharing a database between repetitions, or accessing a live chain would
+introduce uncontrolled inputs.
+
+## Build Hermit
+
+Use x86-64 Linux with user, PID, and mount namespaces, parent-child ptrace, and
+seccomp support. Hermit needs nightly Rust and the libunwind/LZMA development
+packages. On Debian or Ubuntu:
+
+```sh
+sudo apt-get install libunwind-dev liblzma-dev
+git clone https://github.com/rrnewton/hermit.git hermit
+cd hermit
+git checkout f6c836b18dac01a7dc632449d5069ffeb6a3efdc
+cargo rustc --release -p hermit --bin hermit --no-default-features -- -C link-arg=-llzma
+```
+
+The maintained fork is recommended by the upstream README. The upstream revision
+`2c609dd1d392b3d37471a367b750d702b304fe2c` failed to build because experimental
+backend modules lacked corresponding Cargo dependencies. Maintained revision
+`471a14f9374e7d4c05c96a6da18ff7c5e4de64b5` builds, but its Reverie notifier calls
+`pidfd_open(..., PIDFD_THREAD)`, which returns `EINVAL` on the development host's
+Linux 6.8 kernel even for a `/bin/true` guest. The older revision above pins
+Reverie to `22791b2fe7a837da233758ddb8f546b0c8ee07aa`, which uses the compatible
+`waitid` notifier. The explicit LZMA link resolves the distribution's libunwind
+dependencies. These are build/version choices; the setup does not patch Hermit's
+determinization implementation.
+
+## Native control run
+
+Build the guest outside Hermit:
+
+```sh
+CFLAGS=-DMDBX_SAFE4QEMU=1 cargo test --locked -p reth-node-ethereum --test it \
+  hermit::hermit_native_node_transfers -- \
+  --exact --ignored --nocapture --test-threads=1
+```
+
+The native control passed on the development host: three blocks, 15 successful
+transfers, sender nonce 15, recipient balance 1,500 wei, and background persistence.
+Its final block and state root were:
+
+```text
+block: 0x0be2a0d622f46555817f048ead7d21ce0669274ee07adaabd7be702e42b847e0
+state: 0xef064400f6f5002e79e1e054f3290cdd55ac6eea83413c9ef2512aefed18ccc4
+```
+
+Native success alone does not establish deterministic execution. The Hermit
+campaign must also complete and its verification artifacts must be checked.
+
+`MDBX_SAFE4QEMU` is an existing libmdbx build option. It avoids priority-inheritance
+mutexes and OFD file locks; Hermit's futex model does not implement
+`FUTEX_UNLOCK_PI`, which glibc probes during MDBX's default mutex initialization.
+The flag changes the build configuration without editing vendored libmdbx sources.
+Use the same configuration for the native control and Hermit guest.
+
+## Run a seed campaign
+
+From the Reth checkout, point the runner at the compiled Hermit binary:
+
+```sh
+CFLAGS=-DMDBX_SAFE4QEMU=1 \
+CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_DEV_SPLIT_DEBUGINFO=off CARGO_INCREMENTAL=0 \
+HERMIT_BIN=/absolute/path/to/hermit/target/release/hermit \
+HERMIT_SRC=/absolute/path/to/hermit \
+  python3 scripts/hermit-dst.py --verification=standard --no-virtualize-cpuid 1 2 3
+```
+
+The runner discovers the test executable through Cargo's JSON build output.
+Set `GUEST_BIN` to reuse a previously compiled executable. Pass
+`--native-output /path/to/native.stdout` to additionally compare against a saved
+native control run. `--timeout` sets a host wall-clock limit for each Hermit
+invocation; a timeout terminates the process group and fails the campaign.
+
+For each seed, the runner compares two ordinary runs and performs Hermit's
+two-run `--verify` check. The guest RNG seed remains zero.
+`--chaos --sched-heuristic=random` varies thread scheduling. By default the runner
+also enables PMU preemption with `--max-timeslice=200000000` (200 virtual
+milliseconds), RCB-based time, `--clock-multiplier=1`, and
+`--panic-on-rcb-overshoot`. This allows timer interrupts inside CPU-bound code.
+Hermit diagnostics are retained separately from guest stderr, and detected PMU
+validation failures or unavailable counters fail the campaign.
+
+The development host is an AMD EPYC 4585PX running Linux 6.8. Before enabling PMU,
+apply the official [rr Zen workaround](https://github.com/rr-debugger/rr/wiki/Zen)
+on the host and confirm that `AmdSpecLockMapShouldBeDisabled` no longer appears.
+CPUID faulting remains unavailable on this kernel, so the command explicitly
+exposes the host's CPUID results. Reproduction is tied to the same CPU features;
+this does not establish CPU-model independence.
+
+To reproduce the initial syscall-only campaign, pass `--no-pmu`. That explicit
+profile disables PMU preemption and RCB time and sets `--clock-multiplier=0.002`
+to cancel this Hermit revision's implicit 500-fold clock scaling. It explores
+syscall/thread scheduling points without preempting CPU-only stretches. Both
+profiles retain the fixture's ordinary RPC and persistence deadlines.
+
+Artifacts in `target/hermit-dst/campaign-*` include exact commands, exit codes,
+binary/source/lockfile hashes, source snapshots, native and guest transcripts,
+schedule events, Hermit's summaries, verification JSON, and guest/verifier output.
+This older runtime deletes matched internal verification logs; its comparison
+counts and verdict remain in the captured verifier stderr. Newer runtimes with
+`--keep-logs` additionally retain both internal logs.
+The compatible runtime supports standard verification, which compares guest
+stdout/stderr/status and filtered, normalized deterministic logs. Independent
+same-seed comparisons retain exact stdout/stderr and ordered schedule events.
+The runner also requires identical application transcripts across all seeds. Multiple seeds
+must produce different ordered thread/operation event sequences; changing seed
+metadata alone does not count as schedule exploration.
+
+On a compatible newer runtime, the runner's default `--verification=strict` mode
+requires `verified` and `bitwise_parity` from `--verify-strict --verify-json`.
+That policy includes syscall output hashes with host addresses canonicalized;
+it is stronger than the legacy runtime's filtered log comparison. Neither mode
+is a byte-for-byte comparison of process memory or database files. A passing finite campaign is
+evidence for this workload, binary, runtime, and host configuration; it does not
+establish determinism for every Reth path.

--- a/scripts/hermit-dst.py
+++ b/scripts/hermit-dst.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Run the native Ethereum node integration test under Hermit's scheduler.
+
+HERMIT_BIN selects the Hermit executable; GUEST_BIN reuses an already built test
+executable. HERMIT_SRC optionally identifies the corresponding Hermit checkout.
+Strict verification requires --verify-strict/--verify-json. The explicit standard
+policy supports older Hermit versions and supplements their filtered log check
+with exact stdout/stderr and normalized scheduler-event comparisons.
+PMU preemption is enabled by default. The explicit --no-pmu profile uses clock-multiplier=0.002 to cancel Hermit's extra 500x
+sequential clock scaling, which otherwise expires RPC deadlines during this test.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST = "hermit::hermit_native_node_transfers"
+MARKER = "RETH_HERMIT_RESULT "
+GUEST_PATH = "/tmp/reth-hermit-payload/guest"
+BUILD_ENVIRONMENT = ["CFLAGS", "CXXFLAGS", "RUSTFLAGS", "CARGO_PROFILE_DEV_DEBUG",
+                     "CARGO_PROFILE_DEV_SPLIT_DEBUGINFO", "CARGO_INCREMENTAL", "CARGO_TARGET_DIR"]
+GUEST_ENV = {
+    "HOME": "/tmp",
+    "TMPDIR": "/tmp",
+    "RAYON_NUM_THREADS": "2",
+    "TZ": "UTC",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "RUST_BACKTRACE": "0",
+}
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def capture(command):
+    try:
+        result = subprocess.run(command, text=True, capture_output=True, check=False)
+    except OSError:
+        return None
+    if result.returncode:
+        return None
+    return result.stdout.strip()
+
+
+def source_metadata(path, output, name):
+    revision = capture(["git", "-C", str(path), "rev-parse", "HEAD"])
+    if revision is None:
+        return None
+    status = capture(["git", "-C", str(path), "status", "--porcelain"])
+    patch = output / f"{name}.patch"
+    with patch.open("wb") as destination:
+        subprocess.run(
+            ["git", "-C", str(path), "diff", "--binary", "HEAD"],
+            stdout=destination,
+            check=True,
+        )
+    result = {"path": str(path), "revision": revision, "status": status,
+              "patch": patch.name, "patch_sha256": sha256(patch)}
+    source_root = capture(["git", "-C", str(path), "rev-parse", "--show-toplevel"])
+    lock = Path(source_root) / "Cargo.lock"
+    if lock.is_file():
+        snapshot = output / f"{name}-Cargo.lock"
+        shutil.copyfile(lock, snapshot)
+        result["cargo_lock"] = {"snapshot": snapshot.name, "sha256": sha256(snapshot)}
+    return result
+
+
+def executable(value):
+    found = shutil.which(value)
+    if not found:
+        raise RuntimeError(f"executable not found: {value}")
+    return Path(found).resolve()
+
+
+def read_result(path):
+    results = [line.partition(MARKER)[2] for line in path.read_text().splitlines()
+               if MARKER in line]
+    if len(results) != 1:
+        raise RuntimeError(f"{path}: expected exactly one {MARKER.strip()} transcript")
+    return json.loads(results[0])
+
+
+class Campaign:
+    def __init__(self, output, verification, build_environment):
+        self.output = output
+        self.verification = verification
+        self.supported_options = set()
+        self.commands = []
+        self.results = []
+        self.host_tmp = output / "host-tmp"
+        self.host_tmp.mkdir()
+        self.host_env = {"TMPDIR": str(self.host_tmp), "NO_COLOR": "1", **build_environment}
+
+    def run(self, name, command, timeout):
+        stdout = self.output / f"{name}.stdout"
+        stderr = self.output / f"{name}.stderr"
+        record = {"name": name, "argv": command, "cwd": str(ROOT),
+                  "environment_overrides": self.host_env, "timeout_seconds": timeout,
+                  "stdout": stdout.name, "stderr": stderr.name}
+        self.commands.append(record)
+        write_json(self.output / "commands.json", self.commands)
+        shell = "env " + shlex.join([f"{k}={v}" for k, v in self.host_env.items()] + command)
+        with (self.output / "commands.sh").open("a") as commands:
+            commands.write(f"cd {shlex.quote(str(ROOT))}\n{shell} >"
+                           f"{shlex.quote(str(stdout))} 2>{shlex.quote(str(stderr))}\n")
+        print(f"{name}: running (timeout {timeout}s)", flush=True)
+        started = time.monotonic()
+        with stdout.open("wb") as out, stderr.open("wb") as err:
+            process = subprocess.Popen(command, cwd=ROOT, stdout=out, stderr=err,
+                                       env={**os.environ, **self.host_env}, start_new_session=True)
+            try:
+                status = process.wait(timeout=timeout)
+            except (subprocess.TimeoutExpired, KeyboardInterrupt) as error:
+                # Hermit can have tracees and a container supervisor; stop the whole group.
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait()
+                record["timed_out_or_interrupted"] = True
+                status = 124 if isinstance(error, subprocess.TimeoutExpired) else 130
+        record.update(exit_code=status, elapsed_seconds=round(time.monotonic() - started, 3))
+        write_json(self.output / "commands.json", self.commands)
+        if status != 0:
+            tail = stderr.read_text(errors="replace").splitlines()[-25:]
+            print("\n".join(tail), file=sys.stderr)
+            raise RuntimeError(f"{name} failed with status {status}; see {stderr}")
+        diagnostics = stderr.read_text(errors="replace")
+        log = self.output / f"{name}-hermit.log"
+        if log.exists():
+            diagnostics += log.read_text(errors="replace")
+        if re.search(r"PMU validation failed|AmdSpecLockMapShouldBeDisabled|"
+                     r"disabling.*(?:timeslice|preemption)|"
+                     r"perf_event_open.*(?:failed|unavailable)|"
+                     r"continuing with --max-timeslice=disabled",
+                     diagnostics, re.IGNORECASE):
+            raise RuntimeError(f"{name}: unreliable or unavailable PMU; see diagnostic logs")
+        return stdout
+
+    def verify(self, name, common, guest, timeout):
+        options = ["--verify"]
+        report = self.output / f"{name}.json"
+        if self.verification == "strict":
+            options += ["--verify-strict", f"--verify-json={report}"]
+        if {"--keep-logs", "--verify-log-dir"} <= self.supported_options:
+            log_dir = self.output / f"{name}-logs"
+            log_dir.mkdir()
+            options += ["--keep-logs", f"--verify-log-dir={log_dir}"]
+        self.run(name, [common[0], "--log=info"] + common[1:] + options + ["--"] + guest, timeout)
+        if self.verification == "strict":
+            result = json.loads(report.read_text())
+            if result.get("verified") is not True or result.get("bitwise_parity") is not True:
+                raise RuntimeError(f"{name} did not establish strict parity; see {report}")
+        else:
+            result = {"verified": True, "bitwise_parity": None,
+                      "policy": "standard", "reporter": "hermit-dst.py",
+                      "evidence": "Hermit --verify exited successfully; internal logs are filtered"}
+            write_json(report, result)
+        return result
+
+    def guest_run(self, name, common, guest, timeout):
+        summary_path = self.output / f"{name}-summary.json"
+        schedule_path = self.output / f"{name}-schedule.json"
+        stdout = self.run(name, [common[0], "--log=warn", f"--log-file={self.output / (name + '-hermit.log')}"] + common[1:] + [f"--summary-json={summary_path}",
+                          f"--record-preemptions-to={schedule_path}", "--"] + guest, timeout)
+        summary = json.loads(summary_path.read_text())
+        schedule = json.loads(schedule_path.read_text())
+        # Only thread/operation order proves schedule variation. Ignore initial priorities,
+        # addresses, timing, and any configuration metadata in the recording.
+        events = [[event["dettid"], event["op"], event["count"]]
+                  for event in schedule["global"]]
+        if not events:
+            raise RuntimeError(f"{name}: schedule contains no recorded events")
+        write_json(self.output / f"{name}-schedule-events.json", events)
+        return stdout, summary, events
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("seeds", nargs="*", type=int, default=[1, 2, 3],
+                        help="scheduler seeds (default: 1 2 3; guest RNG seed stays 0)")
+    parser.add_argument("--hermit-bin", default=os.environ.get("HERMIT_BIN", "hermit"))
+    parser.add_argument("--guest-bin", default=os.environ.get("GUEST_BIN"))
+    parser.add_argument("--native-output", type=Path,
+                        help="also compare chain results with an existing native test stdout log")
+    parser.add_argument("--output-dir", type=Path,
+                        help="new artifact directory outside /tmp (default: target/hermit-dst)")
+    parser.add_argument("--timeout", type=int, default=900,
+                        help="wall-clock timeout for each Hermit invocation, seconds (default: 900)")
+    parser.add_argument("--build-timeout", type=int, default=7200)
+    parser.add_argument("--verification", choices=["strict", "standard"], default="strict",
+                        help="standard explicitly allows filtered Hermit logs and adds an exact "
+                             "stdout/stderr and event-order repeat check (default: strict)")
+    parser.add_argument("--mdbx-safe4qemu", action="store_true",
+                        help="append -DMDBX_SAFE4QEMU=1 to CFLAGS when building the test guest")
+    parser.add_argument("--no-virtualize-cpuid", action="store_true",
+                        help="explicitly expose host CPU features; records this portability limit")
+    parser.add_argument("--no-pmu", action="store_true",
+                        help="explicitly disable branch-counter preemption and RCB time")
+    args = parser.parse_args()
+    if any(seed < 0 or seed > 2**64 - 1 for seed in args.seeds):
+        parser.error("seeds must fit an unsigned 64-bit integer")
+    if len(set(args.seeds)) != len(args.seeds):
+        parser.error("seeds must be distinct")
+    if args.timeout <= 0 or args.build_timeout <= 0:
+        parser.error("timeouts must be positive")
+    hermit = executable(args.hermit_bin)
+    if args.output_dir:
+        output = args.output_dir.resolve()
+        if output == Path("/tmp") or Path("/tmp") in output.parents:
+            parser.error("Hermit's isolated /tmp would hide summary/preemption artifact paths")
+        output.mkdir(parents=True, exist_ok=False)
+    else:
+        parent = ROOT / "target" / "hermit-dst"
+        parent.mkdir(parents=True, exist_ok=True)
+        output = Path(tempfile.mkdtemp(prefix="campaign-", dir=parent))
+    print(f"Artifacts: {output}", flush=True)
+    build_environment = {name: os.environ[name] for name in BUILD_ENVIRONMENT if name in os.environ}
+    if args.mdbx_safe4qemu:
+        build_environment["CFLAGS"] = (build_environment.get("CFLAGS", "")
+                                      + " -DMDBX_SAFE4QEMU=1").strip()
+    campaign = Campaign(output, args.verification, build_environment)
+    common = [str(hermit), "run", "--backend=ptrace", "--base-env=minimal", "--workdir=/tmp",
+              "--chaos", "--sched-heuristic=random", "--seed=0", "--rng-seed=0", "--fuzz-seed=0",
+              "--epoch=2026-01-01T00:00:00Z"]
+    if args.no_pmu:
+        common += ["--preemption-timeout=disabled", "--no-rcb-time", "--clock-multiplier=0.002"]
+    else:
+        common += ["--max-timeslice=200000000", "--clock-multiplier=1",
+                   "--panic-on-rcb-overshoot"]
+    for name, value in GUEST_ENV.items():
+        common += ["-e", f"{name}={value}"]
+    if args.no_virtualize_cpuid:
+        common.append("--no-virtualize-cpuid")
+    hermit_source = Path(os.environ.get("HERMIT_SRC", hermit.parent))
+    metadata = {
+        "created_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "host": platform.uname()._asdict(),
+        "cpu": capture(["lscpu"]),
+        "reth": source_metadata(ROOT, output, "reth"),
+        "hermit": {"path": str(hermit), "sha256": sha256(hermit),
+                   "version": capture([str(hermit), "--version"]),
+                   "source": source_metadata(hermit_source, output, "hermit")},
+        "rustc": capture(["rustc", "-Vv"]),
+        "cargo": capture(["cargo", "-V"]),
+        "test": TEST,
+        "scheduler_seeds": args.seeds,
+        "guest_rng_seed": 0,
+        "fuzz_seed": 0,
+        "epoch": "2026-01-01T00:00:00Z",
+        "guest_environment": GUEST_ENV,
+        "virtualize_cpuid": not args.no_virtualize_cpuid,
+        "preemption_timeout": "disabled" if args.no_pmu else 200000000,
+        "rcb_time": not args.no_pmu,
+        "clock_multiplier": 0.002 if args.no_pmu else 1,
+        "build_environment": build_environment,
+        "verification": args.verification,
+        "comparison": ("--verify-strict (Hermit canonical INFO parity)"
+                       if args.verification == "strict" else
+                       "--verify (filtered internal logs) plus exact external stdout/stderr "
+                       "and normalized scheduler-event repeat; no bitwise internal-log parity claim"),
+        "source_sha256": {str(path.relative_to(ROOT)): sha256(path) for path in [
+            ROOT / "Cargo.lock", ROOT / "Cargo.toml", Path(__file__).resolve(),
+            ROOT / "crates/ethereum/node/tests/it/main.rs",
+            ROOT / "crates/ethereum/node/tests/it/hermit.rs"]},
+    }
+    write_json(output / "metadata.json", metadata)
+    try:
+        for source in metadata["source_sha256"]:
+            snapshot = output / "source" / source
+            snapshot.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(ROOT / source, snapshot)
+        help_path = campaign.run("hermit-help", [str(hermit), "run", "--help"], args.timeout)
+        campaign.supported_options = set(re.findall(
+            r"^\s+(?:-[A-Za-z],\s+)?(--[a-z][a-z0-9-]*)", help_path.read_text(), re.MULTILINE))
+        metadata["hermit"]["supported_options"] = sorted(campaign.supported_options)
+        metadata["hermit"]["keeps_matched_verification_logs"] = (
+            {"--keep-logs", "--verify-log-dir"} <= campaign.supported_options)
+        write_json(output / "metadata.json", metadata)
+        required = {"--verify", "--summary-json", "--record-preemptions-to"}
+        if args.verification == "strict":
+            required |= {"--verify-strict", "--verify-json"}
+        missing = required - campaign.supported_options
+        if missing:
+            raise RuntimeError(f"Hermit lacks options required by {args.verification} policy: "
+                               + ", ".join(sorted(missing)))
+        campaign.verify("probe", common + [f"--sched-seed={args.seeds[0]}"],
+                        ["/bin/true"], args.timeout)
+        if args.guest_bin:
+            guest = executable(args.guest_bin)
+            metadata["guest_build"] = "supplied via GUEST_BIN/--guest-bin"
+        else:
+            build_log = campaign.run("build", ["cargo", "test", "--locked", "-p",
+                                      "reth-node-ethereum", "--test", "it", "--no-run",
+                                      "--message-format=json"], args.build_timeout)
+            artifacts = set()
+            for line in build_log.read_text().splitlines():
+                message = json.loads(line)
+                if (message.get("reason") == "compiler-artifact"
+                        and message.get("target", {}).get("name") == "it"
+                        and "test" in message.get("target", {}).get("kind", [])
+                        and message.get("executable")):
+                    artifacts.add(message["executable"])
+            if len(artifacts) != 1:
+                raise RuntimeError(f"expected one integration-test executable, found {artifacts}")
+            guest = executable(artifacts.pop())
+            metadata["guest_build"] = "Cargo compiler-artifact executable"
+        metadata["guest"] = {"path": str(guest), "sha256": sha256(guest)}
+        write_json(output / "metadata.json", metadata)
+        # Older Hermit versions cannot resolve a file bind's program path; a directory bind
+        # also limits the guest-visible payload to this exact executable.
+        payload = output / "payload"
+        payload.mkdir()
+        try:
+            os.link(guest, payload / "guest")
+        except OSError:
+            shutil.copy2(guest, payload / "guest")
+        common += [f"--bind={payload}:/tmp/reth-hermit-payload"]
+        guest_args = [GUEST_PATH, TEST, "--ignored", "--exact", "--nocapture", "--test-threads=1"]
+        expected = read_result(args.native_output) if args.native_output else None
+        if args.native_output:
+            write_json(output / "native-result.json", expected)
+            metadata["native_output"] = {"path": str(args.native_output.resolve()),
+                                         "sha256": sha256(args.native_output)}
+            write_json(output / "metadata.json", metadata)
+        schedules = set()
+        for seed in args.seeds:
+            name = f"seed-{seed}"
+            seed_args = common + [f"--sched-seed={seed}"]
+            stdout, summary, events = campaign.guest_run(name, seed_args, guest_args, args.timeout)
+            result = read_result(stdout)
+            write_json(output / f"{name}-result.json", result)
+            if expected is None:
+                expected = result
+            elif result != expected:
+                raise RuntimeError(f"{name}: chain transcript differs from the baseline result")
+            verification = campaign.verify(f"{name}-verify", seed_args, guest_args, args.timeout)
+            if args.verification == "standard":
+                repeated = f"{name}-repeat"
+                _, _, repeated_events = campaign.guest_run(repeated, seed_args, guest_args, args.timeout)
+                for stream in ["stdout", "stderr"]:
+                    original_path = output / f"{name}.{stream}"
+                    repeated_path = output / f"{repeated}.{stream}"
+                    if original_path.read_bytes() != repeated_path.read_bytes():
+                        raise RuntimeError(f"{name}: same-seed {stream} bytes differ on repeat")
+                if events != repeated_events:
+                    raise RuntimeError(f"{name}: same-seed scheduler-event sequence differs on repeat")
+            canonical_schedule = json.dumps(events, sort_keys=True, separators=(",", ":"))
+            schedule_hash = hashlib.sha256(canonical_schedule.encode()).hexdigest()
+            schedules.add(schedule_hash)
+            campaign.results.append({"seed": seed, "verified": verification["verified"],
+                                     "verification": args.verification,
+                                     "bitwise_parity": verification["bitwise_parity"],
+                                     "exact_output_and_event_repeat": args.verification == "standard",
+                                     "schedule_sha256": schedule_hash,
+                                     "schedule_events": len(events),
+                                     "sched_turns": summary["sched_turns"],
+                                     "num_threads": summary["num_threads"],
+                                     "result_sha256": sha256(output / f"{name}-result.json")})
+            write_json(output / "results.json", campaign.results)
+            print(f"{name}: {args.verification} verification passed, {summary['sched_turns']} scheduler turns, "
+                  f"{summary['num_threads']} threads, schedule {schedule_hash[:12]}", flush=True)
+        if len(args.seeds) > 1 and len(schedules) < 2:
+            raise RuntimeError("seeds produced identical schedule records; schedule variation unproven")
+        write_json(output / "status.json", {"status": "passed", "seeds": args.seeds,
+                                           "verification": args.verification,
+                                           "distinct_schedules": len(schedules)})
+        print(f"PASS: {len(args.seeds)} seeds, {len(schedules)} distinct schedules, "
+              f"identical chain transcript. Artifacts: {output}")
+        return 0
+    except (RuntimeError, OSError, ValueError, KeyError, subprocess.SubprocessError) as error:
+        write_json(output / "status.json", {"status": "failed", "error": str(error)})
+        print(f"FAIL: {error}\nArtifacts retained: {output}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Ref: #27017

Adds a native-node Hermit workload and seeded runner covering transactions, block execution, and persistence with ordinary Tokio/Rayon workers. The runner enables PMU preemption by default, retains execution artifacts, and compares repeated schedules and chain transcripts.

Documents host requirements, reproduction steps, and the coverage limits of PMU and syscall-only scheduling. Stacked on #27017.
