### PR TITLE
perf(engine): dispatch full BAL worker sets locally

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -64,7 +64,7 @@ where
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let worker_pool = runtime.bal_streaming_pool();
-    let worker_count = worker_pool.current_num_threads().max(1).min(transaction_count);
+    let worker_pool_size = worker_pool.current_num_threads().max(1);
 
     worker_pool.in_place_scope(|scope| {
         execute_block_inner(
@@ -77,7 +77,7 @@ where
             transaction_count,
             txs,
             receipt_tx,
-            worker_count,
+            worker_pool_size,
         )
     })
 }
@@ -93,7 +93,7 @@ fn execute_block_inner<'scope, Evm, Tx, Err, DB, MakeDb>(
     transaction_count: usize,
     txs: Receiver<(usize, Result<Tx, Err>)>,
     receipt_tx: Sender<IndexedReceipt<ReceiptTy<Evm::Primitives>>>,
-    worker_count: usize,
+    worker_pool_size: usize,
 ) -> Result<
     (BlockExecutionOutput<ReceiptTy<Evm::Primitives>>, Vec<Address>, BlockAccessList),
     BalExecutionError,
@@ -122,9 +122,15 @@ where
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
         let (abort_guard, abort_rx) = AbortGuard::new();
 
-        for _ in 0..worker_count {
+        let worker_count = worker_pool_size.min(transaction_count);
+        // Broadcast jobs enter each thread's queue before it steals more streaming work.
+        // Small blocks remain stealable so any idle thread can execute their workers.
+        let broadcast = worker_count == worker_pool_size;
+        let jobs = if broadcast { 1 } else { worker_count };
+        for _ in 0..jobs {
             worker::spawn_worker(
                 scope,
+                broadcast,
                 txs.clone(),
                 abort_rx.clone(),
                 result_tx.clone(),

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -52,6 +52,7 @@ type WorkerResultSender<Cfg> =
 #[expect(clippy::too_many_arguments)]
 pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
     scope: &rayon::Scope<'scope>,
+    broadcast: bool,
     tx_rx: Receiver<(usize, Result<Tx, Err>)>,
     abort_rx: Receiver<()>,
     result_tx: WorkerResultSender<Evm>,
@@ -67,7 +68,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
     DB: Database + Send + 'scope,
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'scope,
 {
-    scope.spawn(move |_| {
+    let run = move |received_bal_revm, evm_env, ctx| {
         let worker_result = (|| -> Result<(), BalWorkerError> {
             // Create a database with fill_on_miss=true ensuring misses
             // are inserted for the other workers.
@@ -78,7 +79,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 .with_bundle_update()
                 .build();
             let evm = evm_config.evm_with_env(&mut worker_state, evm_env);
-            let mut executor = evm_config.create_executor_with_state(evm, ctx.clone());
+            let mut executor = evm_config.create_executor_with_state(evm, ctx);
 
             loop {
                 let (index, tx) = crossbeam_channel::select_biased! {
@@ -111,5 +112,15 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
         if let Err(err) = worker_result {
             let _ = result_tx.send(Err(err));
         }
-    });
+    };
+    if broadcast {
+        // Execution contexts are Send but need not be Sync. Only cloning holds the lock.
+        let ctx = std::sync::Mutex::new(ctx);
+        scope.spawn_broadcast(move |_, _| {
+            let ctx = ctx.lock().expect("execution context lock poisoned").clone();
+            run(Arc::clone(&received_bal_revm), evm_env.clone(), ctx);
+        });
+    } else {
+        scope.spawn(move |_| run(received_bal_revm, evm_env, ctx));
+    }
 }


### PR DESCRIPTION
Dispatch full BAL worker sets through scoped broadcast so each thread sees its worker before stealing more hashed-state streaming jobs; small blocks retain stealable dispatch. The matched trace reduces dispatch-to-setup from 11.18ms to 2.07ms, but six-pair 300M timing establishes no overall gain (server +1.30%, client -0.02% paired). Keep this as an experiment; later ordered waits absorb the startup improvement.
