### PR TITLE
feat(net): log transaction broadcast topology and summaries

### DIFF
--- a/crates/cli/commands/src/download/config_gen.rs
+++ b/crates/cli/commands/src/download/config_gen.rs
@@ -7,17 +7,12 @@ use reth_config::config::{BlocksPerFileConfig, Config, PruneConfig, StaticFilesC
 use reth_db::tables;
 use reth_db_api::transaction::{DbTx, DbTxMut};
 use reth_node_core::args::DefaultPruningValues;
-use reth_prune_types::{PruneCheckpoint, PruneMode, PruneSegment};
+use reth_prune_types::{
+    PruneCheckpoint, PruneMode, PruneSegment, MINIMUM_DISTANCE, MINIMUM_UNWIND_SAFE_DISTANCE,
+};
 use reth_stages_types::StageCheckpoint;
 use std::{collections::BTreeMap, path::Path};
 use tracing::info;
-
-/// Minimum blocks to keep for receipts, matching `--minimal` prune settings.
-const MINIMUM_RECEIPTS_DISTANCE: u64 = 64;
-
-/// Minimum blocks to keep for history/bodies, matching `--minimal` prune settings
-/// (`MINIMUM_UNWIND_SAFE_DISTANCE`).
-const MINIMUM_HISTORY_DISTANCE: u64 = 10064;
 
 /// Writes a [`Config`] as TOML to `<data_dir>/reth.toml`.
 ///
@@ -181,8 +176,19 @@ pub(crate) fn config_for_selections(
         },
     };
 
