### PR TITLE
feat(engine): trace BAL transaction execution and commit

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -122,6 +122,7 @@ where
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
         let (abort_guard, abort_rx) = AbortGuard::new();
 
+        tracing::trace!(target: "engine::tree::bal", "bal spawning workers");
         for _ in 0..worker_count {
             worker::spawn_worker(
                 scope,
@@ -135,6 +136,7 @@ where
                 ctx.clone(),
             );
         }
+        tracing::trace!(target: "engine::tree::bal", "bal workers spawned");
         drop(result_tx);
 
         let mut gas_tracker =

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -148,6 +148,12 @@ where
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
             let output = output?;
 
+            let _span = tracing::trace_span!(
+                target: "engine::tree::bal",
+                "bal_commit_transaction",
+                index = output.index,
+            )
+            .entered();
             gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
             gas_tracker.record_result(output.result.result());
             canonical_executor.evm_mut().db_mut().bump_bal_index();

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -76,6 +76,12 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
             return None;
         }
 
+        let _span = tracing::trace_span!(
+            target: "engine::tree::bal",
+            "bal_next_output",
+            index = self.next,
+        )
+        .entered();
         loop {
             if let Some(output) = self.pending[self.next].take() {
                 self.next += 1;
@@ -95,6 +101,7 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
             };
 
             let index = output.index;
+            tracing::trace!(target: "engine::tree::bal", index, next = self.next, "bal output received");
             assert!(
                 index < self.total,
                 "BAL worker returned out-of-bounds transaction index {index}; total={}",

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -69,6 +69,8 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
 {
     scope.spawn(move |_| {
         let worker_result = (|| -> Result<(), BalWorkerError> {
+            let setup =
+                tracing::trace_span!(target: "engine::tree::bal", "bal_worker_setup").entered();
             // Create a database with fill_on_miss=true ensuring misses
             // are inserted for the other workers.
             let database = make_db(true).map_err(BalWorkerError::Setup)?;
@@ -79,6 +81,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 .build();
             let evm = evm_config.evm_with_env(&mut worker_state, evm_env);
             let mut executor = evm_config.create_executor_with_state(evm, ctx.clone());
+            drop(setup);
 
             loop {
                 let (index, tx) = crossbeam_channel::select_biased! {

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -92,6 +92,12 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let signer = *tx.signer();
                 let tx_gas_limit = tx.tx().gas_limit();
 
+                let _span = tracing::trace_span!(
+                    target: "engine::tree::bal",
+                    "bal_execute_transaction",
+                    index,
+                )
+                .entered();
                 executor.evm_mut().db_mut().set_bal_index(BlockAccessIndex::new(index as u64 + 1));
                 let result = executor
                     .execute_transaction_without_commit(tx)

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -309,7 +309,7 @@ where
                                     tx
                                 });
                                 let _ = execute_tx.send((idx, tx));
-                                trace!(target: "engine::tree::payload_processor", idx, "yielded transaction");
+                                trace!(target: "engine::tree::bal", idx, "bal recovery ready");
                             });
                     });
                 } else {


### PR DESCRIPTION
Add opt-in transaction-index traces for BAL recovery, worker execution, ordered output waiting, and canonical commit. Enable with `--log.tracing-chrome.filter=debug,engine::tree::bal=trace` to distinguish execution cost from head-of-line blocking and commit backlog.

This is a diagnostic draft; per-transaction tracing remains disabled by the default profiler filter.
