### PR TITLE
fix(net): decode wire bitvectors into typed blob cell masks

### DIFF
--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -127,6 +127,16 @@ pub struct GetCells {
     pub cell_mask: B128,
 }
 
+impl GetCells {
+    /// Returns the requested cell indices as a numeric mask.
+    ///
+    /// The wire bitvector stores the lowest cell indices in the first byte, while numeric masks
+    /// represent the lowest bits in the last byte.
+    pub fn numeric_cell_mask(&self) -> B128 {
+        B128::from(u128::from_le_bytes(self.cell_mask.into()))
+    }
+}
+
 impl InMemorySize for GetCells {
     fn size(&self) -> usize {
         self.hashes.len() * core::mem::size_of::<B256>() + core::mem::size_of::<B128>()

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -3,7 +3,7 @@
 use crate::broadcast::decode_list_with_memory_budget;
 use alloc::vec::Vec;
 use alloy_consensus::transaction::{PooledTransaction, TxHashRef};
-use alloy_eips::eip7594::Cell;
+use alloy_eips::eip7594::{BlobCellMask, Cell};
 use alloy_primitives::{B128, B256};
 use alloy_rlp::{Decodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 use derive_more::{Constructor, Deref, IntoIterator};
@@ -128,12 +128,9 @@ pub struct GetCells {
 }
 
 impl GetCells {
-    /// Returns the requested cell indices as a numeric mask.
-    ///
-    /// The wire bitvector stores the lowest cell indices in the first byte, while numeric masks
-    /// represent the lowest bits in the last byte.
-    pub fn numeric_cell_mask(&self) -> B128 {
-        B128::from(u128::from_le_bytes(self.cell_mask.into()))
+    /// Returns the requested cell indices, decoded from the little-endian wire bitvector.
+    pub fn cell_mask(&self) -> BlobCellMask {
+        BlobCellMask::from_bits(u128::from_le_bytes(self.cell_mask.into()))
     }
 }
 

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -407,7 +407,7 @@ where
     ) {
         let mut cells_response = Cells { cell_mask: request.cell_mask, ..Default::default() };
         let mut total_bytes = 0;
-        let cell_mask = request.numeric_cell_mask();
+        let cell_mask = request.cell_mask();
 
         for hash in request.hashes.into_iter().take(MAX_CELLS_SERVE) {
             let Some(cells) = self.blob_store.get_cells(hash, cell_mask).unwrap_or_default() else {
@@ -858,7 +858,7 @@ mod tests {
     use alloy_consensus::constants::EMPTY_ROOT_HASH;
     use alloy_eips::{
         eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
-        eip7594::{BlobTransactionSidecarVariant, Cell},
+        eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell},
     };
     use alloy_primitives::{keccak256, Address, TxHash, B128, U256};
     use reth_network_api::test_utils::PeersHandle;
@@ -878,7 +878,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct CountingBlobStore {
         get_cells_calls: Arc<AtomicUsize>,
-        expected_cell_mask: Option<B128>,
+        expected_cell_mask: Option<BlobCellMask>,
     }
 
     impl BlobStore for CountingBlobStore {
@@ -955,7 +955,7 @@ mod tests {
         fn get_by_versioned_hashes_v4(
             &self,
             versioned_hashes: &[B256],
-            _indices_bitarray: B128,
+            _cell_mask: BlobCellMask,
         ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
             Ok(vec![None; versioned_hashes.len()])
         }
@@ -970,11 +970,11 @@ mod tests {
         fn get_cells(
             &self,
             _tx_hash: TxHash,
-            indices_bitarray: B128,
+            cell_mask: BlobCellMask,
         ) -> Result<Option<Vec<Cell>>, BlobStoreError> {
             self.get_cells_calls.fetch_add(1, Ordering::Relaxed);
             if let Some(expected) = self.expected_cell_mask {
-                assert_eq!(indices_bitarray, expected);
+                assert_eq!(cell_mask, expected);
                 return Ok(Some(vec![Cell::default()]))
             }
             Ok(None)
@@ -1029,7 +1029,7 @@ mod tests {
         let (_incoming_tx, incoming_rx) = mpsc::channel(1);
         let numeric_mask = 1u128 << index;
         let blob_store = CountingBlobStore {
-            expected_cell_mask: Some(B128::from(numeric_mask)),
+            expected_cell_mask: Some(BlobCellMask::from_bits(numeric_mask)),
             ..Default::default()
         };
         let handler = EthRequestHandler::<NoopProvider>::new(

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -407,8 +407,7 @@ where
     ) {
         let mut cells_response = Cells { cell_mask: request.cell_mask, ..Default::default() };
         let mut total_bytes = 0;
-        // ETH/72 bitvectors index the first byte first; the blob store accepts a numeric mask.
-        let cell_mask = alloy_primitives::B128::from(u128::from_le_bytes(request.cell_mask.into()));
+        let cell_mask = request.numeric_cell_mask();
 
         for hash in request.hashes.into_iter().take(MAX_CELLS_SERVE) {
             let Some(cells) = self.blob_store.get_cells(hash, cell_mask).unwrap_or_default() else {

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -407,11 +407,11 @@ where
     ) {
         let mut cells_response = Cells { cell_mask: request.cell_mask, ..Default::default() };
         let mut total_bytes = 0;
+        // ETH/72 bitvectors index the first byte first; the blob store accepts a numeric mask.
+        let cell_mask = alloy_primitives::B128::from(u128::from_le_bytes(request.cell_mask.into()));
 
         for hash in request.hashes.into_iter().take(MAX_CELLS_SERVE) {
-            let Some(cells) =
-                self.blob_store.get_cells(hash, request.cell_mask).unwrap_or_default()
-            else {
+            let Some(cells) = self.blob_store.get_cells(hash, cell_mask).unwrap_or_default() else {
                 continue;
             };
 
@@ -879,6 +879,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct CountingBlobStore {
         get_cells_calls: Arc<AtomicUsize>,
+        expected_cell_mask: Option<B128>,
     }
 
     impl BlobStore for CountingBlobStore {
@@ -970,9 +971,13 @@ mod tests {
         fn get_cells(
             &self,
             _tx_hash: TxHash,
-            _indices_bitarray: B128,
+            indices_bitarray: B128,
         ) -> Result<Option<Vec<Cell>>, BlobStoreError> {
             self.get_cells_calls.fetch_add(1, Ordering::Relaxed);
+            if let Some(expected) = self.expected_cell_mask {
+                assert_eq!(indices_bitarray, expected);
+                return Ok(Some(vec![Cell::default()]))
+            }
             Ok(None)
         }
 
@@ -990,7 +995,10 @@ mod tests {
         let (peers_tx, _) = mpsc::unbounded_channel();
         let (_incoming_tx, incoming_rx) = mpsc::channel(1);
         let get_cells_calls = Arc::new(AtomicUsize::new(0));
-        let blob_store = CountingBlobStore { get_cells_calls: Arc::clone(&get_cells_calls) };
+        let blob_store = CountingBlobStore {
+            get_cells_calls: Arc::clone(&get_cells_calls),
+            ..Default::default()
+        };
         let handler = EthRequestHandler::<NoopProvider>::new(
             NoopProvider::default(),
             PeersHandle::new(peers_tx),
@@ -1006,6 +1014,47 @@ mod tests {
         let cells = rx.await.unwrap().unwrap();
         assert!(cells.hashes.is_empty());
         assert_eq!(get_cells_calls.load(Ordering::Relaxed), MAX_CELLS_SERVE);
+    }
+
+    #[test_case(0)]
+    #[test_case(7)]
+    #[test_case(8)]
+    #[test_case(63)]
+    #[test_case(64)]
+    #[test_case(127)]
+    #[tokio::test]
+    async fn get_cells_request_uses_little_endian_wire_mask(index: u32) {
+        use alloy_rlp::{Decodable, Encodable};
+
+        let (peers_tx, _) = mpsc::unbounded_channel();
+        let (_incoming_tx, incoming_rx) = mpsc::channel(1);
+        let numeric_mask = 1u128 << index;
+        let blob_store = CountingBlobStore {
+            expected_cell_mask: Some(B128::from(numeric_mask)),
+            ..Default::default()
+        };
+        let handler = EthRequestHandler::<NoopProvider>::new(
+            NoopProvider::default(),
+            PeersHandle::new(peers_tx),
+            incoming_rx,
+        )
+        .with_blob_store(Box::new(blob_store));
+        let wire_mask = B128::from(numeric_mask.to_le_bytes());
+        let request = GetCells { hashes: vec![B256::ZERO], cell_mask: wire_mask };
+        let mut encoded = Vec::new();
+        request.encode(&mut encoded);
+        let request = GetCells::decode(&mut encoded.as_slice()).unwrap();
+        let (response, rx) = oneshot::channel();
+
+        handler.on_cells_request(PeerId::default(), request, response);
+
+        let cells = rx.await.unwrap().unwrap();
+        assert_eq!(cells.hashes, vec![B256::ZERO]);
+        assert_eq!(cells.cells, vec![vec![Cell::default()]]);
+        assert_eq!(cells.cell_mask, wire_mask);
+        encoded.clear();
+        cells.encode(&mut encoded);
+        assert_eq!(Cells::decode(&mut encoded.as_slice()).unwrap(), cells);
     }
 
     #[tokio::test]

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -5,6 +5,7 @@ use alloy_eips::{
     eip1898::BlockHashOrNumber,
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
     eip4895::Withdrawals,
+    eip7594::BlobCellMask,
     eip7685::RequestsOrHash,
 };
 use alloy_primitives::{BlockHash, BlockNumber, Bytes, Sealable, B128, B256, U64};
@@ -1223,9 +1224,8 @@ where
         versioned_hashes: Vec<B256>,
         indices_bitarray: B128,
     ) -> EngineApiResult<Option<Vec<Option<BlobCellsAndProofsV1>>>> {
-        // Engine API bitvectors are little-endian, while B128 integer conversions are
-        // big-endian. The transaction pool uses the latter representation as a numeric cell mask.
-        let indices_bitarray = B128::from(u128::from_le_bytes(indices_bitarray.into()));
+        // Engine API bitvectors encode the lowest cell indices in the first byte.
+        let cell_mask = BlobCellMask::from_bits(u128::from_le_bytes(indices_bitarray.into()));
         let current_timestamp =
             SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs();
         if !self.inner.chain_spec.is_osaka_active_at_timestamp(current_timestamp) {
@@ -1245,7 +1245,7 @@ where
 
         self.inner
             .tx_pool
-            .get_blobs_for_versioned_hashes_v4(&versioned_hashes, indices_bitarray)
+            .get_blobs_for_versioned_hashes_v4(&versioned_hashes, cell_mask)
             .map(Some)
             .map_err(|err| EngineApiError::Internal(Box::new(err)))
     }
@@ -2432,18 +2432,11 @@ mod tests {
 
     #[test]
     fn engine_bitvector_uses_little_endian_cell_indices() {
-        assert_eq!(
-            B128::from(u128::from_le_bytes(B128::from(1u128.to_le_bytes()).into())),
-            B128::from(1u128)
-        );
-        assert_eq!(
-            B128::from(u128::from_le_bytes(B128::from((1u128 << 127).to_le_bytes()).into())),
-            B128::from(1u128 << 127)
-        );
-        assert_eq!(
-            B128::from(u128::from_le_bytes(B128::from(((1u128 << 64) - 1).to_le_bytes()).into(),)),
-            B128::from((1u128 << 64) - 1)
-        );
+        for index in [0, 7, 8, 63, 64, 127] {
+            let wire_mask = B128::from((1u128 << index).to_le_bytes());
+            let mask = BlobCellMask::from_bits(u128::from_le_bytes(wire_mask.into()));
+            assert_eq!(mask.selected_indices().collect::<Vec<_>>(), vec![index]);
+        }
     }
 
     #[tokio::test]

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -9,7 +9,7 @@ use alloy_eips::{
     eip7840::BlobParams,
     merge::EPOCH_SLOTS,
 };
-use alloy_primitives::{map::B256Set, TxHash, B128, B256};
+use alloy_primitives::{map::B256Set, TxHash, B256};
 use parking_lot::{Mutex, RwLock};
 use schnellru::{ByLength, LruMap};
 use std::{fmt, fs, io, path::PathBuf, sync::Arc};
@@ -143,9 +143,8 @@ impl DiskFileBlobStore {
     fn get_by_versioned_hashes_cells_eip7594(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        let cell_mask = BlobCellMask::new(indices_bitarray);
         let mut result = vec![None; versioned_hashes.len()];
         let mut missing_count = result.len();
 
@@ -383,9 +382,9 @@ impl BlobStore for DiskFileBlobStore {
     fn get_by_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, indices_bitarray)
+        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, cell_mask)
     }
 
     fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
@@ -428,7 +427,7 @@ impl BlobStore for DiskFileBlobStore {
     fn get_cells(
         &self,
         tx: B256,
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Option<Vec<Cell>>, BlobStoreError> {
         let Some(sidecar) = self.get(tx)? else {
             return Ok(None);
@@ -439,7 +438,7 @@ impl BlobStore for DiskFileBlobStore {
         };
 
         sidecar
-            .compute_matching_cells(BlobCellMask::new(indices_bitarray))
+            .compute_matching_cells(cell_mask)
             .map(Some)
             .map_err(|err| BlobStoreError::Other(Box::new(err)))
     }
@@ -1090,10 +1089,10 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(TxHash::random(), sidecar.into()).unwrap();
 
-        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let request = vec![versioned_hash, B256::ZERO];
 
-        let v4 = store.get_by_versioned_hashes_v4(&request, indices_bitarray).unwrap();
+        let v4 = store.get_by_versioned_hashes_v4(&request, cell_mask).unwrap();
         assert_eq!(v4.len(), request.len());
         assert!(v4[1].is_none());
 
@@ -1150,7 +1149,9 @@ mod tests {
         store.insert(TxHash::random(), sidecar.into()).unwrap();
         store.clear_cache();
 
-        let v4 = store.get_by_versioned_hashes_v4(&[versioned_hash], B128::from(1u128)).unwrap();
+        let v4 = store
+            .get_by_versioned_hashes_v4(&[versioned_hash], BlobCellMask::from_bits(1u128))
+            .unwrap();
         let cells_and_proofs = v4[0].as_ref().unwrap();
         assert_eq!(cells_and_proofs.blob_cells.len(), 1);
         assert_eq!(cells_and_proofs.proofs, vec![Some(Bytes48::default())]);
@@ -1164,9 +1165,9 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(tx_hash, sidecar.into()).unwrap();
 
-        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let expected = store
-            .get_by_versioned_hashes_v4(&[versioned_hash], indices_bitarray)
+            .get_by_versioned_hashes_v4(&[versioned_hash], cell_mask)
             .unwrap()
             .pop()
             .unwrap()
@@ -1178,7 +1179,7 @@ mod tests {
 
         store.clear_cache();
 
-        assert_eq!(store.get_cells(tx_hash, indices_bitarray).unwrap(), Some(expected));
+        assert_eq!(store.get_cells(tx_hash, cell_mask).unwrap(), Some(expected));
     }
 
     #[test]

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -5,7 +5,7 @@ use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
     eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell},
 };
-use alloy_primitives::{map::B256Map, B128, B256};
+use alloy_primitives::{map::B256Map, B256};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -55,9 +55,8 @@ impl InMemoryBlobStore {
     fn get_by_versioned_hashes_cells_eip7594(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        let cell_mask = BlobCellMask::new(indices_bitarray);
         let mut result = vec![None; versioned_hashes.len()];
         let mut missing_count = result.len();
         let blob_sidecars = self.inner.store.read().values().cloned().collect::<Vec<_>>();
@@ -219,9 +218,9 @@ impl BlobStore for InMemoryBlobStore {
     fn get_by_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, indices_bitarray)
+        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, cell_mask)
     }
 
     fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
@@ -245,7 +244,7 @@ impl BlobStore for InMemoryBlobStore {
     fn get_cells(
         &self,
         tx: B256,
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Option<Vec<Cell>>, BlobStoreError> {
         let Some(sidecar) = self.get(tx)? else {
             return Ok(None);
@@ -256,7 +255,7 @@ impl BlobStore for InMemoryBlobStore {
         };
 
         sidecar
-            .compute_matching_cells(BlobCellMask::new(indices_bitarray))
+            .compute_matching_cells(cell_mask)
             .map(Some)
             .map_err(|err| BlobStoreError::Other(Box::new(err)))
     }
@@ -366,10 +365,10 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(B256::random(), sidecar.into()).unwrap();
 
-        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let request = vec![versioned_hash, B256::ZERO];
 
-        let v4 = store.get_by_versioned_hashes_v4(&request, indices_bitarray).unwrap();
+        let v4 = store.get_by_versioned_hashes_v4(&request, cell_mask).unwrap();
         assert_eq!(v4.len(), request.len());
         assert!(v4[1].is_none());
 
@@ -388,9 +387,9 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(tx_hash, sidecar.into()).unwrap();
 
-        let indices_bitarray = B128::from((1u128 << 0) | (1u128 << 7));
+        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let expected = store
-            .get_by_versioned_hashes_v4(&[versioned_hash], indices_bitarray)
+            .get_by_versioned_hashes_v4(&[versioned_hash], cell_mask)
             .unwrap()
             .pop()
             .unwrap()
@@ -400,6 +399,6 @@ mod tests {
             .collect::<Option<Vec<_>>>()
             .unwrap();
 
-        assert_eq!(store.get_cells(tx_hash, indices_bitarray).unwrap(), Some(expected));
+        assert_eq!(store.get_cells(tx_hash, cell_mask).unwrap(), Some(expected));
     }
 }

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -4,7 +4,7 @@ use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
     eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell},
 };
-use alloy_primitives::{TxHash, B128, B256};
+use alloy_primitives::{TxHash, B256};
 pub use converter::BlobSidecarConverter;
 pub use disk::{DiskFileBlobStore, DiskFileBlobStoreConfig, OpenDiskFileBlobStore};
 pub use mem::InMemoryBlobStore;
@@ -207,7 +207,7 @@ pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
     fn get_by_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError>;
 
     /// Return whether each requested blob versioned hash is available.
@@ -217,7 +217,7 @@ pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
 
     /// Returns all requested cells for all blobs belonging to the transaction.
     ///
-    /// The `indices_bitarray` is applied independently to every blob in the tx.
+    /// The `cell_mask` is applied independently to every blob in the tx.
     ///
     /// Returned cells are flattened in blob order, then cell-index order.
     ///
@@ -238,7 +238,7 @@ pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
     fn get_cells(
         &self,
         tx_hash: TxHash,
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Option<Vec<Cell>>, BlobStoreError>;
 
     /// Data size of all transactions in the blob store.

--- a/crates/transaction-pool/src/blobstore/noop.rs
+++ b/crates/transaction-pool/src/blobstore/noop.rs
@@ -1,9 +1,9 @@
 use crate::blobstore::{BlobStore, BlobStoreCleanupStat, BlobStoreError, PooledBlobSidecar};
 use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
-    eip7594::{BlobTransactionSidecarVariant, Cell},
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell},
 };
-use alloy_primitives::{TxHash, B128, B256};
+use alloy_primitives::{TxHash, B256};
 use std::sync::Arc;
 
 /// A blobstore implementation that does nothing
@@ -81,7 +81,7 @@ impl BlobStore for NoopBlobStore {
     fn get_by_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        _indices_bitarray: B128,
+        _cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
         Ok(vec![None; versioned_hashes.len()])
     }
@@ -93,9 +93,9 @@ impl BlobStore for NoopBlobStore {
     fn get_cells(
         &self,
         tx_hash: TxHash,
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Option<Vec<Cell>>, BlobStoreError> {
-        let _ = (tx_hash, indices_bitarray);
+        let _ = (tx_hash, cell_mask);
         Ok(None)
     }
 

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -305,9 +305,9 @@ pub use crate::{
 use crate::{identifier::TransactionId, pool::PoolInner};
 use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
-    eip7594::BlobTransactionSidecarVariant,
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant},
 };
-use alloy_primitives::{map::AddressSet, Address, TxHash, B128, B256, U256};
+use alloy_primitives::{map::AddressSet, Address, TxHash, B256, U256};
 use aquamarine as _;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_eth_wire_types::HandleMempoolData;
@@ -824,9 +824,9 @@ where
     fn get_blobs_for_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        self.pool.blob_store().get_by_versioned_hashes_v4(versioned_hashes, indices_bitarray)
+        self.pool.blob_store().get_by_versioned_hashes_v4(versioned_hashes, cell_mask)
     }
 
     fn has_blobs_for_versioned_hashes(

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -18,9 +18,9 @@ use crate::{
 use alloy_eips::{
     eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M,
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
-    eip7594::BlobTransactionSidecarVariant,
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant},
 };
-use alloy_primitives::{map::AddressSet, Address, TxHash, B128, B256, U256};
+use alloy_primitives::{map::AddressSet, Address, TxHash, B256, U256};
 use reth_eth_wire_types::HandleMempoolData;
 use reth_primitives_traits::Recovered;
 use std::{marker::PhantomData, sync::Arc};
@@ -398,7 +398,7 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
     fn get_blobs_for_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        _indices_bitarray: B128,
+        _cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
         Ok(vec![None; versioned_hashes.len()])
     }

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -68,12 +68,12 @@ use alloy_eips::{
         env_settings::KzgSettings, BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1,
         BlobTransactionValidationError,
     },
-    eip7594::BlobTransactionSidecarVariant,
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant},
     eip7702::SignedAuthorization,
 };
 use alloy_primitives::{
     map::{AddressSet, B256Map},
-    Address, Bytes, TxHash, TxKind, B128, B256, U256,
+    Address, Bytes, TxHash, TxKind, B256, U256,
 };
 use futures_util::{ready, Stream};
 use reth_eth_wire_types::HandleMempoolData;
@@ -755,7 +755,7 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
     fn get_blobs_for_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: B128,
+        cell_mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError>;
 
     /// Return whether each requested blob versioned hash is available.
@@ -2005,7 +2005,7 @@ mod tests {
         EthereumTxEnvelope, SignableTransaction, TxEip1559, TxEip2930, TxEip4844, TxEip7702,
         TxEnvelope, TxLegacy,
     };
-    use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7594::BlobCellMask};
+    use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
     use alloy_primitives::Signature;
 
     #[test]


### PR DESCRIPTION
Makes blob store and transaction pool cell lookups accept `BlobCellMask`, with ETH/72 and Engine API wire bitvectors decoded at their respective boundaries. `GetCells::cell_mask()` decodes the little-endian request mask while preserving its original bytes in the response, fixing requests for cell 0 selecting cell 120.
