### PR TITLE
fix(download): restore custom static files directory handling

### DIFF
--- a/bin/reth/tests/it/download/mod.rs
+++ b/bin/reth/tests/it/download/mod.rs
@@ -96,6 +96,15 @@ fn success(output: Output) -> String {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn manifest_selection_reuse_and_repair() {
+    check_manifest_selection_reuse_and_repair(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_static_files_selection_reuse_and_repair() {
+    check_manifest_selection_reuse_and_repair(true).await;
+}
+
+async fn check_manifest_selection_reuse_and_repair(custom_static_files: bool) {
     let snapshot = Snapshot::new();
     let state = &snapshot.files["/snapshot/state.tar.zst"];
     let offset = state.len() / 2;
@@ -103,19 +112,28 @@ async fn manifest_selection_reuse_and_repair() {
     fs::create_dir(dir.path().join(".download-cache")).unwrap();
     fs::write(dir.path().join(".download-cache/state.tar.zst.part"), &state[..offset]).unwrap();
     let server = snapshot.serve(true).await;
-    let args = ["--with-txs-since", "10"];
+    let custom_dir = tempfile::tempdir().unwrap();
+    let static_files = if custom_static_files {
+        custom_dir.path().join("nested/static")
+    } else {
+        dir.path().join("static_files")
+    };
+    let mut args = vec!["--with-txs-since", "10"];
+    if custom_static_files {
+        args.extend(["--datadir.static-files", static_files.to_str().unwrap()]);
+    }
     success(download(&server, dir.path(), &args));
     for (path, expected) in [
-        ("db/snapshot", "state.tar.zst"),
-        ("static_files/headers", "headers.tar.zst"),
-        ("static_files/txs-1", "txs-1.tar.zst"),
+        (dir.path().join("db/snapshot"), "state.tar.zst"),
+        (static_files.join("headers"), "headers.tar.zst"),
+        (static_files.join("txs-1"), "txs-1.tar.zst"),
     ] {
-        assert_eq!(fs::read(dir.path().join(path)).unwrap(), expected.as_bytes());
+        assert_eq!(fs::read(path).unwrap(), expected.as_bytes());
     }
     assert!(server.requests().iter().any(|(path, range)| {
         path.ends_with("state.tar.zst") && range.as_deref() == Some(&format!("bytes={offset}-"))
     }));
-    assert!(!dir.path().join("static_files/txs-0").exists());
+    assert!(!static_files.join("txs-0").exists());
     assert!(!server.requests().iter().any(|(path, _)| path.ends_with("txs-0.tar.zst")));
     let config: toml::Value =
         toml::from_str(&fs::read_to_string(dir.path().join("reth.toml")).unwrap()).unwrap();
@@ -126,15 +144,18 @@ async fn manifest_selection_reuse_and_repair() {
     assert_eq!(server.requests(), vec![("/snapshot/manifest.json".into(), None)]);
 
     // Same-size corruption must be detected by checksum, not just the file length.
-    fs::write(dir.path().join("static_files/txs-1"), b"bad-1.tar.zst").unwrap();
+    fs::write(static_files.join("txs-1"), b"bad-1.tar.zst").unwrap();
     server.clear_requests();
     success(download(&server, dir.path(), &args));
-    assert_eq!(fs::read(dir.path().join("static_files/txs-1")).unwrap(), b"txs-1.tar.zst");
+    assert_eq!(fs::read(static_files.join("txs-1")).unwrap(), b"txs-1.tar.zst");
     assert!(server.requests().iter().any(|(path, _)| path.ends_with("txs-1.tar.zst")));
     assert!(server
         .requests()
         .iter()
         .all(|(path, _)| path.ends_with("manifest.json") || path.ends_with("txs-1.tar.zst")));
+    if custom_static_files {
+        assert!(!dir.path().join("static_files").exists());
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -180,6 +201,41 @@ async fn legacy_streaming_and_resume() {
                 .iter()
                 .any(|(_, range)| range.as_deref() == Some(&format!("bytes={offset}-"))));
         }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_static_files_legacy_http_and_local_archives() {
+    for local in [false, true] {
+        let bytes = archive_bytes("./static_files/nested/headers", b"snapshot contents");
+        let archive_name = "headers.tar.zst";
+        let source = tempfile::tempdir().unwrap();
+        let archive_path = source.path().join(archive_name);
+        fs::write(&archive_path, &bytes).unwrap();
+        let server =
+            SnapshotServer::start(BTreeMap::from([(format!("/{archive_name}"), bytes)]), true)
+                .await;
+        let url = if local {
+            format!("file://{}", archive_path.display())
+        } else {
+            format!("{}/{archive_name}", server.url)
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let static_dir = tempfile::tempdir().unwrap();
+        reth_ok(&[
+            "download",
+            "--url",
+            &url,
+            "--datadir",
+            dir.path().to_str().unwrap(),
+            "--datadir.static-files",
+            static_dir.path().to_str().unwrap(),
+        ]);
+        assert_eq!(
+            fs::read(static_dir.path().join("nested/headers")).unwrap(),
+            b"snapshot contents"
+        );
+        assert!(!dir.path().join("static_files").exists());
     }
 }
 

--- a/bin/reth/tests/it/download/mod.rs
+++ b/bin/reth/tests/it/download/mod.rs
@@ -156,6 +156,11 @@ async fn check_manifest_selection_reuse_and_repair(custom_static_files: bool) {
     if custom_static_files {
         assert!(!dir.path().join("static_files").exists());
     }
+    fs::write(static_files.join("stale"), b"stale").unwrap();
+    args.push("--force");
+    success(download(&server, dir.path(), &args));
+    assert!(!static_files.join("stale").exists());
+    assert_eq!(fs::read(static_files.join("headers")).unwrap(), b"headers.tar.zst");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/cli/commands/src/download/archive.rs
+++ b/crates/cli/commands/src/download/archive.rs
@@ -29,6 +29,7 @@ const DOWNLOAD_CACHE_DIR: &str = ".download-cache";
 pub(crate) async fn run_modular_downloads(
     planned_downloads: PlannedDownloads,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
     download_concurrency: usize,
     cancel_token: CancellationToken,
     retry_backoff: Option<Duration>,
@@ -48,8 +49,12 @@ pub(crate) async fn run_modular_downloads(
         cancel_token,
     )
     .with_retry_backoff(retry_backoff);
-    let ctx =
-        ArchiveProcessContext::new(target_dir.to_path_buf(), Some(download_cache_dir), session);
+    let ctx = ArchiveProcessContext::new(
+        target_dir.to_path_buf(),
+        static_files_dir.map(Path::to_path_buf),
+        Some(download_cache_dir),
+        session,
+    );
 
     ModularDownloadJob::new(ctx, download_concurrency).run(planned_downloads).await
 }
@@ -220,7 +225,7 @@ impl ArchiveProcessor {
 
     /// Returns the verifier for this archive's output files.
     fn output_verifier(&self) -> OutputVerifier<'_> {
-        OutputVerifier::new(self.ctx.target_dir())
+        OutputVerifier::new(self.ctx.target_dir(), self.ctx.static_files_dir())
     }
 
     /// Returns `true` if this archive can be reused from existing verified outputs.
@@ -304,6 +309,7 @@ impl ArchiveProcessor {
             &self.archive().url,
             format,
             self.ctx.target_dir(),
+            self.ctx.static_files_dir(),
             self.ctx.session(),
         )
     }
@@ -316,6 +322,7 @@ impl ArchiveProcessor {
             file,
             format,
             self.ctx.target_dir(),
+            self.ctx.static_files_dir(),
             Some(&mut extraction_progress),
         );
         extraction_progress.finish();

--- a/crates/cli/commands/src/download/extract.rs
+++ b/crates/cli/commands/src/download/extract.rs
@@ -2,7 +2,7 @@ use super::{
     fetch::{ArchiveFetcher, DownloadedArchive},
     progress::{
         ArchiveExtractionProgress, ArchiveExtractionProgressHandle, DownloadProgress,
-        DownloadRequestLimiter, ProgressReader, SharedProgress, SharedProgressReader,
+        DownloadRequestLimiter, ProgressReader, SharedProgressReader,
     },
     session::DownloadSession,
     MAX_DOWNLOAD_RETRIES, RETRY_BACKOFF_SECS,
@@ -67,6 +67,7 @@ fn extract_archive<R: Read>(
     total_size: u64,
     format: CompressionFormat,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
     cancel_token: CancellationToken,
 ) -> Result<()> {
     let progress_reader = ProgressReader::new(reader, total_size, cancel_token);
@@ -74,11 +75,11 @@ fn extract_archive<R: Read>(
     match format {
         CompressionFormat::Lz4 => {
             let decoder = Decoder::new(progress_reader)?;
-            Archive::new(decoder).unpack(target_dir)?;
+            unpack_archive(Archive::new(decoder), target_dir, static_files_dir, None)?;
         }
         CompressionFormat::Zstd => {
             let decoder = ZstdDecoder::new(progress_reader)?;
-            Archive::new(decoder).unpack(target_dir)?;
+            unpack_archive(Archive::new(decoder), target_dir, static_files_dir, None)?;
         }
     }
 
@@ -91,14 +92,25 @@ pub(crate) fn extract_archive_raw<R: Read>(
     reader: R,
     format: CompressionFormat,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
     progress: Option<&mut ArchiveExtractionProgress>,
 ) -> Result<()> {
     match format {
         CompressionFormat::Lz4 => {
-            unpack_archive(Archive::new(Decoder::new(reader)?), target_dir, progress)?;
+            unpack_archive(
+                Archive::new(Decoder::new(reader)?),
+                target_dir,
+                static_files_dir,
+                progress,
+            )?;
         }
         CompressionFormat::Zstd => {
-            unpack_archive(Archive::new(ZstdDecoder::new(reader)?), target_dir, progress)?;
+            unpack_archive(
+                Archive::new(ZstdDecoder::new(reader)?),
+                target_dir,
+                static_files_dir,
+                progress,
+            )?;
         }
     }
 
@@ -108,8 +120,13 @@ pub(crate) fn extract_archive_raw<R: Read>(
 fn unpack_archive<R: Read>(
     mut archive: Archive<R>,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
     mut progress: Option<&mut ArchiveExtractionProgress>,
 ) -> Result<()> {
+    if static_files_dir.is_none() && progress.is_none() {
+        archive.unpack(target_dir)?;
+        return Ok(())
+    }
     let entries = archive.entries().wrap_err_with(|| {
         format!("failed to read archive entries for `{}`", target_dir.display())
     })?;
@@ -118,29 +135,99 @@ fn unpack_archive<R: Read>(
         let mut entry = entry.wrap_err_with(|| {
             format!("failed to read archive entry for `{}`", target_dir.display())
         })?;
-        extract_entry_with_progress(&mut entry, target_dir, progress.as_deref_mut())?;
+        extract_entry_with_progress(
+            &mut entry,
+            target_dir,
+            static_files_dir,
+            progress.as_deref_mut(),
+        )?;
     }
 
     Ok(())
 }
 
+/// Returns the path within the static files directory, accepting tar's optional `./` prefix.
+pub(crate) fn static_file_relative_path(path: &Path) -> Option<&Path> {
+    path.strip_prefix(".").unwrap_or(path).strip_prefix("static_files").ok()
+}
+
+/// Extracts static files beneath their configured root without allowing archive paths or links
+/// to escape it.
+fn unpack_static_file<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    static_files_dir: &Path,
+    relative_path: &Path,
+) -> Result<()> {
+    eyre::ensure!(
+        relative_path
+            .components()
+            .all(|part| matches!(part, Component::Normal(_) | Component::CurDir)),
+        "Invalid static file archive path: {}",
+        relative_path.display()
+    );
+    let entry_type = entry.header().entry_type();
+    eyre::ensure!(
+        entry_type.is_file() || entry_type.is_dir(),
+        "Unsupported static file archive entry"
+    );
+    fs::create_dir_all(static_files_dir)?;
+    let root = static_files_dir.to_path_buf();
+    let dest = root.join(relative_path);
+    // Check each existing ancestor before creating directories or replacing an output.
+    let mut current = root.clone();
+    for part in relative_path.components() {
+        current.push(part);
+        if let Ok(metadata) = std::fs::symlink_metadata(&current) {
+            eyre::ensure!(
+                !metadata.file_type().is_symlink(),
+                "Static file archive path contains a symlink"
+            );
+        }
+    }
+    if relative_path.as_os_str().is_empty() {
+        return Ok(())
+    }
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    entry.unpack(dest)?;
+    Ok(())
+}
+
+fn unpack_entry<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    target_dir: &Path,
+    static_files_dir: Option<&Path>,
+) -> Result<()> {
+    let path = entry.path()?.into_owned();
+    if let Some(static_files_dir) = static_files_dir &&
+        let Some(relative_path) = static_file_relative_path(&path)
+    {
+        unpack_static_file(entry, static_files_dir, relative_path)
+    } else {
+        entry.unpack_in(target_dir)?;
+        Ok(())
+    }
+}
+
 fn extract_entry_with_progress<R: Read>(
     entry: &mut tar::Entry<'_, R>,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
     progress: Option<&mut ArchiveExtractionProgress>,
 ) -> Result<()> {
     let size = entry.header().entry_size().unwrap_or(0);
     let entry_type = entry.header().entry_type();
 
     if !entry_type.is_file() || size == 0 {
-        entry.unpack_in(target_dir).wrap_err_with(|| {
+        unpack_entry(entry, target_dir, static_files_dir).wrap_err_with(|| {
             format!("failed to extract archive into `{}`", target_dir.display())
         })?;
         return Ok(())
     }
 
     if size < STREAMING_EXTRACTION_PROGRESS_MIN_FILE_SIZE {
-        entry.unpack_in(target_dir).wrap_err_with(|| {
+        unpack_entry(entry, target_dir, static_files_dir).wrap_err_with(|| {
             format!("failed to extract archive into `{}`", target_dir.display())
         })?;
         if let Some(progress) = progress {
@@ -150,14 +237,14 @@ fn extract_entry_with_progress<R: Read>(
     }
 
     let Some(progress_handle) = progress.as_ref().and_then(|progress| progress.handle()) else {
-        entry.unpack_in(target_dir).wrap_err_with(|| {
+        unpack_entry(entry, target_dir, static_files_dir).wrap_err_with(|| {
             format!("failed to extract archive into `{}`", target_dir.display())
         })?;
         return Ok(())
     };
 
-    let Some(entry_path) = entry_destination_path(entry, target_dir)? else {
-        entry.unpack_in(target_dir).wrap_err_with(|| {
+    let Some(entry_path) = entry_destination_path(entry, target_dir, static_files_dir)? else {
+        unpack_entry(entry, target_dir, static_files_dir).wrap_err_with(|| {
             format!("failed to extract archive into `{}`", target_dir.display())
         })?;
         return Ok(())
@@ -165,8 +252,7 @@ fn extract_entry_with_progress<R: Read>(
 
     let stop = Arc::new(AtomicBool::new(false));
     let monitor = spawn_extraction_progress_monitor(entry_path, progress_handle, Arc::clone(&stop));
-    let unpack_result = entry
-        .unpack_in(target_dir)
+    let unpack_result = unpack_entry(entry, target_dir, static_files_dir)
         .wrap_err_with(|| format!("failed to extract archive into `{}`", target_dir.display()));
     stop.store(true, Ordering::Relaxed);
 
@@ -180,9 +266,18 @@ fn extract_entry_with_progress<R: Read>(
 fn entry_destination_path<R: Read>(
     entry: &tar::Entry<'_, R>,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
 ) -> Result<Option<PathBuf>> {
     let mut file_dst = target_dir.to_path_buf();
     let path = entry.path().wrap_err("invalid path in archive entry")?;
+    let path = if let Some(static_files_dir) = static_files_dir &&
+        let Some(relative_path) = static_file_relative_path(&path)
+    {
+        file_dst = static_files_dir.to_path_buf();
+        relative_path
+    } else {
+        path.as_ref()
+    };
 
     for part in path.components() {
         match part {
@@ -231,7 +326,12 @@ fn record_extracted_file_bytes(
 }
 
 /// Extracts a snapshot from a local file.
-fn extract_from_file(path: &Path, format: CompressionFormat, target_dir: &Path) -> Result<()> {
+fn extract_from_file(
+    path: &Path,
+    format: CompressionFormat,
+    target_dir: &Path,
+    static_files_dir: Option<&Path>,
+) -> Result<()> {
     let file = std::fs::File::open(path)?;
     let total_size = file.metadata()?.len();
     info!(target: "reth::cli",
@@ -240,7 +340,14 @@ fn extract_from_file(path: &Path, format: CompressionFormat, target_dir: &Path) 
         "Extracting local archive"
     );
     let start = Instant::now();
-    extract_archive(file, total_size, format, target_dir, CancellationToken::new())?;
+    extract_archive(
+        file,
+        total_size,
+        format,
+        target_dir,
+        static_files_dir,
+        CancellationToken::new(),
+    )?;
     info!(target: "reth::cli",
         file = %path.display(),
         elapsed = %DownloadProgress::format_duration(start.elapsed()),
@@ -256,11 +363,12 @@ pub(crate) fn streaming_download_and_extract(
     url: &str,
     format: CompressionFormat,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
     session: &DownloadSession,
 ) -> Result<()> {
     if let Some(path) = archive_file_url_path(url)? {
         let size = path.metadata()?.len();
-        extract_from_file(&path, format, target_dir)?;
+        extract_from_file(&path, format, target_dir, static_files_dir)?;
         session.record_archive_output_complete(size);
         return Ok(())
     }
@@ -318,7 +426,7 @@ pub(crate) fn streaming_download_and_extract(
 
         let result = if let Some(progress) = shared {
             let reader = SharedProgressReader { inner: response, progress: Arc::clone(progress) };
-            extract_archive_raw(reader, format, target_dir, None)
+            extract_archive_raw(reader, format, target_dir, static_files_dir, None)
         } else {
             let total_size = response.content_length().unwrap_or(0);
             extract_archive(
@@ -326,6 +434,7 @@ pub(crate) fn streaming_download_and_extract(
                 total_size,
                 format,
                 target_dir,
+                static_files_dir,
                 session.cancel_token().clone(),
             )
         };
@@ -375,6 +484,7 @@ fn download_and_extract(
     url: &str,
     format: CompressionFormat,
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
     session: DownloadSession,
 ) -> Result<()> {
     let quiet = session.progress().is_some();
@@ -394,9 +504,16 @@ fn download_and_extract(
     let file = fs::open(&downloaded_path)?;
 
     if quiet {
-        extract_archive_raw(file, format, target_dir, None)?;
+        extract_archive_raw(file, format, target_dir, static_files_dir, None)?;
     } else {
-        extract_archive(file, total_size, format, target_dir, session.cancel_token().clone())?;
+        extract_archive(
+            file,
+            total_size,
+            format,
+            target_dir,
+            static_files_dir,
+            session.cancel_token().clone(),
+        )?;
         info!(target: "reth::cli",
             file = %file_name,
             "Extraction complete"
@@ -417,7 +534,7 @@ fn download_and_extract(
 fn blocking_download_and_extract(
     url: &str,
     target_dir: &Path,
-    shared: Option<Arc<SharedProgress>>,
+    static_files_dir: Option<&Path>,
     resumable: bool,
     request_limiter: Option<Arc<DownloadRequestLimiter>>,
     cancel_token: CancellationToken,
@@ -428,12 +545,12 @@ fn blocking_download_and_extract(
     if let Ok(parsed_url) = Url::parse(url) &&
         parsed_url.scheme() == "file"
     {
-        let session = DownloadSession::new(shared, request_limiter, cancel_token)
+        let session = DownloadSession::new(None, request_limiter, cancel_token)
             .with_retry_backoff(retry_backoff);
         let file_path = parsed_url
             .to_file_path()
             .map_err(|_| eyre::eyre!("Invalid file:// URL path: {}", url))?;
-        let result = extract_from_file(&file_path, format, target_dir);
+        let result = extract_from_file(&file_path, format, target_dir, static_files_dir);
         if result.is_ok() {
             session.record_archive_output_complete(file_path.metadata()?.len());
         }
@@ -443,18 +560,20 @@ fn blocking_download_and_extract(
             url,
             format,
             target_dir,
-            DownloadSession::new(shared, Some(request_limiter), cancel_token)
+            static_files_dir,
+            DownloadSession::new(None, Some(request_limiter), cancel_token)
                 .with_retry_backoff(retry_backoff),
         )
     } else if resumable {
         let session =
-            DownloadSession::new(shared, Some(DownloadRequestLimiter::new(1)), cancel_token)
+            DownloadSession::new(None, Some(DownloadRequestLimiter::new(1)), cancel_token)
                 .with_retry_backoff(retry_backoff);
-        download_and_extract(url, format, target_dir, session)
+        download_and_extract(url, format, target_dir, static_files_dir, session)
     } else {
         let session =
-            DownloadSession::new(shared, None, cancel_token).with_retry_backoff(retry_backoff);
-        let result = streaming_download_and_extract(url, format, target_dir, &session);
+            DownloadSession::new(None, None, cancel_token).with_retry_backoff(retry_backoff);
+        let result =
+            streaming_download_and_extract(url, format, target_dir, static_files_dir, &session);
         if result.is_ok() {
             session.record_archive_output_complete(0);
         }
@@ -464,25 +583,25 @@ fn blocking_download_and_extract(
 
 /// Downloads and extracts a snapshot archive asynchronously.
 ///
-/// When `shared` is provided, download progress is reported to the shared
-/// counter for aggregated display. Otherwise uses a local progress bar.
+/// Download progress is reported using a local progress bar.
 /// When `resumable` is true, uses two-phase download with `.part` files.
 pub(crate) async fn stream_and_extract(
     url: &str,
     target_dir: &Path,
-    shared: Option<Arc<SharedProgress>>,
+    static_files_dir: Option<&Path>,
     resumable: bool,
     request_limiter: Option<Arc<DownloadRequestLimiter>>,
     cancel_token: CancellationToken,
     retry_backoff: Option<Duration>,
 ) -> Result<()> {
     let target_dir = target_dir.to_path_buf();
+    let static_files_dir = static_files_dir.map(Path::to_path_buf);
     let url = url.to_string();
     task::spawn_blocking(move || {
         blocking_download_and_extract(
             &url,
             &target_dir,
-            shared,
+            static_files_dir.as_deref(),
             resumable,
             request_limiter,
             cancel_token,
@@ -497,6 +616,44 @@ pub(crate) async fn stream_and_extract(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remap_static_files_in_both_compression_formats() {
+        let mut archive = tar::Builder::new(Vec::new());
+        let mut directory = tar::Header::new_gnu();
+        directory.set_entry_type(tar::EntryType::Directory);
+        directory.set_size(0);
+        directory.set_mode(0o755);
+        directory.set_cksum();
+        archive.append_data(&mut directory, "./static_files/", std::io::empty()).unwrap();
+        for path in ["./static_files/nested/headers", "db/data"] {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(4);
+            header.set_mode(0o644);
+            header.set_cksum();
+            archive.append_data(&mut header, path, b"data".as_slice()).unwrap();
+        }
+        let tar = archive.into_inner().unwrap();
+        for format in [CompressionFormat::Lz4, CompressionFormat::Zstd] {
+            let bytes = match format {
+                CompressionFormat::Lz4 => {
+                    let mut encoder = lz4::EncoderBuilder::new().build(Vec::new()).unwrap();
+                    std::io::copy(&mut tar.as_slice(), &mut encoder).unwrap();
+                    let (bytes, result) = encoder.finish();
+                    result.unwrap();
+                    bytes
+                }
+                CompressionFormat::Zstd => zstd::encode_all(tar.as_slice(), 0).unwrap(),
+            };
+            let target = tempfile::tempdir().unwrap();
+            let custom = tempfile::tempdir().unwrap();
+            extract_archive_raw(bytes.as_slice(), format, target.path(), Some(custom.path()), None)
+                .unwrap();
+            assert_eq!(fs::read(custom.path().join("nested/headers")).unwrap(), b"data");
+            assert_eq!(fs::read(target.path().join("db/data")).unwrap(), b"data");
+            assert!(!target.path().join("static_files").exists());
+        }
+    }
 
     #[test]
     fn test_compression_format_detection() {

--- a/crates/cli/commands/src/download/extract.rs
+++ b/crates/cli/commands/src/download/extract.rs
@@ -199,6 +199,12 @@ fn unpack_entry<R: Read>(
     target_dir: &Path,
     static_files_dir: Option<&Path>,
 ) -> Result<()> {
+    // A non-static entry could otherwise plant a symlink at a nested custom root before
+    // extraction or retry cleanup uses it.
+    eyre::ensure!(
+        static_files_dir.is_none() || !entry.header().entry_type().is_symlink(),
+        "Archive symlinks are unsupported with a custom static files directory"
+    );
     let path = entry.path()?.into_owned();
     if let Some(static_files_dir) = static_files_dir &&
         let Some(relative_path) = static_file_relative_path(&path)
@@ -616,6 +622,45 @@ pub(crate) async fn stream_and_extract(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn custom_static_root_cannot_be_redirected_by_archive_symlinks() {
+        for custom_path in ["custom", "custom/nested"] {
+            let target = tempfile::tempdir().unwrap();
+            let outside = tempfile::tempdir().unwrap();
+            fs::create_dir_all(outside.path().join("nested")).unwrap();
+            for path in ["headers", "nested/headers"] {
+                fs::write(outside.path().join(path), b"keep").unwrap();
+            }
+            let custom = target.path().join(custom_path);
+            let mut archive = tar::Builder::new(Vec::new());
+            let mut link = tar::Header::new_gnu();
+            link.set_entry_type(tar::EntryType::Symlink);
+            link.set_size(0);
+            link.set_mode(0o777);
+            archive.append_link(&mut link, "custom", outside.path()).unwrap();
+            let mut file = tar::Header::new_gnu();
+            file.set_size(4);
+            file.set_mode(0o644);
+            file.set_cksum();
+            archive.append_data(&mut file, "static_files/headers", b"data".as_slice()).unwrap();
+            let tar = archive.into_inner().unwrap();
+            let err =
+                unpack_archive(Archive::new(tar.as_slice()), target.path(), Some(&custom), None)
+                    .unwrap_err();
+            assert!(format!("{err:#}").contains("Archive symlinks are unsupported"));
+            let outputs = [super::super::manifest::OutputFileChecksum {
+                path: "static_files/headers".into(),
+                size: 4,
+                blake3: String::new(),
+            }];
+            super::super::verify::OutputVerifier::new(target.path(), Some(&custom))
+                .cleanup(&outputs);
+            for path in ["headers", "nested/headers"] {
+                assert_eq!(fs::read(outside.path().join(path)).unwrap(), b"keep");
+            }
+        }
+    }
 
     #[test]
     fn remap_static_files_in_both_compression_formats() {

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -487,7 +487,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             let data_dir = self.env.datadir.clone().resolve_datadir(chain);
             let target_dir = data_dir.data_dir();
             if self.force {
-                clear_existing_datadir(target_dir)?;
+                clear_existing_datadir(target_dir, static_files_dir.as_deref())?;
             }
             fs::create_dir_all(target_dir)?;
 
@@ -527,7 +527,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         let cancel_token = CancellationToken::new();
         let _cancel_guard = cancel_token.drop_guard();
         if self.force {
-            clear_existing_datadir(target_dir)?;
+            clear_existing_datadir(target_dir, static_files_dir.as_deref())?;
         }
         fs::create_dir_all(target_dir)?;
         let startup_summary =
@@ -923,14 +923,14 @@ fn selection_from_prune_mode(mode: Option<PruneMode>, snapshot_block: u64) -> Co
 }
 
 /// Removes existing snapshot data that is managed by `reth download`.
-fn clear_existing_datadir(target_dir: &Path) -> Result<()> {
-    if !target_dir.try_exists()? {
-        return Ok(());
-    }
-
+fn clear_existing_datadir(target_dir: &Path, static_files_dir: Option<&Path>) -> Result<()> {
     info!(target: "reth::cli", dir = ?target_dir, "Clearing existing snapshot data");
     for entry in FORCE_REMOVED_DATADIR_PATHS {
-        let path = target_dir.join(entry);
+        let path = if *entry == "static_files" {
+            static_files_dir.map_or_else(|| target_dir.join(entry), Path::to_path_buf)
+        } else {
+            target_dir.join(entry)
+        };
         if !path.try_exists()? {
             continue;
         }

--- a/crates/cli/commands/src/download/mod.rs
+++ b/crates/cli/commands/src/download/mod.rs
@@ -475,6 +475,11 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             return Ok(None);
         }
 
+        let data_dir = self.env.datadir.clone().resolve_datadir(chain);
+        let static_files_dir = data_dir.static_files();
+        let static_files_dir = (static_files_dir != data_dir.data_dir().join("static_files"))
+            .then_some(static_files_dir);
+
         // Legacy single-URL mode: download one archive and extract it
         if let Some(ref url) = self.url {
             let cancel_token = CancellationToken::new();
@@ -496,7 +501,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             stream_and_extract(
                 url,
                 data_dir.data_dir(),
-                None,
+                static_files_dir.as_deref(),
                 self.resumable,
                 Some(request_limiter),
                 cancel_token.clone(),
@@ -525,7 +530,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
             clear_existing_datadir(target_dir)?;
         }
         fs::create_dir_all(target_dir)?;
-        let startup_summary = summarize_download_startup(&planned.archives, target_dir)?;
+        let startup_summary =
+            summarize_download_startup(&planned.archives, target_dir, static_files_dir.as_deref())?;
         info!(target: "reth::cli",
             reusable = startup_summary.reusable,
             needs_download = startup_summary.needs_download,
@@ -542,6 +548,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> DownloadCo
         run_modular_downloads(
             planned,
             target_dir,
+            static_files_dir.as_deref(),
             self.download_concurrency.max(1),
             cancel_token.clone(),
             self.retry_backoff,

--- a/crates/cli/commands/src/download/planning.rs
+++ b/crates/cli/commands/src/download/planning.rs
@@ -153,9 +153,10 @@ pub(crate) struct DownloadStartupSummary {
 pub(crate) fn summarize_download_startup(
     all_downloads: &[PlannedArchive],
     target_dir: &Path,
+    static_files_dir: Option<&Path>,
 ) -> Result<DownloadStartupSummary> {
     let mut summary = DownloadStartupSummary::default();
-    let verifier = OutputVerifier::new(target_dir);
+    let verifier = OutputVerifier::new(target_dir, static_files_dir);
 
     for planned in all_downloads {
         if verifier.verify(&planned.archive.output_files)? {
@@ -303,7 +304,7 @@ mod tests {
             },
         ];
 
-        let summary = summarize_download_startup(&planned, target_dir).unwrap();
+        let summary = summarize_download_startup(&planned, target_dir, None).unwrap();
         assert_eq!(summary.reusable, 1);
         assert_eq!(summary.needs_download, 2);
     }

--- a/crates/cli/commands/src/download/session.rs
+++ b/crates/cli/commands/src/download/session.rs
@@ -81,6 +81,8 @@ impl DownloadSession {
 pub(crate) struct ArchiveProcessContext {
     /// Directory where extracted output files are written.
     target_dir: PathBuf,
+    /// Custom location of static file outputs.
+    static_files_dir: Option<PathBuf>,
     /// Directory used for cached archive downloads, when enabled.
     cache_dir: Option<PathBuf>,
     /// Shared command-scoped download state.
@@ -91,15 +93,21 @@ impl ArchiveProcessContext {
     /// Creates the context used while processing modular archives.
     pub(crate) fn new(
         target_dir: PathBuf,
+        static_files_dir: Option<PathBuf>,
         cache_dir: Option<PathBuf>,
         session: DownloadSession,
     ) -> Self {
-        Self { target_dir, cache_dir, session }
+        Self { target_dir, static_files_dir, cache_dir, session }
     }
 
     /// Returns the directory where extracted outputs should be written.
     pub(crate) fn target_dir(&self) -> &Path {
         &self.target_dir
+    }
+
+    /// Returns the custom static files directory, if configured.
+    pub(crate) fn static_files_dir(&self) -> Option<&Path> {
+        self.static_files_dir.as_deref()
     }
 
     /// Returns the cache directory for two-phase downloads, if enabled.

--- a/crates/cli/commands/src/download/verify.rs
+++ b/crates/cli/commands/src/download/verify.rs
@@ -8,12 +8,14 @@ use std::{io::Read, path::Path};
 pub(crate) struct OutputVerifier<'a> {
     /// Directory containing the output files declared by the manifest.
     target_dir: &'a Path,
+    /// Custom location of static file outputs.
+    static_files_dir: Option<&'a Path>,
 }
 
 impl<'a> OutputVerifier<'a> {
     /// Creates a verifier for one extraction target directory.
-    pub(crate) const fn new(target_dir: &'a Path) -> Self {
-        Self { target_dir }
+    pub(crate) const fn new(target_dir: &'a Path, static_files_dir: Option<&'a Path>) -> Self {
+        Self { target_dir, static_files_dir }
     }
 
     /// Returns `true` only when every declared output file exists and matches size and BLAKE3.
@@ -34,7 +36,7 @@ impl<'a> OutputVerifier<'a> {
         }
 
         for expected in output_files {
-            let output_path = self.target_dir.join(&expected.path);
+            let output_path = self.output_path(&expected.path);
             let meta = match fs::metadata(&output_path) {
                 Ok(meta) => meta,
                 Err(_) => return Ok(false),
@@ -55,8 +57,18 @@ impl<'a> OutputVerifier<'a> {
     /// Removes any declared output files so a fresh archive attempt can restart cleanly.
     pub(crate) fn cleanup(&self, output_files: &[OutputFileChecksum]) {
         for output in output_files {
-            let _ = fs::remove_file(self.target_dir.join(&output.path));
+            let _ = fs::remove_file(self.output_path(&output.path));
         }
+    }
+
+    /// Resolves archive paths consistently for verification and retry cleanup.
+    fn output_path(&self, path: &str) -> std::path::PathBuf {
+        if let Some(static_files_dir) = self.static_files_dir &&
+            let Some(relative_path) = super::extract::static_file_relative_path(Path::new(path))
+        {
+            return static_files_dir.join(relative_path)
+        }
+        self.target_dir.join(path)
     }
 
     /// Computes the hex-encoded BLAKE3 checksum for one plain output file.
@@ -80,5 +92,32 @@ impl<'a> OutputVerifier<'a> {
         }
 
         Ok(hasher.finalize().to_hex().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_static_files_verification_and_cleanup() {
+        let datadir = tempfile::tempdir().unwrap();
+        let static_dir = tempfile::tempdir().unwrap();
+        let default_file = datadir.path().join("static_files/headers");
+        fs::create_dir_all(default_file.parent().unwrap()).unwrap();
+        fs::write(&default_file, b"headers").unwrap();
+        let outputs = [OutputFileChecksum {
+            path: "./static_files/headers".into(),
+            size: 7,
+            blake3: blake3::hash(b"headers").to_hex().to_string(),
+        }];
+        let verifier = OutputVerifier::new(datadir.path(), Some(static_dir.path()));
+        assert!(!verifier.verify(&outputs).unwrap());
+        let custom_file = static_dir.path().join("headers");
+        fs::write(&custom_file, b"headers").unwrap();
+        assert!(verifier.verify(&outputs).unwrap());
+        verifier.cleanup(&outputs);
+        assert!(!custom_file.exists());
+        assert_eq!(fs::read(default_file).unwrap(), b"headers");
     }
 }


### PR DESCRIPTION
Restores `--datadir.static-files` routing for snapshot extraction, integrity checks, and retry cleanup, which was dropped by #23028 after the fix in #23445 (reported in #23436). `--force` also clears the configured static-files directory; archive symlinks are rejected when remapping so an archive cannot redirect a nested custom root.

Adds CLI regression coverage for modular downloads, verified-output reuse, corruption repair, force cleanup, and HTTP/local archives, plus unit coverage for LZ4/Zstandard extraction and custom-directory cleanup.