-    if is_archive || matches!(preset, Some(SelectionPreset::Archive)) {
+    if matches!(preset, Some(SelectionPreset::Archive)) {
         return Config { static_files, ..Default::default() };
+    }
+
+    if matches!(preset, Some(SelectionPreset::Minimal)) {
+        return Config {
+            prune: PruneConfig {
+                segments: DefaultPruningValues::get_global().minimal_prune_modes.clone(),
+                ..Default::default()
+            },
+            static_files,
+            ..Default::default()
+        };
     }
 
     if matches!(preset, Some(SelectionPreset::Full)) {
@@ -205,6 +211,10 @@ pub(crate) fn config_for_selections(
         };
     }
 
+    if is_archive {
+        return Config { static_files, ..Default::default() };
+    }
+
     let mut config = Config::default();
     let mut prune = PruneConfig::default();
 
@@ -213,19 +223,21 @@ pub(crate) fn config_for_selections(
     }
     prune.segments.transaction_lookup = Some(PruneMode::Full);
 
-    if let Some(mode) = selection_to_prune_mode(tx_sel, Some(MINIMUM_HISTORY_DISTANCE)) {
+    if let Some(mode) = selection_to_prune_mode(tx_sel, Some(MINIMUM_UNWIND_SAFE_DISTANCE)) {
         prune.segments.bodies_history = Some(mode);
     }
 
-    if let Some(mode) = selection_to_prune_mode(receipt_sel, Some(MINIMUM_RECEIPTS_DISTANCE)) {
+    if let Some(mode) = selection_to_prune_mode(receipt_sel, Some(MINIMUM_DISTANCE)) {
         prune.segments.receipts = Some(mode);
     }
 
-    if let Some(mode) = selection_to_prune_mode(account_cs_sel, Some(MINIMUM_HISTORY_DISTANCE)) {
+    if let Some(mode) = selection_to_prune_mode(account_cs_sel, Some(MINIMUM_UNWIND_SAFE_DISTANCE))
+    {
         prune.segments.account_history = Some(mode);
     }
 
-    if let Some(mode) = selection_to_prune_mode(storage_cs_sel, Some(MINIMUM_HISTORY_DISTANCE)) {
+    if let Some(mode) = selection_to_prune_mode(storage_cs_sel, Some(MINIMUM_UNWIND_SAFE_DISTANCE))
+    {
         prune.segments.storage_history = Some(mode);
     }
 
@@ -409,19 +421,16 @@ mod tests {
         // All segments clamped to their minimum distances
         assert_eq!(
             config.prune.segments.bodies_history,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
+            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
         );
-        assert_eq!(
-            config.prune.segments.receipts,
-            Some(PruneMode::Distance(MINIMUM_RECEIPTS_DISTANCE))
-        );
+        assert_eq!(config.prune.segments.receipts, Some(PruneMode::Distance(MINIMUM_DISTANCE)));
         assert_eq!(
             config.prune.segments.account_history,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
+            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
         );
         assert_eq!(
             config.prune.segments.storage_history,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
+            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
         );
     }
 
@@ -448,10 +457,7 @@ mod tests {
         assert_eq!(config.prune.segments.sender_recovery, Some(PruneMode::Full));
         // Bodies follows tx selection
         assert_eq!(config.prune.segments.bodies_history, Some(PruneMode::Distance(10_064)));
-        assert_eq!(
-            config.prune.segments.receipts,
-            Some(PruneMode::Distance(MINIMUM_RECEIPTS_DISTANCE))
-        );
+        assert_eq!(config.prune.segments.receipts, Some(PruneMode::Distance(MINIMUM_DISTANCE)));
         assert_eq!(config.prune.segments.account_history, Some(PruneMode::Distance(10_064)));
         assert_eq!(config.prune.segments.storage_history, Some(PruneMode::Distance(10_064)));
     }
@@ -507,15 +513,15 @@ mod tests {
         assert_eq!(config.prune.segments.transaction_lookup, None);
         assert_eq!(
             config.prune.segments.receipts,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
+            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
         );
         assert_eq!(
             config.prune.segments.account_history,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
+            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
         );
         assert_eq!(
             config.prune.segments.storage_history,
-            Some(PruneMode::Distance(MINIMUM_HISTORY_DISTANCE))
+            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
         );
 
         let paris_block = chain_spec
@@ -523,6 +529,18 @@ mod tests {
             .block_number()
             .expect("mainnet Paris block should be known");
         assert_eq!(config.prune.segments.bodies_history, Some(PruneMode::Before(paris_block)));
+    }
+
+    #[test]
+    fn minimal_preset_matches_default_minimal_prune_config() {
+        let config = config_for_selections(
+            &BTreeMap::new(),
+            &empty_manifest(),
+            Some(SelectionPreset::Minimal),
+            None::<&reth_chainspec::ChainSpec>,
+        );
+
+        assert_eq!(&config.prune.segments, &DefaultPruningValues::get_global().minimal_prune_modes);
     }
 
     #[test]

--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -257,28 +257,6 @@ impl SnapshotComponentType {
         matches!(self, Self::State | Self::Headers)
     }
 
-    /// Returns the default selection for this component in the minimal download preset.
-    ///
-    /// Matches the `--minimal` prune configuration:
-    /// - State/Headers: always All (required)
-    /// - Transactions/Changesets: Distance(10_064) (`MINIMUM_UNWIND_SAFE_DISTANCE`)
-    /// - Receipts: Distance(64) (`MINIMUM_DISTANCE`)
-    /// - TransactionSenders: None (only downloaded for archive nodes)
-    /// - RocksdbIndices: None (only downloaded for archive nodes)
-    ///
-    /// `tx_lookup` and `sender_recovery` are always pruned full regardless.
-    pub const fn minimal_selection(&self) -> ComponentSelection {
-        match self {
-            Self::State | Self::Headers => ComponentSelection::All,
-            Self::Transactions | Self::AccountChangesets | Self::StorageChangesets => {
-                ComponentSelection::Distance(10_064)
-            }
-            Self::Receipts => ComponentSelection::Distance(64),
-            Self::TransactionSenders => ComponentSelection::None,
-            Self::RocksdbIndices => ComponentSelection::None,
-        }
-    }
-
     /// Whether this component type uses chunked archives.
     pub const fn is_chunked(&self) -> bool {
         !matches!(self, Self::State | Self::RocksdbIndices)

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -108,7 +108,7 @@ use reth_db::{init_db, Database};
 use reth_db_api::transaction::DbTx;
 use reth_fs_util as fs;
 use reth_node_core::args::DefaultPruningValues;
-use reth_prune_types::PruneMode;
+use reth_prune_types::{PruneMode, PruneModes};
 use source::{
     discover_manifest_url, fetch_manifest_from_source, fetch_snapshot_api_entries,
     print_snapshot_listing, resolve_manifest_base_url,
@@ -741,8 +741,10 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         }
 
         // Interactive TUI
+        let minimal_preset = self.minimal_preset_selections(manifest);
         let full_preset = self.full_preset_selections(manifest);
-        let SelectorOutput { selections, preset } = run_selector(manifest.clone(), &full_preset)?;
+        let SelectorOutput { selections, preset } =
+            run_selector(manifest.clone(), &minimal_preset, &full_preset)?;
         let selected =
             selections.into_iter().filter(|(_, sel)| *sel != ComponentSelection::None).collect();
 
@@ -754,12 +756,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         &self,
         manifest: &SnapshotManifest,
     ) -> BTreeMap<SnapshotComponentType, ComponentSelection> {
-        SnapshotComponentType::ALL
-            .iter()
-            .copied()
-            .filter(|ty| manifest.component(*ty).is_some())
-            .map(|ty| (ty, ty.minimal_selection()))
-            .collect()
+        self.pruning_preset_selections(manifest, SelectionPreset::Minimal)
     }
 
     /// Builds the default full-node component selection for the manifest.
@@ -767,23 +764,36 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         &self,
         manifest: &SnapshotManifest,
     ) -> BTreeMap<SnapshotComponentType, ComponentSelection> {
+        self.pruning_preset_selections(manifest, SelectionPreset::Full)
+    }
+
+    /// Builds component selections from the configured pruning preset.
+    fn pruning_preset_selections(
+        &self,
+        manifest: &SnapshotManifest,
+        preset: SelectionPreset,
+    ) -> BTreeMap<SnapshotComponentType, ComponentSelection> {
+        let defaults = DefaultPruningValues::get_global();
+        let (prune_modes, bodies_history_use_pre_merge) = match preset {
+            SelectionPreset::Minimal => (&defaults.minimal_prune_modes, false),
+            SelectionPreset::Full => {
+                (&defaults.full_prune_modes, defaults.full_bodies_history_use_pre_merge)
+            }
+            SelectionPreset::Archive => unreachable!("archive selects every component"),
+        };
         let mut selections = BTreeMap::new();
 
-        for ty in [
-            SnapshotComponentType::State,
-            SnapshotComponentType::Headers,
-            SnapshotComponentType::Transactions,
-            SnapshotComponentType::Receipts,
-            SnapshotComponentType::AccountChangesets,
-            SnapshotComponentType::StorageChangesets,
-            SnapshotComponentType::TransactionSenders,
-            SnapshotComponentType::RocksdbIndices,
-        ] {
+        for &ty in &SnapshotComponentType::ALL {
             if manifest.component(ty).is_none() {
                 continue;
             }
 
-            let selection = self.full_selection_for_component(ty, manifest.block);
+            let selection = self.pruning_selection_for_component(
+                ty,
+                manifest.block,
+                prune_modes,
+                bodies_history_use_pre_merge,
+            );
             if selection != ComponentSelection::None {
                 selections.insert(ty, selection);
             }
@@ -792,51 +802,40 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         selections
     }
 
-    /// Returns the full preset selection for one component type.
-    fn full_selection_for_component(
+    /// Returns the component selection for one configured pruning preset.
+    fn pruning_selection_for_component(
         &self,
         ty: SnapshotComponentType,
         snapshot_block: u64,
+        prune_modes: &PruneModes,
+        bodies_history_use_pre_merge: bool,
     ) -> ComponentSelection {
-        let defaults = DefaultPruningValues::get_global();
-        match ty {
-            SnapshotComponentType::State | SnapshotComponentType::Headers => {
-                ComponentSelection::All
+        if ty == SnapshotComponentType::Transactions && bodies_history_use_pre_merge {
+            return match self
+                .env
+                .chain
+                .ethereum_fork_activation(EthereumHardfork::Paris)
+                .block_number()
+            {
+                Some(paris) if snapshot_block >= paris => ComponentSelection::Since(paris),
+                Some(_) => ComponentSelection::None,
+                None => ComponentSelection::All,
             }
-            SnapshotComponentType::Transactions => {
-                if defaults.full_bodies_history_use_pre_merge {
-                    match self
-                        .env
-                        .chain
-                        .ethereum_fork_activation(EthereumHardfork::Paris)
-                        .block_number()
-                    {
-                        Some(paris) if snapshot_block >= paris => ComponentSelection::Since(paris),
-                        Some(_) => ComponentSelection::None,
-                        None => ComponentSelection::All,
-                    }
-                } else {
-                    selection_from_prune_mode(
-                        defaults.full_prune_modes.bodies_history,
-                        snapshot_block,
-                    )
-                }
-            }
-            SnapshotComponentType::Receipts => {
-                selection_from_prune_mode(defaults.full_prune_modes.receipts, snapshot_block)
-            }
-            SnapshotComponentType::AccountChangesets => {
-                selection_from_prune_mode(defaults.full_prune_modes.account_history, snapshot_block)
-            }
-            SnapshotComponentType::StorageChangesets => {
-                selection_from_prune_mode(defaults.full_prune_modes.storage_history, snapshot_block)
-            }
-            SnapshotComponentType::TransactionSenders => {
-                selection_from_prune_mode(defaults.full_prune_modes.sender_recovery, snapshot_block)
-            }
-            // Keep hidden by default in full mode; if users want indices they can use archive.
-            SnapshotComponentType::RocksdbIndices => ComponentSelection::None,
         }
+
+        let mode = match ty {
+            SnapshotComponentType::State | SnapshotComponentType::Headers => {
+                return ComponentSelection::All
+            }
+            SnapshotComponentType::Transactions => prune_modes.bodies_history,
+            SnapshotComponentType::TransactionSenders => prune_modes.sender_recovery,
+            SnapshotComponentType::Receipts => prune_modes.receipts,
+            SnapshotComponentType::AccountChangesets => prune_modes.account_history,
+            SnapshotComponentType::StorageChangesets => prune_modes.storage_history,
+            SnapshotComponentType::RocksdbIndices => return ComponentSelection::None,
+        };
+
+        selection_from_prune_mode(mode, snapshot_block)
     }
 
     /// Resolves the manifest source from CLI input or snapshot discovery.
@@ -1278,6 +1277,67 @@ mod tests {
         ]);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn minimal_component_selection_uses_configured_prune_modes() {
+        let args =
+            CommandParser::<DownloadCommand<EthereumChainSpecParser>>::parse_from(["reth"]).args;
+        let history_distance = 64_864;
+        let modes = PruneModes {
+            sender_recovery: Some(PruneMode::Full),
+            receipts: Some(PruneMode::Distance(128)),
+            account_history: Some(PruneMode::Distance(history_distance)),
+            storage_history: Some(PruneMode::Distance(history_distance)),
+            bodies_history: Some(PruneMode::Distance(history_distance)),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            args.pruning_selection_for_component(
+                SnapshotComponentType::Transactions,
+                1_000_000,
+                &modes,
+                false,
+            ),
+            ComponentSelection::Distance(history_distance)
+        );
+        assert_eq!(
+            args.pruning_selection_for_component(
+                SnapshotComponentType::Receipts,
+                1_000_000,
+                &modes,
+                false,
+            ),
+            ComponentSelection::Distance(128)
+        );
+        assert_eq!(
+            args.pruning_selection_for_component(
+                SnapshotComponentType::AccountChangesets,
+                1_000_000,
+                &modes,
+                false,
+            ),
+            ComponentSelection::Distance(history_distance)
+        );
+        assert_eq!(
+            args.pruning_selection_for_component(
+                SnapshotComponentType::StorageChangesets,
+                1_000_000,
+                &modes,
+                false,
+            ),
+            ComponentSelection::Distance(history_distance)
+        );
+        assert_eq!(
+            args.pruning_selection_for_component(
+                SnapshotComponentType::TransactionSenders,
+                1_000_000,
+                &modes,
+                false,
+            ),
+            ComponentSelection::None
+        );
     }
 
     #[test]

--- a/crates/cli/commands/src/download/tui.rs
+++ b/crates/cli/commands/src/download/tui.rs
@@ -16,6 +16,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
     Frame, Terminal,
 };
+use reth_prune_types::{MINIMUM_DISTANCE, MINIMUM_UNWIND_SAFE_DISTANCE};
 use std::{
     collections::BTreeMap,
     io,
@@ -33,25 +34,25 @@ pub struct SelectorOutput {
 /// All distance presets. Groups filter this to only valid options.
 const DISTANCE_PRESETS: [ComponentSelection; 6] = [
     ComponentSelection::None,
-    ComponentSelection::Distance(64),
-    ComponentSelection::Distance(10_064),
+    ComponentSelection::Distance(MINIMUM_DISTANCE),
+    ComponentSelection::Distance(MINIMUM_UNWIND_SAFE_DISTANCE),
     ComponentSelection::Distance(100_000),
     ComponentSelection::Distance(1_000_000),
     ComponentSelection::All,
 ];
 
-/// Presets for components that require at least 64 blocks (receipts).
+/// Presets for components that require the minimum pruning distance (receipts).
 const RECEIPTS_PRESETS: [ComponentSelection; 5] = [
-    ComponentSelection::Distance(64),
-    ComponentSelection::Distance(10_064),
+    ComponentSelection::Distance(MINIMUM_DISTANCE),
+    ComponentSelection::Distance(MINIMUM_UNWIND_SAFE_DISTANCE),
     ComponentSelection::Distance(100_000),
     ComponentSelection::Distance(1_000_000),
     ComponentSelection::All,
 ];
 
-/// Presets for components that require at least 10064 blocks (account/storage history).
+/// Presets for components that require the minimum unwind-safe history.
 const HISTORY_PRESETS: [ComponentSelection; 4] = [
-    ComponentSelection::Distance(10_064),
+    ComponentSelection::Distance(MINIMUM_UNWIND_SAFE_DISTANCE),
     ComponentSelection::Distance(100_000),
     ComponentSelection::Distance(1_000_000),
     ComponentSelection::All,
@@ -67,11 +68,43 @@ struct DisplayGroup {
     required: bool,
     /// Valid presets for this group. Components with minimum distance requirements
     /// exclude presets that would produce invalid prune configs.
-    presets: &'static [ComponentSelection],
+    presets: Vec<ComponentSelection>,
+}
+
+/// Adds a configured preset to the ordered list of generic TUI choices.
+fn presets_with_configured(
+    presets: &[ComponentSelection],
+    configured: ComponentSelection,
+) -> Vec<ComponentSelection> {
+    let mut presets = presets.to_vec();
+    if presets.contains(&configured) {
+        return presets;
+    }
+
+    let insert_at = match configured {
+        ComponentSelection::None => 0,
+        ComponentSelection::Distance(distance) => presets
+            .iter()
+            .position(|selection| {
+                matches!(selection, ComponentSelection::Distance(other) if *other > distance) ||
+                    matches!(selection, ComponentSelection::All)
+            })
+            .unwrap_or(presets.len()),
+        ComponentSelection::Since(_) => presets
+            .iter()
+            .position(|selection| matches!(selection, ComponentSelection::All))
+            .unwrap_or(presets.len()),
+        ComponentSelection::All => presets.len(),
+    };
+    presets.insert(insert_at, configured);
+    presets
 }
 
 /// Build the display groups from available components in the manifest.
-fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
+fn build_groups(
+    manifest: &SnapshotManifest,
+    minimal_preset: &BTreeMap<SnapshotComponentType, ComponentSelection>,
+) -> Vec<DisplayGroup> {
     let has = |ty: SnapshotComponentType| manifest.component(ty).is_some();
 
     let mut groups = Vec::new();
@@ -81,7 +114,7 @@ fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
             name: "State (mdbx)",
             types: vec![SnapshotComponentType::State],
             required: true,
-            presets: &DISTANCE_PRESETS,
+            presets: DISTANCE_PRESETS.to_vec(),
         });
     }
 
@@ -90,7 +123,7 @@ fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
             name: "Headers",
             types: vec![SnapshotComponentType::Headers],
             required: true,
-            presets: &DISTANCE_PRESETS,
+            presets: DISTANCE_PRESETS.to_vec(),
         });
     }
 
@@ -99,7 +132,13 @@ fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
             name: "Transactions",
             types: vec![SnapshotComponentType::Transactions],
             required: false,
-            presets: &HISTORY_PRESETS,
+            presets: presets_with_configured(
+                &HISTORY_PRESETS,
+                minimal_preset
+                    .get(&SnapshotComponentType::Transactions)
+                    .copied()
+                    .unwrap_or(ComponentSelection::None),
+            ),
         });
     }
 
@@ -108,7 +147,13 @@ fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
             name: "Receipts",
             types: vec![SnapshotComponentType::Receipts],
             required: false,
-            presets: &RECEIPTS_PRESETS,
+            presets: presets_with_configured(
+                &RECEIPTS_PRESETS,
+                minimal_preset
+                    .get(&SnapshotComponentType::Receipts)
+                    .copied()
+                    .unwrap_or(ComponentSelection::None),
+            ),
         });
     }
 
