### PR TITLE
fix(rpc): validate V6 BAL gas budget before KZG

### DIFF
--- a/crates/ethereum/node/tests/e2e/rpc.rs
+++ b/crates/ethereum/node/tests/e2e/rpc.rs
@@ -696,6 +696,25 @@ async fn test_flashbots_validate_v6() -> eyre::Result<()> {
         .unwrap_err();
     assert!(err.to_string().contains("invalid KZG proof"), "{err}");
 
+    // A zero item budget must reject the BAL before checking the invalid cell proof.
+    let mut over_budget_request = invalid_proof_request;
+    over_budget_request
+        .request
+        .execution_payload
+        .payload_inner
+        .payload_inner
+        .payload_inner
+        .gas_limit = 0;
+    over_budget_request.request.message.gas_limit = 0;
+    let err = provider
+        .raw_request::<_, ()>(
+            "flashbots_validateBuilderSubmissionV6".into(),
+            (&over_budget_request,),
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("block access list item cost exceeds gas limit"), "{err}");
+
     request.registered_gas_limit -= 1;
     assert!(provider
         .raw_request::<_, ()>("flashbots_validateBuilderSubmissionV6".into(), (&request,))

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -3,7 +3,7 @@ use alloy_consensus::{
 };
 use alloy_eip7928::{bal::DecodedBal, compute_block_access_list_hash};
 use alloy_eips::eip7685::RequestsOrHash;
-use alloy_primitives::{map::AddressSet, Address, B256, U256};
+use alloy_primitives::{map::AddressSet, Address, Bytes, B256, U256};
 use alloy_rpc_types_beacon::relay::{
     BidTrace, BuilderBlockValidationRequest, BuilderBlockValidationRequestV2,
     BuilderBlockValidationRequestV3, BuilderBlockValidationRequestV4,
@@ -469,9 +469,10 @@ where
         &self,
         request: BuilderBlockValidationRequestV6,
     ) -> Result<(), ValidationApiError> {
-        let decoded_bal =
-            DecodedBal::from_rlp_bytes(request.request.execution_payload.block_access_list.clone())
-                .map_err(ValidationApiError::InvalidBlockAccessList)?;
+        decode_and_validate_bal_gas_limit(
+            request.request.execution_payload.block_access_list.clone(),
+            request.request.execution_payload.payload_inner.payload_inner.payload_inner.gas_limit,
+        )?;
 
         let block = self.payload_validator.ensure_well_formed_payload(ExecutionData {
             payload: ExecutionPayload::V4(request.request.execution_payload),
@@ -504,7 +505,7 @@ where
             block,
             request.request.message,
             request.registered_gas_limit,
-            Some(decoded_bal),
+            None,
         )
         .await
     }
@@ -633,6 +634,17 @@ pub struct ValidationApiInner<Provider, E: ConfigureEvm, T: PayloadTypes> {
     task_spawner: Runtime,
     /// Validation metrics
     metrics: ValidationMetrics,
+}
+
+/// Decodes the submitted BAL and checks its EIP-7928 item budget before blob verification.
+fn decode_and_validate_bal_gas_limit(
+    bytes: Bytes,
+    gas_limit: u64,
+) -> Result<(), ValidationApiError> {
+    let decoded_bal =
+        DecodedBal::from_rlp_bytes(bytes).map_err(ValidationApiError::InvalidBlockAccessList)?;
+    decoded_bal.as_bal().validate_gas_limit(gas_limit).map_err(ConsensusError::from)?;
+    Ok(())
 }
 
 /// Calculates a deterministic hash of the blocklist for change detection.

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -772,8 +772,40 @@ pub(crate) struct ValidationMetrics {
 
 #[cfg(test)]
 mod tests {
-    use super::{hash_disallow_list, AddressSet};
-    use alloy_primitives::Address;
+    use super::{
+        decode_and_validate_bal_gas_limit, hash_disallow_list, AddressSet, ValidationApiError,
+    };
+    use alloy_eip7928::{bal::Bal, AccountChanges, BlockAccessListGasError, ITEM_COST};
+    use alloy_primitives::{Address, U256};
+    use reth_errors::ConsensusError;
+
+    #[test]
+    fn test_bal_gas_budget_boundary() {
+        let bal = Bal::new(vec![AccountChanges::new(Address::ZERO)
+            .with_storage_read(U256::from(1))
+            .with_storage_read(U256::from(2))]);
+        assert_eq!(bal.total_bal_items(), 3);
+
+        decode_and_validate_bal_gas_limit(alloy_rlp::encode(&bal).into(), 3 * ITEM_COST as u64)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_bal_gas_budget_boundary_plus_one() {
+        let bal = Bal::new(vec![AccountChanges::new(Address::ZERO)
+            .with_storage_read(U256::from(1))
+            .with_storage_read(U256::from(2))
+            .with_storage_read(U256::from(3))]);
+        let gas_limit = 3 * ITEM_COST as u64;
+        let err = decode_and_validate_bal_gas_limit(alloy_rlp::encode(&bal).into(), gas_limit)
+            .unwrap_err();
+        let ValidationApiError::Consensus(ConsensusError::BlockAccessListCostMoreThanGasLimit(err)) =
+            err
+        else {
+            panic!("expected BAL gas-limit error, got {err:?}");
+        };
+        assert_eq!(*err, BlockAccessListGasError::new(4, gas_limit));
+    }
 
     #[test]
     fn test_hash_disallow_list_deterministic() {


### PR DESCRIPTION
Moves V6 EIP-7928 block access list gas-budget validation immediately after decoding, before V2 blob proof verification, so over-budget submissions fail without paying the KZG validation cost. Keeps the late gas-budget check for other callers and the post-execution BAL/header commitment comparison, with boundary and error-precedence coverage.