### PR TITLE
perf(txpool): cache pooled transaction in-memory size

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1544,6 +1544,7 @@ pub trait EthPoolTransaction: PoolTransaction {
 ///
 /// - `cost`: Pre-calculated max cost (gas * price + value + blob costs)
 /// - `encoded_length`: Cached RLP encoding length for size limits
+/// - `in_memory_size`: Cached transaction size for subpool memory accounting
 /// - `blob_sidecar`: Blob data state (None/Missing/Present)
 /// - `blob_cell_availability`: Cached blob cell availability for eth/72 announcements
 ///
@@ -1562,6 +1563,11 @@ pub struct EthPooledTransaction<T = TransactionSigned> {
     /// This is the RLP length of the transaction, computed when the transaction is added to the
     /// pool.
     pub encoded_length: usize,
+
+    /// Cached in-memory size of `transaction`, excluding the blob sidecar.
+    ///
+    /// Must be updated if `transaction` is modified or replaced.
+    pub in_memory_size: usize,
 
     /// The blob side car for this transaction
     pub blob_sidecar: EthBlobTransactionSidecar,
@@ -1601,7 +1607,15 @@ impl<T: SignedTransaction> EthPooledTransaction<T> {
             blob_cell_availability = Some(BlobCellAvailability::full());
         }
 
-        Self { transaction, cost, encoded_length, blob_sidecar, blob_cell_availability }
+        let in_memory_size = transaction.size();
+        Self {
+            transaction,
+            cost,
+            encoded_length,
+            in_memory_size,
+            blob_sidecar,
+            blob_cell_availability,
+        }
     }
 
     /// Return the reference to the underlying transaction.
@@ -1699,8 +1713,9 @@ impl<T: Typed2718> Typed2718 for EthPooledTransaction<T> {
 }
 
 impl<T: InMemorySize> InMemorySize for EthPooledTransaction<T> {
+    #[inline]
     fn size(&self) -> usize {
-        self.transaction.size()
+        self.in_memory_size
     }
 }
 


### PR DESCRIPTION
Caches the transaction's in-memory size in `EthPooledTransaction::in_memory_size`, alongside `encoded_length`, so subpool insertion, removal and promotion accounting can reuse it instead of walking the transaction's variable-length fields repeatedly. Blob sidecar accounting is unchanged; callers that construct the public struct directly must initialize the new field.

Supersedes https://github.com/tempoxyz/tempo/pull/7422 by placing the cache in the shared Reth wrapper.