@@ -123,11 +168,12 @@ fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
         if has_stor {
             types.push(SnapshotComponentType::StorageChangesets);
         }
+        let configured = minimal_preset.get(&types[0]).copied().unwrap_or(ComponentSelection::None);
         groups.push(DisplayGroup {
             name: "State History",
             types,
             required: false,
-            presets: &HISTORY_PRESETS,
+            presets: presets_with_configured(&HISTORY_PRESETS, configured),
         });
     }
 
@@ -136,6 +182,7 @@ fn build_groups(manifest: &SnapshotManifest) -> Vec<DisplayGroup> {
 
 struct SelectorApp {
     manifest: SnapshotManifest,
+    minimal_preset: BTreeMap<SnapshotComponentType, ComponentSelection>,
     full_preset: BTreeMap<SnapshotComponentType, ComponentSelection>,
     /// Display groups shown in the TUI.
     groups: Vec<DisplayGroup>,
@@ -152,18 +199,23 @@ struct SelectorApp {
 impl SelectorApp {
     fn new(
         manifest: SnapshotManifest,
+        minimal_preset: BTreeMap<SnapshotComponentType, ComponentSelection>,
         full_preset: BTreeMap<SnapshotComponentType, ComponentSelection>,
     ) -> Self {
-        let groups = build_groups(&manifest);
+        let groups = build_groups(&manifest, &minimal_preset);
 
         // Default to the minimal preset (matches --minimal prune config)
-        let selections = groups.iter().map(|g| g.types[0].minimal_selection()).collect();
+        let selections = groups
+            .iter()
+            .map(|g| minimal_preset.get(&g.types[0]).copied().unwrap_or(ComponentSelection::None))
+            .collect();
 
         let mut list_state = ListState::default();
         list_state.select(Some(0));
 
         Self {
             manifest,
+            minimal_preset,
             full_preset,
             groups,
             selections,
@@ -178,7 +230,7 @@ impl SelectorApp {
             if group.required {
                 return;
             }
-            let presets = group.presets;
+            let presets = &group.presets;
             let current = self.selections[self.cursor];
             let idx = presets.iter().position(|p| *p == current).unwrap_or(0);
             self.selections[self.cursor] = presets[(idx + 1) % presets.len()];
@@ -191,7 +243,7 @@ impl SelectorApp {
             if group.required {
                 return;
             }
-            let presets = group.presets;
+            let presets = &group.presets;
             let current = self.selections[self.cursor];
             let idx = presets.iter().position(|p| *p == current).unwrap_or(0);
             self.selections[self.cursor] = presets[(idx + presets.len() - 1) % presets.len()];
@@ -206,14 +258,22 @@ impl SelectorApp {
 
     fn select_minimal(&mut self) {
         for (i, group) in self.groups.iter().enumerate() {
-            self.selections[i] = group.types[0].minimal_selection();
+            self.selections[i] = self
+                .minimal_preset
+                .get(&group.types[0])
+                .copied()
+                .unwrap_or(ComponentSelection::None);
         }
         self.preset = Some(SelectionPreset::Minimal);
     }
 
     fn select_full(&mut self) {
         for (i, group) in self.groups.iter().enumerate() {
-            let mut selection = group.types[0].minimal_selection();
+            let mut selection = self
+                .minimal_preset
+                .get(&group.types[0])
+                .copied()
+                .unwrap_or(ComponentSelection::None);
             for ty in &group.types {
                 if let Some(sel) = self.full_preset.get(ty).copied() {
                     selection = sel;
@@ -278,6 +338,7 @@ impl SelectorApp {
 /// Runs the interactive component selector TUI.
 pub fn run_selector(
     manifest: SnapshotManifest,
+    minimal_preset: &BTreeMap<SnapshotComponentType, ComponentSelection>,
     full_preset: &BTreeMap<SnapshotComponentType, ComponentSelection>,
 ) -> eyre::Result<SelectorOutput> {
     enable_raw_mode()?;
@@ -286,7 +347,7 @@ pub fn run_selector(
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = SelectorApp::new(manifest, full_preset.clone());
+    let mut app = SelectorApp::new(manifest, minimal_preset.clone(), full_preset.clone());
     let result = event_loop(&mut terminal, &mut app);
 
     disable_raw_mode()?;
@@ -435,4 +496,26 @@ fn render(f: &mut Frame<'_>, app: &mut SelectorApp) {
     .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
     .block(Block::default().borders(Borders::ALL));
     f.render_widget(footer, chunks[2]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_distance_is_an_ordered_tui_choice() {
+        let configured = ComponentSelection::Distance(64_864);
+        let presets = presets_with_configured(&HISTORY_PRESETS, configured);
+
+        assert_eq!(
+            presets,
+            vec![
+                ComponentSelection::Distance(MINIMUM_UNWIND_SAFE_DISTANCE),
+                configured,
+                ComponentSelection::Distance(100_000),
+                ComponentSelection::Distance(1_000_000),
+                ComponentSelection::All,
+            ]
+        );
+    }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -330,9 +330,6 @@ where
     payload_builds: PayloadBuildTracker,
     /// Notifies the engine when the final active payload job finishes.
     payload_build_finished: Receiver<()>,
-    /// A durable persistence completion whose destructive in-memory handoff is deferred until
-    /// payload jobs finish.
-    pending_persisted_handoff: Option<PersistenceResult>,
     /// Task runtime for spawning blocking work on named, reusable threads.
     runtime: reth_tasks::Runtime,
 }
@@ -361,7 +358,6 @@ where
             .field("evm_config", &self.evm_config)
             .field("execution_timing_stats", &self.execution_timing_stats.len())
             .field("payload_builds_active", &self.payload_builds.is_active())
-            .field("pending_persisted_handoff", &self.pending_persisted_handoff)
             .field("runtime", &self.runtime)
             .finish()
     }
@@ -429,7 +425,6 @@ where
             execution_timing_stats: B256Map::default(),
             payload_builds,
             payload_build_finished,
-            pending_persisted_handoff: None,
             runtime,
         }
     }
@@ -606,12 +601,7 @@ where
                         return
                     }
                 }
-                LoopEvent::PayloadBuildFinished => {
-                    if let Err(err) = self.on_payload_build_finished() {
-                        error!(target: "engine::tree", %err, "Payload build completion handling failed");
-                        return
-                    }
-                }
+                LoopEvent::PayloadBuildFinished => {}
                 LoopEvent::Disconnected => {
                     error!(target: "engine::tree", "Channel disconnected");
                     return
@@ -647,28 +637,11 @@ where
         }
     }
 
-    /// Blocks until the next event that can safely be processed is ready.
+    /// Blocks until the next event is ready.
     ///
-    /// A pending persisted handoff keeps processing engine messages while prioritizing the
-    /// notification that all active payload builds have finished. This keeps the engine responsive
-    /// without reclaiming the in-memory overlay while a payload job may still access it. Otherwise,
-    /// uses biased selection to prioritize persistence completion to update in-memory state and
-    /// unblock further writes.
+    /// Uses biased selection to prioritize persistence completion so in-memory state is updated and
+    /// further writes are unblocked.
     fn wait_for_event(&mut self) -> LoopEvent<T, N> {
-        if self.pending_persisted_handoff.is_some() {
-            self.metrics.engine.backpressure_active.set(0.0);
-            return crossbeam_channel::select_biased! {
-                recv(self.payload_build_finished) -> result => match result {
-                    Ok(()) => LoopEvent::PayloadBuildFinished,
-                    Err(_) => LoopEvent::Disconnected,
-                },
-                recv(self.incoming) -> msg => match msg {
-                    Ok(m) => LoopEvent::EngineMessage(m),
-                    Err(_) => LoopEvent::Disconnected,
-                },
-            }
-        }
-
         // Take ownership of persistence rx if present
         let maybe_persistence = self.persistence_state.rx.take();
 
@@ -1466,12 +1439,6 @@ where
     /// This checks if we need to remove blocks (disk reorg) or save new blocks to disk.
     /// Persistence completion is handled separately via the `wait_for_event` method.
     fn advance_persistence(&mut self) -> Result<(), AdvancePersistenceError> {
-        // A second persistence completion would overwrite the frontier needed by the deferred
-        // handoff. Wait until the payload jobs using the old overlay have finished.
-        if self.pending_persisted_handoff.is_some() {
-            return Ok(())
-        }
-
         if !self.persistence_state.in_progress() {
             if let Some(new_tip_num) = self.find_disk_reorg()? {
                 self.remove_blocks(new_tip_num)
@@ -1504,7 +1471,7 @@ where
             if let Some((rx, start_time, action)) = self.persistence_state.rx.take() {
                 debug!(target: "engine::tree", ?action, "waiting for in-flight persistence");
                 let result = rx.recv().map_err(|_| AdvancePersistenceError::ChannelClosed)?;
-                self.finish_persistence(result, start_time);
+                self.on_persistence_complete(result, start_time)?;
                 continue
             }
 
@@ -1556,31 +1523,9 @@ where
         result: PersistenceResult,
         start_time: Instant,
     ) -> Result<(), AdvancePersistenceError> {
-        let handoff = self.finish_persistence(result, start_time);
-
-        if self.payload_builds.is_active() {
-            debug_assert!(
-                self.pending_persisted_handoff.is_none(),
-                "a new persistence task must not start while its predecessor handoff is pending"
-            );
-            debug!(target: "engine::tree", "Deferring persisted in-memory handoff until payload jobs finish");
-            self.pending_persisted_handoff = Some(handoff);
-            return Ok(())
-        }
-
-        self.on_persisted_handoff(handoff)
-    }
-
-    /// Records a completed persistence operation and returns its deferred in-memory handoff.
-    fn finish_persistence(
-        &mut self,
-        result: PersistenceResult,
-        start_time: Instant,
-    ) -> PersistenceResult {
         self.metrics.engine.persistence_duration.record(start_time.elapsed());
 
-        let last_block = result.last_block;
-        let last_state_trie_block = result.last_state_trie_block;
+        let PersistenceResult { last_block, last_state_trie_block, commit_duration } = result;
         debug_assert!(
             last_state_trie_block.number <= last_block.number,
             "state/trie frontier cannot exceed the last persisted block"
@@ -1589,28 +1534,6 @@ where
         debug!(target: "engine::tree", ?last_block, ?last_state_trie_block, elapsed=?start_time.elapsed(), "Finished persisting, calling finish");
         self.persistence_state.finish(last_block, last_state_trie_block);
 
-        result
-    }
-
-    /// Applies the destructive in-memory portion of a completed persistence operation.
-    fn on_persisted_handoff(
-        &mut self,
-        handoff: PersistenceResult,
-    ) -> Result<(), AdvancePersistenceError> {
-        if handoff.last_block != self.persistence_state.last_persisted_block ||
-            handoff.last_state_trie_block !=
-                self.persistence_state.last_state_trie_persisted_block
-        {
-            debug!(
-                target: "engine::tree",
-                handoff_last_block = ?handoff.last_block,
-                current_last_block = ?self.persistence_state.last_persisted_block,
-                "Discarding stale persisted handoff"
-            );
-            return Ok(())
-        }
-
-        let PersistenceResult { last_block, commit_duration, .. } = handoff;
         let last_block_number = last_block.number;
 
         // Evict cached changesets for blocks below the eviction threshold.
@@ -1637,19 +1560,6 @@ where
         self.on_new_persisted_block()?;
 
         self.purge_timing_stats(last_block_number, commit_duration);
-
-        Ok(())
-    }
-
-    /// Releases work deferred until all payload jobs have finished.
-    fn on_payload_build_finished(&mut self) -> Result<(), AdvancePersistenceError> {
-        if self.payload_builds.is_active() {
-            return Ok(())
-        }
-
-        if let Some(handoff) = self.pending_persisted_handoff.take() {
-            self.on_persisted_handoff(handoff)?;
-        }
 
         Ok(())
     }
@@ -1704,16 +1614,15 @@ where
                             }
                         };
 
-                        // if the parent is the canonical head, we can insert the block as the
-                        // pending block
-                        if self.state.tree_state.canonical_block_hash() ==
-                            block.recovered_block().parent_hash()
-                        {
+                        let is_pending = self.state.tree_state.canonical_block_hash() ==
+                            block.recovered_block().parent_hash();
+                        self.state.tree_state.insert_executed(block.clone());
+
+                        if is_pending {
                             debug!(target: "engine::tree", pending=?block_num_hash, "updating pending block");
                             self.canonical_in_memory_state.set_pending_block(block.clone());
                         }
 
-                        self.state.tree_state.insert_executed(block.clone());
                         self.metrics.engine.inserted_already_executed_blocks.increment(1);
                         self.emit_event(EngineApiEvent::BeaconConsensus(
                             ConsensusEngineEvent::CanonicalBlockAdded(block, now.elapsed()),
@@ -2174,12 +2083,9 @@ where
                 "backfill action should only be emitted when backfill is idle"
             );
 
-            if self.payload_builds.is_active() ||
-                self.persistence_state.in_progress() ||
-                self.pending_persisted_handoff.is_some()
-            {
-                // Backfill can remove the same in-memory blocks as an active payload job or a
-                // persisted handoff, so it must not start until the next sync trigger.
+            if self.payload_builds.is_active() || self.persistence_state.in_progress() {
+                // Backfill can remove the same in-memory blocks as an active payload job or
+                // persistence task, so it must not start until the next sync trigger.
                 debug!(target: "engine::tree", "skipping backfill while in-memory overlay is in use");
                 return
             }
@@ -3227,14 +3133,15 @@ where
             self.execution_timing_stats.insert(executed.recovered_block().hash(), stats);
         }
 
-        // if the parent is the canonical head, we can insert the block as the pending block
-        if self.state.tree_state.canonical_block_hash() == executed.recovered_block().parent_hash()
-        {
+        let is_pending = self.state.tree_state.canonical_block_hash() ==
+            executed.recovered_block().parent_hash();
+        self.state.tree_state.insert_executed(executed.clone());
+
+        if is_pending {
             debug!(target: "engine::tree", pending=?block_num_hash, "updating pending block");
             self.canonical_in_memory_state.set_pending_block(executed.clone());
         }
 
-        self.state.tree_state.insert_executed(executed.clone());
         self.metrics.engine.executed_blocks.set(self.state.tree_state.block_count() as f64);
 
         // emit insert event
@@ -3559,7 +3466,7 @@ where
         /// When the persistence operation started.
         start_time: Instant,
     },
-    /// The last active payload job has finished, so deferred in-memory work may proceed.
+    /// The last active payload job has finished, so suppressed persistence may resume.
     PayloadBuildFinished,
     /// A channel was disconnected.
     Disconnected,

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -683,7 +683,7 @@ fn payload_build_tracker_notifies_after_last_lease_drops() {
 }
 
 #[test]
-fn persistence_handoff_waits_for_active_payload_jobs() {
+fn persistence_completion_does_not_wait_for_active_payload_jobs() {
     let config = TreeConfig::default()
         .with_has_enough_parallelism(true)
         .with_persistence_threshold(0)
@@ -693,8 +693,7 @@ fn persistence_handoff_waits_for_active_payload_jobs() {
         TestHarness::with_config(MAINNET.clone(), config).with_blocks(blocks.clone());
     let persisted = blocks[0].recovered_block().num_hash();
     let persisted_hash = persisted.hash;
-    let first = test_harness.tree.payload_builds.acquire();
-    let second = test_harness.tree.payload_builds.acquire();
+    let _payload_build = test_harness.tree.payload_builds.acquire();
 
     test_harness
         .tree
@@ -708,102 +707,11 @@ fn persistence_handoff_waits_for_active_payload_jobs() {
         )
         .unwrap();
 
-    // Durability advances immediately, but the in-memory overlay remains available to jobs.
+    // Payload jobs own an overlay snapshot, so persistence can immediately reclaim the manager's
+    // copy.
     assert_eq!(test_harness.tree.persistence_state.last_persisted_block, persisted);
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-    assert!(test_harness.tree.state.tree_state.contains_hash(&persisted_hash));
-    assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(persisted_hash).is_some());
-
-    // Do not let another persistence action overwrite the deferred handoff's frontier.
-    test_harness.tree.advance_persistence().unwrap();
-    assert!(!test_harness.tree.persistence_state.in_progress());
-
-    drop(first);
-    assert!(test_harness.tree.payload_build_finished.try_recv().is_err());
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-
-    drop(second);
-    assert!(matches!(test_harness.tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished));
-    test_harness.tree.on_payload_build_finished().unwrap();
-
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
     assert!(!test_harness.tree.state.tree_state.contains_hash(&persisted_hash));
     assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(persisted_hash).is_none());
-}
-
-#[test]
-fn pending_persisted_handoff_keeps_engine_messages_responsive() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
-    let mut test_harness = TestHarness::with_config(
-        MAINNET.clone(),
-        TreeConfig::default().with_has_enough_parallelism(true),
-    )
-    .with_blocks(blocks.clone());
-    let persisted = blocks[0].recovered_block().num_hash();
-    let payload_build = test_harness.tree.payload_builds.acquire();
-
-    test_harness
-        .tree
-        .on_persistence_complete(
-            PersistenceResult {
-                last_block: persisted,
-                last_state_trie_block: persisted,
-                commit_duration: Some(Duration::ZERO),
-            },
-            Instant::now(),
-        )
-        .unwrap();
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-
-    // Engine messages remain processable while the handoff waits for the active payload build.
-    test_harness.to_tree_tx.send(FromEngine::Event(FromOrchestrator::BackfillSyncStarted)).unwrap();
-    assert_matches!(
-        test_harness.tree.wait_for_event(),
-        super::LoopEvent::EngineMessage(FromEngine::Event(FromOrchestrator::BackfillSyncStarted))
-    );
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-    assert!(test_harness.tree.state.tree_state.contains_hash(&persisted.hash));
-
-    // Once the final lease drops, its completion is prioritized over queued engine messages so the
-    // handoff gets the first opportunity to reclaim the overlay.
-    test_harness.to_tree_tx.send(FromEngine::Event(FromOrchestrator::BackfillSyncStarted)).unwrap();
-    drop(payload_build);
-    assert_matches!(test_harness.tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished);
-    test_harness.tree.on_payload_build_finished().unwrap();
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
-    assert!(!test_harness.tree.state.tree_state.contains_hash(&persisted.hash));
-    assert_matches!(
-        test_harness.tree.wait_for_event(),
-        super::LoopEvent::EngineMessage(FromEngine::Event(FromOrchestrator::BackfillSyncStarted))
-    );
-}
-
-#[test]
-fn persist_until_complete_updates_frontiers_without_in_memory_handoff() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
-    let mut test_harness = TestHarness::new(MAINNET.clone()).with_blocks(blocks.clone());
-    let persisted = blocks.last().unwrap().recovered_block().num_hash();
-    let persisted_hash = persisted.hash;
-    let (tx, rx) = crossbeam_channel::bounded(1);
-
-    tx.send(PersistenceResult {
-        last_block: persisted,
-        last_state_trie_block: persisted,
-        commit_duration: Some(Duration::ZERO),
-    })
-    .unwrap();
-    test_harness.tree.persistence_state.start_save(persisted, rx);
-
-    test_harness.tree.persist_until_complete().unwrap();
-
-    // Shutdown waits for the durable write, but process teardown does not need the destructive
-    // in-memory handoff that normally follows a completed persistence task.
-    assert_eq!(test_harness.tree.persistence_state.last_persisted_block, persisted);
-    assert_eq!(test_harness.tree.persistence_state.last_state_trie_persisted_block, persisted);
-    assert!(!test_harness.tree.persistence_state.in_progress());
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
-    assert!(test_harness.tree.state.tree_state.contains_hash(&persisted_hash));
-    assert!(test_harness.tree.canonical_in_memory_state.state_by_hash(persisted_hash).is_some());
 }
 
 #[test]
@@ -813,50 +721,13 @@ fn backfill_action_skips_while_payload_build_is_active() {
     let action = BackfillAction::Start(B256::random().into());
 
     test_harness.tree.emit_event(EngineApiEvent::BackfillAction(action));
-    assert!(test_harness.tree.pending_persisted_handoff.is_none());
     assert!(test_harness.tree.backfill_sync_state.is_idle());
     assert!(test_harness.from_tree_rx.try_recv().is_err());
 
     drop(payload_build);
     assert!(matches!(test_harness.tree.wait_for_event(), super::LoopEvent::PayloadBuildFinished));
-    test_harness.tree.on_payload_build_finished().unwrap();
 
     // The skipped action is not queued for a later replay.
-    assert!(test_harness.tree.backfill_sync_state.is_idle());
-    assert!(test_harness.from_tree_rx.try_recv().is_err());
-}
-
-#[test]
-fn backfill_action_skips_while_persisted_handoff_is_pending() {
-    let blocks: Vec<_> = TestBlockBuilder::eth().get_executed_blocks(1..4).collect();
-    let mut test_harness = TestHarness::with_config(
-        MAINNET.clone(),
-        TreeConfig::default().with_has_enough_parallelism(true),
-    )
-    .with_blocks(blocks.clone());
-    let persisted = blocks[0].recovered_block().num_hash();
-    let payload_build = test_harness.tree.payload_builds.acquire();
-
-    test_harness
-        .tree
-        .on_persistence_complete(
-            PersistenceResult {
-                last_block: persisted,
-                last_state_trie_block: persisted,
-                commit_duration: Some(Duration::ZERO),
-            },
-            Instant::now(),
-        )
-        .unwrap();
-
-    drop(payload_build);
-    assert!(!test_harness.tree.payload_builds.is_active());
-    assert!(test_harness.tree.pending_persisted_handoff.is_some());
-
-    test_harness
-        .tree
-        .emit_event(EngineApiEvent::BackfillAction(BackfillAction::Start(B256::random().into())));
-
     assert!(test_harness.tree.backfill_sync_state.is_idle());
     assert!(test_harness.from_tree_rx.try_recv().is_err());
 }

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -85,7 +85,7 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot, oneshot::error::RecvError};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 /// The future for importing transactions into the pool.
 ///
@@ -346,6 +346,10 @@ pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives
     bad_imports: LruCache<TxHash, FbBuildHasher<32>>,
     /// All the connected peers.
     peers: HashMap<PeerId, PeerMetadata<N>, FbBuildHasher<64>>,
+    /// Last observed full-transaction recipient set, for change-only topology logs.
+    logged_full_transaction_peers: SmallVec<[PeerId; 8]>,
+    /// Limits cumulative broadcast summaries to one per peer every ten seconds.
+    last_broadcast_summary: Instant,
     /// Send half for the command channel.
     ///
     /// This is kept so that a new [`TransactionsHandle`] can be created at any time.
@@ -439,6 +443,8 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             pending_pool_imports_info,
             bad_imports: LruCache::with_hasher(DEFAULT_MAX_COUNT_BAD_IMPORTS, Default::default()),
             peers: Default::default(),
+            logged_full_transaction_peers: Default::default(),
+            last_broadcast_summary: Instant::now(),
             command_tx,
             command_rx: UnboundedReceiverStream::new(command_rx),
             pending_transactions: pending,
@@ -1080,6 +1086,7 @@ where
 
         // send full transactions to a set of the connected peers based on the configured mode
         let max_num_full = self.config.propagation_mode.full_peer_count(self.peers.len());
+        let mut full_transaction_peers = SmallVec::<[PeerId; 8]>::new();
 
         // Note: Assuming ~random~ order due to random state of the peers map hasher
         let mut num_full_peers = 0;
@@ -1092,6 +1099,7 @@ where
             // determine whether to send full tx objects or hashes.
             let mut builder = if num_full_peers < max_num_full {
                 num_full_peers += 1;
+                full_transaction_peers.push(*peer_id);
                 PropagateTransactionsBuilder::full(peer.version, to_propagate.len())
             } else {
                 PropagateTransactionsBuilder::pooled(peer.version, to_propagate.len())
@@ -1161,10 +1169,39 @@ where
                 }
 
                 trace!(target: "net::tx", ?peer_id, num_txs=?new_full_transactions.len(), "Propagating full transactions to peer");
+                peer.full_transactions_broadcast += new_full_transactions.len() as u64;
+                peer.full_transaction_broadcast_batches += 1;
 
                 // send full transactions
                 self.network.send_broadcast_pool_transactions(*peer_id, new_full_transactions);
             }
+        }
+
+        full_transaction_peers.sort_unstable();
+        if full_transaction_peers != self.logged_full_transaction_peers {
+            info!(
+                target: "net::tx::topology",
+                local_peer_id = ?self.network.peer_id(),
+                connected_peers = self.peers.len(),
+                ?full_transaction_peers,
+                "Full transaction broadcast recipient set changed"
+            );
+            self.logged_full_transaction_peers = full_transaction_peers;
+        }
+        if self.last_broadcast_summary.elapsed() >= Duration::from_secs(10) {
+            for (remote_peer_id, peer) in &self.peers {
+                if peer.full_transaction_broadcast_batches > 0 {
+                    info!(
+                        target: "net::tx::topology",
+                        local_peer_id = ?self.network.peer_id(),
+                        ?remote_peer_id,
+                        full_transactions = peer.full_transactions_broadcast,
+                        batches = peer.full_transaction_broadcast_batches,
+                        "Cumulative full transaction broadcasts for peer session"
+                    );
+                }
+            }
+            self.last_broadcast_summary = Instant::now();
         }
 
         // Update propagated transactions metrics
@@ -2225,6 +2262,11 @@ impl TransactionSource {
 /// Tracks a single peer in the context of [`TransactionsManager`].
 #[derive(Debug)]
 pub struct PeerMetadata<N: NetworkPrimitives = EthNetworkPrimitives> {
+    /// Broadcast attempts during this peer session, not delivery acknowledgements or fetch
+    /// replies.
+    full_transactions_broadcast: u64,
+    /// Nonempty full-transaction broadcast messages during this peer session.
+    full_transaction_broadcast_batches: u64,
     /// Optimistically keeps track of transactions that we know the peer has seen. Optimistic, in
     /// the sense that transactions are preemptively marked as seen by peer when they are sent to
     /// the peer.
@@ -2249,6 +2291,8 @@ impl<N: NetworkPrimitives> PeerMetadata<N> {
         peer_kind: PeerKind,
     ) -> Self {
         Self {
+            full_transactions_broadcast: 0,
+            full_transaction_broadcast_batches: 0,
             seen_transactions: LruCache::with_hasher(
                 max_transactions_seen_by_peer,
                 Default::default(),
@@ -3379,6 +3423,9 @@ mod tests {
         assert!(prop_txs[0].is_hash());
 
         let peer = tx_manager.peers.get(&peer_id).unwrap();
+        assert_eq!(peer.full_transactions_broadcast, 1);
+        assert_eq!(peer.full_transaction_broadcast_batches, 1);
+        assert_eq!(tx_manager.logged_full_transaction_peers.as_slice(), &[peer_id]);
         assert!(peer.seen_transactions.contains(eip1559_tx.transaction.hash()));
         assert!(peer.seen_transactions.contains(eip1559_tx.transaction.hash()));
         peer.seen_transactions.contains(eip4844_tx.transaction.hash());
@@ -3389,6 +3436,14 @@ mod tests {
             PropagationMode::Basic,
         );
         assert!(propagated.is_empty());
+        let peer = tx_manager.peers.get(&peer_id).unwrap();
+        assert_eq!(peer.full_transactions_broadcast, 1);
+        assert_eq!(peer.full_transaction_broadcast_batches, 1);
+        assert_eq!(tx_manager.logged_full_transaction_peers.as_slice(), &[peer_id]);
+
+        tx_manager.peers.remove(&peer_id);
+        tx_manager.propagate_transactions(Vec::new(), PropagationMode::Basic);
+        assert!(tx_manager.logged_full_transaction_peers.is_empty());
     }
 
     #[test]

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
     Address, BlockHash, BlockNumber, B256, U256,
 };
 use metrics::{Counter, Histogram};
-use reth_chain_state::ExecutedBlock;
+use reth_chain_state::{BlockState, ExecutedBlock};
 use reth_errors::{ProviderError, ProviderResult};
 use reth_ethereum_primitives::EthPrimitives;
 use reth_metrics::Metrics;
@@ -240,8 +240,10 @@ pub struct OverlayBuilder<N: NodePrimitives = EthPrimitives> {
     parent_hash: B256,
     /// Optional overlay source.
     overlay_source: Option<OverlaySource>,
-    /// Manager used for cached changesets and in-memory parent state.
+    /// Manager used for cached changesets and overlays.
     overlay_manager: OverlayManager<N>,
+    /// Snapshot of the in-memory chain ending at the requested parent.
+    parent_state: Option<BlockState<N>>,
     /// Anchor hash of the reused sparse trie, if this task reused one.
     reused_sparse_trie_anchor_hash: Option<B256>,
     /// Whether building the overlay may query revert changesets.
@@ -252,11 +254,16 @@ pub struct OverlayBuilder<N: NodePrimitives = EthPrimitives> {
 
 impl<N: NodePrimitives> OverlayBuilder<N> {
     /// Create a new manager-backed overlay builder.
-    pub(crate) fn new(parent_hash: B256, overlay_manager: OverlayManager<N>) -> Self {
+    pub(crate) fn new(
+        parent_hash: B256,
+        parent_state: Option<BlockState<N>>,
+        overlay_manager: OverlayManager<N>,
+    ) -> Self {
         Self {
             parent_hash,
             overlay_source: Some(OverlaySource::Managed),
             overlay_manager,
+            parent_state,
             reused_sparse_trie_anchor_hash: None,
             no_reverts: false,
             metrics: OverlayBuilderMetrics::default(),
@@ -295,10 +302,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Returns the durable anchor to use for this builder's parent.
-    pub fn anchor_at_parent<Provider>(
-        &self,
-        provider: &Provider,
-    ) -> ProviderResult<AnchorForParent<N>>
+    pub fn anchor_at_parent<Provider>(&self, provider: &Provider) -> ProviderResult<AnchorForParent>
     where
         Provider: StageCheckpointReader + BlockNumReader + PruneCheckpointReader,
     {
@@ -312,21 +316,21 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         provider: &Provider,
         partial_state_trie: BlockNumHash,
         finish: BlockNumHash,
-    ) -> ProviderResult<AnchorForParent<N>>
+    ) -> ProviderResult<AnchorForParent>
     where
         Provider: BlockNumReader + PruneCheckpointReader,
     {
         match &self.overlay_source {
             Some(OverlaySource::Managed) => anchor_for_parent_with_frontiers(
                 self.parent_hash,
-                self.overlay_manager.parent_chain(self.parent_hash),
+                self.parent_state.iter().flat_map(|state| state.chain()).map(BlockState::block),
                 partial_state_trie,
                 finish,
                 provider,
             ),
             _ => anchor_for_parent_with_frontiers(
                 self.parent_hash,
-                std::iter::empty(),
+                std::iter::empty::<ExecutedBlock<N>>(),
                 partial_state_trie,
                 finish,
                 provider,
@@ -460,7 +464,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
                 (trie_updates, hashed_state_updates)
             }
-            AnchorForParent::NoReverts { anchor, .. } => {
+            AnchorForParent::NoReverts { anchor } => {
                 // If no reverts are needed, use the manager overlay directly unless the reused
                 // sparse trie already covers both durable frontiers through the
                 // requested parent.
@@ -586,8 +590,13 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         Arc::new(HashedPostStateSorted::default()),
                     ))
                 } else {
+                    let parent_state = self.parent_state.as_ref().ok_or_else(|| {
+                        ProviderError::other(std::io::Error::other(
+                            "state trie overlay cannot be anchored without in-memory parent state",
+                        ))
+                    })?;
                     self.overlay_manager
-                        .overlay_for_parent(self.parent_hash, anchor_hash)
+                        .overlay_for_parent(parent_state, anchor_hash)
                         .map_err(ProviderError::other)
                 }
             }
@@ -613,10 +622,14 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         anchor_hash: BlockHash,
     ) -> ProviderResult<Arc<ExecutionOverlay>> {
         match &self.overlay_source {
-            Some(OverlaySource::Managed) if anchor_hash != self.parent_hash => self
-                .overlay_manager
-                .execution_overlay_for_parent(self.parent_hash, anchor_hash)
-                .map_err(ProviderError::other),
+            Some(OverlaySource::Managed) if anchor_hash != self.parent_hash => {
+                let parent_state = self.parent_state.as_ref().ok_or_else(|| {
+                    ProviderError::other(std::io::Error::other("missing in-memory parent state"))
+                })?;
+                self.overlay_manager
+                    .execution_overlay_for_block_state(parent_state, anchor_hash)
+                    .map_err(ProviderError::other)
+            }
             Some(OverlaySource::Managed) | None => Ok(Arc::new(ExecutionOverlay::default())),
             Some(OverlaySource::Immediate { .. }) => Err(ProviderError::other(
                 std::io::Error::other("immediate state trie overlay has no execution state"),
@@ -627,7 +640,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     /// Returns the blocks to revert from Finish to the selected anchor, if any.
     fn revert_blocks(
         &self,
-        anchor_for_parent: &AnchorForParent<N>,
+        anchor_for_parent: &AnchorForParent,
     ) -> ProviderResult<Option<RangeInclusive<BlockNumber>>> {
         match anchor_for_parent {
             AnchorForParent::NoReverts { .. } => Ok(None),
@@ -653,17 +666,27 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
 
         match &self.overlay_source {
             Some(OverlaySource::Managed) => {
-                self.overlay_manager.contains_hash(
-                    self.parent_hash,
-                    anchor_hash,
-                    state_trie_tip_hash,
-                ) && self.overlay_manager.contains_hash(
-                    self.parent_hash,
-                    anchor_hash,
-                    finish_tip_hash,
-                )
+                self.contains_hash(anchor_hash, state_trie_tip_hash) &&
+                    self.contains_hash(anchor_hash, finish_tip_hash)
             }
             _ => false,
+        }
+    }
+
+    fn contains_hash(&self, anchor_hash: B256, hash: B256) -> bool {
+        let mut current_hash = self.parent_hash;
+        let mut blocks = self.parent_state.iter().flat_map(|state| state.chain());
+
+        loop {
+            if current_hash == hash {
+                return true
+            }
+            if current_hash == anchor_hash {
+                return false
+            }
+
+            let Some(block) = blocks.next() else { return false };
+            current_hash = block.block_ref().recovered_block().parent_hash();
         }
     }
 }
@@ -738,13 +761,11 @@ fn anchor_for_parent_in<N: NodePrimitives>(
 
 /// Describes whether an overlay must revert the database before using its anchor.
 #[derive(Debug)]
-pub enum AnchorForParent<N: NodePrimitives> {
+pub enum AnchorForParent {
     /// The in-memory chain covers the durable frontiers through this anchor.
     NoReverts {
         /// Block to anchor the overlay to.
         anchor: BlockNumHash,
-        /// In-memory blocks from `parent_hash` through, but excluding, `anchor`.
-        overlay: Vec<ExecutedBlock<N>>,
     },
     /// The database must be reverted from `finish` to `anchor` first.
     RevertsRequired {
@@ -752,12 +773,10 @@ pub enum AnchorForParent<N: NodePrimitives> {
         anchor: BlockNumHash,
         /// Current Finish frontier.
         finish: BlockNumHash,
-        /// In-memory blocks from `parent_hash` through, but excluding, `anchor`.
-        overlay: Vec<ExecutedBlock<N>>,
     },
 }
 
-impl<N: NodePrimitives> AnchorForParent<N> {
+impl AnchorForParent {
     /// Returns the durable block anchoring this overlay.
     pub const fn anchor(&self) -> BlockNumHash {
         match self {
@@ -809,7 +828,7 @@ pub fn anchor_for_parent<N, Provider>(
     parent_hash: B256,
     in_mem_chain: impl Iterator<Item = ExecutedBlock<N>>,
     provider: &Provider,
-) -> ProviderResult<AnchorForParent<N>>
+) -> ProviderResult<AnchorForParent>
 where
     N: NodePrimitives,
     Provider: StageCheckpointReader + BlockNumReader + PruneCheckpointReader,
@@ -839,7 +858,7 @@ pub fn anchor_for_parent_with_frontiers<N, Provider>(
     partial_state_trie: BlockNumHash,
     finish: BlockNumHash,
     provider: &Provider,
-) -> ProviderResult<AnchorForParent<N>>
+) -> ProviderResult<AnchorForParent>
 where
     N: NodePrimitives,
     Provider: BlockNumReader + PruneCheckpointReader,
@@ -851,26 +870,23 @@ where
         .filter(|&parent_number| parent_number <= partial_state_trie.number);
 
     let mut finish_seen = parent_hash == finish.hash;
-    let (anchor, overlay) = if let Some(parent_number) = persisted_parent {
-        (BlockNumHash::new(parent_number, parent_hash), Vec::new())
+    let anchor = if let Some(parent_number) = persisted_parent {
+        BlockNumHash::new(parent_number, parent_hash)
     } else {
-        let mut overlay = Vec::new();
         let mut in_mem_chain = in_mem_chain.inspect(|block| {
             finish_seen |= block.recovered_block().hash() == finish.hash;
-            overlay.push(block.clone());
         });
 
         let anchor_hash =
             anchor_for_parent_in(parent_hash, &mut in_mem_chain, partial_state_trie.hash);
-        let anchor = if anchor_hash == partial_state_trie.hash {
+        if anchor_hash == partial_state_trie.hash {
             BlockNumHash::new(partial_state_trie.number, anchor_hash)
         } else {
             let anchor_number = provider
                 .convert_hash_or_number(anchor_hash.into())?
                 .ok_or(ProviderError::BlockHashNotFound(anchor_hash))?;
             BlockNumHash::new(anchor_number, anchor_hash)
-        };
-        (anchor, overlay)
+        }
     };
 
     finish_seen |= anchor.hash == finish.hash;
@@ -892,7 +908,7 @@ where
     // be sure that the in-memory chain is a superset of partial_state_trie+1..finish, and therefore
     // can be used without reverts.
     if finish_seen {
-        return Ok(AnchorForParent::NoReverts { anchor, overlay })
+        return Ok(AnchorForParent::NoReverts { anchor })
     }
 
     // Otherwise reverts are required; we check the changesets to make sure they are actually
@@ -912,7 +928,7 @@ where
         })
     }
 
-    Ok(AnchorForParent::RevertsRequired { anchor, finish, overlay })
+    Ok(AnchorForParent::RevertsRequired { anchor, finish })
 }
 
 #[cfg(test)]
@@ -1374,10 +1390,9 @@ mod tests {
         let provider = factory.provider().unwrap();
         let builder = manager.overlay_builder(blocks[1].recovered_block().hash());
         match builder.anchor_at_parent(&provider).unwrap() {
-            AnchorForParent::RevertsRequired { anchor, finish, overlay } => {
+            AnchorForParent::RevertsRequired { anchor, finish } => {
                 assert_eq!(anchor, blocks[1].recovered_block().num_hash());
                 assert_eq!(finish, blocks[3].recovered_block().num_hash());
-                assert!(overlay.is_empty());
             }
             AnchorForParent::NoReverts { .. } => {
                 panic!("persisted parent below Finish must require reverts")

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -13,7 +13,7 @@ use crate::{
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockNumber, B256};
 use parking_lot::Mutex;
-use reth_chain_state::{ExecutedBlock, PreservedSparseTrie};
+use reth_chain_state::{BlockState, ExecutedBlock, PreservedSparseTrie};
 use reth_errors::ProviderResult;
 use reth_ethereum_primitives::EthPrimitives;
 use reth_primitives_traits::{
@@ -96,7 +96,16 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
     /// Creates an overlay builder for `parent_hash`.
     pub fn overlay_builder(&self, parent_hash: B256) -> OverlayBuilder<N> {
-        OverlayBuilder::new(parent_hash, self.clone())
+        OverlayBuilder::new(parent_hash, self.block_state(parent_hash), self.clone())
+    }
+
+    fn block_state(&self, parent_hash: B256) -> Option<BlockState<N>> {
+        let mut blocks = self.parent_chain(parent_hash).collect::<Vec<_>>();
+        blocks.pop().map(|oldest| {
+            blocks.into_iter().rev().fold(BlockState::new(oldest), |parent, block| {
+                BlockState::with_parent(block, Some(Arc::new(parent)))
+            })
+        })
     }
 
     pub(crate) const fn changeset_cache(&self) -> &ChangesetCache {
@@ -340,13 +349,20 @@ impl<N: NodePrimitives> OverlayManager<N> {
         level = "trace",
         target = "storage::overlay::manager",
         skip_all,
-        fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
+        fields(tip_hash = %parent_state.hash(), anchor_hash = %anchor_hash)
     )]
     pub(crate) fn overlay_for_parent(
         &self,
-        parent_hash: B256,
+        parent_state: &BlockState<N>,
         anchor_hash: B256,
     ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
+        let parent_hash = parent_state.hash();
+        if parent_hash == anchor_hash {
+            return Ok((
+                Arc::new(TrieUpdatesSorted::default()),
+                Arc::new(HashedPostStateSorted::default()),
+            ))
+        }
         debug!(
             target: "storage::overlay::manager",
             tip_hash = %parent_hash,
@@ -357,8 +373,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
             .get_or_compute_overlay(
                 &self.state_trie_overlays,
                 &self.metrics,
-                parent_hash,
                 anchor_hash,
+                parent_state,
                 true,
                 |input, span| self.compute_state_trie_overlay(input, anchor_hash, span),
             )?
@@ -371,15 +387,15 @@ impl<N: NodePrimitives> OverlayManager<N> {
         level = "trace",
         target = "storage::overlay::manager",
         skip_all,
-        fields(tip_hash = %parent_hash, anchor_hash = %anchor_hash)
+        fields(tip_hash = %parent_state.hash(), anchor_hash = %anchor_hash)
     )]
-    pub fn execution_overlay_for_parent(
+    pub(crate) fn execution_overlay_for_block_state(
         &self,
-        parent_hash: B256,
+        parent_state: &BlockState<N>,
         anchor_hash: B256,
     ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
         Ok(self
-            .execution_overlay_for_parent_inner(parent_hash, anchor_hash, true)?
+            .execution_overlay_for_parent_inner(parent_state, anchor_hash, true)?
             .expect("required overlay lookup cannot skip an in-progress computation"))
     }
 
@@ -389,15 +405,19 @@ impl<N: NodePrimitives> OverlayManager<N> {
         parent_hash: B256,
         anchor_hash: B256,
     ) -> Result<(), StateTrieOverlayError> {
-        self.execution_overlay_for_parent_inner(parent_hash, anchor_hash, false).map(drop)
+        let parent_state = self
+            .block_state(parent_hash)
+            .ok_or(StateTrieOverlayError { tip_hash: parent_hash, anchor_hash })?;
+        self.execution_overlay_for_parent_inner(&parent_state, anchor_hash, false).map(drop)
     }
 
     fn execution_overlay_for_parent_inner(
         &self,
-        parent_hash: B256,
+        parent_state: &BlockState<N>,
         anchor_hash: B256,
         wait_for_pending: bool,
     ) -> Result<Option<Arc<ExecutionOverlay>>, StateTrieOverlayError> {
+        let parent_hash = parent_state.hash();
         if parent_hash == anchor_hash {
             return Ok(Some(Arc::new(ExecutionOverlay::default())))
         }
@@ -405,8 +425,8 @@ impl<N: NodePrimitives> OverlayManager<N> {
         self.get_or_compute_overlay(
             &self.execution_overlays,
             &self.execution_metrics,
-            parent_hash,
             anchor_hash,
+            parent_state,
             wait_for_pending,
             |input, span| self.compute_execution_overlay(input, anchor_hash, span),
         )
@@ -417,7 +437,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         target = "storage::overlay::manager",
         skip_all,
         fields(
-            tip_hash = %tip_hash,
+            tip_hash = %parent_state.hash(),
             anchor_hash = %anchor_hash,
             cache_reused = tracing::field::Empty,
             block_count = tracing::field::Empty,
@@ -428,17 +448,17 @@ impl<N: NodePrimitives> OverlayManager<N> {
         &self,
         cache: &OverlayCache<T>,
         metrics: &M,
-        tip_hash: B256,
         anchor_hash: B256,
+        parent_state: &BlockState<N>,
         wait_for_pending: bool,
         compute: impl FnOnce(ComputeOverlayInput<N, T>, tracing::Span) -> T,
     ) -> Result<Option<Arc<T>>, StateTrieOverlayError>
     where
         M: OverlayCacheMetrics,
     {
+        let tip_hash = parent_state.hash();
         let key = OverlayCacheKey { anchor_hash, tip_hash };
         let span = tracing::Span::current();
-
         if let Some(entry) = cache.entries.get(&key).map(|entry| entry.value().clone()) {
             metrics.record_cache_reuse();
             span.record("cache_reused", true);
@@ -451,19 +471,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         span.record("cache_reused", false);
 
         // Resolve the block path and any cached parent overlay before locking the child entry.
-        let mut hash = tip_hash;
-        let mut blocks = Vec::new();
-        loop {
-            let block =
-                self.blocks.get(&hash).ok_or(StateTrieOverlayError { tip_hash, anchor_hash })?;
-            let parent_hash = block.recovered_block().parent_hash();
-            blocks.push(block.clone());
-
-            if parent_hash == anchor_hash {
-                break
-            }
-            hash = parent_hash;
-        }
+        let mut blocks = Self::blocks_from_parent_state(parent_state, anchor_hash)?;
         span.record("block_count", blocks.len());
         enum CacheAction<T> {
             Ready(Arc<T>),
@@ -531,6 +539,27 @@ impl<N: NodePrimitives> OverlayManager<N> {
         }
     }
 
+    fn blocks_from_parent_state(
+        parent_state: &BlockState<N>,
+        anchor_hash: B256,
+    ) -> Result<Vec<ExecutedBlock<N>>, StateTrieOverlayError> {
+        let tip_hash = parent_state.hash();
+        let mut hash = tip_hash;
+        let mut blocks = Vec::new();
+        for state in parent_state.chain() {
+            let block = state.block();
+            if block.recovered_block().hash() != hash {
+                return Err(StateTrieOverlayError { tip_hash, anchor_hash })
+            }
+            hash = block.recovered_block().parent_hash();
+            blocks.push(block);
+            if hash == anchor_hash {
+                return Ok(blocks)
+            }
+        }
+        Err(StateTrieOverlayError { tip_hash, anchor_hash })
+    }
+
     /// Returns every in-memory block in the chain whose tip is `parent_hash`.
     pub(crate) fn parent_chain(
         &self,
@@ -546,7 +575,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
 
     /// Returns true if `hash` is in the parent chain segment from `anchor_hash` inclusive to
     /// `parent_hash` inclusive.
-    pub fn contains_hash(&self, parent_hash: B256, anchor_hash: B256, hash: B256) -> bool {
+    fn contains_hash(&self, parent_hash: B256, anchor_hash: B256, hash: B256) -> bool {
         let mut current_hash = parent_hash;
 
         loop {
@@ -942,13 +971,40 @@ mod tests {
             .collect()
     }
 
+    impl OverlayManager {
+        fn execution_overlay_for_parent(
+            &self,
+            parent_hash: B256,
+            anchor_hash: B256,
+        ) -> Result<Arc<ExecutionOverlay>, StateTrieOverlayError> {
+            if parent_hash == anchor_hash {
+                return Ok(Arc::new(ExecutionOverlay::default()))
+            }
+            let parent_state = self
+                .block_state(parent_hash)
+                .ok_or(StateTrieOverlayError { tip_hash: parent_hash, anchor_hash })?;
+            self.execution_overlay_for_block_state(&parent_state, anchor_hash)
+        }
+    }
+
+    fn overlay_for_parent(
+        manager: &OverlayManager,
+        parent_hash: B256,
+        anchor_hash: B256,
+    ) -> Result<(Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>), StateTrieOverlayError> {
+        let parent_state = manager
+            .block_state(parent_hash)
+            .ok_or(StateTrieOverlayError { tip_hash: parent_hash, anchor_hash })?;
+        manager.overlay_for_parent(&parent_state, anchor_hash)
+    }
+
     #[test]
     fn errors_for_unknown_parent() {
         let manager = OverlayManager::<EthPrimitives>::default();
         let parent = B256::random();
         let anchor = B256::random();
 
-        let err = manager.overlay_for_parent(parent, anchor).unwrap_err();
+        let err = overlay_for_parent(&manager, parent, anchor).unwrap_err();
 
         assert_eq!(err.tip_hash, parent);
         assert_eq!(err.anchor_hash, anchor);
@@ -965,15 +1021,15 @@ mod tests {
         let anchor_hash = blocks[0].recovered_block().parent_hash();
 
         let (_, state) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), anchor_hash).unwrap();
         assert_eq!(state.accounts.len(), 3);
 
         let short_anchor = blocks[1].recovered_block().hash();
         let (_, short) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), short_anchor).unwrap();
         assert_eq!(short.accounts.len(), 1);
         let (_, cached_short) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), short_anchor).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), short_anchor).unwrap();
         assert!(Arc::ptr_eq(&short, &cached_short));
     }
 
@@ -1042,10 +1098,10 @@ mod tests {
         let parent_key = OverlayCacheKey { anchor_hash, tip_hash: parent_hash };
         let child_key = OverlayCacheKey { anchor_hash, tip_hash: child_hash };
 
-        manager.overlay_for_parent(parent_hash, anchor_hash).unwrap();
+        overlay_for_parent(&manager, parent_hash, anchor_hash).unwrap();
         manager.execution_overlay_for_parent(parent_hash, anchor_hash).unwrap();
 
-        manager.overlay_for_parent(child_hash, anchor_hash).unwrap();
+        overlay_for_parent(&manager, child_hash, anchor_hash).unwrap();
         manager.execution_overlay_for_parent(child_hash, anchor_hash).unwrap();
 
         assert!(!manager.state_trie_overlays.entries.contains_key(&parent_key));
@@ -1067,7 +1123,7 @@ mod tests {
         let child_hash = blocks[2].recovered_block().hash();
         let parent_key = OverlayCacheKey { anchor_hash, tip_hash: parent_hash };
 
-        manager.overlay_for_parent(parent_hash, anchor_hash).unwrap();
+        overlay_for_parent(&manager, parent_hash, anchor_hash).unwrap();
         let state_parent = manager
             .state_trie_overlays
             .entries
@@ -1080,7 +1136,7 @@ mod tests {
         let execution_parent =
             manager.execution_overlay_for_parent(parent_hash, anchor_hash).unwrap();
 
-        let (_, child_state) = manager.overlay_for_parent(child_hash, anchor_hash).unwrap();
+        let (_, child_state) = overlay_for_parent(&manager, child_hash, anchor_hash).unwrap();
         let child_execution =
             manager.execution_overlay_for_parent(child_hash, anchor_hash).unwrap();
 
@@ -1230,9 +1286,11 @@ mod tests {
     #[test]
     fn required_lookup_waits_for_in_progress_overlay() {
         let manager = OverlayManager::<EthPrimitives>::default();
+        let block = test_blocks().remove(0);
+        let parent_state = BlockState::new(block);
         let key = OverlayCacheKey {
-            anchor_hash: B256::with_last_byte(1),
-            tip_hash: B256::with_last_byte(2),
+            anchor_hash: parent_state.block_ref().recovered_block().parent_hash(),
+            tip_hash: parent_state.hash(),
         };
         let waiter = Arc::new(OverlayWaiter::new());
         manager
@@ -1243,7 +1301,7 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
             let res =
-                manager.overlay_for_parent(key.tip_hash, key.anchor_hash).map(|(_, state)| state);
+                manager.overlay_for_parent(&parent_state, key.anchor_hash).map(|(_, state)| state);
             tx.send(res).unwrap();
         });
 
@@ -1267,7 +1325,7 @@ mod tests {
         }
 
         let original_anchor = blocks[0].recovered_block().parent_hash();
-        manager.overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor).unwrap();
+        overlay_for_parent(&manager, blocks[2].recovered_block().hash(), original_anchor).unwrap();
         manager
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
             .unwrap();
@@ -1278,15 +1336,14 @@ mod tests {
         ]);
 
         let anchor_hash = blocks[1].recovered_block().hash();
-        assert!(manager
-            .overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
+        assert!(overlay_for_parent(&manager, blocks[2].recovered_block().hash(), original_anchor)
             .is_err());
         assert!(manager
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), original_anchor)
             .is_err());
 
         let (_, state) =
-            manager.overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash).unwrap();
+            overlay_for_parent(&manager, blocks[2].recovered_block().hash(), anchor_hash).unwrap();
         assert_eq!(state.accounts.len(), 1);
         let execution = manager
             .execution_overlay_for_parent(blocks[2].recovered_block().hash(), anchor_hash)

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -1063,6 +1063,32 @@ mod tests {
     }
 
     #[test]
+    fn lazy_overlays_survive_manager_block_removal() {
+        let (factory, blocks) = setup_frontiers(1, 1);
+        let manager = OverlayManager::default();
+        for block in &blocks[2..=3] {
+            manager.insert_block(block.clone());
+        }
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            factory,
+            manager.overlay_builder(blocks[3].recovered_block().hash()),
+        );
+        let provider = state_provider_factory.database_provider_ro().unwrap();
+
+        manager.remove_blocks(blocks[2..=3].iter().map(|block| block.recovered_block().hash()));
+
+        let execution_overlay = provider.execution_overlay().unwrap();
+        assert_eq!(
+            execution_overlay.block_hashes(),
+            [blocks[2].recovered_block().num_hash(), blocks[3].recovered_block().num_hash()]
+        );
+        assert_eq!(
+            account_keys(provider.state_trie_overlay().unwrap()),
+            vec![B256::with_last_byte(3), B256::with_last_byte(4)]
+        );
+    }
+
+    #[test]
     fn skipped_state_trie_overlay_is_not_cached_or_used_for_state_roots() {
         let (factory, blocks) = setup_frontiers(3, 3);
         let manager = OverlayManager::default();


### PR DESCRIPTION
Log the selected full-transaction peer set only when it changes, and cumulative per-session broadcast counts at most every ten seconds, so uneven transaction propagation can be investigated without per-transaction trace logging. Counts represent broadcast attempts, not delivery acknowledgements or hash-fetch responses. Validation: nightly formatting and all 207 network library tests pass; targeted nightly clippy completes with an existing warning in peers.rs and existing manifest warnings.

Prompted by: @mediocregopher