### PR TITLE
perf(engine): start trie proofs with an early update batch

### DIFF
--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -113,6 +113,8 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
     pending_updates: usize,
+    /// Whether the first buffered leaf batch has been applied.
+    initial_updates_applied: bool,
     /// Combined final hashed state.
     ///
     /// Sparse trie task observes and hashes all state updates, allowing it to cheaply construct a
@@ -182,6 +184,7 @@ where
             pending_targets: Default::default(),
             in_flight_proof_batches: 0,
             pending_updates: Default::default(),
+            initial_updates_applied: false,
             final_hashed_state: Default::default(),
             metrics,
         }
@@ -438,6 +441,14 @@ where
             self.process_new_updates()?;
             self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
             self.dispatch_pending_targets()?;
+        } else if !self.initial_updates_applied && self.pending_updates >= INITIAL_UPDATE_BATCH_SIZE
+        {
+            // Start proof fetching before a continuously arriving state stream drains. Later
+            // batches retain the usual coalescing policy to avoid repeatedly sorting small maps.
+            let t = Instant::now();
+            self.process_new_updates()?;
+            self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
+            self.dispatch_pending_targets()?;
         } else if self.pending_targets.len() > self.chunk_size {
             // Make sure to dispatch targets if we've accumulated a lot of them.
             self.dispatch_pending_targets()?;
@@ -570,6 +581,7 @@ where
 
         let _span = debug_span!("process_new_updates").entered();
         self.pending_updates = 0;
+        self.initial_updates_applied = true;
 
         // Firstly apply all new storage and account updates to the tries.
         self.process_leaf_updates(true)?;
@@ -1007,6 +1019,9 @@ pub(super) struct SparseTrieTaskMetrics {
 /// fetched by a single worker. If exceeded, chunking is forced regardless of worker availability.
 const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 
+/// Start proof fetching while the first state-update batch is still arriving.
+const INITIAL_UPDATE_BATCH_SIZE: usize = 64;
+
 /// Dispatches work items as a single unit or in chunks based on target size and worker
 /// availability.
 #[expect(clippy::too_many_arguments)]
@@ -1212,6 +1227,90 @@ mod tests {
         assert_eq!(decoded.balance, U256::from(42));
         assert_eq!(decoded.storage_root, storage_root);
         assert_eq!(account_rlp_buf, encoded);
+    }
+
+    #[test]
+    fn first_leaf_batch_starts_proofs_before_input_queue_drains() {
+        let runtime = reth_tasks::Runtime::test();
+        let provider_factory = create_test_provider_factory();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            provider_factory,
+            OverlayManager::<reth_chain_state::EthPrimitives>::default()
+                .overlay_builder(anchor_hash),
+        );
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(state_provider_factory),
+            false,
+            proof_result_tx.clone(),
+        );
+
+        let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
+        let trie = SparseStateTrie::default()
+            .with_accounts_trie(default_trie.clone())
+            .with_default_storage_trie(default_trie)
+            .with_updates(true);
+
+        let parent_state_root = B256::from([0x55; 32]);
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (_cancel_guard, cancel_rx) = crossbeam_channel::bounded::<()>(0);
+        let mut task = SparseTrieCacheTask::new_with_trie(
+            &runtime,
+            updates_rx,
+            cancel_rx,
+            std::sync::mpsc::channel().0,
+            proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
+            SparseTrieTaskMetrics::default(),
+            trie,
+            parent_state_root,
+            TrieNodeEpoch::UNMODIFIED,
+            1,
+        );
+
+        // Keep an input queued so progress cannot use its normal queue-empty flush.
+        updates_tx.send(StateRootMessage::PrefetchProofs(Default::default())).unwrap();
+        let deadline = std::time::Instant::now();
+        while task.updates.is_empty() {
+            assert!(deadline.elapsed() < std::time::Duration::from_secs(1));
+            std::thread::yield_now();
+        }
+        for index in 0..INITIAL_UPDATE_BATCH_SIZE {
+            let mut state = HashedPostState::default();
+            state.accounts.insert(
+                B256::repeat_byte(index as u8),
+                Some(Account { nonce: 1, ..Default::default() }),
+            );
+            task.on_hashed_state_update(state);
+            task.pending_updates += 1;
+            assert!(!task.make_progress().unwrap());
+            if index + 1 < INITIAL_UPDATE_BATCH_SIZE {
+                assert_eq!(task.in_flight_proof_batches, 0);
+            }
+        }
+        assert!(task.in_flight_proof_batches > 0, "proof work must start before the queue drains");
+        assert_eq!(task.pending_updates, 0);
+
+        // A second batch remains buffered; the early flush must not become a permanent small
+        // batch policy that repeatedly scans and sorts pending leaves.
+        for index in INITIAL_UPDATE_BATCH_SIZE..INITIAL_UPDATE_BATCH_SIZE * 2 {
+            let mut state = HashedPostState::default();
+            state.accounts.insert(
+                B256::repeat_byte(index as u8),
+                Some(Account { nonce: 1, ..Default::default() }),
+            );
+            task.on_hashed_state_update(state);
+            task.pending_updates += 1;
+            assert!(!task.make_progress().unwrap());
+        }
+        assert_eq!(task.pending_updates, INITIAL_UPDATE_BATCH_SIZE);
+        assert_eq!(task.new_account_updates.len(), INITIAL_UPDATE_BATCH_SIZE);
+        drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
     }
 
     #[test]


### PR DESCRIPTION
Allow an initial trie update batch while input is queued so proof fetching can start sooner. Six-pair 300M BAL timing is inconclusive for server mean (−1.34%) and slightly worse for client mean (+0.50%); keep experimental. Matched traces show earlier proof readiness but little change in first consumption.

Based directly on `main`, without the closed early BAL recovery experiment (#27077) or the other follow-up experiments. The benchmark results above describe the previous base and have not been rerun on this base.
