### PR TITLE
perf(trie): compare packed keys when sorting leaf updates

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2614,10 +2614,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
             return Ok(());
         }
 
-        // Drain and sort updates lexicographically by nibbles path.
+        // Full-length nibble paths have the same order as their packed keys.
         let mut sorted: Vec<_> =
             updates.drain().map(|(key, update)| (key, Nibbles::unpack(key), update)).collect();
-        sorted.sort_unstable_by_key(|entry| entry.1);
+        sorted.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
         let threshold = self.parallelism_thresholds.min_updates;
         let parallelize_distributed_updates = sorted.len() >= threshold.saturating_mul(4);


### PR DESCRIPTION
Sort full-length sparse-trie leaf updates using their packed keys, which have the same ordering as the unpacked nibble paths. Revisits #25548 and the sorting portion of #26344 against the current engine and overlay implementation.

Six-pair BAL runs at 100M / 200M / 300M targets changed mean server newPayload latency by +0.40% / -0.60% / -1.41%; all were classified as inconclusive. Kept as a draft experiment: there is no demonstrated end-to-end improvement.
