### PR TITLE
perf(engine): skip unused pool cleanup on BAL path

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -450,7 +450,6 @@ where
 
         // Drop the per-thread providers
         executor.bal_streaming_pool().clear();
-        executor.prewarming_pool().clear();
 
         let _ = actions_tx.send(PrewarmTaskEvent::FinishedTxExecution { executed_transactions: 0 });
     }


### PR DESCRIPTION
Skip clearing the serial prewarming pool after BAL prewarm; that path only uses the BAL streaming pool. This avoids an unused synchronous broadcast and lazy pool initialization. Six-pair BAL benchmarks at 100M and 300M show no established latency improvement.
