### PR TITLE
fix(test): stabilize gossip disconnect and testing RPC tests

### DIFF
--- a/crates/ethereum/node/tests/it/testing.rs
+++ b/crates/ethereum/node/tests/it/testing.rs
@@ -24,7 +24,8 @@ use tokio::sync::oneshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn testing_rpc_build_block_works() -> eyre::Result<()> {
     let runtime = Runtime::test();
-    let mut rpc_args = reth_node_core::args::RpcServerArgs::default().with_http();
+    let mut rpc_args =
+        reth_node_core::args::RpcServerArgs::default().with_http().with_unused_ports();
     rpc_args.http_api = Some(RpcModuleSelection::from_iter([RethRpcModule::Testing]));
     let tempdir = tempdir().expect("temp datadir");
     let datadir_args = DatadirArgs {
@@ -95,7 +96,8 @@ async fn testing_rpc_build_block_works() -> eyre::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn testing_rpc_commit_block_works() -> eyre::Result<()> {
     let runtime = Runtime::test();
-    let mut rpc_args = reth_node_core::args::RpcServerArgs::default().with_http();
+    let mut rpc_args =
+        reth_node_core::args::RpcServerArgs::default().with_http().with_unused_ports();
     rpc_args.http_api =
         Some(RpcModuleSelection::from_iter([RethRpcModule::Eth, RethRpcModule::Testing]));
     let tempdir = tempdir().expect("temp datadir");

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -1,16 +1,15 @@
 //! Testing gossiping of transactions.
 use alloy_consensus::TxLegacy;
 use alloy_primitives::{Signature, U256};
-use futures::StreamExt;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_network::{
     test_utils::{NetworkEventStream, Testnet},
     transactions::config::{
         TransactionIngressPolicy, TransactionPropagationKind, TransactionsManagerConfig,
     },
-    NetworkEvent, NetworkEventListenerProvider, Peers,
+    NetworkEventListenerProvider, Peers,
 };
-use reth_network_api::{events::PeerEvent, PeerKind, PeersInfo};
+use reth_network_api::{PeerKind, PeersInfo};
 use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 use reth_transaction_pool::{
     test_utils::TransactionGenerator, AddedTransactionOutcome, PoolTransaction, TransactionPool,
@@ -256,11 +255,12 @@ async fn test_sending_invalid_transactions() {
     let peer0 = &handle.peers()[0];
     let peer1 = &handle.peers()[1];
 
+    let mut peer1_events = NetworkEventStream::new(peer1.network().event_listener());
+
     // connect all the peers
     handle.connect_peers().await;
 
     assert_eq!(peer0.network().num_connected_peers(), 1);
-    let mut peer1_events = peer1.network().event_listener();
     let mut tx_listener = peer1.pool().unwrap().new_transactions_listener();
 
     for idx in 0..10 {
@@ -278,24 +278,16 @@ async fn test_sending_invalid_transactions() {
         peer0.network().send_transactions(*peer1.peer_id(), vec![Arc::new(tx)]);
     }
 
-    // await disconnect for bad tx spam
-    if let Some(ev) = peer1_events.next().await {
-        match ev {
-            NetworkEvent::Peer(PeerEvent::SessionClosed { peer_id, .. }) => {
-                assert_eq!(peer_id, *peer0.peer_id());
-            }
-            NetworkEvent::ActivePeerSession { .. } |
-            NetworkEvent::Peer(PeerEvent::SessionEstablished { .. }) => {
-                panic!("unexpected SessionEstablished event")
-            }
-            NetworkEvent::Peer(PeerEvent::PeerAdded(_)) => {
-                panic!("unexpected PeerAdded event")
-            }
-            NetworkEvent::Peer(PeerEvent::PeerRemoved(_)) => {
-                panic!("unexpected PeerRemoved event")
-            }
-        }
-    }
+    // The listener also receives connection events, and PeerAdded can still be queued after
+    // connect_peers returns. Wait specifically for the disconnect after bad transaction spam.
+    let (peer_id, _) = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        peer1_events.next_session_closed(),
+    )
+    .await
+    .expect("peer did not disconnect after invalid transaction spam")
+    .expect("network event stream ended before disconnect");
+    assert_eq!(peer_id, *peer0.peer_id());
 
     // ensure txs never made it to the pool
     assert!(tx_listener.try_recv().is_err());


### PR DESCRIPTION
Fixes the failures in [this CI job](https://github.com/paradigmxyz/reth/actions/runs/34225154160/job/102057343599).

Wait explicitly for the invalid-transaction peer to disconnect: incoming-session setup can leave `PeerAdded` queued after `connect_peers()` returns, so the next event is not necessarily `SessionClosed`. Subscribe before connecting to exercise intervening events, and fail on timeout or stream closure.

Use OS-assigned RPC ports and unique IPC paths in both testing-namespace tests; replacing the test node’s RPC configuration with default arguments restored shared ports and caused the observed auth-port 8551 collision.
