### PR TITLE
perf(engine): prioritize early BAL transaction recovery

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -290,12 +290,13 @@ where
             self.executor.spawn_blocking_named("tx-iterator", move || {
                 let (transactions, convert) = transactions.into_parts();
                 if parallel_bal_execution {
-                    // With BALs, we don't care about the order of transactions in execution and
-                    // prewarming, so we don't have to use `for_each_ordered_in`.
+                    // Workers can execute out of order, but canonical commit needs the earliest
+                    // transactions first. Recover growing prefixes before scheduling the tail.
                     executor.cpu_pool().install(|| {
                         transactions
                             .into_par_iter()
                             .enumerate()
+                            .by_exponential_blocks()
                             .map(|(i, tx)| {
                                 let tx = convert.convert(tx);
                                 (i, tx)


### PR DESCRIPTION
Recover BAL transactions in exponentially increasing prefixes so early indices reach execution sooner. Six-pair BAL runs reduce server newPayload mean by 3.52% at 200M and 3.23% at 300M; 100M and saturated client latency remain neutral. Matched traces show roughly 30% fewer ready-but-uncommitted outputs at peak.

# PR stack
Review in order:

1. perf: early BAL recovery #27077 — this PR
2. perf: leave BAL pool capacity for state streaming #27084 — experimental follow-up


Alternative experiment based directly on #27077: #27088 retries storage leaves after relevant changes; it does not include #27084.


Alternative experiment based directly on #27077: #27091 moves blocked leaf values instead of cloning; it includes neither #27084 nor #27088.


Alternative experiment based directly on #27077: #27093 starts trie proofs with an early update batch; it includes none of the other alternative experiments.

Alternative experiment based directly on #27077: #27094 reveals already queued proofs before applying buffered trie leaves; it includes none of the other alternative experiments.

Follow-up experiment: #27100 gates account leaf retries on relevant progress, stacked on #27088 (which is based on #27077).

Further stacked experiment: #27101 skips storage retries after new batches that applied no leaves, on top of #27100.

Follow-up #27124 reuses computed storage roots during account promotion. It now targets current main directly; it is not stacked on this closed PR.

