### PR TITLE
perf(engine): leave BAL pool capacity for state streaming

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -64,7 +64,8 @@ where
     ReceiptTy<Evm::Primitives>: Clone,
 {
     let worker_pool = runtime.bal_streaming_pool();
-    let worker_count = worker_pool.current_num_threads().max(1).min(transaction_count);
+    // Leave shared-pool capacity available for BAL state streaming.
+    let worker_count = worker_pool.current_num_threads().div_ceil(2).max(1).min(transaction_count);
 
     worker_pool.in_place_scope(|scope| {
         execute_block_inner(


### PR DESCRIPTION
Limit BAL execution to half the shared pool's threads, leaving capacity for hashed-state streaming. Six-pair BAL runs show a small server mean reduction (1.01% at 300M, 1.28% at 200M), but saturated client latency is neutral; keep experimental pending stronger evidence.

# PR stack
Review in order:

1. perf: early BAL recovery #27077
2. perf: leave BAL pool capacity for state streaming — this PR
