### PR TITLE
perf(engine): reserve canonical BAL account capacity

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -117,6 +117,13 @@ where
         .with_bundle_update()
         .with_bal_builder()
         .build();
+    canonical_state
+        .bal_state
+        .bal_builder
+        .as_mut()
+        .expect("with_bal_builder set")
+        .accounts
+        .reserve(bal.len());
 
     let (block_result, senders) = {
         let (result_tx, result_rx) = crossbeam_channel::unbounded();


### PR DESCRIPTION
Reserve canonical BAL account capacity from the received account count while preserving independent reconstruction. Six-pair BAL runs at 200M and 300M show no server or client latency improvement.
