### PR TITLE
feat(txpool): support eth72 sparse blobpool

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -20,7 +20,10 @@ use reth_evm::{
 use reth_evm_ethereum::factory::RethEvmFactory;
 #[cfg(feature = "jit")]
 use reth_evm_ethereum::factory::{JitBackend, JitMode, RevmcMetrics, RuntimeConfig, RuntimeTuning};
-use reth_network::{primitives::BasicNetworkPrimitives, NetworkHandle, PeersInfo};
+use reth_network::{
+    primitives::BasicNetworkPrimitives, types::EncodableEth72PooledTransaction, NetworkHandle,
+    PeersInfo,
+};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, HeaderTy, NodeAddOns, NodePrimitives,
     PayloadAttributesBuilder, PrimitivesTy, TxTy,
@@ -772,6 +775,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
+    PoolPooledTx<Pool>: EncodableEth72PooledTransaction,
 {
     type Network =
         NetworkHandle<BasicNetworkPrimitives<PrimitivesTy<Node::Types>, PoolPooledTx<Pool>>>;

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -10,7 +10,7 @@ use super::{
     broadcast::NewBlockHashes, BlockAccessLists, BlockBodies, BlockHeaders, GetBlockAccessLists,
     GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
     GetReceipts70, NewPooledTransactionHashes66, NewPooledTransactionHashes68, NodeData,
-    PooledTransactions, Receipts, Status, StatusEth69, Transactions,
+    PooledTransactions, PooledTransactionsEth72, Receipts, Status, StatusEth69, Transactions,
 };
 use crate::{
     status::StatusMessage, BlockRangeUpdate, BroadcastPoolTransactions, Cells,
@@ -152,9 +152,15 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 EthMessage::GetPooledTransactions(RequestPair::decode(buf)?)
             }
             EthMessageID::PooledTransactions => {
-                EthMessage::PooledTransactions(RequestPair::decode_with(buf, |buf| {
-                    PooledTransactions::decode_with_memory_budget(buf, tx_memory_budget)
-                })?)
+                if version >= EthVersion::Eth72 {
+                    EthMessage::PooledTransactionsEth72(RequestPair::decode_with(buf, |buf| {
+                        PooledTransactionsEth72::decode_with_memory_budget(buf, tx_memory_budget)
+                    })?)
+                } else {
+                    EthMessage::PooledTransactions(RequestPair::decode_with(buf, |buf| {
+                        PooledTransactions::decode_with_memory_budget(buf, tx_memory_budget)
+                    })?)
+                }
             }
             EthMessageID::GetNodeData => {
                 if version >= EthVersion::Eth67 {
@@ -358,6 +364,12 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
         serde(bound = "N::PooledTransaction: serde::Serialize + serde::de::DeserializeOwned")
     )]
     PooledTransactions(RequestPair<PooledTransactions<N::PooledTransaction>>),
+    /// Represents an eth/72 `PooledTransactions` response.
+    ///
+    /// This is kept separate from [`Self::PooledTransactions`] only to select the eth/72 wire
+    /// encoding. It uses the same protocol message ID and is normalized back to the regular typed
+    /// response after decoding.
+    PooledTransactionsEth72(RequestPair<PooledTransactionsEth72<N::PooledTransaction>>),
     /// Represents a `GetNodeData` request-response pair.
     GetNodeData(RequestPair<GetNodeData>),
     /// Represents a `NodeData` request-response pair.
@@ -426,7 +438,9 @@ impl<N: NetworkPrimitives> EthMessage<N> {
             Self::GetBlockBodies(_) => EthMessageID::GetBlockBodies,
             Self::BlockBodies(_) => EthMessageID::BlockBodies,
             Self::GetPooledTransactions(_) => EthMessageID::GetPooledTransactions,
-            Self::PooledTransactions(_) => EthMessageID::PooledTransactions,
+            Self::PooledTransactions(_) | Self::PooledTransactionsEth72(_) => {
+                EthMessageID::PooledTransactions
+            }
             Self::GetNodeData(_) => EthMessageID::GetNodeData,
             Self::NodeData(_) => EthMessageID::NodeData,
             Self::GetReceipts(_) | Self::GetReceipts70(_) => EthMessageID::GetReceipts,
@@ -460,6 +474,7 @@ impl<N: NetworkPrimitives> EthMessage<N> {
         matches!(
             self,
             Self::PooledTransactions(_) |
+                Self::PooledTransactionsEth72(_) |
                 Self::Receipts(_) |
                 Self::Receipts69(_) |
                 Self::Receipts70(_) |
@@ -481,6 +496,15 @@ impl<N: NetworkPrimitives> EthMessage<N> {
         // user-facing `PeerRequest` API unchanged.
         if version >= EthVersion::Eth70 {
             return match self {
+                Self::PooledTransactions(pair) if version >= EthVersion::Eth72 => {
+                    // The request/response API remains version-neutral. Only the final wire
+                    // representation changes for an eth/72 peer.
+                    let RequestPair { request_id, message } = pair;
+                    Self::PooledTransactionsEth72(RequestPair {
+                        request_id,
+                        message: PooledTransactionsEth72::from_transactions(message),
+                    })
+                }
                 Self::GetReceipts(pair) => {
                     let RequestPair { request_id, message } = pair;
                     let req = RequestPair {
@@ -516,6 +540,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::BlockBodies(bodies) => bodies.encode(out),
             Self::GetPooledTransactions(request) => request.encode(out),
             Self::PooledTransactions(transactions) => transactions.encode(out),
+            Self::PooledTransactionsEth72(transactions) => transactions.encode(out),
             Self::GetNodeData(request) => request.encode(out),
             Self::NodeData(data) => data.encode(out),
             Self::GetReceipts(request) => request.encode(out),
@@ -546,6 +571,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::BlockBodies(bodies) => bodies.length(),
             Self::GetPooledTransactions(request) => request.length(),
             Self::PooledTransactions(transactions) => transactions.length(),
+            Self::PooledTransactionsEth72(transactions) => transactions.length(),
             Self::GetNodeData(request) => request.length(),
             Self::NodeData(data) => data.length(),
             Self::GetReceipts(request) => request.length(),

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -221,13 +221,24 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 if version < EthVersion::Eth72 {
                     return Err(MessageError::Invalid(version, EthMessageID::Cells))
                 }
-                EthMessage::Cells(RequestPair::decode(buf)?)
+                EthMessage::Cells(RequestPair::decode_with(buf, |buf| {
+                    Ok(Cells {
+                        hashes: Decodable::decode(buf)?,
+                        cells: Decodable::decode(buf)?,
+                        cell_mask: Decodable::decode(buf)?,
+                    })
+                })?)
             }
             EthMessageID::GetCells => {
                 if version < EthVersion::Eth72 {
                     return Err(MessageError::Invalid(version, EthMessageID::GetCells))
                 }
-                EthMessage::GetCells(RequestPair::decode(buf)?)
+                EthMessage::GetCells(RequestPair::decode_with(buf, |buf| {
+                    Ok(GetCells {
+                        hashes: Decodable::decode(buf)?,
+                        cell_mask: Decodable::decode(buf)?,
+                    })
+                })?)
             }
             EthMessageID::Other(_) => {
                 let raw_payload = Bytes::copy_from_slice(buf);
@@ -546,13 +557,39 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::GetReceipts(request) => request.encode(out),
             Self::GetReceipts70(request) => request.encode(out),
             Self::GetBlockAccessLists(request) => request.encode(out),
-            Self::GetCells(request) => request.encode(out),
+            Self::GetCells(request) => {
+                // ETH/72 cell packets put their fields directly after the request ID.
+                Header {
+                    list: true,
+                    payload_length: request.request_id.length() +
+                        request.message.hashes.length() +
+                        request.message.cell_mask.length(),
+                }
+                .encode(out);
+                request.request_id.encode(out);
+                request.message.hashes.encode(out);
+                request.message.cell_mask.encode(out);
+            }
             Self::Receipts(receipts) => receipts.encode(out),
             Self::Receipts69(receipt69) => receipt69.encode(out),
             Self::Receipts70(receipt70) => receipt70.encode(out),
             Self::BlockAccessLists(block_access_lists) => block_access_lists.encode(out),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.encode(out),
-            Self::Cells(cells) => cells.encode(out),
+            Self::Cells(cells) => {
+                // ETH/72 cell packets put their fields directly after the request ID.
+                Header {
+                    list: true,
+                    payload_length: cells.request_id.length() +
+                        cells.message.hashes.length() +
+                        cells.message.cells.length() +
+                        cells.message.cell_mask.length(),
+                }
+                .encode(out);
+                cells.request_id.encode(out);
+                cells.message.hashes.encode(out);
+                cells.message.cells.encode(out);
+                cells.message.cell_mask.encode(out);
+            }
             Self::Other(unknown) => out.put_slice(&unknown.payload),
         }
     }
@@ -577,13 +614,24 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::GetReceipts(request) => request.length(),
             Self::GetReceipts70(request) => request.length(),
             Self::GetBlockAccessLists(request) => request.length(),
-            Self::GetCells(request) => request.length(),
+            Self::GetCells(request) => {
+                let length = request.request_id.length() +
+                    request.message.hashes.length() +
+                    request.message.cell_mask.length();
+                length + length_of_length(length)
+            }
             Self::Receipts(receipts) => receipts.length(),
             Self::Receipts69(receipt69) => receipt69.length(),
             Self::Receipts70(receipt70) => receipt70.length(),
             Self::BlockAccessLists(block_access_lists) => block_access_lists.length(),
             Self::BlockRangeUpdate(block_range_update) => block_range_update.length(),
-            Self::Cells(cells) => cells.length(),
+            Self::Cells(cells) => {
+                let length = cells.request_id.length() +
+                    cells.message.hashes.length() +
+                    cells.message.cells.length() +
+                    cells.message.cell_mask.length();
+                length + length_of_length(length)
+            }
             Self::Other(unknown) => unknown.length(),
         }
     }
@@ -929,6 +977,77 @@ mod tests {
         let mut buf = vec![];
         value.encode(&mut buf);
         buf
+    }
+
+    #[test]
+    fn eth72_cell_packets_match_geth_vectors() {
+        use crate::{Cells, GetCells};
+        use alloy_eips::eip7594::Cell;
+        use alloy_primitives::{keccak256, B128, B256};
+
+        // Generated with Geth 24b38e763fdd7dee8b91007d5f1a94cd21c9a7f0.
+        let mask = B128::from((1u128 | (1 << 8) | (1 << 127)).to_le_bytes());
+        let hash =
+            B256::from(hex!("0000000000000000000000000000000000000000000000000000000000001234"));
+        let request = EthMessage::<EthNetworkPrimitives>::GetCells(RequestPair {
+            request_id: 42,
+            message: GetCells { hashes: vec![hash], cell_mask: mask },
+        });
+        let empty = EthMessage::Cells(RequestPair {
+            request_id: 42,
+            message: Cells { cell_mask: mask, ..Default::default() },
+        });
+        assert_eq!(alloy_rlp::encode(&request), hex!("f42ae1a000000000000000000000000000000000000000000000000000000000000012349001010000000000000000000000000080"));
+        assert_eq!(alloy_rlp::encode(&empty), hex!("d42ac0c09001010000000000000000000000000080"));
+        let mut cell = Cell::default();
+        cell[0] = 1;
+        cell[2047] = 2;
+        let response = EthMessage::Cells(RequestPair {
+            request_id: 42,
+            message: Cells { hashes: vec![hash], cells: vec![vec![cell; 3]], cell_mask: mask },
+        });
+        let encoded = alloy_rlp::encode(&response);
+        assert_eq!(encoded.len(), 6214);
+        assert_eq!(
+            keccak256(&encoded),
+            B256::from(hex!("72c2afa3c896b0666ae473f075c1fc48133563f4bc8d22f7c1abb2aaf215dc3f"))
+        );
+        for message in [request, empty, response] {
+            let encoded = alloy_rlp::encode(&message);
+            assert_eq!(encoded.len(), message.length());
+            let mut packet = vec![message.message_id().to_u8()];
+            packet.extend_from_slice(&encoded);
+            let mut input = packet.as_slice();
+            assert_eq!(
+                ProtocolMessage::decode_message(EthVersion::Eth72, &mut input).unwrap().message,
+                message
+            );
+            assert!(input.is_empty());
+            assert!(ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+                EthVersion::Eth71,
+                &mut packet.as_slice()
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn eth72_cell_packets_reject_nested_fields() {
+        use crate::{Cells, GetCells};
+        let request = RequestPair { request_id: 42, message: GetCells::default() };
+        let response = RequestPair { request_id: 42, message: Cells::default() };
+        for (id, encoded) in [
+            (EthMessageID::GetCells, alloy_rlp::encode(request)),
+            (EthMessageID::Cells, alloy_rlp::encode(response)),
+        ] {
+            let mut packet = vec![id.to_u8()];
+            packet.extend(encoded);
+            assert!(ProtocolMessage::<EthNetworkPrimitives>::decode_message(
+                EthVersion::Eth72,
+                &mut packet.as_slice()
+            )
+            .is_err());
+        }
     }
 
     #[test]

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -1,6 +1,6 @@
 //! Abstraction over primitive types in network messages.
 
-use crate::NewBlockPayload;
+use crate::{EncodableEth72PooledTransaction, NewBlockPayload};
 use alloy_consensus::{RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt};
 use alloy_rlp::{Decodable, Encodable};
 use core::fmt::Debug;
@@ -53,7 +53,10 @@ pub trait NetworkPrimitives: Send + Sync + Unpin + Clone + Debug + 'static {
     /// For EIP-4844 blob transactions, this includes the full blob sidecar with
     /// KZG commitments and proofs that are needed for validation but are not
     /// included in the consensus block format.
-    type PooledTransaction: SignedTransaction + TryFrom<Self::BroadcastedTransaction> + 'static;
+    type PooledTransaction: SignedTransaction
+        + TryFrom<Self::BroadcastedTransaction>
+        + EncodableEth72PooledTransaction
+        + 'static;
 
     /// The transaction type which peers return in `GetReceipts` messages.
     type Receipt: TxReceipt
@@ -102,7 +105,7 @@ pub struct BasicNetworkPrimitives<N: NodePrimitives, Pooled, NewBlock = crate::N
 impl<N, Pooled, NewBlock> NetworkPrimitives for BasicNetworkPrimitives<N, Pooled, NewBlock>
 where
     N: NodePrimitives,
-    Pooled: SignedTransaction + TryFrom<N::SignedTx> + 'static,
+    Pooled: SignedTransaction + TryFrom<N::SignedTx> + EncodableEth72PooledTransaction + 'static,
     NewBlock: NewBlockPayload<Block = N::Block>,
 {
     type BlockHeader = N::BlockHeader;

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -2,12 +2,22 @@
 
 use crate::broadcast::decode_list_with_memory_budget;
 use alloc::vec::Vec;
-use alloy_consensus::transaction::{PooledTransaction, TxHashRef};
-use alloy_eips::eip7594::{BlobCellMask, Cell};
+use alloy_consensus::{
+    transaction::{PooledTransaction, RlpEcdsaEncodableTx, TxEip4844WithSidecar, TxHashRef},
+    Signed,
+};
+use alloy_eips::{
+    eip4844::Blob,
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell, EIP_7594_WRAPPER_VERSION},
+};
 use alloy_primitives::{B128, B256};
-use alloy_rlp::{Decodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
+use alloy_rlp::{
+    BufMut, Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+    RlpEncodableWrapper,
+};
 use derive_more::{Constructor, Deref, IntoIterator};
 use reth_codecs_derive::add_arbitrary_tests;
+use reth_ethereum_primitives::PooledTransactionVariant;
 use reth_primitives_traits::InMemorySize;
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
@@ -69,6 +79,158 @@ pub struct PooledTransactions<T = PooledTransaction>(
     /// The transaction bodies, each of which should correspond to a requested hash.
     pub Vec<T>,
 );
+
+/// An eth/72 `PooledTransactions` response.
+///
+/// Eth/72 elides the blob list from type-3 transactions because blob data is fetched separately
+/// with `GetCells`. The transactions remain typed here; a borrowed type-3 encoding view elides
+/// the blob list. This is still the same `PooledTransactions` message (`0x0a`) on the wire, not a
+/// new protocol message.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PooledTransactionsEth72<T = PooledTransaction>(pub Vec<T>);
+
+/// Encodes a pooled transaction for an eth/72 response.
+pub trait EncodableEth72PooledTransaction: Encodable {
+    /// Writes this transaction using the eth/72 representation.
+    fn encode_eth72(&self, out: &mut dyn BufMut);
+
+    /// Returns the encoded length of the eth/72 representation.
+    fn eth72_length(&self) -> usize;
+}
+
+impl EncodableEth72PooledTransaction for PooledTransactionVariant {
+    fn encode_eth72(&self, out: &mut dyn BufMut) {
+        Eth72Pooled(self).encode(out);
+    }
+
+    fn eth72_length(&self) -> usize {
+        Eth72Pooled(self).length()
+    }
+}
+
+impl<T> PooledTransactionsEth72<T> {
+    /// Converts a regular pooled transaction response into the eth/72 response view.
+    pub fn from_transactions(transactions: PooledTransactions<T>) -> Self {
+        Self(transactions.0)
+    }
+}
+
+impl<T> From<PooledTransactionsEth72<T>> for PooledTransactions<T> {
+    fn from(transactions: PooledTransactionsEth72<T>) -> Self {
+        Self(transactions.0)
+    }
+}
+
+impl<T: Decodable + InMemorySize> PooledTransactionsEth72<T> {
+    /// Decodes an eth/72 response while applying the same memory budget as the regular response.
+    pub fn decode_with_memory_budget(
+        buf: &mut &[u8],
+        memory_budget: usize,
+    ) -> alloy_rlp::Result<Self> {
+        decode_list_with_memory_budget(buf, memory_budget).map(Self)
+    }
+}
+
+impl<T: EncodableEth72PooledTransaction> Encodable for PooledTransactionsEth72<T> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let payload_length = self.0.iter().map(T::eth72_length).sum();
+        Header { list: true, payload_length }.encode(out);
+        for transaction in &self.0 {
+            transaction.encode_eth72(out);
+        }
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.0.iter().map(T::eth72_length).sum();
+        Header { list: true, payload_length }.length_with_payload()
+    }
+}
+
+/// Borrowed eth/72 view of a pooled transaction.
+struct Eth72Pooled<'a>(&'a PooledTransactionVariant);
+
+impl Encodable for Eth72Pooled<'_> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self.0 {
+            PooledTransactionVariant::Eip4844(transaction) => {
+                Eth72PooledEip4844(transaction).encode(out)
+            }
+            transaction => transaction.encode(out),
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self.0 {
+            PooledTransactionVariant::Eip4844(transaction) => {
+                Eth72PooledEip4844(transaction).length()
+            }
+            transaction => transaction.length(),
+        }
+    }
+}
+
+/// Borrowed eth/72 view of a type-3 transaction.
+struct Eth72PooledEip4844<'a>(&'a Signed<TxEip4844WithSidecar<BlobTransactionSidecarVariant>>);
+
+impl Encodable for Eth72PooledEip4844<'_> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: false, payload_length: self.typed_length() }.encode(out);
+        out.put_u8(3);
+        Header { list: true, payload_length: self.payload_length() }.encode(out);
+        self.0.tx().tx.rlp_encode_signed(self.0.signature(), out);
+        Eth72BlobSidecar(&self.0.tx().sidecar).encode(out);
+    }
+
+    fn length(&self) -> usize {
+        Header { list: false, payload_length: self.typed_length() }.length_with_payload()
+    }
+}
+
+impl Eth72PooledEip4844<'_> {
+    fn payload_length(&self) -> usize {
+        self.0.tx().tx.rlp_encoded_length_with_signature(self.0.signature()) +
+            Eth72BlobSidecar(&self.0.tx().sidecar).length()
+    }
+
+    fn typed_length(&self) -> usize {
+        1 + Header { list: true, payload_length: self.payload_length() }.length_with_payload()
+    }
+}
+
+/// Borrowed sidecar view that writes an empty blob vector and preserves metadata.
+struct Eth72BlobSidecar<'a>(&'a BlobTransactionSidecarVariant);
+
+impl Encodable for Eth72BlobSidecar<'_> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self.0 {
+            BlobTransactionSidecarVariant::Eip4844(sidecar) => {
+                Vec::<Blob>::new().encode(out);
+                sidecar.commitments.encode(out);
+                sidecar.proofs.encode(out);
+            }
+            BlobTransactionSidecarVariant::Eip7594(sidecar) => {
+                out.put_u8(EIP_7594_WRAPPER_VERSION);
+                Vec::<Blob>::new().encode(out);
+                sidecar.commitments.encode(out);
+                sidecar.cell_proofs.encode(out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self.0 {
+            BlobTransactionSidecarVariant::Eip4844(sidecar) => {
+                Vec::<Blob>::new().length() + sidecar.commitments.length() + sidecar.proofs.length()
+            }
+            BlobTransactionSidecarVariant::Eip7594(sidecar) => {
+                1 + Vec::<Blob>::new().length() +
+                    sidecar.commitments.length() +
+                    sidecar.cell_proofs.length()
+            }
+        }
+    }
+}
 
 impl<T: Decodable + InMemorySize> PooledTransactions<T> {
     /// Decodes the RLP list of transactions, stopping once the cumulative

--- a/crates/net/eth-wire-types/src/version.rs
+++ b/crates/net/eth-wire-types/src/version.rs
@@ -47,11 +47,18 @@ pub enum EthVersion {
 
 impl EthVersion {
     /// The latest known eth version
-    pub const LATEST: Self = Self::Eth71;
+    pub const LATEST: Self = Self::Eth72;
 
     /// All known eth versions
-    pub const ALL_VERSIONS: &'static [Self] =
-        &[Self::Eth71, Self::Eth70, Self::Eth69, Self::Eth68, Self::Eth67, Self::Eth66];
+    pub const ALL_VERSIONS: &'static [Self] = &[
+        Self::Eth72,
+        Self::Eth71,
+        Self::Eth70,
+        Self::Eth69,
+        Self::Eth68,
+        Self::Eth67,
+        Self::Eth66,
+    ];
 
     /// Returns true if the version is eth/66
     pub const fn is_eth66(&self) -> bool {

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -103,7 +103,9 @@ pub struct EthRequestHandler<C, N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The client type that can interact with the chain.
     client: C,
     /// Blob store used for serving blob cell requests.
-    blob_store: Box<dyn BlobStore>,
+    blob_store: std::sync::Arc<dyn BlobStore>,
+    /// Limits concurrent cell reads and legacy sidecar conversions.
+    cell_responses: std::sync::Arc<tokio::sync::Semaphore>,
     /// Used for reporting peers.
     // TODO use to report spammers
     #[expect(dead_code)]
@@ -120,7 +122,8 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
     pub fn new(client: C, peers: PeersHandle, incoming: Receiver<IncomingEthRequest<N>>) -> Self {
         Self {
             client,
-            blob_store: Box::<NoopBlobStore>::default(),
+            blob_store: std::sync::Arc::<NoopBlobStore>::default(),
+            cell_responses: std::sync::Arc::new(tokio::sync::Semaphore::new(16)),
             peers,
             incoming_requests: ReceiverStream::new(incoming),
             metrics: Default::default(),
@@ -129,7 +132,7 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
 
     /// Set blob store for the request handler
     pub fn with_blob_store(mut self, blob_store: Box<dyn BlobStore>) -> Self {
-        self.blob_store = blob_store;
+        self.blob_store = blob_store.into();
         self
     }
 }
@@ -405,25 +408,36 @@ where
         request: GetCells,
         response: oneshot::Sender<RequestResult<Cells>>,
     ) {
-        let mut cells_response = Cells { cell_mask: request.cell_mask, ..Default::default() };
-        let mut total_bytes = 0;
-        let cell_mask = request.cell_mask();
-
-        for hash in request.hashes.into_iter().take(MAX_CELLS_SERVE) {
-            let Some(cells) = self.blob_store.get_cells(hash, cell_mask).unwrap_or_default() else {
-                continue;
-            };
-
-            total_bytes += hash.length() + cells.length();
-            cells_response.hashes.push(hash);
-            cells_response.cells.push(cells);
-
-            if total_bytes > SOFT_RESPONSE_LIMIT {
-                break
+        let Ok(permit) = self.cell_responses.clone().try_acquire_owned() else {
+            let _ = response.send(Ok(Cells { cell_mask: request.cell_mask, ..Default::default() }));
+            return
+        };
+        let blob_store = self.blob_store.clone();
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            if response.is_closed() {
+                return
             }
-        }
+            let mut cells_response = Cells { cell_mask: request.cell_mask, ..Default::default() };
+            let mut total_bytes = 0;
+            let cell_mask = request.cell_mask();
 
-        let _ = response.send(Ok(cells_response));
+            for hash in request.hashes.into_iter().take(MAX_CELLS_SERVE) {
+                let Some(cells) = blob_store.get_cells(hash, cell_mask).unwrap_or_default() else {
+                    continue;
+                };
+
+                total_bytes += hash.length() + cells.length();
+                cells_response.hashes.push(hash);
+                cells_response.cells.push(cells);
+
+                if total_bytes > SOFT_RESPONSE_LIMIT {
+                    break
+                }
+            }
+
+            let _ = response.send(Ok(cells_response));
+        });
     }
 }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -34,7 +34,7 @@ use reth_eth_wire::{
 };
 use reth_eth_wire_types::{
     message::RequestPair, snap::SnapProtocolMessage, NewPooledTransactionHashes,
-    RawCapabilityMessage,
+    PooledTransactions, RawCapabilityMessage,
 };
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_network_api::{PeerRequest, RequestMessage};
@@ -358,6 +358,12 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
             EthMessage::PooledTransactions(resp) => {
                 on_response!(resp, GetPooledTransactions)
             }
+            EthMessage::PooledTransactionsEth72(resp) => {
+                // Keep the existing transaction fetcher and request correlation version-neutral;
+                // the eth/72 wrapper only describes how this response was encoded on the wire.
+                let resp = resp.map(PooledTransactions::from);
+                on_response!(resp, GetPooledTransactions)
+            }
             EthMessage::GetNodeData(req) => {
                 on_request!(req, NodeData, GetNodeData)
             }
@@ -588,7 +594,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     fn handle_outgoing_response(&mut self, id: u64, resp: PeerResponseResult<N>) {
         match resp.try_into_message(id) {
             Ok(RequestMessage::Eth(msg)) => {
-                self.queued_outgoing.push_back(msg.into());
+                self.queued_outgoing.push_back(msg.map_versioned(self.conn.version()).into());
             }
             Ok(RequestMessage::Snap(msg)) => {
                 self.queued_outgoing.push_back(OutgoingMessage::Snap(msg));

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -1197,6 +1197,10 @@ impl<N: NetworkPrimitives> OutgoingMessage<N> {
                 EthMessage::NewPooledTransactionHashes72(existing),
                 NewPooledTransactionHashes::Eth72(inc),
             ) => {
+                // One mask describes every blob transaction in the message.
+                if existing.cell_mask != inc.cell_mask {
+                    return Some(inc.into())
+                }
                 existing.hashes.extend(inc.hashes);
                 existing.sizes.extend(inc.sizes);
                 existing.types.extend(inc.types);
@@ -1288,7 +1292,7 @@ impl<N: NetworkPrimitives> QueuedOutgoingMessages<N> {
     }
 
     /// Pushes a pooled transaction hash announcement, merging into the last queued message if
-    /// it is the same variant (eth66, eth68, or eth72).
+    /// it is the same variant (eth66, eth68, or eth72) and has a compatible cell mask.
     pub(crate) fn push_pooled_hashes(&mut self, msg: NewPooledTransactionHashes) {
         let msg = if let Some(last) = self.messages.back_mut() {
             match last.try_merge_hashes(msg) {
@@ -2061,6 +2065,46 @@ mod tests {
                 ..
             }))
         ));
+    }
+
+    #[test]
+    fn eth72_coalescing_preserves_cell_masks() {
+        use alloy_primitives::B128;
+
+        let masks =
+            [None, Some(B128::repeat_byte(0xff)), Some(B128::from(1u128)), Some(B128::from(2u128))];
+        for existing_mask in masks {
+            for incoming_mask in masks {
+                let announcement = |mask: Option<B128>, byte| NewPooledTransactionHashes72 {
+                    types: vec![if mask.is_some() { 3 } else { 2 }],
+                    sizes: vec![100],
+                    hashes: vec![B256::repeat_byte(byte)],
+                    cell_mask: mask,
+                };
+                let existing = announcement(existing_mask, 1);
+                let incoming = announcement(incoming_mask, 2);
+                let mut message: OutgoingMessage<EthNetworkPrimitives> =
+                    EthMessage::NewPooledTransactionHashes72(existing.clone()).into();
+
+                let remainder = message.try_merge_hashes(incoming.clone().into());
+
+                let OutgoingMessage::Eth(EthMessage::NewPooledTransactionHashes72(merged)) =
+                    message
+                else {
+                    panic!("expected eth72 announcement");
+                };
+                if existing_mask == incoming_mask {
+                    assert!(remainder.is_none());
+                    assert_eq!(merged.cell_mask, existing_mask);
+                    assert_eq!(merged.hashes, vec![B256::repeat_byte(1), B256::repeat_byte(2)]);
+                    assert_eq!(merged.types, [existing.types, incoming.types].concat());
+                    assert_eq!(merged.sizes, vec![100, 100]);
+                } else {
+                    assert_eq!(remainder, Some(incoming.into()));
+                    assert_eq!(merged, existing);
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -150,6 +150,7 @@ impl BroadcastItemCounter {
 ///    - responses for handled ETH requests received from the remote peer.
 #[expect(dead_code)]
 pub(crate) struct ActiveSession<N: NetworkPrimitives> {
+    pub(crate) pooled_rlp_cache: super::PooledRlpCache,
     /// Keeps track of request ids.
     pub(crate) next_id: u64,
     /// The underlying connection.
@@ -244,6 +245,20 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
             progress = true;
             let res = match msg {
                 OutgoingMessage::Snap(msg) => self.conn.start_send_snap(msg),
+                OutgoingMessage::Eth(EthMessage::PooledTransactions(response)) => {
+                    self.conn.start_send_raw(self.pooled_rlp_cache.response(
+                        response.request_id,
+                        &response.message.0,
+                        false,
+                    ))
+                }
+                OutgoingMessage::Eth(EthMessage::PooledTransactionsEth72(response)) => {
+                    self.conn.start_send_raw(self.pooled_rlp_cache.response(
+                        response.request_id,
+                        &response.message.0,
+                        true,
+                    ))
+                }
                 OutgoingMessage::Eth(msg) => self.conn.start_send_unpin(msg),
                 OutgoingMessage::Broadcast(msg) => self.conn.start_send_broadcast(msg),
                 OutgoingMessage::Raw(msg) => self.conn.start_send_raw(msg),
@@ -1457,6 +1472,7 @@ mod tests {
                     self.to_sessions.push(commands_to_session);
 
                     ActiveSession {
+                        pooled_rlp_cache: Default::default(),
                         next_id: 0,
                         remote_peer_id: peer_id,
                         remote_addr,
@@ -2176,7 +2192,7 @@ mod tests {
 
         let fut = builder.with_client_stream(local_addr, async move |mut client_stream| {
             client_stream
-                .send(EthMessage::NewPooledTransactionHashes68(Default::default()))
+                .send(EthMessage::NewPooledTransactionHashes72(Default::default()))
                 .await
                 .unwrap();
             let _ = tokio::time::timeout(Duration::from_secs(100), client_stream.next()).await;

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -1,6 +1,8 @@
 //! Support for handling peer sessions.
 
 mod active;
+mod pooled_rlp;
+use pooled_rlp::PooledRlpCache;
 mod conn;
 mod counter;
 mod handle;
@@ -70,6 +72,7 @@ pub struct SessionId(usize);
 #[must_use = "Session Manager must be polled to process session events."]
 #[derive(Debug)]
 pub struct SessionManager<N: NetworkPrimitives> {
+    pooled_rlp_cache: PooledRlpCache,
     /// Tracks the identifier for the next session.
     next_id: usize,
     /// Keeps track of all sessions
@@ -162,6 +165,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
         );
 
         Self {
+            pooled_rlp_cache: Default::default(),
             next_id: 0,
             counter: SessionCounter::new(config.limits),
             initial_internal_request_timeout: config.initial_internal_request_timeout,
@@ -598,6 +602,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                 }
 
                 let session = ActiveSession {
+                    pooled_rlp_cache: self.pooled_rlp_cache.clone(),
                     next_id: 0,
                     remote_peer_id: peer_id,
                     remote_addr,

--- a/crates/net/network/src/session/pooled_rlp.rs
+++ b/crates/net/network/src/session/pooled_rlp.rs
@@ -1,0 +1,146 @@
+//! Shared byte-bounded cache for version-specific blob transaction response encodings.
+
+use alloy_primitives::{Bytes, B256};
+use alloy_rlp::{Encodable, Header};
+use parking_lot::Mutex;
+use reth_eth_wire_types::{EncodableEth72PooledTransaction, EthMessageID, RawCapabilityMessage};
+use reth_primitives_traits::SignedTransaction;
+use schnellru::{LruMap, Unlimited};
+use std::sync::Arc;
+
+/// Shared by sessions, so repeated requests from different peers reuse the same encoding.
+#[derive(Clone, Debug, Default)]
+pub(super) struct PooledRlpCache(Arc<Mutex<Cache>>);
+
+impl PooledRlpCache {
+    pub(super) fn response<T: SignedTransaction + EncodableEth72PooledTransaction>(
+        &self,
+        request_id: u64,
+        transactions: &[T],
+        eth72: bool,
+    ) -> RawCapabilityMessage {
+        let mut payload = Vec::new();
+        for tx in transactions {
+            let length = if eth72 { tx.eth72_length() } else { tx.length() };
+            // The length distinguishes pre/post-Osaka wrappers for the same signed transaction.
+            let key = (*tx.tx_hash(), eth72, length);
+            if tx.is_eip4844() &&
+                let Some(encoded) = self.0.lock().entries.get(&key).cloned()
+            {
+                payload.extend_from_slice(&encoded);
+                continue
+            }
+            let mut encoded = Vec::with_capacity(length);
+            if eth72 {
+                tx.encode_eth72(&mut encoded);
+            } else {
+                tx.encode(&mut encoded);
+            }
+            payload.extend_from_slice(&encoded);
+            if tx.is_eip4844() {
+                self.0.lock().insert(key, encoded.into());
+            }
+        }
+        let list = Header { list: true, payload_length: payload.len() };
+        let outer =
+            Header { list: true, payload_length: request_id.length() + list.length_with_payload() };
+        let mut out = Vec::with_capacity(outer.length_with_payload());
+        outer.encode(&mut out);
+        request_id.encode(&mut out);
+        list.encode(&mut out);
+        out.extend_from_slice(&payload);
+        RawCapabilityMessage::eth(EthMessageID::PooledTransactions, out.into())
+    }
+}
+
+#[derive(Debug)]
+struct Cache {
+    entries: LruMap<(B256, bool, usize), Bytes, Unlimited>,
+    bytes: usize,
+}
+impl Default for Cache {
+    fn default() -> Self {
+        Self { entries: LruMap::new(Unlimited), bytes: 0 }
+    }
+}
+impl Cache {
+    const MAX_BYTES: usize = 16 * 1024 * 1024;
+    fn insert(&mut self, key: (B256, bool, usize), value: Bytes) {
+        if value.len() > Self::MAX_BYTES {
+            return
+        }
+        if let Some(old) = self.entries.remove(&key) {
+            self.bytes -= old.len();
+        }
+        self.bytes += value.len();
+        self.entries.insert(key, value);
+        while self.bytes > Self::MAX_BYTES || self.entries.len() > 4096 {
+            if let Some((_, oldest)) = self.entries.pop_oldest() {
+                self.bytes -= oldest.len();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{SignableTransaction, TxEip4844, TxEip4844WithSidecar};
+    use alloy_eips::{
+        eip4844::{Blob, Bytes48},
+        eip7594::BlobTransactionSidecarEip7594,
+    };
+    use alloy_primitives::Signature;
+    use reth_eth_wire_types::{message::RequestPair, PooledTransactions, PooledTransactionsEth72};
+    use reth_ethereum_primitives::PooledTransactionVariant;
+
+    #[test]
+    fn cached_responses_match_both_wire_encodings_and_keep_request_ids() {
+        let sidecar = BlobTransactionSidecarEip7594::new(
+            vec![Blob::default()],
+            vec![Bytes48::ZERO],
+            vec![Bytes48::ZERO; 128],
+        );
+        let tx = TxEip4844WithSidecar {
+            tx: TxEip4844 { blob_versioned_hashes: vec![B256::ZERO], ..Default::default() },
+            sidecar: sidecar.into(),
+        }
+        .into_signed(Signature::test_signature());
+        let transactions = vec![PooledTransactionVariant::Eip4844(tx)];
+        let cache = PooledRlpCache::default();
+        for request_id in [1, 128, 65536] {
+            let full = cache.response(request_id, &transactions, false);
+            assert_eq!(
+                full.payload.as_ref(),
+                alloy_rlp::encode(RequestPair {
+                    request_id,
+                    message: PooledTransactions(transactions.clone())
+                })
+            );
+            let elided = cache.response(request_id, &transactions, true);
+            assert_eq!(
+                elided.payload.as_ref(),
+                alloy_rlp::encode(RequestPair {
+                    request_id,
+                    message: PooledTransactionsEth72(transactions.clone())
+                })
+            );
+            assert!(elided.payload.len() < full.payload.len());
+        }
+        assert_eq!(cache.0.lock().entries.len(), 2);
+    }
+
+    #[test]
+    fn encoded_cache_enforces_byte_budget_on_replacement_and_eviction() {
+        let mut cache = Cache::default();
+        let first = (B256::ZERO, false, 10 * 1024 * 1024);
+        let second = (B256::repeat_byte(1), false, 10 * 1024 * 1024);
+        cache.insert(first, vec![0; first.2].into());
+        cache.insert(first, vec![0; first.2].into());
+        assert_eq!(cache.bytes, first.2);
+        cache.insert(second, vec![0; second.2].into());
+        assert_eq!(cache.bytes, second.2);
+        assert!(cache.entries.peek(&first).is_none());
+        assert_eq!(cache.entries.len(), 1);
+    }
+}

--- a/crates/net/network/src/test_utils/testnet.rs
+++ b/crates/net/network/src/test_utils/testnet.rs
@@ -54,7 +54,7 @@ use tokio::{
 use crate::transactions::constants::tx_manager::DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES;
 
 /// A test network consisting of multiple peers.
-pub struct Testnet<C, Pool> {
+pub struct Testnet<C, Pool: TransactionPool> {
     /// All running peers in the network.
     peers: Vec<Peer<C, Pool>>,
 }
@@ -304,13 +304,13 @@ impl Testnet<NoopProvider, TestPool> {
     }
 }
 
-impl<C, Pool> Default for Testnet<C, Pool> {
+impl<C, Pool: TransactionPool> Default for Testnet<C, Pool> {
     fn default() -> Self {
         Self { peers: Vec::new() }
     }
 }
 
-impl<C, Pool> fmt::Debug for Testnet<C, Pool> {
+impl<C, Pool: TransactionPool> fmt::Debug for Testnet<C, Pool> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Testnet {{}}").finish_non_exhaustive()
     }
@@ -349,7 +349,7 @@ where
 
 /// A handle to a [`Testnet`] that can be shared.
 #[derive(Debug)]
-pub struct TestnetHandle<C, Pool> {
+pub struct TestnetHandle<C, Pool: TransactionPool> {
     _handle: JoinHandle<()>,
     peers: Vec<PeerHandle<Pool>>,
     terminate: oneshot::Sender<oneshot::Sender<Testnet<C, Pool>>>,
@@ -357,7 +357,7 @@ pub struct TestnetHandle<C, Pool> {
 
 // === impl TestnetHandle ===
 
-impl<C, Pool> TestnetHandle<C, Pool> {
+impl<C, Pool: TransactionPool> TestnetHandle<C, Pool> {
     /// Terminates the task and returns the [`Testnet`] back.
     pub async fn terminate(self) -> Testnet<C, Pool> {
         let (tx, rx) = oneshot::channel();
@@ -404,7 +404,7 @@ impl<C, Pool> TestnetHandle<C, Pool> {
 /// A peer in the [`Testnet`].
 #[pin_project]
 #[derive(Debug)]
-pub struct Peer<C, Pool = TestPool> {
+pub struct Peer<C, Pool: TransactionPool = TestPool> {
     #[pin]
     network: NetworkManager<EthNetworkPrimitives>,
     #[pin]

--- a/crates/net/network/src/transactions/blob_buffer.rs
+++ b/crates/net/network/src/transactions/blob_buffer.rs
@@ -1,0 +1,302 @@
+//! Bounded rendezvous between ETH/72 transaction bodies and independently fetched cells.
+
+use alloy_eips::{
+    eip4844::env_settings::EnvKzgSettings,
+    eip7594::{BlobCellMask, Cell},
+};
+use alloy_primitives::{map::B256Map, B128, B256};
+use reth_network_peers::PeerId;
+use reth_transaction_pool::{
+    blobstore::{BlobTxCellSidecar, PooledBlobSidecar},
+    PoolTransaction,
+};
+use std::time::{Duration, Instant};
+
+/// Body and cell buffer. Cryptographic checks run after entries leave this buffer.
+#[derive(Debug)]
+pub(super) struct BlobBuffer<T> {
+    entries: B256Map<Entry<T>>,
+    bytes: usize,
+}
+
+impl<T> Default for BlobBuffer<T> {
+    fn default() -> Self {
+        Self { entries: Default::default(), bytes: 0 }
+    }
+}
+
+/// Maximum retained bodies, deliveries, and total cell memory.
+const MAX_ENTRIES: usize = 256;
+const MAX_BYTES: usize = 64 * 1024 * 1024;
+const TTL: Duration = Duration::from_secs(120);
+
+impl<T: PoolTransaction> BlobBuffer<T> {
+    pub(super) fn stats(&self) -> (usize, usize) {
+        (self.entries.len(), self.bytes)
+    }
+    pub(super) fn expire(&mut self, now: Instant) -> Vec<B256> {
+        let mut expired = Vec::new();
+        self.entries.retain(|hash, entry| {
+            if now.duration_since(entry.created) < TTL {
+                return true
+            }
+            self.bytes -= entry.bytes;
+            expired.push(*hash);
+            false
+        });
+        expired
+    }
+
+    /// Rejects malformed metadata before reserving buffer memory. Stateful admission happens later.
+    pub(super) fn body(&mut self, peer: PeerId, tx: T, now: Instant) -> Result<(), ()> {
+        let sidecar = tx.blob_sidecar().and_then(|s| s.as_eip7594()).ok_or(())?;
+        let hashes = tx.blob_versioned_hashes().ok_or(())?;
+        if !sidecar.blobs.is_empty() ||
+            hashes.is_empty() ||
+            hashes.len() > 128 ||
+            sidecar.commitments.len() != hashes.len() ||
+            sidecar.cell_proofs.len() != hashes.len() * 128 ||
+            sidecar
+                .commitments
+                .iter()
+                .zip(hashes)
+                .any(|(c, h)| alloy_eips::eip4844::kzg_to_versioned_hash(c.as_slice()) != *h) ||
+            tx.max_priority_fee_per_gas().is_some_and(|tip| tip > tx.max_fee_per_gas())
+        {
+            return Err(())
+        }
+        let hash = *tx.hash();
+        let size = tx.size();
+        if self.bytes.saturating_add(size) > MAX_BYTES ||
+            (!self.entries.contains_key(&hash) && self.entries.len() >= MAX_ENTRIES)
+        {
+            return Ok(())
+        }
+        let entry = self.entries.entry(hash).or_insert_with(|| Entry::new(now));
+        if entry.body.is_none() {
+            entry.body = Some((peer, tx));
+            entry.bytes += size;
+            self.bytes += size;
+        }
+        Ok(())
+    }
+
+    pub(super) fn cells(
+        &mut self,
+        hash: B256,
+        peer: PeerId,
+        mask: BlobCellMask,
+        cells: Vec<Cell>,
+        now: Instant,
+    ) -> bool {
+        let size = cells.len() * core::mem::size_of::<Cell>();
+        if mask.count() == 0 ||
+            cells.is_empty() ||
+            !cells.len().is_multiple_of(mask.count()) ||
+            cells.len() / mask.count() > 128 ||
+            self.bytes.saturating_add(size) > MAX_BYTES ||
+            (!self.entries.contains_key(&hash) && self.entries.len() >= MAX_ENTRIES)
+        {
+            return false
+        }
+        let entry = self.entries.entry(hash).or_insert_with(|| Entry::new(now));
+        // Fetch requests reserve disjoint columns; overlapping replies are stale.
+        if entry.mask & mask.bits() != 0 {
+            return false
+        }
+        entry.mask |= mask.bits();
+        entry.deliveries.push(Delivery { peer, mask, cells });
+        entry.bytes += size;
+        self.bytes += size;
+        true
+    }
+
+    pub(super) fn take_ready(
+        &mut self,
+        hash: B256,
+        target: BlobCellMask,
+    ) -> Option<BufferedBlob<T>> {
+        let entry = self.entries.get(&hash)?;
+        if entry.body.is_none() ||
+            entry.mask & target.bits() != target.bits() ||
+            target.count() == 0
+        {
+            return None
+        }
+        let entry = self.entries.remove(&hash)?;
+        self.bytes -= entry.bytes;
+        let (peer, transaction) = entry.body?;
+        Some(BufferedBlob { peer, transaction, deliveries: entry.deliveries })
+    }
+}
+
+/// Owned verification job. Keeps provenance until every peer's delivery has been checked.
+pub(super) struct BufferedBlob<T> {
+    pub(super) peer: PeerId,
+    transaction: T,
+    deliveries: Vec<Delivery>,
+}
+
+impl<T: PoolTransaction> BufferedBlob<T> {
+    pub(super) fn verify(mut self) -> Result<(PeerId, T), Vec<PeerId>> {
+        let metadata = self
+            .transaction
+            .blob_sidecar()
+            .and_then(|s| s.as_eip7594())
+            .expect("buffer validates metadata");
+        let hashes = self.transaction.blob_versioned_hashes().expect("blob transaction");
+        let mut bad = Vec::new();
+        let mut verified = Vec::new();
+        let mut mask = 0;
+        for delivery in self.deliveries {
+            let sidecar = BlobTxCellSidecar {
+                commitments: metadata.commitments.clone(),
+                proofs: metadata.cell_proofs.clone(),
+                cells: delivery.cells,
+                cell_mask: B128::from(delivery.mask.bits()),
+            };
+            if sidecar.validate(hashes, EnvKzgSettings::Default.get()).is_err() {
+                if !bad.contains(&delivery.peer) {
+                    bad.push(delivery.peer);
+                }
+            } else {
+                mask |= delivery.mask.bits();
+                verified.push(sidecar);
+            }
+        }
+        if !bad.is_empty() {
+            return Err(bad)
+        }
+        let mask = BlobCellMask::from_bits(mask);
+        let mut cells = Vec::with_capacity(metadata.commitments.len() * mask.count());
+        for blob in 0..metadata.commitments.len() {
+            for column in mask.selected_indices() {
+                let source = verified
+                    .iter()
+                    .find(|s| s.mask().contains(column))
+                    .expect("union of verified masks");
+                let offset = source.mask().selected_indices().position(|i| i == column).unwrap();
+                cells.push(source.cells[blob * source.mask().count() + offset]);
+            }
+        }
+        let sidecar = BlobTxCellSidecar {
+            commitments: metadata.commitments.clone(),
+            proofs: metadata.cell_proofs.clone(),
+            cells,
+            cell_mask: B128::from(mask.bits()),
+        };
+        if !self.transaction.set_blob_sidecar(PooledBlobSidecar::from_cells(sidecar)) {
+            return Err(Vec::new())
+        }
+        Ok((self.peer, self.transaction))
+    }
+}
+
+#[derive(Debug)]
+struct Entry<T> {
+    created: Instant,
+    body: Option<(PeerId, T)>,
+    deliveries: Vec<Delivery>,
+    mask: u128,
+    bytes: usize,
+}
+impl<T> Entry<T> {
+    const fn new(created: Instant) -> Self {
+        Self { created, body: None, deliveries: Vec::new(), mask: 0, bytes: 0 }
+    }
+}
+#[derive(Debug)]
+struct Delivery {
+    peer: PeerId,
+    mask: BlobCellMask,
+    cells: Vec<Cell>,
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+    use alloy_consensus::{Signed, TxEip4844, TxEip4844WithSidecar};
+    use alloy_eips::{eip4844::Blob, eip7594::BlobTransactionSidecarEip7594};
+    use alloy_primitives::{Address, Signature};
+    use reth_ethereum_primitives::PooledTransactionVariant;
+    use reth_primitives_traits::Recovered;
+    use reth_transaction_pool::EthPooledTransaction;
+
+    pub(in crate::transactions) fn fixture() -> (EthPooledTransaction, BlobTxCellSidecar) {
+        let full = BlobTransactionSidecarEip7594::try_from_blobs(vec![Blob::default()]).unwrap();
+        let cells = BlobTxCellSidecar::from_full(&full, EnvKzgSettings::Default.get()).unwrap();
+        let tx = TxEip4844 {
+            blob_versioned_hashes: cells.versioned_hashes().collect(),
+            gas_limit: 21000,
+            ..Default::default()
+        };
+        let tx = Signed::new_unhashed(
+            TxEip4844WithSidecar { tx, sidecar: cells.elided().into() },
+            Signature::test_signature(),
+        );
+        let pooled = PooledTransactionVariant::Eip4844(tx);
+        (EthPooledTransaction::from_pooled(Recovered::new_unchecked(pooled, Address::ZERO)), cells)
+    }
+
+    #[test]
+    fn rendezvous_in_either_order_and_partial_custody() {
+        for body_first in [true, false] {
+            let (tx, cells) = fixture();
+            let hash = *tx.hash();
+            let peer = PeerId::random();
+            let mask = BlobCellMask::from_bits((1 << 127) | 1);
+            let now = Instant::now();
+            let mut buffer = BlobBuffer::default();
+            if body_first {
+                buffer.body(peer, tx.clone(), now).unwrap();
+            }
+            assert!(buffer.cells(hash, peer, mask, cells.get_cells(mask).unwrap(), now));
+            if !body_first {
+                assert!(buffer.take_ready(hash, mask).is_none());
+                buffer.body(peer, tx, now).unwrap();
+            }
+            let (_, tx) = buffer.take_ready(hash, mask).unwrap().verify().unwrap();
+            assert_eq!(tx.blob_cell_availability().unwrap().get(), mask);
+            assert!(!tx.blob_cell_availability().unwrap().is_recoverable());
+            assert_eq!(buffer.bytes, 0);
+        }
+    }
+
+    #[test]
+    fn only_bad_cell_provider_is_reported() {
+        let (tx, cells) = fixture();
+        let hash = *tx.hash();
+        let body_peer = PeerId::random();
+        let honest = PeerId::random();
+        let bad = PeerId::random();
+        let now = Instant::now();
+        let mut buffer = BlobBuffer::default();
+        buffer.body(body_peer, tx, now).unwrap();
+        let first = BlobCellMask::from_bits(1);
+        let second = BlobCellMask::from_bits(2);
+        buffer.cells(hash, honest, first, cells.get_cells(first).unwrap(), now);
+        let mut corrupted = cells.get_cells(second).unwrap();
+        corrupted[0][31] ^= 1;
+        buffer.cells(hash, bad, second, corrupted, now);
+        let result = buffer.take_ready(hash, BlobCellMask::from_bits(3)).unwrap().verify();
+        assert_eq!(result.unwrap_err(), vec![bad]);
+    }
+
+    #[test]
+    fn buffer_expiry_and_overlapping_deliveries() {
+        let (tx, cells) = fixture();
+        let hash = *tx.hash();
+        let peer = PeerId::random();
+        let mask = BlobCellMask::from_bits(1);
+        let now = Instant::now();
+        let mut buffer = BlobBuffer::default();
+        buffer.body(peer, tx, now).unwrap();
+        assert!(buffer.cells(hash, peer, mask, cells.get_cells(mask).unwrap(), now));
+        let bytes = buffer.bytes;
+        assert!(!buffer.cells(hash, peer, mask, cells.get_cells(mask).unwrap(), now));
+        assert_eq!(bytes, buffer.bytes);
+        assert_eq!(buffer.expire(now + TTL), vec![hash]);
+        assert_eq!(buffer.bytes, 0);
+        assert!(buffer.take_ready(hash, mask).is_none());
+    }
+}

--- a/crates/net/network/src/transactions/blob_fetcher.rs
+++ b/crates/net/network/src/transactions/blob_fetcher.rs
@@ -1,0 +1,453 @@
+//! ETH/72 cell scheduling, provider failover, and sparse custody selection.
+
+use super::{blob_buffer::BlobBuffer, PeerMetadata};
+use alloy_eips::eip7594::BlobCellMask;
+use alloy_primitives::{
+    map::{B256Map, FbBuildHasher, HashMap},
+    B128, B256,
+};
+use futures::{stream::FuturesUnordered, Future, StreamExt};
+use reth_eth_wire::{Cells, GetCells, NetworkPrimitives};
+use reth_network_api::{CellCustody, PeerRequest};
+use reth_network_peers::PeerId;
+use reth_transaction_pool::PoolTransaction;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+use tokio::sync::oneshot;
+
+/// Independent cell fetcher. Transaction bodies still use the transaction fetcher.
+pub(super) struct BlobFetcher<T> {
+    buffer: BlobBuffer<T>,
+    pending: B256Map<Pending>,
+    requests: FuturesUnordered<RequestFuture>,
+    verification: FuturesUnordered<VerifyFuture<T>>,
+    budgets: HashMap<PeerId, Budget, FbBuildHasher<64>>,
+    custody: CellCustody,
+    probability: u8,
+    tick: tokio::time::Interval,
+    metrics: BlobFetcherMetrics,
+}
+
+// No field exposes a pinned transaction or relies on its address.
+impl<T> Unpin for BlobFetcher<T> {}
+impl<T> std::fmt::Debug for BlobFetcher<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlobFetcher")
+            .field("pending", &self.pending.len())
+            .field("requests", &self.requests.len())
+            .finish_non_exhaustive()
+    }
+}
+
+type RequestFuture =
+    Pin<Box<dyn Future<Output = (B256, PeerId, BlobCellMask, Option<Cells>)> + Send>>;
+type VerifyFuture<T> =
+    Pin<Box<dyn Future<Output = (B256, Result<(PeerId, T), Vec<PeerId>>)> + Send>>;
+const MAX_PENDING: usize = 4096;
+const MAX_REQUESTS: usize = 16;
+const WAIT: Duration = Duration::from_secs(2);
+const TIMEOUT: Duration = Duration::from_secs(5);
+const TTL: Duration = Duration::from_secs(120);
+
+impl<T: PoolTransaction + 'static> BlobFetcher<T> {
+    pub(super) fn new(custody: CellCustody, probability: u8) -> Self {
+        Self {
+            buffer: Default::default(),
+            pending: Default::default(),
+            requests: Default::default(),
+            verification: Default::default(),
+            budgets: Default::default(),
+            custody,
+            probability: probability.clamp(15, 100),
+            tick: tokio::time::interval(Duration::from_millis(100)),
+            metrics: Default::default(),
+        }
+    }
+
+    pub(super) fn announce(&mut self, hash: B256, peer: PeerId, mask: BlobCellMask) {
+        if mask.count() == 0 ||
+            (!self.pending.contains_key(&hash) && self.pending.len() >= MAX_PENDING)
+        {
+            return
+        }
+        let pending = self.pending.entry(hash).or_insert_with(|| Pending::new(Instant::now()));
+        if let Some(provider) = pending.providers.iter_mut().find(|(id, _)| *id == peer) {
+            provider.1 = mask;
+        } else if pending.providers.len() < 16 {
+            pending.providers.push((peer, mask));
+        }
+    }
+
+    pub(super) fn body(&mut self, peer: PeerId, tx: T) -> Result<(), ()> {
+        self.buffer.body(peer, tx, Instant::now())
+    }
+
+    pub(super) fn drop_peer(&mut self, peer: PeerId) {
+        self.budgets.remove(&peer);
+        for pending in self.pending.values_mut() {
+            pending.providers.retain(|(id, _)| *id != peer);
+        }
+    }
+
+    pub(super) fn poll<N: NetworkPrimitives>(
+        &mut self,
+        cx: &mut Context<'_>,
+        peers: &HashMap<PeerId, PeerMetadata<N>, FbBuildHasher<64>>,
+    ) -> Poll<BlobFetchEvent<T>> {
+        let (buffered, bytes) = self.buffer.stats();
+        self.metrics.buffered.set(buffered as f64);
+        self.metrics.buffer_bytes.set(bytes as f64);
+        self.metrics.pending.set(self.pending.len() as f64);
+        self.metrics.inflight.set(self.requests.len() as f64);
+        if let Poll::Ready(Some((hash, result))) = self.verification.poll_next_unpin(cx) {
+            if result.is_ok() {
+                self.metrics.completed.increment(1);
+            } else {
+                self.metrics.invalid.increment(1);
+            }
+            self.pending.remove(&hash);
+            return Poll::Ready(match result {
+                Ok((peer, tx)) => BlobFetchEvent::Transaction(peer, tx),
+                Err(peers) => BlobFetchEvent::BadPeers(peers),
+            })
+        }
+        while let Poll::Ready(Some((hash, peer, requested, response))) =
+            self.requests.poll_next_unpin(cx)
+        {
+            let Some(pending) = self.pending.get_mut(&hash) else { continue };
+            pending.inflight = false;
+            pending.providers.retain(|(id, _)| *id != peer);
+            let Some(response) = response else {
+                self.metrics.failed_requests.increment(1);
+                if pending.full == Some(true) {
+                    pending.target = None;
+                }
+                continue
+            };
+            if u128::from_le_bytes(response.cell_mask.into()) != requested.bits() ||
+                response.hashes.len() != response.cells.len() ||
+                response.hashes.len() > 1 ||
+                response.hashes.first().is_some_and(|h| *h != hash)
+            {
+                if pending.full == Some(true) {
+                    pending.target = None;
+                }
+                return Poll::Ready(BlobFetchEvent::BadPeers(vec![peer]))
+            }
+            if response.cells.is_empty() && pending.full == Some(true) {
+                pending.target = None;
+            }
+            if let Some(cells) = response.cells.into_iter().next() {
+                if cells.is_empty() ||
+                    !cells.len().is_multiple_of(requested.count()) ||
+                    cells.len() / requested.count() > 128
+                {
+                    if pending.full == Some(true) {
+                        pending.target = None;
+                    }
+                    return Poll::Ready(BlobFetchEvent::BadPeers(vec![peer]))
+                }
+                if self.buffer.cells(hash, peer, requested, cells, Instant::now()) {
+                    pending.received |= requested.bits();
+                }
+            }
+        }
+        let now = Instant::now();
+        while self.tick.poll_tick(cx).is_ready() {
+            self.metrics.expired.increment(self.buffer.expire(now).len() as u64);
+            self.pending.retain(|_, p| now.duration_since(p.created) < TTL);
+        }
+        let mut queued = false;
+        // Bound proof verification jobs independently of network request concurrency.
+        for (&hash, pending) in &mut self.pending {
+            if self.verification.len() >= 4 {
+                break
+            }
+            if pending.verifying {
+                continue
+            }
+            if let Some(target) = pending.target &&
+                let Some(job) = self.buffer.take_ready(hash, target)
+            {
+                pending.verifying = true;
+                queued = true;
+                self.verification.push(Box::pin(async move {
+                    let result = tokio::task::spawn_blocking(move || job.verify())
+                        .await
+                        .unwrap_or_else(|_| Err(Vec::new()));
+                    (hash, result)
+                }));
+            }
+        }
+        for (&hash, pending) in &mut self.pending {
+            if self.requests.len() >= MAX_REQUESTS {
+                break
+            }
+            if pending.inflight || pending.verifying {
+                continue
+            }
+            if pending.target.is_none() {
+                let full_providers =
+                    pending.providers.iter().filter(|(_, m)| m.count() >= 64).count();
+                if pending.full.is_none() &&
+                    full_providers < 2 &&
+                    now.duration_since(pending.created) < WAIT
+                {
+                    continue
+                }
+                let custody = BlobCellMask::new(self.custody.get());
+                let first_decision = pending.full.is_none();
+                let full = *pending.full.get_or_insert_with(|| {
+                    custody.count() == 0 ||
+                        custody.count() >= 64 ||
+                        full_providers < 2 ||
+                        rand::random_range(0..100u8) < self.probability
+                });
+                if first_decision {
+                    if full {
+                        self.metrics.full.increment(1);
+                    } else {
+                        self.metrics.sampled.increment(1);
+                    }
+                }
+                pending.target = if full {
+                    let available = pending
+                        .providers
+                        .iter()
+                        .fold(pending.received, |mask, (_, provider)| mask | provider.bits());
+                    let mut selected = pending.received;
+                    for index in BlobCellMask::from_bits(available & !pending.received)
+                        .selected_indices()
+                        .take(64usize.saturating_sub(pending.received.count_ones() as usize))
+                    {
+                        selected |= 1 << index;
+                    }
+                    (selected.count_ones() == 64).then_some(BlobCellMask::from_bits(selected))
+                } else {
+                    Some(custody)
+                };
+            }
+            let Some(target) = pending.target else { continue };
+            let missing = target.bits() & !pending.received;
+            if missing == 0 {
+                continue
+            }
+            for &(peer, available) in &pending.providers {
+                let Some(metadata) = peers.get(&peer) else { continue };
+                let requested = BlobCellMask::from_bits(missing & available.bits());
+                if requested.count() == 0 {
+                    continue
+                }
+                let budget = self
+                    .budgets
+                    .entry(peer)
+                    .or_insert_with(|| Budget { tokens: 256.0, updated: now });
+                budget.refill(now);
+                if budget.tokens < requested.count() as f64 {
+                    continue
+                }
+                let (tx, rx) = oneshot::channel();
+                let request = PeerRequest::GetCells {
+                    request: GetCells {
+                        hashes: vec![hash],
+                        cell_mask: B128::from(requested.bits().to_le_bytes()),
+                    },
+                    response: tx,
+                };
+                if metadata.request_tx.try_send(request).is_err() {
+                    continue
+                }
+                self.metrics.requests.increment(1);
+                budget.tokens -= requested.count() as f64;
+                pending.inflight = true;
+                queued = true;
+                self.requests.push(Box::pin(async move {
+                    let response = tokio::time::timeout(TIMEOUT, rx)
+                        .await
+                        .ok()
+                        .and_then(Result::ok)
+                        .and_then(Result::ok);
+                    (hash, peer, requested, response)
+                }));
+                break
+            }
+        }
+        // Newly queued futures need a first poll to register their request/worker wakers.
+        if queued {
+            cx.waker().wake_by_ref();
+        }
+        Poll::Pending
+    }
+}
+
+pub(super) enum BlobFetchEvent<T> {
+    Transaction(PeerId, T),
+    BadPeers(Vec<PeerId>),
+}
+struct Pending {
+    created: Instant,
+    providers: Vec<(PeerId, BlobCellMask)>,
+    target: Option<BlobCellMask>,
+    full: Option<bool>,
+    received: u128,
+    inflight: bool,
+    verifying: bool,
+}
+impl Pending {
+    const fn new(created: Instant) -> Self {
+        Self {
+            created,
+            providers: Vec::new(),
+            target: None,
+            full: None,
+            received: 0,
+            inflight: false,
+            verifying: false,
+        }
+    }
+}
+struct Budget {
+    tokens: f64,
+    updated: Instant,
+}
+impl Budget {
+    fn refill(&mut self, now: Instant) {
+        self.tokens =
+            now.duration_since(self.updated).as_secs_f64().mul_add(9.0, self.tokens).min(256.0);
+        self.updated = now;
+    }
+}
+
+#[derive(reth_metrics::Metrics)]
+#[metrics(scope = "network.blob_fetcher")]
+struct BlobFetcherMetrics {
+    /// Transactions awaiting cell acquisition.
+    pending: reth_metrics::metrics::Gauge,
+    /// Buffered body/cell rendezvous entries.
+    buffered: reth_metrics::metrics::Gauge,
+    /// Bytes retained by incomplete body/cell deliveries.
+    buffer_bytes: reth_metrics::metrics::Gauge,
+    /// Active cell requests.
+    inflight: reth_metrics::metrics::Gauge,
+    /// Requests sent to peers.
+    requests: reth_metrics::metrics::Counter,
+    /// Timed out or disconnected requests.
+    failed_requests: reth_metrics::metrics::Counter,
+    /// Transactions selected for recoverable storage.
+    full: reth_metrics::metrics::Counter,
+    /// Transactions selected for custody-only storage.
+    sampled: reth_metrics::metrics::Counter,
+    /// Successfully verified transactions passed to the pool.
+    completed: reth_metrics::metrics::Counter,
+    /// Failed cell verification jobs.
+    invalid: reth_metrics::metrics::Counter,
+    /// Incomplete buffers removed at their deadline.
+    expired: reth_metrics::metrics::Counter,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::task::noop_waker_ref;
+    use reth_eth_wire::{EthNetworkPrimitives, EthVersion};
+    use reth_network_api::{PeerKind, PeerRequestSender};
+    use reth_transaction_pool::EthPooledTransaction;
+
+    fn peer(
+        id: PeerId,
+    ) -> (PeerMetadata<EthNetworkPrimitives>, tokio::sync::mpsc::Receiver<PeerRequest>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        (
+            PeerMetadata::new(
+                PeerRequestSender::new(id, tx),
+                EthVersion::Eth72,
+                "test".into(),
+                100,
+                PeerKind::Basic,
+            ),
+            rx,
+        )
+    }
+
+    #[tokio::test]
+    async fn full_fetch_falls_back_after_empty_response() {
+        let (tx, cells) = super::super::blob_buffer::tests::fixture();
+        let hash = *tx.hash();
+        let first = PeerId::random();
+        let second = PeerId::random();
+        let (p1, mut rx1) = peer(first);
+        let (p2, mut rx2) = peer(second);
+        let peers = HashMap::from_iter([(first, p1), (second, p2)]);
+        let mut fetcher = BlobFetcher::new(CellCustody::default(), 100);
+        let all = BlobCellMask::from_bits(u128::MAX);
+        fetcher.announce(hash, first, all);
+        fetcher.announce(hash, second, all);
+        fetcher.body(first, tx).unwrap();
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(fetcher.poll(&mut cx, &peers).is_pending());
+        let PeerRequest::GetCells { request, response } = rx1.try_recv().unwrap() else {
+            panic!("expected cells")
+        };
+        assert_eq!(request.cell_mask, B128::from((u64::MAX as u128).to_le_bytes()));
+        response.send(Ok(Cells { cell_mask: request.cell_mask, ..Default::default() })).unwrap();
+        assert!(fetcher.poll(&mut cx, &peers).is_pending());
+        let PeerRequest::GetCells { request, response } = rx2.try_recv().unwrap() else {
+            panic!("expected fallback")
+        };
+        let mask = BlobCellMask::from_bits(u128::from_le_bytes(request.cell_mask.into()));
+        response
+            .send(Ok(Cells {
+                hashes: vec![hash],
+                cells: vec![cells.get_cells(mask).unwrap()],
+                cell_mask: request.cell_mask,
+            }))
+            .unwrap();
+        let event = tokio::time::timeout(
+            Duration::from_secs(10),
+            std::future::poll_fn(|cx| fetcher.poll(cx, &peers)),
+        )
+        .await
+        .unwrap();
+        let BlobFetchEvent::Transaction(_, tx) = event else { panic!("valid cells must import") };
+        assert_eq!(tx.blob_cell_availability().unwrap().get().count(), 64);
+    }
+
+    #[tokio::test]
+    async fn custody_sampling_requires_two_full_providers_and_preserves_wire_order() {
+        let first = PeerId::random();
+        let second = PeerId::random();
+        let (p1, mut rx1) = peer(first);
+        let (p2, _rx2) = peer(second);
+        let peers = HashMap::from_iter([(first, p1), (second, p2)]);
+        let custody = CellCustody::default();
+        let bits: u128 = 1 | (1 << 8) | (1 << 127);
+        custody.set(B128::from(bits));
+        let mut fetcher = BlobFetcher::<EthPooledTransaction>::new(custody, 15);
+        fetcher.probability = 0;
+        let hash = B256::random();
+        let all = BlobCellMask::from_bits(u128::MAX);
+        fetcher.announce(hash, first, all);
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(fetcher.poll(&mut cx, &peers).is_pending());
+        assert!(rx1.try_recv().is_err());
+        fetcher.announce(hash, second, all);
+        assert!(fetcher.poll(&mut cx, &peers).is_pending());
+        let PeerRequest::GetCells { request, .. } = rx1.try_recv().unwrap() else {
+            panic!("expected sample")
+        };
+        assert_eq!(request.cell_mask, B128::from(bits.to_le_bytes()));
+    }
+
+    #[test]
+    fn peer_budget_refills_and_is_capped() {
+        let now = Instant::now();
+        let mut budget = Budget { tokens: 0.0, updated: now };
+        budget.refill(now + Duration::from_secs(1));
+        assert_eq!(budget.tokens, 9.0);
+        budget.refill(now + Duration::from_secs(100));
+        assert_eq!(budget.tokens, 256.0);
+    }
+}

--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -32,6 +32,10 @@ pub struct TransactionsManagerConfig {
     /// Max number of transactions allowed to be imported concurrently.
     #[cfg_attr(feature = "serde", serde(default = "default_max_pending_pool_imports"))]
     pub max_pending_pool_imports: usize,
+    /// Percentage of blob transactions fetched in full, with a minimum of 15; 100 disables
+    /// sampling.
+    #[cfg_attr(feature = "serde", serde(default = "default_blob_fetch_probability"))]
+    pub blob_fetch_probability: u8,
     /// How new pending transactions are propagated.
     #[cfg_attr(feature = "serde", serde(default))]
     pub propagation_mode: TransactionPropagationMode,
@@ -56,12 +60,17 @@ const fn default_tx_channel_memory_limit_bytes() -> usize {
     DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES
 }
 
+const fn default_blob_fetch_probability() -> u8 {
+    15
+}
+
 impl Default for TransactionsManagerConfig {
     fn default() -> Self {
         Self {
             transaction_fetcher_config: TransactionFetcherConfig::default(),
             max_transactions_seen_by_peer_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
             max_pending_pool_imports: DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS,
+            blob_fetch_probability: default_blob_fetch_probability(),
             propagation_mode: TransactionPropagationMode::default(),
             ingress_policy: TransactionIngressPolicy::default(),
             tx_channel_memory_limit_bytes: DEFAULT_TX_MANAGER_CHANNEL_MEMORY_LIMIT_BYTES,

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -4,12 +4,15 @@ use alloy_consensus::{constants::EIP4844_TX_TYPE_ID, transaction::TxHashRef};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use smallvec::SmallVec;
 
+mod blob_buffer;
+mod blob_fetcher;
 /// Aggregation on configurable parameters for [`TransactionsManager`].
 pub mod config;
 /// Default and spec'd bounds.
 pub mod constants;
 /// Component responsible for fetching transactions from [`NewPooledTransactionHashes`].
 pub mod fetcher;
+use blob_fetcher::{BlobFetchEvent, BlobFetcher};
 /// Defines the traits for transaction-related policies.
 pub mod policy;
 
@@ -310,7 +313,7 @@ impl<N: NetworkPrimitives> TransactionsHandle<N> {
 /// Rate limiting via reputation, bad transaction isolation, peer scoring.
 #[derive(Debug)]
 #[must_use = "Manager does nothing unless polled."]
-pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives> {
+pub struct TransactionsManager<Pool: TransactionPool, N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Access to the transaction pool.
     pool: Pool,
     /// Cache of recovered transaction senders shared with payload execution, if enabled.
@@ -323,6 +326,10 @@ pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives
     network_events: EventStream<NetworkEvent<PeerRequest<N>>>,
     /// Transaction fetcher to handle inflight and missing transaction requests.
     transaction_fetcher: TransactionFetcher<N>,
+    /// Sparse cell scheduling and body/cell rendezvous.
+    blob_fetcher: BlobFetcher<Pool::Transaction>,
+    /// Bounds concurrent disk reads and legacy blob reconstructions.
+    blob_responses: Arc<tokio::sync::Semaphore>,
     /// All currently pending transactions grouped by peers.
     ///
     /// This way we can track incoming transactions and prevent multiple pool imports for the same
@@ -428,7 +435,13 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             .capacity_pending_pool_imports
             .increment(pending_pool_imports_info.max_pending_pool_imports as u64);
 
+        let blob_fetcher = BlobFetcher::new(
+            reth_network_api::NetworkInfo::cell_custody(&network).clone(),
+            transactions_manager_config.blob_fetch_probability,
+        );
         Self {
+            blob_fetcher,
+            blob_responses: Arc::new(tokio::sync::Semaphore::new(16)),
             pool,
             sender_recovery_cache: None,
             network,
@@ -501,6 +514,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             self.policies.propagation_policy_mut().on_session_closed(&mut peer);
         }
         self.transaction_fetcher.remove_peer(peer_id);
+        self.blob_fetcher.drop_peer(*peer_id);
     }
 
     /// Clear the transaction
@@ -802,6 +816,16 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
             return
         }
 
+        if let Some(mask) = valid_announcement_data.eth72_cell_mask() {
+            let mask =
+                alloy_eips::eip7594::BlobCellMask::from_bits(u128::from_le_bytes(mask.into()));
+            for (&hash, metadata) in valid_announcement_data.iter() {
+                if metadata.is_some_and(|(ty, _)| ty == EIP4844_TX_TYPE_ID) {
+                    self.blob_fetcher.announce(hash, peer_id, mask);
+                }
+            }
+        }
+
         // 5. filter out already seen unknown hashes
         //
         // seen hashes are already in the tx fetcher, pending fetch.
@@ -968,7 +992,7 @@ where
         let PropagateTransactions { pooled, full } = full_transactions.build();
 
         // send hashes if any
-        if let Some(new_pooled_hashes) = pooled {
+        for new_pooled_hashes in pooled {
             for hash in new_pooled_hashes.iter_hashes().copied() {
                 propagated.record(hash, PropagateKind::Hash(peer_id));
                 // mark transaction as seen by peer
@@ -1035,22 +1059,17 @@ where
                 }
             }
 
-            let new_pooled_hashes = hashes.build();
+            for new_pooled_hashes in hashes.build() {
+                for hash in new_pooled_hashes.iter_hashes().copied() {
+                    propagated.record(hash, PropagateKind::Hash(peer_id));
+                    peer.seen_transactions.insert(hash);
+                }
 
-            if new_pooled_hashes.is_empty() {
-                // nothing to propagate
-                return
+                trace!(target: "net::tx::propagation", ?peer_id, ?new_pooled_hashes, "Propagating transactions to peer");
+
+                // send hashes of transactions
+                self.network.send_transactions_hashes(peer_id, new_pooled_hashes);
             }
-
-            for hash in new_pooled_hashes.iter_hashes().copied() {
-                propagated.record(hash, PropagateKind::Hash(peer_id));
-                peer.seen_transactions.insert(hash);
-            }
-
-            trace!(target: "net::tx::propagation", ?peer_id, ?new_pooled_hashes, "Propagating transactions to peer");
-
-            // send hashes of transactions
-            self.network.send_transactions_hashes(peer_id, new_pooled_hashes);
 
             // Update propagated transactions metrics
             self.metrics.propagated_transactions.increment(propagated.len() as u64);
@@ -1101,6 +1120,11 @@ where
             // message, see `PeerMetadata::seen_transactions`.
             if propagation_mode.is_forced() {
                 for tx in &to_propagate {
+                    if peer.version < EthVersion::Eth72 &&
+                        tx.cell_mask.is_some_and(|m| m.count_ones() < 64)
+                    {
+                        continue
+                    }
                     peer.seen_transactions.insert(*tx.tx_hash());
                     builder.push(tx);
                 }
@@ -1109,6 +1133,11 @@ where
                 // transaction lists, before deciding whether or not to send full transactions to
                 // the peer.
                 for tx in &to_propagate {
+                    if peer.version < EthVersion::Eth72 &&
+                        tx.cell_mask.is_some_and(|m| m.count_ones() < 64)
+                    {
+                        continue
+                    }
                     // Only include the transaction if the peer hasn't seen it yet
                     if peer.seen_transactions.insert(*tx.tx_hash()) {
                         builder.push(tx);
@@ -1124,7 +1153,7 @@ where
             let PropagateTransactions { pooled, full } = builder.build();
 
             // send hashes if any
-            if let Some(mut new_pooled_hashes) = pooled {
+            for mut new_pooled_hashes in pooled {
                 // Unhappy path: too many hashes for a single message. This should not happen
                 // during regular propagation, which is capped at the soft limit per batch, and
                 // is only reachable via manual propagation commands with oversized batches.
@@ -1211,15 +1240,20 @@ where
             } else {
                 GetPooledTransactionLimit::ResponseSizeSoftLimit(response_size_limit)
             };
-            let transactions = self.pool.get_pooled_transaction_elements(request.0, limit);
-            trace!(target: "net::tx::propagation", sent_txs=?transactions.iter().map(|tx| tx.tx_hash()), "Sending requested transactions to peer");
-
-            // we sent a response at which point we assume that the peer is aware of the
-            // transactions
-            peer.seen_transactions.extend(transactions.iter().map(|tx| *tx.tx_hash()));
-
-            let resp = PooledTransactions(transactions);
-            let _ = response.send(Ok(resp));
+            let Ok(permit) = self.blob_responses.clone().try_acquire_owned() else {
+                let _ = response.send(Ok(PooledTransactions::default()));
+                return
+            };
+            peer.seen_transactions.extend(request.0.iter().copied());
+            let pool = self.pool.clone();
+            tokio::task::spawn_blocking(move || {
+                let _permit = permit;
+                if response.is_closed() {
+                    return
+                }
+                let transactions = pool.get_pooled_transaction_elements(request.0, limit);
+                let _ = response.send(Ok(PooledTransactions(transactions)));
+            });
         }
     }
 
@@ -1315,13 +1349,22 @@ where
         // Build and send transaction hashes message
         let mut msg_builder = PooledTransactionsHashesBuilder::new(version);
         for pooled_tx in pooled_txs {
+            if version < EthVersion::Eth72 &&
+                pooled_tx
+                    .transaction
+                    .blob_cell_availability()
+                    .is_some_and(|a| !a.is_recoverable())
+            {
+                continue
+            }
             peer.seen_transactions.insert(*pooled_tx.hash());
             msg_builder.push_pooled(pooled_tx);
         }
 
         debug!(target: "net::tx", ?peer_id, tx_count = msg_builder.len(), "Broadcasting transaction hashes");
-        let msg = msg_builder.build();
-        self.network.send_transactions_hashes(peer_id, msg);
+        for msg in msg_builder.build() {
+            self.network.send_transactions_hashes(peer_id, msg);
+        }
     }
 
     /// Handles a received event related to common network events.
@@ -1404,6 +1447,40 @@ where
         }
     }
 
+    /// Queues validated-signature transactions using the shared pool import budget.
+    fn import_recovered_transactions(&self, new_txs: Vec<Pool::Transaction>) {
+        // 3. import new transactions as a batch to minimize lock contention on the underlying
+        // pool
+        if !new_txs.is_empty() {
+            let pool = self.pool.clone();
+            // update metrics
+            let metric_pending_pool_imports = self.metrics.pending_pool_imports.clone();
+            metric_pending_pool_imports.increment(new_txs.len() as f64);
+
+            // update self-monitoring info
+            self.pending_pool_imports_info
+                .pending_pool_imports
+                .fetch_add(new_txs.len(), Ordering::Relaxed);
+            let tx_manager_info_pending_pool_imports =
+                self.pending_pool_imports_info.pending_pool_imports.clone();
+
+            trace!(target: "net::tx::propagation", new_txs_len=?new_txs.len(), "Importing new transactions");
+            let import = Box::pin(async move {
+                let added = new_txs.len();
+                let res = pool.add_external_transactions(new_txs).await;
+
+                // update metrics
+                metric_pending_pool_imports.decrement(added as f64);
+                // update self-monitoring info
+                tx_manager_info_pending_pool_imports.fetch_sub(added, Ordering::Relaxed);
+
+                res
+            });
+
+            self.pool_imports.push(import);
+        }
+    }
+
     /// Starts the import process for the given transactions.
     fn import_transactions(
         &mut self,
@@ -1459,22 +1536,7 @@ where
             }
         }
 
-        // Eth/72 `PooledTransactions` responses elide blob payloads from type 3 transactions per
-        // EIP-8070, so their sidecars can never validate. Drop them before touching the pool;
-        // geth equivalently diverts these bodies into a buffer that is completed with cells
-        // fetched via `GetCells`, which is not implemented yet.
-        if peer.version() == EthVersion::Eth72 {
-            let len_before = transactions.len();
-            transactions.retain(|tx| !tx.is_eip4844());
-            let dropped = len_before - transactions.len();
-            if dropped > 0 {
-                trace!(target: "net::tx",
-                    peer_id=format!("{peer_id:#}"),
-                    dropped,
-                    "dropped blob transactions from eth72 response, cell fetching not implemented"
-                );
-            }
-        }
+        let eth72 = peer.version() == EthVersion::Eth72;
 
         // tracks the quality of the given transactions
         let mut has_bad_transactions = false;
@@ -1534,45 +1596,28 @@ where
             }
         };
 
-        let new_txs = transactions.into_par_iter().filter_map(recover).collect::<Vec<_>>();
+        let mut new_txs = transactions.into_par_iter().filter_map(recover).collect::<Vec<_>>();
 
         has_bad_transactions |= new_txs.len() != txs_len;
+
+        if eth72 {
+            new_txs.retain_mut(|tx| {
+                if !tx.is_eip4844() {
+                    return true
+                }
+                if self.blob_fetcher.body(peer_id, tx.clone()).is_err() {
+                    has_bad_transactions = true;
+                }
+                false
+            });
+        }
 
         // Record the transactions as seen by the peer
         for tx in &new_txs {
             self.transactions_by_peers.insert(*tx.hash(), smallvec::smallvec![peer_id]);
         }
 
-        // 3. import new transactions as a batch to minimize lock contention on the underlying
-        // pool
-        if !new_txs.is_empty() {
-            let pool = self.pool.clone();
-            // update metrics
-            let metric_pending_pool_imports = self.metrics.pending_pool_imports.clone();
-            metric_pending_pool_imports.increment(new_txs.len() as f64);
-
-            // update self-monitoring info
-            self.pending_pool_imports_info
-                .pending_pool_imports
-                .fetch_add(new_txs.len(), Ordering::Relaxed);
-            let tx_manager_info_pending_pool_imports =
-                self.pending_pool_imports_info.pending_pool_imports.clone();
-
-            trace!(target: "net::tx::propagation", new_txs_len=?new_txs.len(), "Importing new transactions");
-            let import = Box::pin(async move {
-                let added = new_txs.len();
-                let res = pool.add_external_transactions(new_txs).await;
-
-                // update metrics
-                metric_pending_pool_imports.decrement(added as f64);
-                // update self-monitoring info
-                tx_manager_info_pending_pool_imports.fetch_sub(added, Ordering::Relaxed);
-
-                res
-            });
-
-            self.pool_imports.push(import);
-        }
+        self.import_recovered_transactions(new_txs);
 
         if num_already_seen_by_peer > 0 {
             self.metrics.messages_with_transactions_already_seen_by_peer.increment(1);
@@ -1695,6 +1740,23 @@ where
             this.transaction_fetcher.poll_next_unpin(cx),
             |event| this.on_fetch_event(event),
         );
+
+        if this.has_capacity_for_pending_pool_imports() &&
+            let Poll::Ready(event) = this.blob_fetcher.poll(cx, &this.peers)
+        {
+            match event {
+                BlobFetchEvent::Transaction(peer, tx) => {
+                    this.transactions_by_peers.insert(*tx.hash(), smallvec::smallvec![peer]);
+                    this.import_recovered_transactions(vec![tx]);
+                }
+                BlobFetchEvent::BadPeers(peers) => {
+                    for peer in peers {
+                        this.report_peer_bad_transactions(peer);
+                    }
+                }
+            }
+            cx.waker().wake_by_ref();
+        }
 
         // Advance pool imports (flush txns to pool).
         //
@@ -1843,6 +1905,8 @@ struct PropagateTransaction {
     /// Type-3 transactions omit blob payloads in eth/72 `PooledTransactions` responses, so this
     /// must match that blob-elided representation rather than [`Self::propagation_size`].
     eth72_propagation_size: usize,
+    /// Numeric mask; absent for transaction types without blobs.
+    cell_mask: Option<u128>,
     transaction: LazyEncodedTransaction,
 }
 
@@ -1860,6 +1924,7 @@ impl PropagateTransaction {
             is_broadcastable_in_full,
             propagation_size,
             eth72_propagation_size: propagation_size,
+            cell_mask: (transaction.ty() == EIP4844_TX_TYPE_ID).then_some(u128::MAX),
             transaction: LazyEncoded::new(transaction),
         }
     }
@@ -1877,6 +1942,7 @@ impl PropagateTransaction {
             is_broadcastable_in_full,
             propagation_size,
             eth72_propagation_size,
+            cell_mask: tx.transaction.blob_cell_availability().map(|a| a.get().bits()),
             transaction: LazyEncoded::new(PropagatePooledTransactionEncoder::new(tx)),
         }
     }
@@ -1978,9 +2044,7 @@ impl PropagateTransactionsBuilder {
     /// Consumes the type and returns the built messages that should be sent to the peer.
     fn build(self) -> PropagateTransactions {
         match self {
-            Self::Pooled(pooled) => {
-                PropagateTransactions { pooled: Some(pooled.build()), full: None }
-            }
+            Self::Pooled(pooled) => PropagateTransactions { pooled: pooled.build(), full: None },
             Self::Full(full) => full.build(),
         }
     }
@@ -1999,7 +2063,7 @@ impl PropagateTransactionsBuilder {
 /// Represents how the transactions should be sent to a peer if any.
 struct PropagateTransactions {
     /// The pooled transaction hashes to send.
-    pooled: Option<NewPooledTransactionHashes>,
+    pooled: Vec<NewPooledTransactionHashes>,
     /// The transactions to send in full.
     full: Option<BroadcastPoolTransactions>,
 }
@@ -2047,7 +2111,7 @@ impl FullTransactionsBuilder {
 
     /// Returns the messages that should be propagated to the peer.
     fn build(self) -> PropagateTransactions {
-        let pooled = Some(self.pooled.build()).filter(|pooled| !pooled.is_empty());
+        let pooled = self.pooled.build();
         let full =
             (!self.transactions.is_empty()).then_some(BroadcastPoolTransactions(self.transactions));
         PropagateTransactions { pooled, full }
@@ -2103,7 +2167,7 @@ impl FullTransactionsBuilder {
 enum PooledTransactionsHashesBuilder {
     Eth66(NewPooledTransactionHashes66),
     Eth68(NewPooledTransactionHashes68),
-    Eth72(NewPooledTransactionHashes72),
+    Eth72(Vec<NewPooledTransactionHashes72>),
 }
 
 // === impl PooledTransactionsHashesBuilder ===
@@ -2111,45 +2175,27 @@ enum PooledTransactionsHashesBuilder {
 impl PooledTransactionsHashesBuilder {
     /// Push a transaction from the pool to the list.
     fn push_pooled<T: PoolTransaction>(&mut self, pooled_tx: Arc<ValidPoolTransaction<T>>) {
-        match self {
-            Self::Eth66(msg) => msg.push(*pooled_tx.hash()),
-            Self::Eth68(msg) => {
-                msg.hashes.push(*pooled_tx.hash());
-                msg.sizes.push(pooled_tx.encoded_length());
-                msg.types.push(pooled_tx.transaction.ty());
-            }
-            Self::Eth72(msg) => {
-                msg.hashes.push(*pooled_tx.hash());
-                msg.sizes.push(pooled_tx.transaction.eth72_encoded_length());
-                let ty = pooled_tx.transaction.ty();
-                msg.types.push(ty);
-                if ty == EIP4844_TX_TYPE_ID {
-                    // The pool holds the full sidecar, so every cell can be served.
-                    msg.cell_mask = Some(NewPooledTransactionHashes72::ALL_CELLS_MASK);
-                }
-            }
-        }
+        self.push_metadata(
+            *pooled_tx.hash(),
+            pooled_tx.transaction.ty(),
+            pooled_tx.encoded_length(),
+            pooled_tx.transaction.eth72_encoded_length(),
+            pooled_tx.transaction.blob_cell_availability().map(|a| a.get().bits()),
+        );
     }
 
-    /// Returns whether or not any transactions are in the [`PooledTransactionsHashesBuilder`].
     fn is_empty(&self) -> bool {
-        match self {
-            Self::Eth66(hashes) => hashes.is_empty(),
-            Self::Eth68(hashes) => hashes.is_empty(),
-            Self::Eth72(hashes) => hashes.is_empty(),
-        }
+        self.len() == 0
     }
 
-    /// Returns the number of transactions in the builder.
     fn len(&self) -> usize {
         match self {
-            Self::Eth66(hashes) => hashes.len(),
-            Self::Eth68(hashes) => hashes.len(),
-            Self::Eth72(hashes) => hashes.len(),
+            Self::Eth66(msg) => msg.len(),
+            Self::Eth68(msg) => msg.len(),
+            Self::Eth72(messages) => messages.iter().map(|msg| msg.len()).sum(),
         }
     }
 
-    /// Appends all hashes
     fn extend(&mut self, txs: impl IntoIterator<Item = PropagateTransaction>) {
         for tx in txs {
             self.push(&tx);
@@ -2157,22 +2203,47 @@ impl PooledTransactionsHashesBuilder {
     }
 
     fn push(&mut self, tx: &PropagateTransaction) {
+        self.push_metadata(
+            *tx.tx_hash(),
+            tx.tx_type(),
+            tx.propagation_size(),
+            tx.eth72_propagation_size(),
+            tx.cell_mask,
+        );
+    }
+
+    fn push_metadata(
+        &mut self,
+        hash: TxHash,
+        tx_type: u8,
+        size: usize,
+        eth72_size: usize,
+        cell_mask: Option<u128>,
+    ) {
+        if !matches!(self, Self::Eth72(_)) && cell_mask.is_some_and(|mask| mask.count_ones() < 64) {
+            return
+        }
         match self {
-            Self::Eth66(msg) => msg.push(*tx.tx_hash()),
+            Self::Eth66(msg) => msg.push(hash),
             Self::Eth68(msg) => {
-                msg.hashes.push(*tx.tx_hash());
-                msg.sizes.push(tx.propagation_size());
-                msg.types.push(tx.tx_type());
+                msg.hashes.push(hash);
+                msg.sizes.push(size);
+                msg.types.push(tx_type);
             }
-            Self::Eth72(msg) => {
-                msg.hashes.push(*tx.tx_hash());
-                msg.sizes.push(tx.eth72_propagation_size());
-                let ty = tx.tx_type();
-                msg.types.push(ty);
-                if ty == EIP4844_TX_TYPE_ID {
-                    // The pool holds the full sidecar, so every cell can be served.
-                    msg.cell_mask = Some(NewPooledTransactionHashes72::ALL_CELLS_MASK);
-                }
+            Self::Eth72(messages) => {
+                let mask = cell_mask.map(|mask| alloy_primitives::B128::from(mask.to_le_bytes()));
+                let index =
+                    messages.iter().position(|msg| msg.cell_mask == mask).unwrap_or_else(|| {
+                        messages.push(NewPooledTransactionHashes72 {
+                            cell_mask: mask,
+                            ..Default::default()
+                        });
+                        messages.len() - 1
+                    });
+                let msg = &mut messages[index];
+                msg.hashes.push(hash);
+                msg.sizes.push(eth72_size);
+                msg.types.push(tx_type);
             }
         }
     }
@@ -2198,25 +2269,29 @@ impl PooledTransactionsHashesBuilder {
             EthVersion::Eth68 | EthVersion::Eth69 | EthVersion::Eth70 | EthVersion::Eth71 => {
                 Self::Eth68(NewPooledTransactionHashes68::with_capacity(capacity))
             }
-            EthVersion::Eth72 => Self::Eth72(NewPooledTransactionHashes72::with_capacity(capacity)),
+            EthVersion::Eth72 => Self::Eth72(Vec::new()),
         }
     }
 
-    fn build(self) -> NewPooledTransactionHashes {
-        match self {
+    fn build(self) -> Vec<NewPooledTransactionHashes> {
+        let messages: Vec<NewPooledTransactionHashes> = match self {
             Self::Eth66(mut msg) => {
                 msg.shrink_to_fit();
-                msg.into()
+                vec![msg.into()]
             }
             Self::Eth68(mut msg) => {
                 msg.shrink_to_fit();
-                msg.into()
+                vec![msg.into()]
             }
-            Self::Eth72(mut msg) => {
-                msg.shrink_to_fit();
-                msg.into()
-            }
-        }
+            Self::Eth72(messages) => messages
+                .into_iter()
+                .map(|mut msg| {
+                    msg.shrink_to_fit();
+                    msg.into()
+                })
+                .collect(),
+        };
+        messages.into_iter().filter(|msg| !msg.is_empty()).collect()
     }
 }
 
@@ -3267,14 +3342,14 @@ mod tests {
         builder.push_pooled(tx.clone());
 
         let PooledTransactionsHashesBuilder::Eth72(message) = builder else { unreachable!() };
-        assert_eq!(message.sizes, vec![10]);
+        assert_eq!(message[0].sizes, vec![10]);
 
         let tx = PropagateTransaction::pool_tx(tx);
         let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
         builder.push(&tx);
 
         let PooledTransactionsHashesBuilder::Eth72(message) = builder else { unreachable!() };
-        assert_eq!(message.sizes, vec![10]);
+        assert_eq!(message[0].sizes, vec![10]);
     }
 
     #[test]
@@ -3290,7 +3365,7 @@ mod tests {
 
         let txs = builder.build();
         assert!(txs.full.is_none());
-        let txs = txs.pooled.unwrap();
+        let txs = txs.pooled.into_iter().next().unwrap();
         assert_eq!(txs.len(), 1);
     }
 
@@ -3331,14 +3406,14 @@ mod tests {
         assert!(!builder.is_empty());
 
         let txs = builder.clone().build();
-        assert!(txs.pooled.is_none());
+        assert!(txs.pooled.is_empty());
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
 
         builder.push(&tx);
 
         let txs = builder.clone().build();
-        let pooled = txs.pooled.unwrap();
+        let pooled = txs.pooled.into_iter().next().unwrap();
         assert_eq!(pooled.len(), 1);
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
@@ -3357,7 +3432,7 @@ mod tests {
 
         let txs = builder.clone().build();
         assert!(txs.full.is_none());
-        let txs = txs.pooled.unwrap();
+        let txs = txs.pooled.into_iter().next().unwrap();
         assert_eq!(txs.len(), 1);
 
         let tx =
@@ -3365,7 +3440,7 @@ mod tests {
         builder.push(&tx);
 
         let txs = builder.clone().build();
-        let pooled = txs.pooled.unwrap();
+        let pooled = txs.pooled.into_iter().next().unwrap();
         assert_eq!(pooled.len(), 1);
         let txs = txs.full.unwrap();
         assert_eq!(txs.len(), 1);
@@ -3438,7 +3513,7 @@ mod tests {
         builder.push(&PropagateTransaction::pool_tx(valid_eth_pool_transaction(
             tx_gen.gen_eip1559_pooled(),
         )));
-        let msg = builder.build();
+        let msg = builder.build().pop().unwrap();
         assert_eq!(msg.as_eth72().unwrap().cell_mask, None);
 
         // announcing a blob transaction advertises every cell as available
@@ -3447,11 +3522,50 @@ mod tests {
             tx_gen.gen_eip1559_pooled(),
         )));
         builder.push_pooled(valid_eth_pool_transaction(tx_gen.gen_eip4844_pooled()));
-        let msg = builder.build();
+        let msg = builder.build().pop().unwrap();
         assert_eq!(
             msg.as_eth72().unwrap().cell_mask,
             Some(NewPooledTransactionHashes72::ALL_CELLS_MASK)
         );
+    }
+
+    #[test]
+    fn sparse_announcements_group_actual_masks_and_suppress_legacy() {
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let mut txs = Vec::new();
+        for mask in [None, Some(1 | (1u128 << 127)), Some(u128::MAX), Some(1 | (1u128 << 127))] {
+            let mut tx = if mask.is_some() {
+                PropagateTransaction::pool_tx(valid_eth_pool_transaction(
+                    tx_gen.gen_eip4844_pooled(),
+                ))
+            } else {
+                PropagateTransaction::pool_tx(valid_eth_pool_transaction(
+                    tx_gen.gen_eip1559_pooled(),
+                ))
+            };
+            tx.cell_mask = mask;
+            txs.push(tx);
+        }
+        let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
+        for tx in &txs {
+            builder.push(tx);
+        }
+        let messages = builder.build();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].as_eth72().unwrap().cell_mask, None);
+        let partial = messages[1].as_eth72().unwrap();
+        assert_eq!(partial.hashes, vec![*txs[1].tx_hash(), *txs[3].tx_hash()]);
+        assert_eq!(partial.cell_mask.unwrap().as_slice(), &(1u128 | (1u128 << 127)).to_le_bytes());
+        assert_eq!(messages[2].as_eth72().unwrap().hashes, vec![*txs[2].tx_hash()]);
+        for version in [EthVersion::Eth66, EthVersion::Eth68, EthVersion::Eth71] {
+            let mut builder = PooledTransactionsHashesBuilder::new(version);
+            for tx in &txs {
+                builder.push(tx);
+            }
+            let messages = builder.build();
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].len(), 2);
+        }
     }
 
     #[tokio::test]

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1204,12 +1204,14 @@ where
             return
         }
         if let Some(peer) = self.peers.get_mut(&peer_id) {
-            let transactions = self.pool.get_pooled_transaction_elements(
-                request.0,
-                GetPooledTransactionLimit::ResponseSizeSoftLimit(
-                    self.transaction_fetcher.info.soft_limit_byte_size_pooled_transactions_response,
-                ),
-            );
+            let response_size_limit =
+                self.transaction_fetcher.info.soft_limit_byte_size_pooled_transactions_response;
+            let limit = if peer.version() >= EthVersion::Eth72 {
+                GetPooledTransactionLimit::Eth72ResponseSizeSoftLimit(response_size_limit)
+            } else {
+                GetPooledTransactionLimit::ResponseSizeSoftLimit(response_size_limit)
+            };
+            let transactions = self.pool.get_pooled_transaction_elements(request.0, limit);
             trace!(target: "net::tx::propagation", sent_txs=?transactions.iter().map(|tx| tx.tx_hash()), "Sending requested transactions to peer");
 
             // we sent a response at which point we assume that the peer is aware of the
@@ -1829,13 +1831,18 @@ impl PropagationMode {
 #[derive(Debug, Clone)]
 struct PropagateTransaction {
     is_broadcastable_in_full: bool,
-    /// Size advertised in `NewPooledTransactionHashes` metadata and used for full broadcast
-    /// soft-limit accounting.
+    /// Size advertised to pre-eth/72 peers in `NewPooledTransactionHashes` metadata and used for
+    /// full broadcast soft-limit accounting.
     ///
     /// This is the network encoded transaction size. For pool-backed blob transactions, this is
     /// the pool's cached encoded length, which includes the sidecar returned by
     /// `PooledTransactions`.
     propagation_size: usize,
+    /// Size advertised to eth/72 peers in `NewPooledTransactionHashes` metadata.
+    ///
+    /// Type-3 transactions omit blob payloads in eth/72 `PooledTransactions` responses, so this
+    /// must match that blob-elided representation rather than [`Self::propagation_size`].
+    eth72_propagation_size: usize,
     transaction: LazyEncodedTransaction,
 }
 
@@ -1852,6 +1859,7 @@ impl PropagateTransaction {
         Self {
             is_broadcastable_in_full,
             propagation_size,
+            eth72_propagation_size: propagation_size,
             transaction: LazyEncoded::new(transaction),
         }
     }
@@ -1864,9 +1872,11 @@ impl PropagateTransaction {
     fn pool_tx<P: PoolTransaction>(tx: Arc<ValidPoolTransaction<P>>) -> Self {
         let is_broadcastable_in_full = tx.transaction.consensus_ref().is_broadcastable_in_full();
         let propagation_size = tx.encoded_length();
+        let eth72_propagation_size = tx.transaction.eth72_encoded_length();
         Self {
             is_broadcastable_in_full,
             propagation_size,
+            eth72_propagation_size,
             transaction: LazyEncoded::new(PropagatePooledTransactionEncoder::new(tx)),
         }
     }
@@ -1878,6 +1888,11 @@ impl PropagateTransaction {
     /// Returns the network encoded size used for propagation limits and hash metadata.
     const fn propagation_size(&self) -> usize {
         self.propagation_size
+    }
+
+    /// Returns the size advertised to an eth/72 peer.
+    const fn eth72_propagation_size(&self) -> usize {
+        self.eth72_propagation_size
     }
 
     fn tx_type(&self) -> u8 {
@@ -2105,7 +2120,7 @@ impl PooledTransactionsHashesBuilder {
             }
             Self::Eth72(msg) => {
                 msg.hashes.push(*pooled_tx.hash());
-                msg.sizes.push(pooled_tx.encoded_length());
+                msg.sizes.push(pooled_tx.transaction.eth72_encoded_length());
                 let ty = pooled_tx.transaction.ty();
                 msg.types.push(ty);
                 if ty == EIP4844_TX_TYPE_ID {
@@ -2151,7 +2166,7 @@ impl PooledTransactionsHashesBuilder {
             }
             Self::Eth72(msg) => {
                 msg.hashes.push(*tx.tx_hash());
-                msg.sizes.push(tx.propagation_size());
+                msg.sizes.push(tx.eth72_propagation_size());
                 let ty = tx.tx_type();
                 msg.types.push(ty);
                 if ty == EIP4844_TX_TYPE_ID {
@@ -3237,6 +3252,29 @@ mod tests {
         let tx = PropagateTransaction::new(tx);
 
         assert_eq!(tx.propagation_size(), expected_size);
+        assert_eq!(tx.eth72_propagation_size(), expected_size);
+    }
+
+    #[test]
+    fn test_eth72_hash_announcement_uses_blob_elided_size() {
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let mut tx = tx_gen.gen_eip4844_pooled();
+        tx.encoded_length = 100;
+        tx.eth72_encoded_length = 10;
+
+        let tx = valid_eth_pool_transaction(tx);
+        let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
+        builder.push_pooled(tx.clone());
+
+        let PooledTransactionsHashesBuilder::Eth72(message) = builder else { unreachable!() };
+        assert_eq!(message.sizes, vec![10]);
+
+        let tx = PropagateTransaction::pool_tx(tx);
+        let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
+        builder.push(&tx);
+
+        let PooledTransactionsHashesBuilder::Eth72(message) = builder else { unreachable!() };
+        assert_eq!(message.sizes, vec![10]);
     }
 
     #[test]

--- a/crates/net/network/tests/it/eth72.rs
+++ b/crates/net/network/tests/it/eth72.rs
@@ -9,7 +9,7 @@ use alloy_consensus::{
     TxEip4844,
 };
 use alloy_eips::{
-    eip2718::Encodable2718,
+    eip4844::{env_settings::EnvKzgSettings, Blob},
     eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant},
 };
 use alloy_primitives::{Address, B256, U256};
@@ -17,10 +17,12 @@ use futures::{SinkExt, StreamExt};
 use reth_chainspec::MAINNET;
 use reth_ecies::stream::ECIESStream;
 use reth_eth_wire::{
-    EthMessage, EthNetworkPrimitives, EthStream, EthVersion, HelloMessageWithProtocols,
+    Cells, EthMessage, EthNetworkPrimitives, EthStream, EthVersion, HelloMessageWithProtocols,
     NewPooledTransactionHashes72, P2PStream, StatusBuilder, UnauthedEthStream, UnauthedP2PStream,
 };
-use reth_eth_wire_types::{message::RequestPair, PooledTransactions};
+use reth_eth_wire_types::{
+    message::RequestPair, EncodableEth72PooledTransaction, PooledTransactionsEth72,
+};
 use reth_ethereum_forks::EthereumHardfork;
 use reth_ethereum_primitives::{Block, PooledTransactionVariant};
 use reth_network::{
@@ -32,7 +34,8 @@ use reth_network_peers::pk2id;
 use reth_primitives_traits::{crypto::secp256k1::sign_message, SignerRecoverable};
 use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 use reth_transaction_pool::{
-    test_utils::TransactionGenerator, AddedTransactionOutcome, PoolTransaction, TransactionPool,
+    blobstore::BlobTxCellSidecar, test_utils::TransactionGenerator, AddedTransactionOutcome,
+    PoolTransaction, TransactionPool,
 };
 use secp256k1::{SecretKey, SECP256K1};
 use std::time::Duration;
@@ -57,9 +60,9 @@ async fn next_message(stream: &mut RawEthStream) -> EthMessage<EthNetworkPrimiti
 
 /// A signed EIP-4844 pooled transaction in the eth/72 shape: the sidecar keeps commitments and
 /// cell proof metadata while the blob payloads are elided (fetched separately via `GetCells`).
-fn blob_tx_without_blobs() -> PooledTransactionVariant {
-    let mut versioned_hash = B256::random();
-    versioned_hash.0[0] = 0x01;
+fn blob_tx_without_blobs() -> (PooledTransactionVariant, BlobTxCellSidecar) {
+    let full = BlobTransactionSidecarEip7594::try_from_blobs(vec![Blob::default()]).unwrap();
+    let cells = BlobTxCellSidecar::from_full(&full, EnvKzgSettings::Default.get()).unwrap();
 
     let tx = TxEip4844 {
         chain_id: 1,
@@ -70,25 +73,32 @@ fn blob_tx_without_blobs() -> PooledTransactionVariant {
         to: Address::random(),
         value: U256::ZERO,
         access_list: Default::default(),
-        blob_versioned_hashes: vec![versioned_hash],
+        blob_versioned_hashes: cells.versioned_hashes().collect(),
         max_fee_per_blob_gas: 20_000_000_000,
         input: Default::default(),
     };
 
     let signature = sign_message(B256::random(), tx.signature_hash()).unwrap();
-    let sidecar = BlobTransactionSidecarVariant::Eip7594(BlobTransactionSidecarEip7594 {
-        blobs: vec![],
-        commitments: vec![Default::default()],
-        cell_proofs: vec![],
-    });
-
-    PooledTransactionVariant::Eip4844(
-        TxEip4844WithSidecar::from_tx_and_sidecar(tx, sidecar).into_signed(signature),
+    let sidecar = BlobTransactionSidecarVariant::Eip7594(cells.elided());
+    (
+        PooledTransactionVariant::Eip4844(
+            TxEip4844WithSidecar::from_tx_and_sidecar(tx, sidecar).into_signed(signature),
+        ),
+        cells,
     )
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_eth72_blob_announcements_and_elided_pooled_response() {
+async fn test_eth72_body_before_cells() {
+    run_eth72_blob_receive(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth72_cells_before_body() {
+    run_eth72_blob_receive(true).await;
+}
+
+async fn run_eth72_blob_receive(cells_first: bool) {
     reth_tracing::init_test_tracing();
 
     let provider = MockEthProvider::default().with_genesis_block();
@@ -98,7 +108,7 @@ async fn test_eth72_blob_announcements_and_elided_pooled_response() {
     let tip = Header {
         number: 1,
         parent_hash: MAINNET.genesis_hash(),
-        timestamp: 1_750_000_000,
+        timestamp: 1_780_000_000,
         gas_limit: 30_000_000,
         base_fee_per_gas: Some(7),
         excess_blob_gas: Some(0),
@@ -169,14 +179,14 @@ async fn test_eth72_blob_announcements_and_elided_pooled_response() {
     assert_eq!(announcement.cell_mask, None);
 
     // 2) raw peer -> node: a geth style blob announcement carrying the custody mask
-    let pooled = blob_tx_without_blobs();
+    let (pooled, cells) = blob_tx_without_blobs();
     let blob_tx_hash = *pooled.tx_hash();
     let sender = pooled.recover_signer().unwrap();
     provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(19))));
 
     let announcement = NewPooledTransactionHashes72 {
         types: vec![EIP4844_TX_TYPE_ID],
-        sizes: vec![pooled.encode_2718_len()],
+        sizes: vec![pooled.eth72_length()],
         hashes: vec![blob_tx_hash],
         cell_mask: Some(NewPooledTransactionHashes72::ALL_CELLS_MASK),
     };
@@ -189,22 +199,46 @@ async fn test_eth72_blob_announcements_and_elided_pooled_response() {
     };
     assert_eq!(request.message.0, vec![blob_tx_hash]);
 
-    // 3) raw peer -> node: the eth/72 response elides the blob payloads
+    let body = EthMessage::PooledTransactionsEth72(RequestPair {
+        request_id: request.request_id,
+        message: PooledTransactionsEth72(vec![pooled]),
+    });
+    if !cells_first {
+        eth_stream.send(body.clone()).await.unwrap();
+    }
+    let request = match next_message(&mut eth_stream).await {
+        EthMessage::GetCells(request) => request,
+        message => panic!("unexpected message {message:?}"),
+    };
+    assert_eq!(request.message.hashes, vec![blob_tx_hash]);
+    let mask = alloy_eips::eip7594::BlobCellMask::from_bits(u128::from_le_bytes(
+        request.message.cell_mask.into(),
+    ));
+    assert_eq!(mask.count(), 64);
     eth_stream
-        .send(EthMessage::PooledTransactions(RequestPair {
+        .send(EthMessage::Cells(RequestPair {
             request_id: request.request_id,
-            message: PooledTransactions(vec![pooled]),
+            message: Cells {
+                hashes: vec![blob_tx_hash],
+                cells: vec![cells.get_cells(mask).unwrap()],
+                cell_mask: request.message.cell_mask,
+            },
         }))
         .await
         .unwrap();
-
-    // The blob-elided body is dropped before the pool import (cell fetching is not implemented
-    // yet), and the eth/72 peer served a spec compliant response so it must not be penalized.
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    assert!(!node_pool.contains(&blob_tx_hash));
+    if cells_first {
+        eth_stream.send(body).await.unwrap();
+    }
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while !node_pool.contains(&blob_tx_hash) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("verified body and cells must be admitted");
+    assert!(node_pool.get_blob(blob_tx_hash).unwrap().is_some());
     let reputation = node.peer_handle().peer_by_id(raw_id).await.unwrap().reputation();
     assert_eq!(reputation, baseline_reputation);
-    // the session survives serving the blob-elided response
+    // The valid independent body and cell responses do not penalize their provider.
     assert_eq!(node.network().num_connected_peers(), 1);
 }

--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -220,13 +220,14 @@ pub fn create_blob_store_with_cache<Node: FullNodeTypes>(
     cache_size: Option<u32>,
 ) -> eyre::Result<DiskFileBlobStore> {
     let data_dir = ctx.config().datadir();
-    let config = if let Some(cache_size) = cache_size {
+    let mut config = if let Some(cache_size) = cache_size {
         reth_transaction_pool::blobstore::DiskFileBlobStoreConfig::default()
             .with_max_cached_entries(cache_size)
     } else {
         Default::default()
     };
 
+    config.open = reth_transaction_pool::blobstore::OpenDiskFileBlobStore::ReIndex;
     Ok(reth_transaction_pool::blobstore::DiskFileBlobStore::open(data_dir.blobstore(), config)?)
 }
 

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -339,6 +339,10 @@ pub struct NetworkArgs {
     /// Max number of transactions to import concurrently.
     pub max_pending_pool_imports: usize,
 
+    /// Percentage of blob transactions fetched in full. Use 100 to disable sparse sampling.
+    #[arg(long = "blob-fetch-probability", default_value_t = 15, value_parser = clap::value_parser!(u8).range(15..=100))]
+    pub blob_fetch_probability: u8,
+
     /// Experimental, for usage in research. Sets the max accumulated byte size of transactions
     /// to pack in one response.
     /// Spec'd at 2MiB.
@@ -531,6 +535,7 @@ impl NetworkArgs {
             ),
             max_transactions_seen_by_peer_history: self.max_seen_tx_history,
             max_pending_pool_imports: self.max_pending_pool_imports,
+            blob_fetch_probability: self.blob_fetch_probability,
             propagation_mode: self.propagation_mode,
             ingress_policy: self.tx_ingress_policy,
             tx_channel_memory_limit_bytes: self.tx_channel_memory_limit_bytes,
@@ -725,6 +730,7 @@ impl Default for NetworkArgs {
             enforce_enr_fork_id,
         } = DefaultNetworkArgs::get_global().clone();
         Self {
+            blob_fetch_probability: 15,
             discovery: DiscoveryArgs::default(),
             trusted_peers: vec![],
             trusted_only: false,

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -325,6 +325,14 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.blob-cache-size", alias = "txpool.blob_cache_size", default_value = Resettable::from(DefaultTxPoolValues::get_global().blob_cache_size.map(|v| v.to_string().into())))]
     pub blob_cache_size: Option<u32>,
 
+    /// Soft cap for stored blob cells across all subpools, in MiB.
+    #[arg(long = "txpool.blob-storage-size", default_value_t = 2560)]
+    pub blob_storage_size: usize,
+
+    /// Maximum percentage of blob storage occupied by nonce suffixes blocked on missing cells.
+    #[arg(long = "txpool.blocked-blob-storage-percent", default_value_t = 50, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub blocked_blob_storage_percent: u8,
+
     /// Disable EIP-4844 blob transaction support
     #[arg(long = "txpool.disable-blobs-support", alias = "txpool.disable_blobs_support", default_value_t = DefaultTxPoolValues::get_global().disable_blobs_support, conflicts_with_all = ["blobpool_max_count", "blobpool_max_size", "blob_cache_size", "blob_transaction_price_bump"])]
     pub disable_blobs_support: bool,
@@ -469,6 +477,8 @@ impl Default for TxPoolArgs {
             max_batch_size,
         } = DefaultTxPoolValues::get_global().clone();
         Self {
+            blob_storage_size: 2560,
+            blocked_blob_storage_percent: 50,
             pending_max_count,
             pending_max_size,
             basefee_max_count,
@@ -530,6 +540,8 @@ impl RethTransactionPoolConfig for TxPoolArgs {
                 max_size: self.blobpool_max_size.saturating_mul(1024 * 1024),
             },
             blob_cache_size: self.blob_cache_size,
+            max_blob_storage_size: self.blob_storage_size.saturating_mul(1024 * 1024),
+            max_blocked_blob_storage_percent: self.blocked_blob_storage_percent,
             max_account_slots: self.max_account_slots,
             price_bumps: PriceBumpConfig {
                 default_price_bump: self.price_bump,
@@ -615,6 +627,8 @@ mod tests {
             blobpool_max_count: 4000,
             blobpool_max_size: 500,
             blob_cache_size: Some(100),
+            blob_storage_size: 2560,
+            blocked_blob_storage_percent: 50,
             disable_blobs_support: false,
             max_account_slots: 20,
             price_bump: 15,

--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -114,6 +114,7 @@ where
             payload_store,
             task_spawner,
             metrics: EngineApiMetrics::default(),
+            blob_prefetch: Arc::new(tokio::sync::Semaphore::new(1)),
             client,
             capabilities,
             tx_pool,
@@ -1109,10 +1110,24 @@ where
             return Err(EngineApiError::BlobRequestTooLarge { len: versioned_hashes.len() })
         }
 
-        self.inner
+        let available = self
+            .inner
             .tx_pool
             .has_blobs_for_versioned_hashes(&versioned_hashes)
-            .map_err(|err| EngineApiError::Internal(Box::new(err)))
+            .map_err(|err| EngineApiError::Internal(Box::new(err)))?;
+        if let Ok(permit) = self.inner.blob_prefetch.clone().try_acquire_owned() {
+            let pool = self.inner.tx_pool.clone();
+            let hashes: Vec<_> = versioned_hashes
+                .into_iter()
+                .zip(&available)
+                .filter_map(|(hash, available)| available.then_some(hash))
+                .collect();
+            self.inner.task_spawner.spawn_blocking_task(async move {
+                let _permit = permit;
+                pool.blob_store().warm_versioned_hashes(&hashes);
+            });
+        }
+        Ok(available)
     }
 
     /// Metered version of `has_blobs`.
@@ -1723,6 +1738,9 @@ where
 
         let el_caps = self.capabilities();
         el_caps.log_capability_mismatches(&capabilities);
+        if capabilities.iter().any(|cap| cap == "engine_getBlobsV4") {
+            self.inner.tx_pool.blob_store().set_cell_mode();
+        }
 
         Ok(el_caps.list())
     }
@@ -1745,7 +1763,12 @@ where
         versioned_hashes: Vec<B256>,
     ) -> RpcResult<Option<Vec<BlobAndProofV2>>> {
         trace!(target: "rpc::engine", "Serving engine_getBlobsV2");
-        Ok(self.get_blobs_v2_metered(versioned_hashes)?)
+        let (tx, rx) = oneshot::channel();
+        let this = self.clone();
+        self.inner.task_spawner.spawn_blocking_task(async move {
+            let _ = tx.send(this.get_blobs_v2_metered(versioned_hashes));
+        });
+        Ok(rx.await.map_err(|err| EngineApiError::Internal(Box::new(err)))??)
     }
 
     async fn get_blobs_v3(
@@ -1753,7 +1776,12 @@ where
         versioned_hashes: Vec<B256>,
     ) -> RpcResult<Option<Vec<Option<BlobAndProofV2>>>> {
         trace!(target: "rpc::engine", "Serving engine_getBlobsV3");
-        Ok(self.get_blobs_v3_metered(versioned_hashes)?)
+        let (tx, rx) = oneshot::channel();
+        let this = self.clone();
+        self.inner.task_spawner.spawn_blocking_task(async move {
+            let _ = tx.send(this.get_blobs_v3_metered(versioned_hashes));
+        });
+        Ok(rx.await.map_err(|err| EngineApiError::Internal(Box::new(err)))??)
     }
 
     async fn get_blobs_v4(
@@ -1762,7 +1790,12 @@ where
         indices_bitarray: B128,
     ) -> RpcResult<Option<Vec<Option<BlobCellsAndProofsV1>>>> {
         trace!(target: "rpc::engine", "Serving engine_getBlobsV4");
-        Ok(self.get_blobs_v4_metered(versioned_hashes, indices_bitarray)?)
+        let (tx, rx) = oneshot::channel();
+        let this = self.clone();
+        self.inner.task_spawner.spawn_blocking_task(async move {
+            let _ = tx.send(this.get_blobs_v4_metered(versioned_hashes, indices_bitarray));
+        });
+        Ok(rx.await.map_err(|err| EngineApiError::Internal(Box::new(err)))??)
     }
 }
 
@@ -1811,6 +1844,8 @@ struct EngineApiInner<Provider, PayloadT: PayloadTypes, Pool, Validator, ChainSp
     task_spawner: Runtime,
     /// The latency and response type metrics for engine api calls
     metrics: EngineApiMetrics,
+    /// At most one speculative blob-cache fill may run at a time.
+    blob_prefetch: Arc<tokio::sync::Semaphore>,
     /// Identification of the execution client used by the consensus client
     client: ClientVersionV1,
     /// The list of all supported Engine capabilities available over the engine endpoint.

--- a/crates/transaction-pool/src/blobstore/cells.rs
+++ b/crates/transaction-pool/src/blobstore/cells.rs
@@ -1,0 +1,303 @@
+//! Cell-based EIP-7594 sidecars used by the sparse blob pool.
+
+use alloy_eips::{
+    eip4844::{
+        env_settings::KzgSettings, kzg_to_versioned_hash, AsAlloy, AsCkzg, BlobCellsAndProofsV1,
+        BlobTransactionValidationError, Bytes48,
+    },
+    eip7594::{BlobCellMask, BlobTransactionSidecarEip7594, Cell, CELLS_PER_EXT_BLOB},
+};
+use alloy_primitives::{B128, B256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+
+/// An EIP-7594 sidecar retaining only a common subset of cells for every blob.
+///
+/// Cells are stored in blob-major order, with increasing cell indices within each blob.
+/// All cell proofs are retained so the transaction can be served without fetching its blobs.
+/// The mask is numeric internally: bit `i` selects cell `i`, independently of wire byte order.
+#[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+pub struct BlobTxCellSidecar {
+    /// One commitment per blob.
+    pub commitments: Vec<Bytes48>,
+    /// All 128 cell proofs per blob, in blob-major order.
+    pub proofs: Vec<Bytes48>,
+    /// Available cells, in blob-major, then ascending-index order.
+    pub cells: Vec<Cell>,
+    /// Numeric bitmap shared by every blob in this sidecar.
+    pub cell_mask: B128,
+}
+
+impl BlobTxCellSidecar {
+    /// Returns the locally stored cell indices.
+    pub fn mask(&self) -> BlobCellMask {
+        BlobCellMask::new(self.cell_mask)
+    }
+
+    /// Returns whether every blob can be recovered without network access.
+    pub fn is_recoverable(&self) -> bool {
+        self.mask().count() >= CELLS_PER_EXT_BLOB / 2
+    }
+
+    /// Returns whether the cell and proof counts agree with the commitments and bitmap.
+    pub fn has_valid_shape(&self) -> bool {
+        !self.commitments.is_empty() &&
+            self.mask().count() > 0 &&
+            self.commitments.len().checked_mul(self.mask().count()) == Some(self.cells.len()) &&
+            self.commitments.len().checked_mul(CELLS_PER_EXT_BLOB) == Some(self.proofs.len())
+    }
+
+    /// Verifies the commitment hashes and the proof of every stored cell.
+    pub fn validate(
+        &self,
+        versioned_hashes: &[B256],
+        settings: &KzgSettings,
+    ) -> Result<(), BlobTransactionValidationError> {
+        if !self.has_valid_shape() || versioned_hashes.len() != self.commitments.len() {
+            return Err(BlobTransactionValidationError::InvalidProof)
+        }
+        for (expected, commitment) in versioned_hashes.iter().zip(&self.commitments) {
+            let have = kzg_to_versioned_hash(commitment.as_slice());
+            if *expected != have {
+                return Err(BlobTransactionValidationError::WrongVersionedHash {
+                    have,
+                    expected: *expected,
+                })
+            }
+        }
+        let indices: Vec<_> = self.mask().selected_indices().collect();
+        let mut commitments = Vec::with_capacity(self.cells.len());
+        let mut proofs = Vec::with_capacity(self.cells.len());
+        let mut cell_indices = Vec::with_capacity(self.cells.len());
+        for (blob, commitment) in self.commitments.iter().enumerate() {
+            for &index in &indices {
+                commitments.push(*commitment);
+                proofs.push(self.proofs[blob * CELLS_PER_EXT_BLOB + index]);
+                cell_indices.push(index as u64);
+            }
+        }
+        if !settings.verify_cell_kzg_proof_batch(
+            Bytes48::slice_as_ckzg(&commitments),
+            &cell_indices,
+            Cell::slice_as_ckzg(&self.cells),
+            Bytes48::slice_as_ckzg(&proofs),
+        )? {
+            return Err(BlobTransactionValidationError::InvalidProof)
+        }
+        Ok(())
+    }
+
+    /// Computes the complete cell set from a full sidecar. The caller validates its proofs.
+    pub fn from_full(
+        sidecar: &BlobTransactionSidecarEip7594,
+        settings: &KzgSettings,
+    ) -> Result<Self, BlobTransactionValidationError> {
+        let mut cells = Vec::with_capacity(sidecar.blobs.len() * CELLS_PER_EXT_BLOB);
+        for blob in &sidecar.blobs {
+            let computed = settings.compute_cells(blob.as_ckzg())?;
+            cells.extend(computed.iter().map(|cell| *cell.as_alloy()));
+        }
+        Ok(Self {
+            commitments: sidecar.commitments.clone(),
+            proofs: sidecar.cell_proofs.clone(),
+            cells,
+            cell_mask: B128::repeat_byte(0xff),
+        })
+    }
+
+    /// Recovers a full sidecar, authenticating each reconstructed commitment.
+    pub fn recover(
+        &self,
+        settings: &KzgSettings,
+    ) -> Result<BlobTransactionSidecarEip7594, super::BlobStoreError> {
+        BlobTransactionSidecarEip7594::try_recover_from_cells_with_settings(
+            self.commitments.clone(),
+            self.mask(),
+            &self.cells,
+            settings,
+        )
+        .map_err(|err| super::BlobStoreError::Other(Box::new(err)))
+    }
+
+    /// Returns the ETH/72 wrapper metadata without reconstructing any blobs.
+    pub fn elided(&self) -> BlobTransactionSidecarEip7594 {
+        BlobTransactionSidecarEip7594::new(
+            Vec::new(),
+            self.commitments.clone(),
+            self.proofs.clone(),
+        )
+    }
+
+    /// Returns the commitment's versioned hashes, including duplicates.
+    pub fn versioned_hashes(&self) -> impl Iterator<Item = B256> + '_ {
+        self.commitments.iter().map(|c| kzg_to_versioned_hash(c.as_slice()))
+    }
+
+    /// Retrieves all requested cells, or `None` if any requested column is unavailable.
+    pub fn get_cells(&self, mask: BlobCellMask) -> Option<Vec<Cell>> {
+        if !self.has_valid_shape() || mask.bits() & !self.mask().bits() != 0 {
+            return None
+        }
+        let stored = self.mask();
+        let positions: Vec<_> = stored
+            .selected_indices()
+            .enumerate()
+            .filter_map(|(pos, index)| mask.contains(index).then_some(pos))
+            .collect();
+        Some(
+            self.cells
+                .chunks_exact(stored.count())
+                .flat_map(|blob| positions.iter().map(move |&pos| blob[pos]))
+                .collect(),
+        )
+    }
+
+    /// Retrieves requested cells for one blob, preserving missing columns as null entries.
+    pub fn blob_cells(&self, blob: usize, mask: BlobCellMask) -> Option<BlobCellsAndProofsV1> {
+        if blob >= self.commitments.len() || !self.has_valid_shape() {
+            return None
+        }
+        let indices: Vec<_> = self.mask().selected_indices().collect();
+        let mut blob_cells = Vec::with_capacity(mask.count());
+        let mut proofs = Vec::with_capacity(mask.count());
+        for index in mask.selected_indices() {
+            if let Ok(pos) = indices.binary_search(&index) {
+                blob_cells.push(Some(self.cells[blob * indices.len() + pos]));
+                proofs.push(Some(self.proofs[blob * CELLS_PER_EXT_BLOB + index]));
+            } else {
+                blob_cells.push(None);
+                proofs.push(None);
+            }
+        }
+        Some(BlobCellsAndProofsV1 { blob_cells, proofs })
+    }
+
+    /// Heap bytes occupied by the stored cells and metadata.
+    pub const fn size(&self) -> usize {
+        self.cells.len() * core::mem::size_of::<Cell>() +
+            (self.commitments.len() + self.proofs.len()) * core::mem::size_of::<Bytes48>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blobstore::{
+        disk::{DiskFileBlobStore, DiskFileBlobStoreConfig, OpenDiskFileBlobStore},
+        BlobStore, InMemoryBlobStore, PooledBlobSidecar,
+    };
+    use alloy_eips::eip4844::{env_settings::EnvKzgSettings, Blob};
+    use std::sync::OnceLock;
+
+    fn fixture() -> &'static (BlobTransactionSidecarEip7594, BlobTxCellSidecar) {
+        static FIXTURE: OnceLock<(BlobTransactionSidecarEip7594, BlobTxCellSidecar)> =
+            OnceLock::new();
+        FIXTURE.get_or_init(|| {
+            let mut second = Blob::default();
+            second[31] = 1;
+            let full = BlobTransactionSidecarEip7594::try_from_blobs(vec![Blob::default(), second])
+                .unwrap();
+            let cells = BlobTxCellSidecar::from_full(&full, EnvKzgSettings::Default.get()).unwrap();
+            (full, cells)
+        })
+    }
+
+    fn subset(mask: BlobCellMask) -> BlobTxCellSidecar {
+        let (_, all) = fixture();
+        BlobTxCellSidecar {
+            cell_mask: B128::from(mask.bits()),
+            cells: all.get_cells(mask).unwrap(),
+            ..all.clone()
+        }
+    }
+
+    #[test]
+    fn recover_non_contiguous_columns_for_multiple_blobs() {
+        let (full, _) = fixture();
+        let sparse = subset(BlobCellMask::from_bits(u128::MAX / 3));
+        assert_eq!(sparse.mask().count(), 64);
+        sparse
+            .validate(&sparse.versioned_hashes().collect::<Vec<_>>(), EnvKzgSettings::Default.get())
+            .unwrap();
+        assert_eq!(&sparse.recover(EnvKzgSettings::Default.get()).unwrap(), full);
+    }
+
+    #[test]
+    fn reject_corrupted_cells_proofs_hashes_and_shape() {
+        let valid = subset(BlobCellMask::from_bits((1 << 127) | 1));
+        let hashes: Vec<_> = valid.versioned_hashes().collect();
+        let settings = EnvKzgSettings::Default.get();
+        valid.validate(&hashes, settings).unwrap();
+        let mut corrupted = valid.clone();
+        corrupted.cells[0][31] ^= 1;
+        assert!(corrupted.validate(&hashes, settings).is_err());
+        let mut corrupted = valid.clone();
+        corrupted.proofs[127] = Bytes48::ZERO;
+        assert!(corrupted.validate(&hashes, settings).is_err());
+        let mut corrupted = valid.clone();
+        corrupted.cells.pop();
+        assert!(corrupted.validate(&hashes, settings).is_err());
+        let mut wrong_hashes = hashes;
+        wrong_hashes[0] = B256::ZERO;
+        assert!(valid.validate(&wrong_hashes, settings).is_err());
+    }
+
+    fn check_sparse_store(store: &impl BlobStore) {
+        let sparse = subset(BlobCellMask::from_bits((1 << 127) | 1));
+        let hashes: Vec<_> = sparse.versioned_hashes().collect();
+        let tx = B256::repeat_byte(42);
+        store.insert(tx, PooledBlobSidecar::from_cells(sparse.clone())).unwrap();
+        assert!(store.contains(tx).unwrap());
+        assert!(store.get(tx).unwrap().is_none());
+        assert_eq!(store.get_pooled_sidecar(tx).unwrap().unwrap().cells(), Some(&sparse));
+        let requested = BlobCellMask::from_bits((1 << 127) | 3);
+        let found = store.get_by_versioned_hashes_v4(&hashes, requested).unwrap();
+        for (blob, result) in found.into_iter().enumerate() {
+            let result = result.unwrap();
+            assert_eq!(result.blob_cells.len(), 3);
+            assert_eq!(result.blob_cells[0], Some(sparse.cells[blob * 2]));
+            assert!(result.blob_cells[1].is_none());
+            assert!(result.proofs[1].is_none());
+            assert_eq!(result.blob_cells[2], Some(sparse.cells[blob * 2 + 1]));
+        }
+        let recoverable = subset(BlobCellMask::from_bits(u64::MAX as u128));
+        store.insert(tx, PooledBlobSidecar::from_cells(recoverable)).unwrap();
+        assert_eq!(store.get(tx).unwrap().unwrap().as_eip7594(), Some(&fixture().0));
+    }
+
+    #[test]
+    fn sparse_memory_store_consumers() {
+        check_sparse_store(&InMemoryBlobStore::default());
+    }
+
+    #[test]
+    fn stored_sparse_body_and_origin_roundtrip() {
+        let sparse = subset(BlobCellMask::from_bits(1));
+        let stored = PooledBlobSidecar::from_cells(sparse)
+            .with_transaction(vec![3, 1, 2].into())
+            .with_origin(crate::TransactionOrigin::Private);
+        let decoded = PooledBlobSidecar::decode_stored(&stored.encode_stored()).unwrap();
+        assert_eq!(decoded, stored);
+        assert_eq!(decoded.origin(), crate::TransactionOrigin::Private);
+        assert_eq!(decoded.transaction().unwrap().as_ref(), &[3, 1, 2]);
+    }
+
+    #[test]
+    fn sparse_disk_store_consumers_and_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let config =
+            DiskFileBlobStoreConfig { open: OpenDiskFileBlobStore::ReIndex, ..Default::default() };
+        let store = DiskFileBlobStore::open(dir.path(), config.clone()).unwrap();
+        check_sparse_store(&store);
+        let bytes = store.data_size_hint();
+        drop(store);
+        let reopened = DiskFileBlobStore::open(dir.path(), config).unwrap();
+        assert_eq!(reopened.data_size_hint(), bytes);
+        let tx = B256::repeat_byte(42);
+        assert_eq!(reopened.get(tx).unwrap().unwrap().as_eip7594(), Some(&fixture().0));
+        reopened.delete(tx).unwrap();
+        let sparse = subset(BlobCellMask::from_bits(1));
+        reopened.insert(tx, PooledBlobSidecar::from_cells(sparse.clone())).unwrap();
+        reopened.cleanup();
+        assert_eq!(reopened.get_pooled_sidecar(tx).unwrap().unwrap().cells(), Some(&sparse));
+    }
+}

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -1,4 +1,4 @@
-//! A simple diskstore for blobs
+//! Persistent full and cell-based blob sidecars.
 
 use crate::blobstore::{
     BlobStore, BlobStoreCleanupStat, BlobStoreError, BlobStoreSize, PooledBlobSidecar,
@@ -6,767 +6,412 @@ use crate::blobstore::{
 use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
     eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell},
-    eip7840::BlobParams,
-    merge::EPOCH_SLOTS,
 };
-use alloy_primitives::{map::B256Set, TxHash, B256};
+use alloy_primitives::{
+    map::{B256Map, B256Set},
+    TxHash, B256,
+};
 use parking_lot::{Mutex, RwLock};
-use schnellru::{ByLength, LruMap};
-use std::{fmt, fs, io, path::PathBuf, sync::Arc};
-use tracing::{debug, trace};
+use schnellru::{Limiter, LruMap};
+use std::{
+    fs,
+    io::{self, Write},
+    path::PathBuf,
+    sync::Arc,
+};
+use tracing::debug;
 
-/// How many [`BlobTransactionSidecarVariant`] to cache in memory.
+/// Maximum number of sidecars retained in the memory cache by default.
 pub const DEFAULT_MAX_CACHED_BLOBS: u32 = 100;
 
-/// A cache size heuristic based on the highest blob params
+/// A disk-backed blob store with a bounded decoded-sidecar cache.
 ///
-/// This uses the max blobs per tx and max blobs per block over 16 epochs: `21 * 6 * 512 = 64512`
-/// This should be ~4MB
-const VERSIONED_HASH_TO_TX_HASH_CACHE_SIZE: u64 =
-    BlobParams::bpo2().max_blobs_per_tx * BlobParams::bpo2().max_blob_count * EPOCH_SLOTS * 16;
-
-/// A blob store that stores blob data on disk.
-///
-/// The type uses deferred deletion, meaning that blobs are not immediately deleted from disk, but
-/// it's expected that the maintenance task will call [`BlobStore::cleanup`] to remove the deleted
-/// blobs from disk.
+/// Cell-backed entries are served without reconstructing blobs. Full blobs are reconstructed only
+/// for legacy consumers, then memoized with the cached sidecar. Deletion is deferred to cleanup.
 #[derive(Clone, Debug)]
 pub struct DiskFileBlobStore {
     inner: Arc<DiskFileBlobStoreInner>,
 }
 
 impl DiskFileBlobStore {
-    /// Opens and initializes a new disk file blob store according to the given options.
+    /// Opens the store, optionally retaining and re-indexing existing sidecars.
     pub fn open(
         blob_dir: impl Into<PathBuf>,
         opts: DiskFileBlobStoreConfig,
     ) -> Result<Self, DiskFileBlobStoreError> {
         let blob_dir = blob_dir.into();
-        let DiskFileBlobStoreConfig { max_cached_entries, .. } = opts;
-        let inner = DiskFileBlobStoreInner::new(blob_dir, max_cached_entries);
-
-        // initialize the blob store
-        inner.delete_all()?;
-        inner.create_blob_dir()?;
-
-        Ok(Self { inner: Arc::new(inner) })
+        if opts.open == OpenDiskFileBlobStore::Clear {
+            match fs::remove_dir_all(&blob_dir) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => return Err(DiskFileBlobStoreError::Open(blob_dir, e)),
+            }
+        }
+        reth_fs_util::create_dir_all(&blob_dir)
+            .map_err(|e| DiskFileBlobStoreError::Open(blob_dir.clone(), io::Error::other(e)))?;
+        let store = Self {
+            inner: Arc::new(DiskFileBlobStoreInner {
+                blob_dir: blob_dir.clone(),
+                blob_cache: Mutex::new(LruMap::new(SidecarCacheLimit {
+                    max_entries: opts.max_cached_entries,
+                    bytes: 0,
+                })),
+                size_tracker: Default::default(),
+                file_lock: Default::default(),
+                txs_to_delete: Default::default(),
+                versioned_hashes_to_txhash: Default::default(),
+                transactions: Default::default(),
+                pinned: Default::default(),
+                cell_mode: Default::default(),
+            }),
+        };
+        if opts.open == OpenDiskFileBlobStore::ReIndex {
+            for entry in reth_fs_util::read_dir(&blob_dir)
+                .map_err(|e| DiskFileBlobStoreError::Open(blob_dir.clone(), io::Error::other(e)))?
+            {
+                let entry = entry.map_err(|e| DiskFileBlobStoreError::Open(blob_dir.clone(), e))?;
+                let Some(name) = entry.file_name().to_str().map(str::to_owned) else { continue };
+                let Ok(tx) = name.parse::<B256>() else { continue };
+                let data = reth_fs_util::read(entry.path())
+                    .map_err(|e| DiskFileBlobStoreError::Open(entry.path(), io::Error::other(e)))?;
+                match PooledBlobSidecar::decode_stored(&data) {
+                    Ok(sidecar) => {
+                        store.inner.index(tx, &sidecar);
+                        store.inner.size_tracker.add_size(data.len());
+                        store.inner.size_tracker.inc_len(1);
+                    }
+                    Err(err) => {
+                        debug!(target: "txpool::blob", %tx, %err, "Discarding corrupt blob sidecar");
+                        reth_fs_util::remove_file(entry.path()).map_err(|e| {
+                            DiskFileBlobStoreError::Open(entry.path(), io::Error::other(e))
+                        })?;
+                    }
+                }
+            }
+        }
+        Ok(store)
     }
 
     #[cfg(test)]
     fn is_cached(&self, tx: &B256) -> bool {
         self.inner.blob_cache.lock().get(tx).is_some()
     }
-
     #[cfg(test)]
     fn clear_cache(&self) {
-        self.inner.blob_cache.lock().clear()
+        self.inner.blob_cache.lock().clear();
     }
 
-    /// Look up EIP-7594 blobs by their versioned hashes.
-    ///
-    /// This returns a result vector with the **same length and order** as the input
-    /// `versioned_hashes`. Each element is `Some(BlobAndProofV2)` if the blob is available, or
-    /// `None` if it is missing or an older sidecar version.
-    ///
-    /// The lookup first scans the in-memory cache and, if not all blobs are found, falls back to
-    /// reading candidate sidecars from disk using the `versioned_hash -> tx_hash` index.
-    fn get_by_versioned_hashes_eip7594(
-        &self,
-        versioned_hashes: &[B256],
-    ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
-        // we must return the blobs in order but we don't necessarily find them in the requested
-        // order
-        let mut result = vec![None; versioned_hashes.len()];
-        let mut missing_count = result.len();
-        // first scan all cached full sidecars
-        for (_tx_hash, blob_sidecar) in self.inner.blob_cache.lock().iter() {
-            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
-                for (hash_idx, match_result) in
-                    blob_sidecar.match_versioned_hashes(versioned_hashes)
-                {
-                    let slot = &mut result[hash_idx];
-                    if slot.is_none() {
-                        missing_count -= 1;
-                    }
-                    *slot = Some(match_result);
-                }
-            }
-
-            // return early if all blobs are found.
-            if missing_count == 0 {
-                // since versioned_hashes may have duplicates, we double check here
-                if result.iter().all(|blob| blob.is_some()) {
-                    return Ok(result);
-                }
+    fn candidates(&self, hashes: &[B256]) -> Result<Vec<Arc<PooledBlobSidecar>>, BlobStoreError> {
+        let txs: B256Set = {
+            let index = self.inner.versioned_hashes_to_txhash.read();
+            hashes.iter().filter_map(|hash| index.get(hash)).flatten().copied().collect()
+        };
+        let mut result = Vec::with_capacity(txs.len());
+        for tx in txs {
+            if let Some(sidecar) = self.get_pooled_sidecar(tx)? {
+                result.push(sidecar);
             }
         }
-
-        // not all versioned hashes were found, try to look up a matching tx
-        let mut missing_tx_hashes = Vec::new();
-        let mut seen_missing_tx_hashes = B256Set::default();
-
-        {
-            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
-            for (idx, _) in
-                result.iter().enumerate().filter(|(_, blob_and_proof)| blob_and_proof.is_none())
-            {
-                // this is safe because the result vec has the same len
-                let versioned_hash = versioned_hashes[idx];
-                if let Some(tx_hash) = versioned_to_txhashes.get(&versioned_hash).copied() &&
-                    seen_missing_tx_hashes.insert(tx_hash)
-                {
-                    missing_tx_hashes.push(tx_hash);
-                }
-            }
-        }
-
-        // if we have missing blobs, try to read them from disk and try again
-        if !missing_tx_hashes.is_empty() {
-            let blobs_from_disk = self.inner.read_many_decoded(missing_tx_hashes);
-            for (_, blob_sidecar) in blobs_from_disk {
-                if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
-                    for (hash_idx, match_result) in
-                        blob_sidecar.match_versioned_hashes(versioned_hashes)
-                    {
-                        if result[hash_idx].is_none() {
-                            result[hash_idx] = Some(match_result);
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Look up EIP-7594 blob cells by their versioned hashes.
-    fn get_by_versioned_hashes_cells_eip7594(
-        &self,
-        versioned_hashes: &[B256],
-        cell_mask: BlobCellMask,
-    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        let mut result = vec![None; versioned_hashes.len()];
-        let mut missing_count = result.len();
-
-        let cached_blob_sidecars = self
-            .inner
-            .blob_cache
-            .lock()
-            .iter()
-            .map(|(_, blob_sidecar)| Arc::clone(blob_sidecar))
-            .collect::<Vec<_>>();
-        for blob_sidecar in cached_blob_sidecars {
-            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
-                for (hash_idx, match_result) in blob_sidecar
-                    .match_versioned_hashes_cells(versioned_hashes, cell_mask)
-                    .map_err(|err| BlobStoreError::Other(Box::new(err)))?
-                {
-                    let slot = &mut result[hash_idx];
-                    if slot.is_none() {
-                        missing_count -= 1;
-                    }
-                    *slot = Some(match_result);
-                }
-            }
-
-            if missing_count == 0 && result.iter().all(Option::is_some) {
-                return Ok(result)
-            }
-        }
-
-        let mut missing_tx_hashes = Vec::new();
-        let mut seen_missing_tx_hashes = B256Set::default();
-        {
-            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
-            for (idx, _) in
-                result.iter().enumerate().filter(|(_, cells_and_proofs)| cells_and_proofs.is_none())
-            {
-                let versioned_hash = versioned_hashes[idx];
-                if let Some(tx_hash) = versioned_to_txhashes.get(&versioned_hash).copied() &&
-                    seen_missing_tx_hashes.insert(tx_hash)
-                {
-                    missing_tx_hashes.push(tx_hash);
-                }
-            }
-        }
-
-        if !missing_tx_hashes.is_empty() {
-            let blobs_from_disk = self.inner.read_many_decoded(missing_tx_hashes);
-            for (_, blob_sidecar) in blobs_from_disk {
-                if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
-                    for (hash_idx, match_result) in blob_sidecar
-                        .match_versioned_hashes_cells(versioned_hashes, cell_mask)
-                        .map_err(|err| BlobStoreError::Other(Box::new(err)))?
-                    {
-                        if result[hash_idx].is_none() {
-                            result[hash_idx] = Some(match_result);
-                        }
-                    }
-                }
-            }
-        }
-
         Ok(result)
     }
 }
 
 impl BlobStore for DiskFileBlobStore {
+    fn set_cell_mode(&self) {
+        self.inner.cell_mode.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn warm_transactions(&self, hashes: &[B256]) {
+        for hash in hashes {
+            if let Ok(Some(sidecar)) = self.get_pooled_sidecar(*hash) &&
+                !self.inner.cell_mode.load(std::sync::atomic::Ordering::Relaxed)
+            {
+                let _ = sidecar.full_sidecar();
+            }
+        }
+    }
+
+    fn warm_versioned_hashes(&self, hashes: &[B256]) {
+        let txs: B256Set = self
+            .inner
+            .versioned_hashes_to_txhash
+            .read()
+            .iter()
+            .filter(|(hash, _)| hashes.contains(hash))
+            .flat_map(|(_, txs)| txs.iter().copied())
+            .collect();
+        for tx in txs {
+            let Ok(Some(sidecar)) = self.get_pooled_sidecar(tx) else { continue };
+            if !self.inner.cell_mode.load(std::sync::atomic::Ordering::Relaxed) {
+                let _ = sidecar.full_sidecar();
+            }
+            let _lock = self.inner.file_lock.read();
+            if !self
+                .inner
+                .blob_cache
+                .lock()
+                .peek(&tx)
+                .is_some_and(|current| Arc::ptr_eq(current, &sidecar))
+            {
+                continue
+            }
+            let now = std::time::Instant::now();
+            let mut pinned = self.inner.pinned.lock();
+            pinned.retain(|_, (expires, _)| *expires > now);
+            let used: usize = pinned
+                .iter()
+                .filter(|(hash, _)| **hash != tx)
+                .map(|(_, (_, sidecar))| SidecarCacheLimit::cost(sidecar))
+                .sum();
+            if used + SidecarCacheLimit::cost(&sidecar) <= SidecarCacheLimit::MAX_BYTES {
+                pinned.insert(tx, (now + std::time::Duration::from_secs(1), sidecar));
+            }
+        }
+    }
+
+    fn transaction_hashes(&self) -> Vec<B256> {
+        self.inner
+            .versioned_hashes_to_txhash
+            .read()
+            .values()
+            .flatten()
+            .copied()
+            .collect::<B256Set>()
+            .into_iter()
+            .collect()
+    }
+
+    fn transactions(&self) -> Vec<(B256, alloy_primitives::Bytes)> {
+        self.inner.transactions.read().iter().map(|(hash, body)| (*hash, body.clone())).collect()
+    }
+
     fn insert(&self, tx: B256, data: PooledBlobSidecar) -> Result<(), BlobStoreError> {
-        self.inner.insert_one(tx, data.into_sidecar())
+        let encoded = data.encode_stored();
+        let _lock = self.inner.file_lock.write();
+        let path = self.inner.blob_disk_file(tx);
+        let previous_size = fs::metadata(&path).ok().map(|m| m.len() as usize);
+        reth_fs_util::atomic_write_file(&path, |file| file.write_all(&encoded))
+            .map_err(|e| BlobStoreError::Other(Box::new(e)))?;
+        self.inner.index(tx, &data);
+        self.inner.pinned.lock().remove(&tx);
+        self.inner.blob_cache.lock().insert(tx, Arc::new(data));
+        self.inner.txs_to_delete.write().remove(&tx);
+        if let Some(size) = previous_size {
+            self.inner.size_tracker.sub_size(size);
+        } else {
+            self.inner.size_tracker.inc_len(1);
+        }
+        self.inner.size_tracker.add_size(encoded.len());
+        Ok(())
     }
 
     fn insert_all(&self, txs: Vec<(B256, PooledBlobSidecar)>) -> Result<(), BlobStoreError> {
-        if txs.is_empty() {
-            return Ok(())
+        for (tx, sidecar) in txs {
+            self.insert(tx, sidecar)?;
         }
-        let txs = txs.into_iter().map(|(tx, data)| (tx, data.into_sidecar())).collect();
-        self.inner.insert_many(txs)
+        Ok(())
     }
 
     fn delete(&self, tx: B256) -> Result<(), BlobStoreError> {
-        if self.inner.contains(tx)? {
+        let _lock = self.inner.file_lock.read();
+        if self.inner.blob_disk_file(tx).is_file() {
             self.inner.txs_to_delete.write().insert(tx);
         }
         Ok(())
     }
 
     fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
-        if txs.is_empty() {
-            return Ok(())
+        for tx in txs {
+            self.delete(tx)?;
         }
-        let txs = self.inner.retain_existing(txs)?;
-        self.inner.txs_to_delete.write().extend(txs);
         Ok(())
     }
 
     fn cleanup(&self) -> BlobStoreCleanupStat {
-        let txs_to_delete = std::mem::take(&mut *self.inner.txs_to_delete.write());
-        let mut stat = BlobStoreCleanupStat::default();
-        let mut subsize = 0;
-        debug!(target:"txpool::blob", num_blobs=%txs_to_delete.len(), "Removing blobs from disk");
-        for tx in txs_to_delete {
+        let _lock = self.inner.file_lock.write();
+        let txs = std::mem::take(&mut *self.inner.txs_to_delete.write());
+        let mut result = BlobStoreCleanupStat::default();
+        for tx in txs {
             let path = self.inner.blob_disk_file(tx);
-            let filesize = fs::metadata(&path).map_or(0, |meta| meta.len());
+            let size = fs::metadata(&path).ok().map(|m| m.len() as usize);
             match fs::remove_file(&path) {
-                Ok(_) => {
-                    stat.delete_succeed += 1;
-                    subsize += filesize;
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    debug!(target: "txpool::blob", %tx, %err, "Failed to delete blob sidecar");
+                    self.inner.txs_to_delete.write().insert(tx);
+                    result.delete_failed += 1;
+                    continue
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    // Already deleted by a concurrent cleanup task
-                    stat.delete_succeed += 1;
-                }
-                Err(e) => {
-                    stat.delete_failed += 1;
-                    let err = DiskFileBlobStoreError::DeleteFile(tx, path, e);
-                    debug!(target:"txpool::blob", %err);
-                }
-            };
+            }
+            self.inner.pinned.lock().remove(&tx);
+            self.inner.blob_cache.lock().remove(&tx);
+            self.inner.transactions.write().remove(&tx);
+            self.inner.versioned_hashes_to_txhash.write().retain(|_, txs| {
+                txs.remove(&tx);
+                !txs.is_empty()
+            });
+            if let Some(size) = size {
+                self.inner.size_tracker.sub_size(size);
+                self.inner.size_tracker.sub_len(1);
+            }
+            result.delete_succeed += 1;
         }
-        self.inner.size_tracker.sub_size(subsize as usize);
-        self.inner.size_tracker.sub_len(stat.delete_succeed);
-        stat
+        result
+    }
+
+    fn get_pooled_sidecar(
+        &self,
+        tx: B256,
+    ) -> Result<Option<Arc<PooledBlobSidecar>>, BlobStoreError> {
+        let _lock = self.inner.file_lock.read();
+        if let Some((expires, sidecar)) = self.inner.pinned.lock().get(&tx) &&
+            *expires > std::time::Instant::now()
+        {
+            return Ok(Some(sidecar.clone()))
+        }
+        if let Some(sidecar) = self.inner.blob_cache.lock().get(&tx).cloned() {
+            return Ok(Some(sidecar))
+        }
+        let path = self.inner.blob_disk_file(tx);
+        let encoded = match reth_fs_util::read(&path) {
+            Ok(data) => data,
+            Err(reth_fs_util::FsPathError::Read { source, .. })
+                if source.kind() == io::ErrorKind::NotFound =>
+            {
+                return Ok(None)
+            }
+            Err(err) => return Err(BlobStoreError::Other(Box::new(err))),
+        };
+        let sidecar = Arc::new(PooledBlobSidecar::decode_stored(&encoded)?);
+        self.inner.blob_cache.lock().insert(tx, sidecar.clone());
+        Ok(Some(sidecar))
     }
 
     fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
-        self.inner.get_one(tx)
+        self.get_pooled_sidecar(tx)?.map(|s| s.full_sidecar()).transpose().map(Option::flatten)
     }
 
     fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
-        self.inner.contains(tx)
+        let _lock = self.inner.file_lock.read();
+        Ok(self.inner.blob_disk_file(tx).is_file())
     }
 
     fn get_all(
         &self,
         txs: Vec<B256>,
     ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
-        if txs.is_empty() {
-            return Ok(Vec::new())
+        let mut result = Vec::new();
+        for tx in txs {
+            if let Some(sidecar) = self.get(tx)? {
+                result.push((tx, sidecar));
+            }
         }
-        self.inner.get_all(txs)
+        Ok(result)
     }
 
     fn get_exact(
         &self,
         txs: Vec<B256>,
     ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
-        if txs.is_empty() {
-            return Ok(Vec::new())
-        }
-        self.inner.get_exact(txs)
+        txs.into_iter().map(|tx| self.get(tx)?.ok_or(BlobStoreError::MissingSidecar(tx))).collect()
     }
 
     fn get_by_versioned_hashes_v1(
         &self,
-        versioned_hashes: &[B256],
+        hashes: &[B256],
     ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
-        // the response must always be the same len as the request, misses must be None
-        let mut result = vec![None; versioned_hashes.len()];
-
-        // first scan all cached full sidecars
-        for (_tx_hash, blob_sidecar) in self.inner.blob_cache.lock().iter() {
-            if let Some(blob_sidecar) = blob_sidecar.as_eip4844() {
-                for (hash_idx, match_result) in
-                    blob_sidecar.match_versioned_hashes(versioned_hashes)
-                {
-                    result[hash_idx] = Some(match_result);
-                }
-            }
-
-            // return early if all blobs are found.
-            if result.iter().all(|blob| blob.is_some()) {
-                return Ok(result);
-            }
-        }
-
-        // not all versioned hashes were be found, try to look up a matching tx
-
-        let mut missing_tx_hashes = Vec::new();
-        let mut seen_missing_tx_hashes = B256Set::default();
-
-        {
-            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
-            for (idx, _) in
-                result.iter().enumerate().filter(|(_, blob_and_proof)| blob_and_proof.is_none())
-            {
-                // this is safe because the result vec has the same len
-                let versioned_hash = versioned_hashes[idx];
-                if let Some(tx_hash) = versioned_to_txhashes.get(&versioned_hash).copied() &&
-                    seen_missing_tx_hashes.insert(tx_hash)
-                {
-                    missing_tx_hashes.push(tx_hash);
+        let mut result = vec![None; hashes.len()];
+        for stored in self.candidates(hashes)? {
+            if let Some(sidecar) = stored.sidecar().as_eip4844() {
+                for (index, value) in sidecar.match_versioned_hashes(hashes) {
+                    result[index] = Some(value);
                 }
             }
         }
-
-        // if we have missing blobs, try to read them from disk and try again
-        if !missing_tx_hashes.is_empty() {
-            let blobs_from_disk = self.inner.read_many_decoded(missing_tx_hashes);
-            for (_, blob_sidecar) in blobs_from_disk {
-                if let Some(blob_sidecar) = blob_sidecar.as_eip4844() {
-                    for (hash_idx, match_result) in
-                        blob_sidecar.match_versioned_hashes(versioned_hashes)
-                    {
-                        if result[hash_idx].is_none() {
-                            result[hash_idx] = Some(match_result);
-                        }
-                    }
-                }
-            }
-        }
-
         Ok(result)
     }
 
     fn get_by_versioned_hashes_v2(
         &self,
-        versioned_hashes: &[B256],
+        hashes: &[B256],
     ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
-        let result = self.get_by_versioned_hashes_eip7594(versioned_hashes)?;
-
-        // only return the blobs if we found all requested versioned hashes
-        if result.iter().all(|blob| blob.is_some()) {
-            Ok(Some(result.into_iter().map(Option::unwrap).collect()))
-        } else {
-            Ok(None)
-        }
+        Ok(self.get_by_versioned_hashes_v3(hashes)?.into_iter().collect())
     }
 
     fn get_by_versioned_hashes_v3(
         &self,
-        versioned_hashes: &[B256],
+        hashes: &[B256],
     ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
-        self.get_by_versioned_hashes_eip7594(versioned_hashes)
+        let mut result = vec![None; hashes.len()];
+        for stored in self.candidates(hashes)? {
+            if let Some(full) = stored.full_sidecar()? &&
+                let Some(sidecar) = full.as_eip7594()
+            {
+                for (index, value) in sidecar.match_versioned_hashes(hashes) {
+                    result[index] = Some(value);
+                }
+            }
+        }
+        Ok(result)
     }
 
     fn get_by_versioned_hashes_v4(
         &self,
-        versioned_hashes: &[B256],
-        cell_mask: BlobCellMask,
+        hashes: &[B256],
+        mask: BlobCellMask,
     ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, cell_mask)
-    }
-
-    fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
-        let mut result = vec![false; versioned_hashes.len()];
-        for (_tx_hash, blob_sidecar) in self.inner.blob_cache.lock().iter() {
-            for available_hash in blob_sidecar.versioned_hashes() {
-                for (idx, requested_hash) in versioned_hashes.iter().enumerate() {
-                    if !result[idx] && *requested_hash == available_hash {
-                        result[idx] = true;
-                    }
-                }
-            }
-
-            if result.iter().all(|available| *available) {
-                return Ok(result)
+        let mut result = vec![None; hashes.len()];
+        for stored in self.candidates(hashes)? {
+            for (index, value) in stored.matching_cells(hashes, mask)? {
+                super::merge_cell_response(&mut result[index], value);
             }
         }
-
-        let mut missing_tx_hashes = Vec::new();
-        {
-            let mut versioned_to_txhashes = self.inner.versioned_hashes_to_txhash.lock();
-            for (idx, requested_hash) in versioned_hashes.iter().enumerate() {
-                if !result[idx] &&
-                    let Some(tx_hash) = versioned_to_txhashes.get(requested_hash).copied()
-                {
-                    missing_tx_hashes.push((idx, tx_hash));
-                }
-            }
-        }
-
-        for (idx, tx_hash) in missing_tx_hashes {
-            if self.inner.contains(tx_hash)? {
-                result[idx] = true;
-            }
-        }
-
         Ok(result)
     }
 
-    fn get_cells(
-        &self,
-        tx: B256,
-        cell_mask: BlobCellMask,
-    ) -> Result<Option<Vec<Cell>>, BlobStoreError> {
-        let Some(sidecar) = self.get(tx)? else {
-            return Ok(None);
-        };
+    fn has_versioned_hashes(&self, hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
+        let index = self.inner.versioned_hashes_to_txhash.read();
+        Ok(hashes.iter().map(|h| index.get(h).is_some_and(|txs| !txs.is_empty())).collect())
+    }
 
-        let Some(sidecar) = sidecar.as_eip7594() else {
-            return Ok(None);
-        };
-
-        sidecar
-            .compute_matching_cells(cell_mask)
-            .map(Some)
-            .map_err(|err| BlobStoreError::Other(Box::new(err)))
+    fn get_cells(&self, tx: B256, mask: BlobCellMask) -> Result<Option<Vec<Cell>>, BlobStoreError> {
+        self.get_pooled_sidecar(tx)?.map(|s| s.get_cells(mask)).transpose().map(Option::flatten)
     }
 
     fn data_size_hint(&self) -> Option<usize> {
         Some(self.inner.size_tracker.data_size())
     }
-
     fn blobs_len(&self) -> usize {
         self.inner.size_tracker.blobs_len()
     }
 }
 
+#[derive(Debug)]
 struct DiskFileBlobStoreInner {
+    cell_mode: std::sync::atomic::AtomicBool,
     blob_dir: PathBuf,
-    blob_cache: Mutex<LruMap<TxHash, Arc<BlobTransactionSidecarVariant>, ByLength>>,
+    blob_cache: Mutex<LruMap<TxHash, Arc<PooledBlobSidecar>, SidecarCacheLimit>>,
     size_tracker: BlobStoreSize,
     file_lock: RwLock<()>,
     txs_to_delete: RwLock<B256Set>,
-    /// Tracks of known versioned hashes and a transaction they exist in
-    ///
-    /// Note: It is possible that one blob can appear in multiple transactions but this only tracks
-    /// the most recent one.
-    versioned_hashes_to_txhash: Mutex<LruMap<B256, B256>>,
+    versioned_hashes_to_txhash: RwLock<B256Map<B256Set>>,
+    transactions: RwLock<B256Map<alloy_primitives::Bytes>>,
+    pinned: Mutex<B256Map<(std::time::Instant, Arc<PooledBlobSidecar>)>>,
 }
 
 impl DiskFileBlobStoreInner {
-    /// Creates a new empty disk file blob store with the given maximum length of the blob cache.
-    fn new(blob_dir: PathBuf, max_length: u32) -> Self {
-        Self {
-            blob_dir,
-            blob_cache: Mutex::new(LruMap::new(ByLength::new(max_length))),
-            size_tracker: Default::default(),
-            file_lock: Default::default(),
-            txs_to_delete: Default::default(),
-            versioned_hashes_to_txhash: Mutex::new(LruMap::new(ByLength::new(
-                VERSIONED_HASH_TO_TX_HASH_CACHE_SIZE as u32,
-            ))),
-        }
-    }
-
-    /// Creates the directory where blobs will be stored on disk.
-    fn create_blob_dir(&self) -> Result<(), DiskFileBlobStoreError> {
-        debug!(target:"txpool::blob", blob_dir = ?self.blob_dir, "Creating blob store");
-        fs::create_dir_all(&self.blob_dir)
-            .map_err(|e| DiskFileBlobStoreError::Open(self.blob_dir.clone(), e))
-    }
-
-    /// Deletes the entire blob store.
-    fn delete_all(&self) -> Result<(), DiskFileBlobStoreError> {
-        match fs::remove_dir_all(&self.blob_dir) {
-            Ok(_) => {
-                debug!(target:"txpool::blob", blob_dir = ?self.blob_dir, "Removed blob store directory");
-            }
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-            Err(err) => return Err(DiskFileBlobStoreError::Open(self.blob_dir.clone(), err)),
-        }
-        Ok(())
-    }
-
-    /// Ensures blob is in the blob cache and written to the disk.
-    fn insert_one(
-        &self,
-        tx: B256,
-        data: BlobTransactionSidecarVariant,
-    ) -> Result<(), BlobStoreError> {
-        let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
-        data.rlp_encode_fields(&mut buf);
-
-        {
-            // cache the versioned hashes to tx hash
-            let mut map = self.versioned_hashes_to_txhash.lock();
-            data.versioned_hashes().for_each(|hash| {
-                map.insert(hash, tx);
-            });
-        }
-
-        self.blob_cache.lock().insert(tx, Arc::new(data));
-
-        let size = self.write_one_encoded(tx, &buf)?;
-
-        self.size_tracker.add_size(size);
-        self.size_tracker.inc_len(1);
-        Ok(())
-    }
-
-    /// Ensures blobs are in the blob cache and written to the disk.
-    fn insert_many(
-        &self,
-        txs: Vec<(B256, BlobTransactionSidecarVariant)>,
-    ) -> Result<(), BlobStoreError> {
-        let raw = txs
-            .iter()
-            .map(|(tx, data)| {
-                let mut buf = Vec::with_capacity(data.rlp_encoded_fields_length());
-                data.rlp_encode_fields(&mut buf);
-                (self.blob_disk_file(*tx), buf)
-            })
-            .collect::<Vec<_>>();
-
-        {
-            // cache versioned hashes to tx hash
-            let mut map = self.versioned_hashes_to_txhash.lock();
-            for (tx, data) in &txs {
-                data.versioned_hashes().for_each(|hash| {
-                    map.insert(hash, *tx);
-                });
-            }
-        }
-
-        {
-            // cache blobs
-            let mut cache = self.blob_cache.lock();
-            for (tx, data) in txs {
-                cache.insert(tx, Arc::new(data));
-            }
-        }
-
-        let mut add = 0;
-        let mut num = 0;
-        {
-            let _lock = self.file_lock.write();
-            for (path, data) in raw {
-                if path.exists() {
-                    debug!(target:"txpool::blob", ?path, "Blob already exists");
-                } else if let Err(err) = fs::write(&path, &data) {
-                    debug!(target:"txpool::blob", %err, ?path, "Failed to write blob file");
-                } else {
-                    add += data.len();
-                    num += 1;
-                }
-            }
-        }
-        self.size_tracker.add_size(add);
-        self.size_tracker.inc_len(num);
-
-        Ok(())
-    }
-
-    /// Returns true if the blob for the given transaction hash is in the blob cache or on disk.
-    fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
-        if self.blob_cache.lock().get(&tx).is_some() {
-            return Ok(true)
-        }
-        // we only check if the file exists and assume it's valid
-        Ok(self.blob_disk_file(tx).is_file())
-    }
-
-    /// Returns all the blob transactions which are in the cache or on the disk.
-    fn retain_existing(&self, txs: Vec<B256>) -> Result<Vec<B256>, BlobStoreError> {
-        let (in_cache, not_in_cache): (Vec<B256>, Vec<B256>) = {
-            let mut cache = self.blob_cache.lock();
-            txs.into_iter().partition(|tx| cache.get(tx).is_some())
-        };
-
-        let mut existing = in_cache;
-        for tx in not_in_cache {
-            if self.blob_disk_file(tx).is_file() {
-                existing.push(tx);
-            }
-        }
-
-        Ok(existing)
-    }
-
-    /// Retrieves the blob for the given transaction hash from the blob cache or disk.
-    fn get_one(
-        &self,
-        tx: B256,
-    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
-        if let Some(blob) = self.blob_cache.lock().get(&tx) {
-            return Ok(Some(blob.clone()))
-        }
-
-        if let Some(blob) = self.read_one(tx)? {
-            let blob_arc = Arc::new(blob);
-            self.blob_cache.lock().insert(tx, blob_arc.clone());
-            return Ok(Some(blob_arc))
-        }
-
-        Ok(None)
-    }
-
-    /// Returns the path to the blob file for the given transaction hash.
-    #[inline]
     fn blob_disk_file(&self, tx: B256) -> PathBuf {
         self.blob_dir.join(format!("{tx:x}"))
     }
-
-    /// Retrieves the blob data for the given transaction hash.
-    #[inline]
-    fn read_one(&self, tx: B256) -> Result<Option<BlobTransactionSidecarVariant>, BlobStoreError> {
-        let path = self.blob_disk_file(tx);
-        let data = {
-            let _lock = self.file_lock.read();
-            match fs::read(&path) {
-                Ok(data) => data,
-                Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
-                Err(e) => {
-                    return Err(BlobStoreError::Other(Box::new(DiskFileBlobStoreError::ReadFile(
-                        tx, path, e,
-                    ))))
-                }
-            }
-        };
-        BlobTransactionSidecarVariant::rlp_decode_fields(&mut data.as_slice())
-            .map(Some)
-            .map_err(BlobStoreError::DecodeError)
-    }
-
-    /// Returns decoded blobs read from disk.
-    ///
-    /// Only returns sidecars that were found and successfully decoded.
-    fn read_many_decoded(&self, txs: Vec<TxHash>) -> Vec<(TxHash, BlobTransactionSidecarVariant)> {
-        self.read_many_raw(txs)
-            .into_iter()
-            .filter_map(|(tx, data)| {
-                BlobTransactionSidecarVariant::rlp_decode_fields(&mut data.as_slice())
-                    .map(|sidecar| (tx, sidecar))
-                    .ok()
-            })
-            .collect()
-    }
-
-    /// Retrieves the raw blob data for the given transaction hashes.
-    ///
-    /// Only returns the blobs that were found in file.
-    #[inline]
-    fn read_many_raw(&self, txs: Vec<TxHash>) -> Vec<(TxHash, Vec<u8>)> {
-        let mut res = Vec::with_capacity(txs.len());
-        let _lock = self.file_lock.read();
-        for tx in txs {
-            let path = self.blob_disk_file(tx);
-            match fs::read(&path) {
-                Ok(data) => {
-                    res.push((tx, data));
-                }
-                Err(err) => {
-                    debug!(target:"txpool::blob", %err, ?tx, "Failed to read blob file");
-                }
-            };
+    fn index(&self, tx: B256, sidecar: &PooledBlobSidecar) {
+        if let Some(body) = sidecar.transaction() {
+            self.transactions.write().insert(tx, body.clone());
         }
-        res
-    }
-
-    /// Writes the blob data for the given transaction hash to the disk.
-    #[inline]
-    fn write_one_encoded(&self, tx: B256, data: &[u8]) -> Result<usize, DiskFileBlobStoreError> {
-        trace!(target:"txpool::blob", "[{:?}] writing blob file", tx);
-        let mut add = 0;
-        let path = self.blob_disk_file(tx);
-        {
-            let _lock = self.file_lock.write();
-            if !path.exists() {
-                fs::write(&path, data)
-                    .map_err(|e| DiskFileBlobStoreError::WriteFile(tx, path, e))?;
-                add = data.len();
-            }
+        let mut index = self.versioned_hashes_to_txhash.write();
+        for hash in sidecar.versioned_hashes() {
+            index.entry(hash).or_default().insert(tx);
         }
-        Ok(add)
-    }
-
-    /// Retrieves blobs for the given transaction hashes from the blob cache or disk.
-    ///
-    /// This will not return an error if there are missing blobs. Therefore, the result may be a
-    /// subset of the request or an empty vector if none of the blobs were found.
-    #[inline]
-    fn get_all(
-        &self,
-        txs: Vec<B256>,
-    ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
-        let mut res = Vec::with_capacity(txs.len());
-        let mut cache_miss = Vec::new();
-        {
-            let mut cache = self.blob_cache.lock();
-            for tx in txs {
-                if let Some(blob) = cache.get(&tx) {
-                    res.push((tx, blob.clone()));
-                } else {
-                    cache_miss.push(tx)
-                }
-            }
-        }
-        if cache_miss.is_empty() {
-            return Ok(res)
-        }
-        let from_disk = self.read_many_decoded(cache_miss);
-        if from_disk.is_empty() {
-            return Ok(res)
-        }
-        let from_disk = from_disk
-            .into_iter()
-            .map(|(tx, data)| {
-                let data = Arc::new(data);
-                res.push((tx, data.clone()));
-                (tx, data)
-            })
-            .collect::<Vec<_>>();
-
-        let mut cache = self.blob_cache.lock();
-        for (tx, data) in from_disk {
-            cache.insert(tx, data);
-        }
-
-        Ok(res)
-    }
-
-    /// Retrieves blobs for the given transaction hashes from the blob cache or disk.
-    ///
-    /// Returns an error if there are any missing blobs.
-    #[inline]
-    fn get_exact(
-        &self,
-        txs: Vec<B256>,
-    ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
-        txs.into_iter()
-            .map(|tx| self.get_one(tx)?.ok_or(BlobStoreError::MissingSidecar(tx)))
-            .collect()
-    }
-}
-
-impl fmt::Debug for DiskFileBlobStoreInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DiskFileBlobStoreInner")
-            .field("blob_dir", &self.blob_dir)
-            .field("cached_blobs", &self.blob_cache.try_lock().map(|lock| lock.len()))
-            .field("txs_to_delete", &self.txs_to_delete.try_read())
-            .finish()
     }
 }
 
@@ -947,14 +592,7 @@ mod tests {
         store.cleanup();
 
         let result = store.get(tx).unwrap();
-        assert_eq!(
-            result,
-            Some(Arc::new(BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar {
-                blobs: vec![],
-                commitments: vec![],
-                proofs: vec![]
-            })))
-        );
+        assert_eq!(result, None);
     }
 
     #[test]
@@ -974,14 +612,7 @@ mod tests {
 
         for tx in txs {
             let result = store.get(tx).unwrap();
-            assert_eq!(
-                result,
-                Some(Arc::new(BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar {
-                    blobs: vec![],
-                    commitments: vec![],
-                    proofs: vec![]
-                })))
-            );
+            assert_eq!(result, None);
         }
     }
 
@@ -1089,10 +720,10 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(TxHash::random(), sidecar.into()).unwrap();
 
-        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
+        let indices_bitarray = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let request = vec![versioned_hash, B256::ZERO];
 
-        let v4 = store.get_by_versioned_hashes_v4(&request, cell_mask).unwrap();
+        let v4 = store.get_by_versioned_hashes_v4(&request, indices_bitarray).unwrap();
         assert_eq!(v4.len(), request.len());
         assert!(v4[1].is_none());
 
@@ -1165,9 +796,9 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(tx_hash, sidecar.into()).unwrap();
 
-        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
+        let indices_bitarray = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let expected = store
-            .get_by_versioned_hashes_v4(&[versioned_hash], cell_mask)
+            .get_by_versioned_hashes_v4(&[versioned_hash], indices_bitarray)
             .unwrap()
             .pop()
             .unwrap()
@@ -1179,7 +810,7 @@ mod tests {
 
         store.clear_cache();
 
-        assert_eq!(store.get_cells(tx_hash, cell_mask).unwrap(), Some(expected));
+        assert_eq!(store.get_cells(tx_hash, indices_bitarray).unwrap(), Some(expected));
     }
 
     #[test]
@@ -1206,5 +837,65 @@ mod tests {
         let stat2 = store.cleanup();
         assert_eq!(stat2.delete_succeed, 5);
         assert_eq!(stat2.delete_failed, 0);
+    }
+}
+
+/// Charges the worst-case reconstructed representation up front, including heap allocations.
+#[derive(Debug)]
+struct SidecarCacheLimit {
+    max_entries: u32,
+    bytes: usize,
+}
+impl SidecarCacheLimit {
+    const MAX_BYTES: usize = 16 * 1024 * 1024;
+    fn cost(sidecar: &PooledBlobSidecar) -> usize {
+        let blobs = sidecar.versioned_hashes().count();
+        sidecar.size() +
+            sidecar.sidecar().size() +
+            blobs * (alloy_eips::eip4844::BYTES_PER_BLOB + 129 * 48)
+    }
+}
+impl Limiter<TxHash, Arc<PooledBlobSidecar>> for SidecarCacheLimit {
+    type KeyToInsert<'a> = TxHash;
+    type LinkType = u32;
+    fn is_over_the_limit(&self, length: usize) -> bool {
+        length > self.max_entries as usize || self.bytes > Self::MAX_BYTES
+    }
+    fn on_insert(
+        &mut self,
+        _: usize,
+        key: TxHash,
+        value: Arc<PooledBlobSidecar>,
+    ) -> Option<(TxHash, Arc<PooledBlobSidecar>)> {
+        let bytes = Self::cost(&value);
+        if self.max_entries == 0 || bytes > Self::MAX_BYTES {
+            return None
+        }
+        self.bytes += bytes;
+        Some((key, value))
+    }
+    fn on_replace(
+        &mut self,
+        _: usize,
+        _: &mut TxHash,
+        _: TxHash,
+        old: &mut Arc<PooledBlobSidecar>,
+        new: &mut Arc<PooledBlobSidecar>,
+    ) -> bool {
+        let bytes = Self::cost(new);
+        if bytes > Self::MAX_BYTES {
+            return false
+        }
+        self.bytes = self.bytes - Self::cost(old) + bytes;
+        true
+    }
+    fn on_removed(&mut self, _: &mut TxHash, value: &mut Arc<PooledBlobSidecar>) {
+        self.bytes -= Self::cost(value);
+    }
+    fn on_cleared(&mut self) {
+        self.bytes = 0;
+    }
+    fn on_grow(&mut self, _: usize) -> bool {
+        true
     }
 }

--- a/crates/transaction-pool/src/blobstore/mem.rs
+++ b/crates/transaction-pool/src/blobstore/mem.rs
@@ -9,133 +9,71 @@ use alloy_primitives::{map::B256Map, B256};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
-/// An in-memory blob store.
+/// An in-memory blob store retaining full legacy sidecars or sparse EIP-7594 cells.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct InMemoryBlobStore {
     inner: Arc<InMemoryBlobStoreInner>,
 }
 
 impl InMemoryBlobStore {
-    /// Look up EIP-7594 blobs by their versioned hashes.
-    ///
-    /// This returns a result vector with the **same length and order** as the input
-    /// `versioned_hashes`. Each element is `Some(BlobAndProofV2)` if the blob is available, or
-    /// `None` if it is missing or an older sidecar version.
-    fn get_by_versioned_hashes_eip7594(
-        &self,
-        versioned_hashes: &[B256],
-    ) -> Vec<Option<BlobAndProofV2>> {
-        let mut result = vec![None; versioned_hashes.len()];
-        let mut missing_count = result.len();
-        for blob_sidecar in self.inner.store.read().values() {
-            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
-                for (hash_idx, match_result) in
-                    blob_sidecar.match_versioned_hashes(versioned_hashes)
-                {
-                    let slot = &mut result[hash_idx];
-                    if slot.is_none() {
-                        missing_count -= 1;
-                    }
-                    *slot = Some(match_result);
-                }
-            }
-
-            // Return early if all blobs are found.
-            if missing_count == 0 {
-                // since versioned_hashes may have duplicates, we double check here
-                if result.iter().all(|blob| blob.is_some()) {
-                    break;
-                }
-            }
-        }
-        result
-    }
-
-    /// Look up EIP-7594 blob cells by their versioned hashes.
-    fn get_by_versioned_hashes_cells_eip7594(
-        &self,
-        versioned_hashes: &[B256],
-        cell_mask: BlobCellMask,
-    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        let mut result = vec![None; versioned_hashes.len()];
-        let mut missing_count = result.len();
-        let blob_sidecars = self.inner.store.read().values().cloned().collect::<Vec<_>>();
-        for blob_sidecar in blob_sidecars {
-            if let Some(blob_sidecar) = blob_sidecar.as_eip7594() {
-                for (hash_idx, match_result) in blob_sidecar
-                    .match_versioned_hashes_cells(versioned_hashes, cell_mask)
-                    .map_err(|err| BlobStoreError::Other(Box::new(err)))?
-                {
-                    let slot = &mut result[hash_idx];
-                    if slot.is_none() {
-                        missing_count -= 1;
-                    }
-                    *slot = Some(match_result);
-                }
-            }
-
-            if missing_count == 0 && result.iter().all(Option::is_some) {
-                break;
-            }
-        }
-        Ok(result)
+    fn sidecars(&self) -> Vec<Arc<PooledBlobSidecar>> {
+        self.inner.store.read().values().cloned().collect()
     }
 }
 
 #[derive(Debug, Default)]
 struct InMemoryBlobStoreInner {
-    /// Storage for all blob data.
-    store: RwLock<B256Map<Arc<BlobTransactionSidecarVariant>>>,
+    store: RwLock<B256Map<Arc<PooledBlobSidecar>>>,
     size_tracker: BlobStoreSize,
 }
 
 impl PartialEq for InMemoryBlobStoreInner {
     fn eq(&self, other: &Self) -> bool {
-        self.store.read().eq(&*other.store.read())
+        self.store.read().eq(&*other.store.read()) && self.size_tracker == other.size_tracker
     }
 }
 
 impl BlobStore for InMemoryBlobStore {
+    fn transaction_hashes(&self) -> Vec<B256> {
+        self.inner.store.read().keys().copied().collect()
+    }
+    fn transactions(&self) -> Vec<(B256, alloy_primitives::Bytes)> {
+        self.inner
+            .store
+            .read()
+            .iter()
+            .filter_map(|(hash, sidecar)| sidecar.transaction().map(|body| (*hash, body.clone())))
+            .collect()
+    }
+
     fn insert(&self, tx: B256, data: PooledBlobSidecar) -> Result<(), BlobStoreError> {
-        let mut store = self.inner.store.write();
-        self.inner.size_tracker.add_size(insert_size(&mut store, tx, data.into_sidecar()));
-        self.inner.size_tracker.update_len(store.len());
-        Ok(())
+        self.insert_all(vec![(tx, data)])
     }
 
     fn insert_all(&self, txs: Vec<(B256, PooledBlobSidecar)>) -> Result<(), BlobStoreError> {
-        if txs.is_empty() {
-            return Ok(())
-        }
         let mut store = self.inner.store.write();
-        let mut total_add = 0;
         for (tx, data) in txs {
-            let add = insert_size(&mut store, tx, data.into_sidecar());
-            total_add += add;
+            let size = data.size();
+            if let Some(previous) = store.insert(tx, Arc::new(data)) {
+                self.inner.size_tracker.sub_size(previous.size());
+            }
+            self.inner.size_tracker.add_size(size);
         }
-        self.inner.size_tracker.add_size(total_add);
         self.inner.size_tracker.update_len(store.len());
         Ok(())
     }
 
     fn delete(&self, tx: B256) -> Result<(), BlobStoreError> {
-        let mut store = self.inner.store.write();
-        let sub = remove_size(&mut store, &tx);
-        self.inner.size_tracker.sub_size(sub);
-        self.inner.size_tracker.update_len(store.len());
-        Ok(())
+        self.delete_all(vec![tx])
     }
 
     fn delete_all(&self, txs: Vec<B256>) -> Result<(), BlobStoreError> {
-        if txs.is_empty() {
-            return Ok(())
-        }
         let mut store = self.inner.store.write();
-        let mut total_sub = 0;
         for tx in txs {
-            total_sub += remove_size(&mut store, &tx);
+            if let Some(sidecar) = store.remove(&tx) {
+                self.inner.size_tracker.sub_size(sidecar.size());
+            }
         }
-        self.inner.size_tracker.sub_size(total_sub);
         self.inner.size_tracker.update_len(store.len());
         Ok(())
     }
@@ -144,9 +82,15 @@ impl BlobStore for InMemoryBlobStore {
         BlobStoreCleanupStat::default()
     }
 
-    // Retrieves the decoded blob data for the given transaction hash.
-    fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+    fn get_pooled_sidecar(
+        &self,
+        tx: B256,
+    ) -> Result<Option<Arc<PooledBlobSidecar>>, BlobStoreError> {
         Ok(self.inner.store.read().get(&tx).cloned())
+    }
+
+    fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        self.get_pooled_sidecar(tx)?.map(|s| s.full_sidecar()).transpose().map(Option::flatten)
     }
 
     fn contains(&self, tx: B256) -> Result<bool, BlobStoreError> {
@@ -157,40 +101,32 @@ impl BlobStore for InMemoryBlobStore {
         &self,
         txs: Vec<B256>,
     ) -> Result<Vec<(B256, Arc<BlobTransactionSidecarVariant>)>, BlobStoreError> {
-        let store = self.inner.store.read();
-        Ok(txs.into_iter().filter_map(|tx| store.get(&tx).map(|item| (tx, item.clone()))).collect())
+        let mut result = Vec::new();
+        for tx in txs {
+            if let Some(sidecar) = self.get(tx)? {
+                result.push((tx, sidecar));
+            }
+        }
+        Ok(result)
     }
 
     fn get_exact(
         &self,
         txs: Vec<B256>,
     ) -> Result<Vec<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
-        if txs.is_empty() {
-            return Ok(Vec::new());
-        }
-        let store = self.inner.store.read();
-        txs.into_iter()
-            .map(|tx| store.get(&tx).cloned().ok_or(BlobStoreError::MissingSidecar(tx)))
-            .collect()
+        txs.into_iter().map(|tx| self.get(tx)?.ok_or(BlobStoreError::MissingSidecar(tx))).collect()
     }
 
     fn get_by_versioned_hashes_v1(
         &self,
-        versioned_hashes: &[B256],
+        hashes: &[B256],
     ) -> Result<Vec<Option<BlobAndProofV1>>, BlobStoreError> {
-        let mut result = vec![None; versioned_hashes.len()];
-        for blob_sidecar in self.inner.store.read().values() {
-            if let Some(blob_sidecar) = blob_sidecar.as_eip4844() {
-                for (hash_idx, match_result) in
-                    blob_sidecar.match_versioned_hashes(versioned_hashes)
-                {
-                    result[hash_idx] = Some(match_result);
+        let mut result = vec![None; hashes.len()];
+        for stored in self.sidecars() {
+            if let Some(sidecar) = stored.sidecar().as_eip4844() {
+                for (index, value) in sidecar.match_versioned_hashes(hashes) {
+                    result[index] = Some(value);
                 }
-            }
-
-            // Return early if all blobs are found.
-            if result.iter().all(|blob| blob.is_some()) {
-                break;
             }
         }
         Ok(result)
@@ -198,95 +134,63 @@ impl BlobStore for InMemoryBlobStore {
 
     fn get_by_versioned_hashes_v2(
         &self,
-        versioned_hashes: &[B256],
+        hashes: &[B256],
     ) -> Result<Option<Vec<BlobAndProofV2>>, BlobStoreError> {
-        let result = self.get_by_versioned_hashes_eip7594(versioned_hashes);
-        if result.iter().all(|blob| blob.is_some()) {
-            Ok(Some(result.into_iter().map(Option::unwrap).collect()))
-        } else {
-            Ok(None)
-        }
+        Ok(self.get_by_versioned_hashes_v3(hashes)?.into_iter().collect())
     }
 
     fn get_by_versioned_hashes_v3(
         &self,
-        versioned_hashes: &[B256],
+        hashes: &[B256],
     ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError> {
-        Ok(self.get_by_versioned_hashes_eip7594(versioned_hashes))
-    }
-
-    fn get_by_versioned_hashes_v4(
-        &self,
-        versioned_hashes: &[B256],
-        cell_mask: BlobCellMask,
-    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
-        self.get_by_versioned_hashes_cells_eip7594(versioned_hashes, cell_mask)
-    }
-
-    fn has_versioned_hashes(&self, versioned_hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
-        let mut result = vec![false; versioned_hashes.len()];
-        for blob_sidecar in self.inner.store.read().values() {
-            for available_hash in blob_sidecar.versioned_hashes() {
-                for (idx, requested_hash) in versioned_hashes.iter().enumerate() {
-                    if !result[idx] && *requested_hash == available_hash {
-                        result[idx] = true;
-                    }
-                }
+        let mut result = vec![None; hashes.len()];
+        for stored in self.sidecars() {
+            if !stored.versioned_hashes().any(|h| hashes.contains(&h)) {
+                continue
             }
-
-            if result.iter().all(|available| *available) {
-                break;
+            if let Some(full) = stored.full_sidecar()? &&
+                let Some(sidecar) = full.as_eip7594()
+            {
+                for (index, value) in sidecar.match_versioned_hashes(hashes) {
+                    result[index] = Some(value);
+                }
             }
         }
         Ok(result)
     }
 
-    fn get_cells(
+    fn get_by_versioned_hashes_v4(
         &self,
-        tx: B256,
-        cell_mask: BlobCellMask,
-    ) -> Result<Option<Vec<Cell>>, BlobStoreError> {
-        let Some(sidecar) = self.get(tx)? else {
-            return Ok(None);
-        };
+        hashes: &[B256],
+        mask: BlobCellMask,
+    ) -> Result<Vec<Option<BlobCellsAndProofsV1>>, BlobStoreError> {
+        let mut result = vec![None; hashes.len()];
+        for stored in self.sidecars() {
+            for (index, value) in stored.matching_cells(hashes, mask)? {
+                super::merge_cell_response(&mut result[index], value);
+            }
+        }
+        Ok(result)
+    }
 
-        let Some(sidecar) = sidecar.as_eip7594() else {
-            return Ok(None);
-        };
+    fn has_versioned_hashes(&self, hashes: &[B256]) -> Result<Vec<bool>, BlobStoreError> {
+        let sidecars = self.sidecars();
+        Ok(hashes
+            .iter()
+            .map(|hash| sidecars.iter().any(|s| s.versioned_hashes().any(|h| h == *hash)))
+            .collect())
+    }
 
-        sidecar
-            .compute_matching_cells(cell_mask)
-            .map(Some)
-            .map_err(|err| BlobStoreError::Other(Box::new(err)))
+    fn get_cells(&self, tx: B256, mask: BlobCellMask) -> Result<Option<Vec<Cell>>, BlobStoreError> {
+        self.get_pooled_sidecar(tx)?.map(|s| s.get_cells(mask)).transpose().map(Option::flatten)
     }
 
     fn data_size_hint(&self) -> Option<usize> {
         Some(self.inner.size_tracker.data_size())
     }
-
     fn blobs_len(&self) -> usize {
         self.inner.size_tracker.blobs_len()
     }
-}
-
-/// Removes the given blob from the store and returns the size of the blob that was removed.
-#[inline]
-fn remove_size(store: &mut B256Map<Arc<BlobTransactionSidecarVariant>>, tx: &B256) -> usize {
-    store.remove(tx).map(|rem| rem.size()).unwrap_or_default()
-}
-
-/// Inserts the given blob into the store and returns the size of the blob that was added.
-///
-/// We don't need to handle the size updates for replacements because transactions are unique.
-#[inline]
-fn insert_size(
-    store: &mut B256Map<Arc<BlobTransactionSidecarVariant>>,
-    tx: B256,
-    blob: BlobTransactionSidecarVariant,
-) -> usize {
-    let add = blob.size();
-    store.insert(tx, Arc::new(blob));
-    add
 }
 
 #[cfg(test)]
@@ -365,10 +269,10 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(B256::random(), sidecar.into()).unwrap();
 
-        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
+        let indices_bitarray = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let request = vec![versioned_hash, B256::ZERO];
 
-        let v4 = store.get_by_versioned_hashes_v4(&request, cell_mask).unwrap();
+        let v4 = store.get_by_versioned_hashes_v4(&request, indices_bitarray).unwrap();
         assert_eq!(v4.len(), request.len());
         assert!(v4[1].is_none());
 
@@ -387,9 +291,9 @@ mod tests {
         let (sidecar, versioned_hash, _) = eip7594_single_blob_sidecar();
         store.insert(tx_hash, sidecar.into()).unwrap();
 
-        let cell_mask = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
+        let indices_bitarray = BlobCellMask::from_bits((1u128 << 0) | (1u128 << 7));
         let expected = store
-            .get_by_versioned_hashes_v4(&[versioned_hash], cell_mask)
+            .get_by_versioned_hashes_v4(&[versioned_hash], indices_bitarray)
             .unwrap()
             .pop()
             .unwrap()
@@ -399,6 +303,6 @@ mod tests {
             .collect::<Option<Vec<_>>>()
             .unwrap();
 
-        assert_eq!(store.get_cells(tx_hash, cell_mask).unwrap(), Some(expected));
+        assert_eq!(store.get_cells(tx_hash, indices_bitarray).unwrap(), Some(expected));
     }
 }

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -5,6 +5,8 @@ use alloy_eips::{
     eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell},
 };
 use alloy_primitives::{TxHash, B256};
+use alloy_rlp::{Decodable, Encodable};
+pub use cells::BlobTxCellSidecar;
 pub use converter::BlobSidecarConverter;
 pub use disk::{DiskFileBlobStore, DiskFileBlobStoreConfig, OpenDiskFileBlobStore};
 pub use mem::InMemoryBlobStore;
@@ -19,6 +21,7 @@ use std::{
 };
 pub use tracker::{BlobStoreCanonTracker, BlobStoreUpdates};
 
+mod cells;
 mod converter;
 pub mod disk;
 mod mem;
@@ -35,6 +38,19 @@ pub struct BlobCellAvailability(Arc<[AtomicU64; 2]>);
 impl BlobCellAvailability {
     const LOW_WORD: usize = 0;
     const HIGH_WORD: usize = 1;
+
+    /// Creates availability for the supplied numeric cell mask.
+    pub fn new(mask: BlobCellMask) -> Self {
+        Self(Arc::new([
+            AtomicU64::new(mask.bits() as u64),
+            AtomicU64::new((mask.bits() >> 64) as u64),
+        ]))
+    }
+
+    /// Returns whether the stored cells suffice to reconstruct every blob.
+    pub fn is_recoverable(&self) -> bool {
+        self.get().count() >= 64
+    }
 
     /// Returns full availability for all blob cells.
     pub fn full() -> Self {
@@ -66,19 +82,199 @@ impl PartialEq for BlobCellAvailability {
 impl Eq for BlobCellAvailability {}
 
 /// A blob sidecar paired with its shared cell availability.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct PooledBlobSidecar {
     sidecar: BlobTransactionSidecarVariant,
     availability: BlobCellAvailability,
+    cells: Option<Arc<BlobTxCellSidecar>>,
+    transaction: Option<alloy_primitives::Bytes>,
+    origin: crate::TransactionOrigin,
+    recovered: Arc<parking_lot::Mutex<Option<Arc<BlobTransactionSidecarVariant>>>>,
 }
 
 impl PooledBlobSidecar {
     /// Creates a sidecar with the given shared cell availability.
-    pub const fn new(
-        sidecar: BlobTransactionSidecarVariant,
-        availability: BlobCellAvailability,
-    ) -> Self {
-        Self { sidecar, availability }
+    pub fn new(sidecar: BlobTransactionSidecarVariant, availability: BlobCellAvailability) -> Self {
+        Self {
+            sidecar,
+            availability,
+            cells: None,
+            transaction: None,
+            origin: crate::TransactionOrigin::External,
+            recovered: Arc::new(parking_lot::Mutex::new(None)),
+        }
+    }
+
+    /// Creates a cell-backed sidecar without reconstructing its blob payloads.
+    pub fn from_cells(cells: BlobTxCellSidecar) -> Self {
+        Self {
+            sidecar: cells.elided().into(),
+            availability: BlobCellAvailability::new(cells.mask()),
+            cells: Some(Arc::new(cells)),
+            transaction: None,
+            origin: crate::TransactionOrigin::External,
+            recovered: Arc::new(parking_lot::Mutex::new(None)),
+        }
+    }
+
+    /// Returns the stored cells, when this sidecar uses sparse storage.
+    pub fn cells(&self) -> Option<&BlobTxCellSidecar> {
+        self.cells.as_deref()
+    }
+
+    /// Returns a full sidecar when it is locally recoverable, memoizing reconstruction.
+    pub fn full_sidecar(
+        &self,
+    ) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
+        let mut cached = self.recovered.lock();
+        if let Some(cached) = cached.as_ref() {
+            return Ok(Some(cached.clone()))
+        }
+        let full = if let Some(cells) = &self.cells {
+            if !cells.is_recoverable() {
+                return Ok(None)
+            }
+            cells.recover(alloy_eips::eip4844::env_settings::EnvKzgSettings::Default.get())?.into()
+        } else {
+            self.sidecar.clone()
+        };
+        let full = Arc::new(full);
+        *cached = Some(full.clone());
+        Ok(Some(full))
+    }
+
+    /// Returns an elided v1 wrapper, preserving legacy sidecars unchanged.
+    pub fn elided_sidecar(&self) -> BlobTransactionSidecarVariant {
+        let mut sidecar = self.sidecar.clone();
+        if let BlobTransactionSidecarVariant::Eip7594(v1) = &mut sidecar {
+            v1.blobs.clear();
+        }
+        sidecar
+    }
+
+    /// Returns all requested cells or no result if any requested column is unavailable.
+    pub fn get_cells(&self, mask: BlobCellMask) -> Result<Option<Vec<Cell>>, BlobStoreError> {
+        if let Some(cells) = &self.cells {
+            return Ok(cells.get_cells(mask))
+        }
+        self.sidecar
+            .as_eip7594()
+            .map(|s| s.compute_matching_cells(mask).map_err(|e| BlobStoreError::Other(Box::new(e))))
+            .transpose()
+    }
+
+    /// Returns requested cells by versioned blob hash, retaining individual missing cells.
+    pub fn matching_cells(
+        &self,
+        hashes: &[B256],
+        mask: BlobCellMask,
+    ) -> Result<Vec<(usize, BlobCellsAndProofsV1)>, BlobStoreError> {
+        if let Some(cells) = &self.cells {
+            let mut result = Vec::new();
+            for (blob, hash) in cells.versioned_hashes().enumerate() {
+                for (index, requested) in hashes.iter().enumerate() {
+                    if *requested == hash &&
+                        let Some(value) = cells.blob_cells(blob, mask)
+                    {
+                        result.push((index, value));
+                    }
+                }
+            }
+            return Ok(result)
+        }
+        self.sidecar
+            .as_eip7594()
+            .map(|s| {
+                s.match_versioned_hashes_cells(hashes, mask)
+                    .map(Iterator::collect)
+                    .map_err(|e| BlobStoreError::Other(Box::new(e)))
+            })
+            .transpose()
+            .map(Option::unwrap_or_default)
+    }
+
+    /// Returns the byte size of the stored representation, excluding reconstructed cache data.
+    pub fn size(&self) -> usize {
+        self.cells.as_ref().map_or_else(|| self.sidecar.size(), |c| c.size()) +
+            self.transaction.as_ref().map_or(0, |tx| tx.len())
+    }
+
+    /// Persists the signed transaction body alongside its sidecar for restart recovery.
+    pub fn with_transaction(mut self, transaction: alloy_primitives::Bytes) -> Self {
+        self.transaction = Some(transaction);
+        self
+    }
+
+    /// Records the admission origin, preserving privacy and local treatment across restarts.
+    pub const fn with_origin(mut self, origin: crate::TransactionOrigin) -> Self {
+        self.origin = origin;
+        self
+    }
+
+    /// Returns the original admission source.
+    pub const fn origin(&self) -> crate::TransactionOrigin {
+        self.origin
+    }
+
+    /// Returns the persisted EIP-2718 transaction body.
+    pub const fn transaction(&self) -> Option<&alloy_primitives::Bytes> {
+        self.transaction.as_ref()
+    }
+
+    /// Encodes the disk representation. Tag 2 distinguishes cells from legacy sidecar fields.
+    pub(crate) fn encode_stored(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        if let Some(transaction) = &self.transaction {
+            out.push(3);
+            transaction.encode(&mut out);
+            let origin: u8 = match self.origin {
+                crate::TransactionOrigin::External => 0,
+                crate::TransactionOrigin::Local => 1,
+                crate::TransactionOrigin::Private => 2,
+            };
+            origin.encode(&mut out);
+        }
+        if let Some(cells) = &self.cells {
+            out.push(2);
+            cells.encode(&mut out);
+        } else {
+            self.sidecar.rlp_encode_fields(&mut out);
+        }
+        out
+    }
+
+    /// Decodes cell storage or the legacy full-sidecar disk representation.
+    pub(crate) fn decode_stored(mut input: &[u8]) -> alloy_rlp::Result<Self> {
+        let mut origin = crate::TransactionOrigin::External;
+        let transaction = if input.first() == Some(&3) {
+            input = &input[1..];
+            let body = alloy_primitives::Bytes::decode(&mut input)?;
+            origin = match u8::decode(&mut input)? {
+                0 => crate::TransactionOrigin::External,
+                1 => crate::TransactionOrigin::Local,
+                2 => crate::TransactionOrigin::Private,
+                _ => return Err(alloy_rlp::Error::Custom("invalid stored transaction origin")),
+            };
+            Some(body)
+        } else {
+            None
+        };
+        let mut sidecar = if input.first() == Some(&2) {
+            input = &input[1..];
+            let cells = BlobTxCellSidecar::decode(&mut input)?;
+            if !cells.has_valid_shape() {
+                return Err(alloy_rlp::Error::Custom("invalid stored blob cells"))
+            }
+            Self::from_cells(cells)
+        } else {
+            BlobTransactionSidecarVariant::rlp_decode_fields(&mut input)?.into()
+        };
+        if !input.is_empty() {
+            return Err(alloy_rlp::Error::Custom("trailing stored blob data"))
+        }
+        sidecar.transaction = transaction;
+        sidecar.origin = origin;
+        Ok(sidecar)
     }
 
     /// Returns the wrapped sidecar.
@@ -102,6 +298,18 @@ impl PooledBlobSidecar {
     }
 }
 
+impl PartialEq for PooledBlobSidecar {
+    fn eq(&self, other: &Self) -> bool {
+        self.sidecar == other.sidecar &&
+            self.cells == other.cells &&
+            self.availability == other.availability &&
+            self.transaction == other.transaction &&
+            self.origin == other.origin
+    }
+}
+
+impl Eq for PooledBlobSidecar {}
+
 impl Deref for PooledBlobSidecar {
     type Target = BlobTransactionSidecarVariant;
 
@@ -112,8 +320,23 @@ impl Deref for PooledBlobSidecar {
 
 impl From<BlobTransactionSidecarVariant> for PooledBlobSidecar {
     fn from(sidecar: BlobTransactionSidecarVariant) -> Self {
-        // TODO: Initialize this with the actual mask once sparse sidecars are supported.
         Self::new(sidecar, BlobCellAvailability::full())
+    }
+}
+
+/// Merges independently retained copies of a blob without overwriting available columns with nulls.
+fn merge_cell_response(target: &mut Option<BlobCellsAndProofsV1>, incoming: BlobCellsAndProofsV1) {
+    if let Some(current) = target {
+        for (index, (cell, proof)) in
+            incoming.blob_cells.into_iter().zip(incoming.proofs).enumerate()
+        {
+            if current.blob_cells[index].is_none() {
+                current.blob_cells[index] = cell;
+                current.proofs[index] = proof;
+            }
+        }
+    } else {
+        *target = Some(incoming);
     }
 }
 
@@ -124,6 +347,31 @@ impl From<BlobTransactionSidecarVariant> for PooledBlobSidecar {
 ///
 /// Note: this is Clone because it is expected to be wrapped in an Arc.
 pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
+    /// Prefer warming cells once the consensus client supports `engine_getBlobsV4`.
+    fn set_cell_mode(&self) {}
+
+    /// Preloads likely block-building candidates without fetching any missing network data.
+    fn warm_transactions(&self, hashes: &[B256]) {
+        for hash in hashes {
+            if let Ok(Some(sidecar)) = self.get_pooled_sidecar(*hash) {
+                let _ = sidecar.full_sidecar();
+            }
+        }
+    }
+
+    /// Preloads and briefly pins data the consensus client has indicated it may request.
+    fn warm_versioned_hashes(&self, _hashes: &[B256]) {}
+
+    /// Hashes of retained sidecars, including recently mined transactions.
+    fn transaction_hashes(&self) -> Vec<B256> {
+        self.transactions().into_iter().map(|(hash, _)| hash).collect()
+    }
+
+    /// Signed bodies retained for restoring both local and remote blob transactions on restart.
+    fn transactions(&self) -> Vec<(B256, alloy_primitives::Bytes)> {
+        Vec::new()
+    }
+
     /// Inserts the blob sidecar into the store
     fn insert(&self, tx: B256, data: PooledBlobSidecar) -> Result<(), BlobStoreError>;
 
@@ -145,6 +393,14 @@ pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
 
     /// Retrieves the decoded blob data for the given transaction hash.
     fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError>;
+
+    /// Returns stored sidecar metadata and cells without requiring blob reconstruction.
+    fn get_pooled_sidecar(
+        &self,
+        tx: B256,
+    ) -> Result<Option<Arc<PooledBlobSidecar>>, BlobStoreError> {
+        Ok(self.get(tx)?.map(|s| Arc::new(s.as_ref().clone().into())))
+    }
 
     /// Checks if the given transaction hash is in the blob store.
     fn contains(&self, tx: B256) -> Result<bool, BlobStoreError>;

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -47,6 +47,10 @@ pub struct PoolConfig {
     pub blob_limit: SubPoolLimit,
     /// Blob cache size
     pub blob_cache_size: Option<u32>,
+    /// Soft cap for cell sidecars across all subpools, in bytes.
+    pub max_blob_storage_size: usize,
+    /// Maximum percentage of blob storage occupied by nonce suffixes blocked on missing cells.
+    pub max_blocked_blob_storage_percent: u8,
     /// Max number of executable transaction slots guaranteed per account
     pub max_account_slots: usize,
     /// Price bump (in %) for the transaction pool underpriced check.
@@ -118,6 +122,8 @@ impl Default for PoolConfig {
             queued_limit: Default::default(),
             blob_limit: Default::default(),
             blob_cache_size: None,
+            max_blob_storage_size: 2560 * 1024 * 1024,
+            max_blocked_blob_storage_percent: 50,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
             minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -8,7 +8,7 @@ use crate::{
     AllPoolTransactions, BlobTransactionSidecarVariant, BlockInfo, PoolTransaction, PoolUpdateKind,
     TransactionOrigin,
 };
-use alloy_consensus::{transaction::TxHashRef, BlockHeader, Typed2718};
+use alloy_consensus::{transaction::TxHashRef, BlockHeader, Transaction, Typed2718};
 use alloy_eips::{BlockNumberOrTag, Decodable2718};
 use alloy_primitives::{
     map::{AddressSet, HashSet},
@@ -40,6 +40,56 @@ use tokio::{
     time::{self, Duration},
 };
 use tracing::{debug, error, info, trace, warn};
+
+/// Restores persisted blob bodies with their sparse sidecars through normal pool validation.
+async fn restore_blob_transactions<
+    P: TransactionPool<Transaction: EthPoolTransaction>,
+    C: BlockReaderIdExt,
+>(
+    pool: P,
+    client: C,
+) {
+    let store = pool.blob_store();
+    let mut transactions = Vec::new();
+    for (hash, body) in store.transactions() {
+        if client.transaction_by_hash(hash).is_ok_and(|tx| tx.is_some()) {
+            continue
+        }
+
+        let Some(tx) =
+            <P::Transaction as PoolTransaction>::Consensus::decode_2718(&mut body.as_ref())
+                .ok()
+                .filter(|tx| *tx.tx_hash() == hash)
+                .and_then(|tx| tx.try_into_recovered().ok())
+        else {
+            let _ = store.delete(hash);
+            continue
+        };
+        transactions.push((hash, tx));
+    }
+    // Blob admission rejects nonce gaps, while the disk index is ordered by hash.
+    transactions.sort_unstable_by_key(|(_, tx)| (tx.signer(), tx.nonce()));
+    for (hash, tx) in transactions {
+        if pool.get(&hash).is_some() {
+            continue
+        }
+        let Ok(Some(sidecar)) = store.get_pooled_sidecar(hash) else { continue };
+        let Some(mut tx) = P::Transaction::try_from_eip4844(tx, sidecar.elided_sidecar()) else {
+            let _ = store.delete(hash);
+            continue
+        };
+        tx.set_blob_sidecar(sidecar.as_ref().clone());
+        if let Err(err) = pool.add_transaction(sidecar.origin(), tx).await {
+            debug!(target: "txpool", %hash, %err, "Failed to restore persisted blob transaction");
+            if pool.get(&hash).is_none() &&
+                client.transaction_by_hash(hash).is_ok_and(|tx| tx.is_none())
+            {
+                let _ = store.delete(hash);
+            }
+        }
+    }
+    store.cleanup();
+}
 
 /// Maximum amount of time non-executable transaction are queued.
 pub const MAX_QUEUED_TRANSACTION_LIFETIME: Duration = Duration::from_secs(3 * 60 * 60);
@@ -158,8 +208,28 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
         pool.set_block_info(info);
     }
 
+    let restore_pool = pool.clone();
+    let restore_client = client.clone();
+    task_spawner.spawn_blocking_task(async move {
+        restore_blob_transactions(restore_pool, restore_client).await;
+    });
+
     // keeps track of mined blob transaction so we can clean finalized transactions
     let mut blob_store_tracker = BlobStoreCanonTracker::default();
+    let finalized = client.finalized_block_number().ok().flatten().unwrap_or_default();
+    let mut mined = std::collections::BTreeMap::<u64, Vec<alloy_primitives::B256>>::new();
+    let store = pool.blob_store();
+    for hash in store.transaction_hashes() {
+        if let Ok(Some((_, meta))) = client.transaction_by_hash_with_meta(hash) {
+            if meta.block_number <= finalized {
+                let _ = store.delete(hash);
+            } else {
+                mined.entry(meta.block_number).or_default().push(hash);
+            }
+        }
+    }
+    blob_store_tracker.add_blocks(mined);
+    store.cleanup();
 
     // keeps track of the latest finalized block
     let mut last_finalized_block =
@@ -176,6 +246,8 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
 
     // eviction interval for stale non local txs
     let mut stale_eviction_interval = time::interval(config.max_tx_lifetime);
+    let mut blob_cache_interval = time::interval(Duration::from_secs(1));
+    let blob_cache_permit = Arc::new(tokio::sync::Semaphore::new(1));
 
     // toggle for the first notification
     let mut first_event = true;
@@ -254,6 +326,20 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
         // select of account reloads and new canonical state updates which should arrive at the rate
         // of the block time
         tokio::select! {
+            _ = blob_cache_interval.tick() => {
+                if let Ok(permit) = blob_cache_permit.clone().try_acquire_owned() {
+                    let cache_pool = pool.clone();
+                    task_spawner.spawn_blocking_task(async move {
+                        let _permit = permit;
+                        let mut candidates = cache_pool.pending_transactions();
+                        candidates.retain(|tx| tx.is_eip4844());
+                        candidates.sort_unstable_by_key(|tx| std::cmp::Reverse(tx.transaction.effective_tip_per_gas(cache_pool.block_info().pending_basefee)));
+                        let mut hashes: Vec<_> = candidates.iter().take(64).map(|tx| *tx.hash()).collect();
+                        hashes.reverse();
+                        cache_pool.blob_store().warm_transactions(&hashes);
+                    });
+                }
+            }
             res = &mut reload_accounts_fut =>  {
                 reloaded = Some(res);
             }
@@ -392,20 +478,15 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                     .filter_map(|(signer, tx)| {
                         let tx = tx.clone().with_signer(*signer);
                         if tx.is_eip4844() {
-                            // reorged blobs no longer include the blob, which is necessary for
-                            // validating the transaction. Even though the transaction could have
-                            // been validated previously, we still need the blob in order to
-                            // accurately set the transaction's
-                            // encoded-length which is propagated over the network.
-                            pool.get_blob(*tx.tx_hash())
-                                .ok()
-                                .flatten()
-                                .map(Arc::unwrap_or_clone)
-                                .and_then(|sidecar| {
-                                    <P as TransactionPool>::Transaction::try_from_eip4844(
-                                        tx, sidecar,
-                                    )
-                                })
+                            let stored =
+                                pool.blob_store().get_pooled_sidecar(*tx.tx_hash()).ok()??;
+                            let mut transaction =
+                                <P as TransactionPool>::Transaction::try_from_eip4844(
+                                    tx,
+                                    stored.elided_sidecar(),
+                                )?;
+                            transaction.set_blob_sidecar(stored.as_ref().clone());
+                            Some(transaction)
                         } else {
                             <P as TransactionPool>::Transaction::try_from_consensus(tx).ok()
                         }

--- a/crates/transaction-pool/src/pool/best.rs
+++ b/crates/transaction-pool/src/pool/best.rs
@@ -229,7 +229,12 @@ impl<T: TransactionOrdering> BestTransactions<T> {
                 self.independent.insert(unlocked.clone());
             }
 
-            if self.skip_blobs && best.transaction.is_eip4844() {
+            if (self.skip_blobs && best.transaction.is_eip4844()) ||
+                best.transaction
+                    .transaction
+                    .blob_cell_availability()
+                    .is_some_and(|availability| !availability.is_recoverable())
+            {
                 // blobs should be skipped, marking them as invalid will ensure that no dependent
                 // transactions are returned
                 self.mark_invalid(

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -416,7 +416,11 @@ where
         let transactions = self.get_all_propagatable(tx_hashes);
         let mut size = 0;
         for transaction in transactions {
-            let encoded_len = transaction.encoded_length();
+            let encoded_len = if limit.is_eth72() {
+                transaction.transaction.eth72_encoded_length()
+            } else {
+                transaction.encoded_length()
+            };
             let Some(pooled) = self.to_pooled_transaction(transaction) else {
                 continue;
             };

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -421,7 +421,9 @@ where
             } else {
                 transaction.encoded_length()
             };
-            let Some(pooled) = self.to_pooled_transaction(transaction) else {
+            let Some(pooled) =
+                self.to_pooled_transaction_with_version(transaction, limit.is_eth72())
+            else {
                 continue;
             };
 
@@ -488,8 +490,25 @@ where
     where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
     {
+        self.to_pooled_transaction_with_version(transaction, false)
+    }
+
+    fn to_pooled_transaction_with_version(
+        &self,
+        transaction: Arc<ValidPoolTransaction<T::Transaction>>,
+        eth72: bool,
+    ) -> Option<Recovered<<<V as TransactionValidator>::Transaction as PoolTransaction>::Pooled>>
+    where
+        <V as TransactionValidator>::Transaction: EthPoolTransaction,
+    {
         if transaction.is_eip4844() {
-            let sidecar = self.blob_store.get(*transaction.hash()).ok()??;
+            let sidecar = if eth72 {
+                Arc::new(
+                    self.blob_store.get_pooled_sidecar(*transaction.hash()).ok()??.elided_sidecar(),
+                )
+            } else {
+                self.blob_store.get(*transaction.hash()).ok()??
+            };
             transaction.transaction.clone().try_into_pooled_eip4844(sidecar)
         } else {
             transaction
@@ -710,8 +729,27 @@ where
             (results, added_metas, discarded)
         };
 
+        let mut failed = alloy_primitives::map::B256Set::default();
         for meta in added_metas {
-            self.on_added_transaction(meta);
+            let hash = *meta.added.hash();
+            if failed.contains(&hash) {
+                continue
+            }
+            if let Err(err) = self.on_added_transaction(meta) {
+                let removed = self.remove_transactions_and_descendants(vec![hash]);
+                self.delete_discarded_blobs(removed.iter());
+                for tx in removed {
+                    failed.insert(*tx.hash());
+                }
+                failed.insert(hash);
+                for result in &mut results {
+                    if let Ok(added) = result &&
+                        failed.contains(&added.hash)
+                    {
+                        *result = Err(PoolError::other(added.hash, err.to_string()));
+                    }
+                }
+            }
         }
 
         if !discarded.is_empty() {
@@ -746,12 +784,27 @@ where
     ///
     /// Performs blob storage operations and sends all notifications. This should be called
     /// after the pool write lock has been released to avoid blocking pool operations.
-    fn on_added_transaction(&self, meta: AddedTransactionMeta<T::Transaction>) {
+    fn on_added_transaction(
+        &self,
+        meta: AddedTransactionMeta<T::Transaction>,
+    ) -> Result<(), crate::blobstore::BlobStoreError> {
         // Handle blob sidecar storage and notifications for EIP-4844 transactions
         if let Some(sidecar) = meta.blob_sidecar {
             let hash = *meta.added.hash();
-            self.on_new_blob_sidecar(&hash, &sidecar);
-            self.insert_blob(hash, sidecar);
+            let notification = if self.blob_transaction_sidecar_listener.lock().is_empty() {
+                None
+            } else {
+                sidecar.full_sidecar()?
+            };
+            self.insert_blob(
+                hash,
+                sidecar
+                    .with_transaction(meta.added.transaction().encoded_2718_consensus())
+                    .with_origin(meta.added.origin()),
+            )?;
+            if let Some(full) = notification {
+                self.on_new_blob_sidecar(&hash, &full);
+            }
         }
 
         // Delete replaced blob sidecar if any
@@ -775,6 +828,7 @@ where
 
         // Notify new transaction listeners
         self.on_new_transaction(meta.added.into_new_transaction_event());
+        Ok(())
     }
 
     /// Notify all listeners about a new pending transaction.
@@ -1318,13 +1372,19 @@ where
     }
 
     /// Inserts a blob transaction into the blob store
-    fn insert_blob(&self, hash: TxHash, blob: PooledBlobSidecar) {
+    fn insert_blob(
+        &self,
+        hash: TxHash,
+        blob: PooledBlobSidecar,
+    ) -> Result<(), crate::blobstore::BlobStoreError> {
         debug!(target: "txpool", "[{:?}] storing blob sidecar", hash);
-        if let Err(err) = self.blob_store.insert(hash, blob) {
+        let result = self.blob_store.insert(hash, blob);
+        if let Err(err) = &result {
             warn!(target: "txpool", %err, "[{:?}] failed to insert blob", hash);
             self.blob_store_metrics.blobstore_failed_inserts.increment(1);
         }
         self.update_blob_store_metrics();
+        result
     }
 
     /// Delete a blob from the blob store
@@ -1481,6 +1541,22 @@ pub enum AddedTransaction<T: PoolTransaction> {
 }
 
 impl<T: PoolTransaction> AddedTransaction<T> {
+    /// Returns the admission source.
+    pub fn origin(&self) -> TransactionOrigin {
+        match self {
+            Self::Pending(tx) => tx.transaction.origin,
+            Self::Parked { transaction, .. } => transaction.origin,
+        }
+    }
+
+    /// Returns the admitted transaction.
+    pub fn transaction(&self) -> &T {
+        match self {
+            Self::Pending(tx) => &tx.transaction.transaction,
+            Self::Parked { transaction, .. } => &transaction.transaction,
+        }
+    }
+
     /// Returns whether the transaction has been added to the pending pool.
     pub const fn as_pending(&self) -> Option<&AddedPendingTransaction<T>> {
         match self {
@@ -1688,7 +1764,7 @@ mod tests {
         identifier::SenderId,
         test_utils::{testing_pool, MockTransaction, TestPoolBuilder},
         validate::ValidTransaction,
-        BlockInfo, PoolConfig, SubPoolLimit, TransactionOrigin, TransactionPool,
+        BlockInfo, PoolConfig, PoolTransaction, SubPoolLimit, TransactionOrigin, TransactionPool,
         TransactionPoolExt, TransactionValidationOutcome, ValidPoolTransaction, U256,
     };
     use alloy_consensus::Transaction;
@@ -1730,6 +1806,45 @@ mod tests {
     }
 
     #[test]
+    fn failed_blob_write_removes_nonce_descendants_before_notification() {
+        use crate::{
+            blobstore::DiskFileBlobStore, noop::MockTransactionValidator, test_utils::MockOrdering,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blobs");
+        let store = DiskFileBlobStore::open(path.clone(), Default::default()).unwrap();
+        // An unavailable storage directory makes the atomic sidecar write fail.
+        reth_fs_util::remove_dir_all(&path).unwrap();
+        reth_fs_util::write(&path, b"not a directory").unwrap();
+        let pool = super::PoolInner::new(
+            MockTransactionValidator::default(),
+            MockOrdering::default(),
+            store,
+            PoolConfig::default(),
+        );
+        let mut listener = pool.add_pending_listener(crate::TransactionListenerKind::All);
+        let sidecar = BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar::default());
+        let sender = Address::random();
+        let outcomes = (0..2).map(|nonce| TransactionValidationOutcome::Valid {
+            balance: U256::MAX,
+            state_nonce: 0,
+            bytecode_hash: None,
+            transaction: ValidTransaction::ValidWithSidecar {
+                transaction: MockTransaction::eip4844_with_sidecar(sidecar.clone())
+                    .with_sender(sender)
+                    .with_nonce(nonce),
+                sidecar: PooledBlobSidecar::from(sidecar.clone()),
+            },
+            propagate: true,
+            authorities: None,
+        });
+        let results = pool.add_transactions(TransactionOrigin::External, outcomes);
+        assert!(results.iter().all(Result::is_err));
+        assert_eq!(pool.size().total, 0);
+        assert!(listener.try_recv().is_err());
+    }
+
+    #[test]
     fn test_discard_blobs_on_blob_tx_eviction() {
         let blobs = {
             // Read the contents of the JSON file into a string.
@@ -1764,7 +1879,11 @@ mod tests {
 
         // Create a test pool with default configuration and the specified blob limit.
         let test_pool = &TestPoolBuilder::default()
-            .with_config(PoolConfig { blob_limit, ..Default::default() })
+            .with_config(PoolConfig {
+                blob_limit,
+                max_blob_storage_size: usize::MAX,
+                ..Default::default()
+            })
             .pool;
 
         // Set the block info for the pool, including a pending blob fee.
@@ -1784,7 +1903,14 @@ mod tests {
 
             // Insert the sidecar into the blob store if the current index is within the blob limit.
             if n < blob_limit.max_txs {
-                blob_store.insert(*tx.get_hash(), sidecar.clone().into()).unwrap();
+                blob_store
+                    .insert(
+                        *tx.get_hash(),
+                        PooledBlobSidecar::from(sidecar.clone())
+                            .with_transaction(tx.encoded_2718_consensus())
+                            .with_origin(TransactionOrigin::External),
+                    )
+                    .unwrap();
             }
 
             // Add the transaction to the pool with external origin and valid outcome.

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -21,9 +21,12 @@ use crate::{
     PoolConfig, PoolResult, PoolTransaction, PoolUpdateKind, PriceBumpConfig, TransactionOrdering,
     ValidPoolTransaction, U256,
 };
-use alloy_consensus::constants::{
-    EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID, KECCAK_EMPTY,
-    LEGACY_TX_TYPE_ID,
+use alloy_consensus::{
+    constants::{
+        EIP1559_TX_TYPE_ID, EIP2930_TX_TYPE_ID, EIP4844_TX_TYPE_ID, EIP7702_TX_TYPE_ID,
+        KECCAK_EMPTY, LEGACY_TX_TYPE_ID,
+    },
+    Transaction, Typed2718,
 };
 use alloy_eips::{
     eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE},
@@ -35,6 +38,7 @@ use alloy_primitives::{
     map::{AddressSet, B256Map, B256Set},
     TxHash, B256,
 };
+use reth_primitives_traits::InMemorySize;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 #[cfg(test)]
@@ -1222,7 +1226,7 @@ impl<T: TransactionOrdering> TxPool<T> {
     ///
     /// This returns all transactions that were removed from the entire pool.
     pub(crate) fn discard_worst(&mut self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
-        let mut removed = Vec::new();
+        let mut removed = self.discard_blob_storage_overflow();
 
         // Helper macro that discards the worst transactions for the pools
         macro_rules! discard_worst {
@@ -1280,6 +1284,77 @@ impl<T: TransactionOrdering> TxPool<T> {
             ]
         );
 
+        removed
+    }
+
+    /// Bounds cell storage independently of transaction metadata and parked-blob limits.
+    fn discard_blob_storage_overflow(&mut self) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
+        if self.all_transactions.tx_type_counts.eip4844 == 0 {
+            return Vec::new()
+        }
+        type StorageEntry = (TransactionId, usize, bool, i64, u128);
+        let mut accounts: Vec<Vec<StorageEntry>> = Vec::new();
+        let mut sender = None;
+        let mut blocked = false;
+        let mut total_bytes = 0usize;
+        let mut blocked_bytes = 0usize;
+        for (id, entry) in &self.all_transactions.txs {
+            let tx = &entry.transaction.transaction;
+            if !tx.is_eip4844() {
+                continue
+            }
+            if sender != Some(id.sender) {
+                sender = Some(id.sender);
+                blocked = false;
+                accounts.push(Vec::new());
+            }
+            let columns = tx.blob_cell_availability().map_or(128, |a| a.get().count());
+            blocked |= columns < 64;
+            let bytes = tx.blob_versioned_hashes().map_or(0, |hashes| hashes.len()) *
+                (48 + 128 * 48 + columns * 2048) +
+                tx.size();
+            total_bytes = total_bytes.saturating_add(bytes);
+            if blocked {
+                blocked_bytes = blocked_bytes.saturating_add(bytes);
+            }
+            let priority = super::blob::blob_tx_priority(
+                tx.max_fee_per_blob_gas().unwrap_or_default(),
+                self.all_transactions.pending_fees.blob_fee,
+                tx.max_fee_per_gas(),
+                self.all_transactions.pending_fees.base_fee as u128,
+            );
+            accounts.last_mut().unwrap().push((
+                *id,
+                bytes,
+                blocked,
+                priority,
+                tx.max_priority_fee_per_gas().unwrap_or_default(),
+            ));
+        }
+        let blocked_cap = self
+            .config
+            .max_blob_storage_size
+            .saturating_mul(self.config.max_blocked_blob_storage_percent.min(100) as usize) /
+            100;
+        let mut removed = Vec::new();
+        while total_bytes > self.config.max_blob_storage_size || blocked_bytes > blocked_cap {
+            let prefer_blocked = blocked_bytes > blocked_cap;
+            let candidate = accounts
+                .iter()
+                .enumerate()
+                .filter(|(_, txs)| !txs.is_empty() && (!prefer_blocked || txs.last().unwrap().2))
+                .min_by_key(|(_, txs)| txs.iter().map(|tx| (tx.3, tx.4)).min().unwrap())
+                .map(|(index, _)| index);
+            let Some(index) = candidate else { break };
+            let (id, bytes, was_blocked, _, _) = accounts[index].pop().unwrap();
+            total_bytes = total_bytes.saturating_sub(bytes);
+            if was_blocked {
+                blocked_bytes = blocked_bytes.saturating_sub(bytes);
+            }
+            if let Some(tx) = self.remove_transaction(&id) {
+                removed.push(tx);
+            }
+        }
         removed
     }
 
@@ -2427,6 +2502,85 @@ impl SenderInfo {
 
 #[cfg(test)]
 mod tests {
+    fn sparse_transaction(
+        sender: u64,
+        nonce: u64,
+        mask: u128,
+    ) -> crate::ValidPoolTransaction<crate::EthPooledTransaction> {
+        use alloy_consensus::SignableTransaction;
+        use alloy_eips::eip2718::Encodable2718;
+        let signed: reth_ethereum_primitives::TransactionSigned = alloy_consensus::TxEip4844 {
+            chain_id: sender + 1,
+            nonce,
+            gas_limit: 21000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+            max_fee_per_blob_gas: 100,
+            blob_versioned_hashes: vec![alloy_primitives::B256::ZERO],
+            ..Default::default()
+        }
+        .into_signed(alloy_primitives::Signature::test_signature())
+        .into();
+        let length = signed.encode_2718_len();
+        let mut transaction = crate::EthPooledTransaction::new(
+            reth_primitives_traits::Recovered::new_unchecked(
+                signed,
+                alloy_primitives::Address::repeat_byte(sender as u8),
+            ),
+            length,
+        );
+        transaction.blob_cell_availability = Some(crate::blobstore::BlobCellAvailability::new(
+            alloy_eips::eip7594::BlobCellMask::from_bits(mask),
+        ));
+        crate::ValidPoolTransaction {
+            transaction,
+            transaction_id: crate::identifier::TransactionId::new(sender.into(), nonce),
+            propagate: true,
+            timestamp: std::time::Instant::now(),
+            origin: crate::TransactionOrigin::External,
+            authority_ids: None,
+        }
+    }
+
+    #[test]
+    fn missing_cells_gate_nonce_descendants_but_allow_other_accounts() {
+        let mut pool =
+            crate::pool::pending::PendingPool::new(crate::CoinbaseTipOrdering::default());
+        for (sender, nonce, mask) in
+            [(0, 0, u128::MAX), (0, 1, 1), (0, 2, u128::MAX), (1, 0, u64::MAX as u128)]
+        {
+            pool.add_transaction(std::sync::Arc::new(sparse_transaction(sender, nonce, mask)), 0);
+        }
+        let ids: Vec<_> = pool.best().map(|tx| *tx.id()).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&crate::identifier::TransactionId::new(0.into(), 0)));
+        assert!(ids.contains(&crate::identifier::TransactionId::new(1.into(), 0)));
+    }
+
+    #[test]
+    fn blocked_storage_cap_counts_full_descendants_and_evicts_the_tail() {
+        let config = crate::PoolConfig {
+            max_blob_storage_size: 600_000,
+            max_blocked_blob_storage_percent: 25,
+            ..Default::default()
+        };
+        let mut pool = super::TxPool::new(crate::CoinbaseTipOrdering::default(), config);
+        for (sender, nonce, mask) in [(0, 0, 1), (0, 1, u128::MAX), (1, 0, u128::MAX)] {
+            pool.add_transaction(
+                sparse_transaction(sender, nonce, mask),
+                alloy_primitives::U256::MAX,
+                0,
+                None,
+            )
+            .unwrap();
+        }
+        let removed = pool.discard_worst();
+        assert_eq!(removed.len(), 1);
+        assert_eq!(*removed[0].id(), crate::identifier::TransactionId::new(0.into(), 1));
+        assert_eq!(pool.len(), 2);
+        pool.assert_invariants();
+    }
+
     use super::*;
     use crate::{
         test_utils::{MockOrdering, MockTransaction, MockTransactionFactory, MockTransactionSet},

--- a/crates/transaction-pool/src/test_utils/tx_gen.rs
+++ b/crates/transaction-pool/src/test_utils/tx_gen.rs
@@ -109,7 +109,10 @@ impl<R: RngCore> TransactionGenerator<R> {
     pub fn gen_eip4844_pooled(&mut self) -> EthPooledTransaction {
         let tx = self.gen_eip4844().try_into_recovered().unwrap();
         let encoded_length = tx.encode_2718_len();
-        EthPooledTransaction::new(tx, encoded_length)
+        let mut tx = EthPooledTransaction::new(tx, encoded_length);
+        // This propagation fixture models a transaction whose sidecar is already in the store.
+        tx.blob_cell_availability = Some(crate::blobstore::BlobCellAvailability::full());
+        tx
     }
 }
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -75,6 +75,7 @@ use alloy_primitives::{
     map::{AddressSet, B256Map},
     Address, Bytes, TxHash, TxKind, B256, U256,
 };
+use alloy_rlp::Encodable;
 use futures_util::{ready, Stream};
 use reth_eth_wire_types::{EncodableEth72PooledTransaction, HandleMempoolData};
 use reth_ethereum_primitives::{PooledTransactionVariant, TransactionSigned};
@@ -1340,6 +1341,21 @@ impl BestTransactionsAttributes {
 pub trait PoolTransaction:
     alloy_consensus::Transaction + InMemorySize + Debug + Send + Sync + Clone
 {
+    /// Returns the shared blob cell availability, if this is a blob transaction.
+    fn blob_cell_availability(&self) -> Option<&BlobCellAvailability> {
+        None
+    }
+
+    /// Returns the attached blob sidecar, when supported by this transaction type.
+    fn blob_sidecar(&self) -> Option<&PooledBlobSidecar> {
+        None
+    }
+
+    /// Attaches sparse or full blob data, updating its shared availability.
+    fn set_blob_sidecar(&mut self, _sidecar: PooledBlobSidecar) -> bool {
+        false
+    }
+
     /// Associated error type for the `try_from_consensus` method.
     type TryFromConsensusError: fmt::Display;
 
@@ -1514,11 +1530,6 @@ pub trait EthPoolTransaction: PoolTransaction {
     /// Extracts the blob sidecar from the transaction.
     fn take_blob(&mut self) -> EthBlobTransactionSidecar;
 
-    /// Returns the shared blob cell availability, if this is a blob transaction.
-    fn blob_cell_availability(&self) -> Option<&BlobCellAvailability> {
-        None
-    }
-
     /// A specialization for the EIP-4844 transaction type.
     /// Tries to reattach the blob sidecar to the transaction.
     ///
@@ -1615,8 +1626,8 @@ impl<T: SignedTransaction> EthPooledTransaction<T> {
             // because the blob sidecar is not included in this transaction variant, mark it as
             // missing
             blob_sidecar = EthBlobTransactionSidecar::Missing;
-            // TODO: Initialize this with the actual mask once sparse sidecars are supported.
-            blob_cell_availability = Some(BlobCellAvailability::full());
+            blob_cell_availability =
+                Some(BlobCellAvailability::new(alloy_eips::eip7594::BlobCellMask::from_bits(0)));
         }
 
         let in_memory_size = transaction.size();
@@ -1643,6 +1654,49 @@ impl<T: SignedTransaction> EthPooledTransaction<T> {
 }
 
 impl PoolTransaction for EthPooledTransaction {
+    fn blob_cell_availability(&self) -> Option<&BlobCellAvailability> {
+        Self::blob_cell_availability(self)
+    }
+
+    fn blob_sidecar(&self) -> Option<&PooledBlobSidecar> {
+        match &self.blob_sidecar {
+            EthBlobTransactionSidecar::Present(sidecar) => Some(sidecar),
+            _ => None,
+        }
+    }
+
+    fn set_blob_sidecar(&mut self, sidecar: PooledBlobSidecar) -> bool {
+        if !self.is_eip4844() {
+            return false
+        }
+        if let Some(v1) = sidecar.as_eip7594() {
+            let metadata_length = 1 + v1.commitments.length() + v1.cell_proofs.length();
+            let signed_length = self.transaction.encode_2718_len() - 1;
+            let elided_length = 1 + alloy_rlp::Header {
+                list: true,
+                payload_length: signed_length + metadata_length + 1,
+            }
+            .length_with_payload();
+            self.eth72_encoded_length =
+                alloy_rlp::Header { list: false, payload_length: elided_length }
+                    .length_with_payload();
+            let blob_length = alloy_eips::eip4844::BYTES_PER_BLOB;
+            let blobs_payload_length =
+                v1.commitments.len() * (blob_length + alloy_rlp::length_of_length(blob_length));
+            let blobs_length =
+                alloy_rlp::Header { list: true, payload_length: blobs_payload_length }
+                    .length_with_payload();
+            self.encoded_length = 1 + alloy_rlp::Header {
+                list: true,
+                payload_length: signed_length + metadata_length + blobs_length,
+            }
+            .length_with_payload();
+        }
+        self.blob_cell_availability = Some(sidecar.availability().clone());
+        self.blob_sidecar = EthBlobTransactionSidecar::Present(sidecar);
+        true
+    }
+
     type TryFromConsensusError = ValueError<TransactionSigned>;
 
     type Consensus = TransactionSigned;
@@ -1661,6 +1715,17 @@ impl PoolTransaction for EthPooledTransaction {
         self.transaction
     }
 
+    fn try_from_consensus(
+        tx: Recovered<Self::Consensus>,
+    ) -> Result<Self, Self::TryFromConsensusError> {
+        if tx.is_eip4844() {
+            let length = tx.encode_2718_len();
+            return Ok(Self::new(tx, length))
+        }
+        let (tx, signer) = tx.into_parts();
+        Ok(Self::from_pooled(Recovered::new_unchecked(tx.try_into()?, signer)))
+    }
+
     fn from_pooled(tx: Recovered<Self::Pooled>) -> Self {
         let encoded_length = tx.encode_2718_len();
         let eth72_encoded_length = tx.eth72_length();
@@ -1675,11 +1740,14 @@ impl PoolTransaction for EthPooledTransaction {
                 let tx = Recovered::new_unchecked(tx, signer);
                 let mut pooled = Self::new(tx, encoded_length);
                 pooled.eth72_encoded_length = eth72_encoded_length;
-                if let Some(availability) = pooled.blob_cell_availability.clone() {
-                    pooled.blob_sidecar = EthBlobTransactionSidecar::Present(
-                        PooledBlobSidecar::new(blob, availability),
-                    );
-                }
+                let availability = if blob.as_eip7594().is_some_and(|s| s.blobs.is_empty()) {
+                    BlobCellAvailability::new(alloy_eips::eip7594::BlobCellMask::from_bits(0))
+                } else {
+                    BlobCellAvailability::full()
+                };
+                pooled.blob_cell_availability = Some(availability.clone());
+                pooled.blob_sidecar =
+                    EthBlobTransactionSidecar::Present(PooledBlobSidecar::new(blob, availability));
                 pooled
             }
             tx => {
@@ -1817,10 +1885,6 @@ impl EthPoolTransaction for EthPooledTransaction {
         } else {
             EthBlobTransactionSidecar::None
         }
-    }
-
-    fn blob_cell_availability(&self) -> Option<&BlobCellAvailability> {
-        Self::blob_cell_availability(self)
     }
 
     fn try_into_pooled_eip4844(
@@ -2189,7 +2253,7 @@ mod tests {
         assert!(pooled_tx.blob_cell_availability.is_some());
         assert_eq!(
             pooled_tx.blob_cell_availability().map(BlobCellAvailability::get),
-            Some(BlobCellMask::from_bits(u128::MAX))
+            Some(BlobCellMask::from_bits(0))
         );
         let expected_cost =
             U256::from(100) + U256::from(10 * 1000) + U256::from(5 * DATA_GAS_PER_BLOB);

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -76,7 +76,7 @@ use alloy_primitives::{
     Address, Bytes, TxHash, TxKind, B256, U256,
 };
 use futures_util::{ready, Stream};
-use reth_eth_wire_types::HandleMempoolData;
+use reth_eth_wire_types::{EncodableEth72PooledTransaction, HandleMempoolData};
 use reth_ethereum_primitives::{PooledTransactionVariant, TransactionSigned};
 use reth_execution_types::ChangedAccount;
 use reth_primitives_traits::{Block, InMemorySize, Recovered, SealedBlock, SignedTransaction};
@@ -1473,6 +1473,14 @@ pub trait PoolTransaction:
     /// Note: Implementations should cache this value.
     fn encoded_length(&self) -> usize;
 
+    /// Returns the encoded transaction length advertised to an eth/72 peer.
+    ///
+    /// The default matches the regular pooled transaction encoding. Ethereum blob transactions
+    /// override this with their blob-elided eth/72 encoding length.
+    fn eth72_encoded_length(&self) -> usize {
+        self.encoded_length()
+    }
+
     /// Ensures that the transaction's code size does not exceed the provided `max_init_code_size`.
     ///
     /// This is specifically relevant for contract creation transactions ([`TxKind::Create`]),
@@ -1545,6 +1553,7 @@ pub trait EthPoolTransaction: PoolTransaction {
 /// - `cost`: Pre-calculated max cost (gas * price + value + blob costs)
 /// - `encoded_length`: Cached RLP encoding length for size limits
 /// - `in_memory_size`: Cached transaction size for subpool memory accounting
+/// - `eth72_encoded_length`: Cached blob-elided RLP encoding length for eth/72 announcements
 /// - `blob_sidecar`: Blob data state (None/Missing/Present)
 /// - `blob_cell_availability`: Cached blob cell availability for eth/72 announcements
 ///
@@ -1568,6 +1577,9 @@ pub struct EthPooledTransaction<T = TransactionSigned> {
     ///
     /// Must be updated if `transaction` is modified or replaced.
     pub in_memory_size: usize,
+    /// This is the RLP length of the blob-elided transaction representation used by eth/72
+    /// pooled transaction responses and announcements.
+    pub eth72_encoded_length: usize,
 
     /// The blob side car for this transaction
     pub blob_sidecar: EthBlobTransactionSidecar,
@@ -1613,6 +1625,7 @@ impl<T: SignedTransaction> EthPooledTransaction<T> {
             cost,
             encoded_length,
             in_memory_size,
+            eth72_encoded_length: encoded_length,
             blob_sidecar,
             blob_cell_availability,
         }
@@ -1650,6 +1663,7 @@ impl PoolTransaction for EthPooledTransaction {
 
     fn from_pooled(tx: Recovered<Self::Pooled>) -> Self {
         let encoded_length = tx.encode_2718_len();
+        let eth72_encoded_length = tx.eth72_length();
         let (tx, signer) = tx.into_parts();
         match tx {
             PooledTransactionVariant::Eip4844(tx) => {
@@ -1660,6 +1674,7 @@ impl PoolTransaction for EthPooledTransaction {
                 let tx = TransactionSigned::from(tx);
                 let tx = Recovered::new_unchecked(tx, signer);
                 let mut pooled = Self::new(tx, encoded_length);
+                pooled.eth72_encoded_length = eth72_encoded_length;
                 if let Some(availability) = pooled.blob_cell_availability.clone() {
                     pooled.blob_sidecar = EthBlobTransactionSidecar::Present(
                         PooledBlobSidecar::new(blob, availability),
@@ -1670,7 +1685,9 @@ impl PoolTransaction for EthPooledTransaction {
             tx => {
                 // no blob sidecar
                 let tx = Recovered::new_unchecked(tx.into(), signer);
-                Self::new(tx, encoded_length)
+                let mut pooled = Self::new(tx, encoded_length);
+                pooled.eth72_encoded_length = eth72_encoded_length;
+                pooled
             }
         }
     }
@@ -1703,6 +1720,10 @@ impl PoolTransaction for EthPooledTransaction {
     /// Returns the length of the rlp encoded object
     fn encoded_length(&self) -> usize {
         self.encoded_length
+    }
+
+    fn eth72_encoded_length(&self) -> usize {
+        self.eth72_encoded_length
     }
 }
 
@@ -1938,6 +1959,11 @@ pub enum GetPooledTransactionLimit {
     None,
     /// Enforce a size limit on the returned transactions, for example 2MB
     ResponseSizeSoftLimit(usize),
+    /// Enforce a size limit on an eth/72 pooled transaction response.
+    ///
+    /// Type-3 transactions omit their blob payload from this response, so its limit must be
+    /// measured against the blob-elided representation.
+    Eth72ResponseSizeSoftLimit(usize),
 }
 
 impl GetPooledTransactionLimit {
@@ -1946,8 +1972,16 @@ impl GetPooledTransactionLimit {
     pub const fn exceeds(&self, size: usize) -> bool {
         match self {
             Self::None => false,
-            Self::ResponseSizeSoftLimit(limit) => size > *limit,
+            Self::ResponseSizeSoftLimit(limit) | Self::Eth72ResponseSizeSoftLimit(limit) => {
+                size > *limit
+            }
         }
+    }
+
+    /// Returns whether this limit applies to eth/72 blob-elided transaction responses.
+    #[inline]
+    pub const fn is_eth72(&self) -> bool {
+        matches!(self, Self::Eth72ResponseSizeSoftLimit(_))
     }
 }
 
@@ -2002,11 +2036,14 @@ mod tests {
     use super::*;
     use crate::{blobstore::BlobCellAvailability, test_utils::MockTransaction};
     use alloy_consensus::{
-        EthereumTxEnvelope, SignableTransaction, TxEip1559, TxEip2930, TxEip4844, TxEip7702,
-        TxEnvelope, TxLegacy,
+        BlobTransactionSidecar, EthereumTxEnvelope, SignableTransaction, TxEip1559, TxEip2930,
+        TxEip4844, TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy,
     };
-    use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
-    use alloy_primitives::Signature;
+    use alloy_eips::{
+        eip4844::{Blob, Bytes48, DATA_GAS_PER_BLOB},
+        eip7594::{BlobCellMask, BlobTransactionSidecarVariant},
+    };
+    use alloy_primitives::{Signature, B256};
 
     #[test]
     fn test_mock_consensus_encoding() {
@@ -2160,6 +2197,32 @@ mod tests {
     }
 
     #[test]
+    fn test_eth_pooled_transaction_caches_eth72_blob_elided_length() {
+        let sidecar = BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar {
+            blobs: vec![Blob::default()],
+            commitments: vec![Bytes48::from([1; 48])],
+            proofs: vec![Bytes48::default()],
+        });
+        let transaction = TxEip4844WithSidecar::from_tx_and_sidecar(
+            TxEip4844 { blob_versioned_hashes: vec![B256::ZERO], ..Default::default() },
+            sidecar,
+        )
+        .into_signed(Signature::test_signature());
+        let transaction = PooledTransactionVariant::Eip4844(transaction);
+        let eth72_encoded_length = transaction.eth72_length();
+        let encoded_length = transaction.encode_2718_len();
+
+        let pooled = EthPooledTransaction::from_pooled(Recovered::new_unchecked(
+            transaction,
+            Default::default(),
+        ));
+
+        assert_eq!(pooled.encoded_length(), encoded_length);
+        assert_eq!(pooled.eth72_encoded_length(), eth72_encoded_length);
+        assert!(pooled.eth72_encoded_length() < pooled.encoded_length());
+    }
+
+    #[test]
     fn test_eth_pooled_transaction_new_eip7702() {
         // Init an EIP-7702 transaction with specific parameters
         let tx = EthereumTxEnvelope::<TxEip4844>::Eip7702(
@@ -2192,6 +2255,8 @@ mod tests {
 
         // Size limit of 2MB (2 * 1024 * 1024 bytes)
         let size_limit_2mb = GetPooledTransactionLimit::ResponseSizeSoftLimit(2 * 1024 * 1024);
+        let eth72_size_limit_2mb =
+            GetPooledTransactionLimit::Eth72ResponseSizeSoftLimit(2 * 1024 * 1024);
 
         // Test with size below the limit
         // 1MB is below 2MB, should return false
@@ -2204,5 +2269,8 @@ mod tests {
         // Test with size exceeding the limit
         // 3MB is above the 2MB limit, should return true
         assert!(size_limit_2mb.exceeds(3 * 1024 * 1024));
+        assert!(!size_limit_2mb.is_eth72());
+        assert!(eth72_size_limit_2mb.is_eth72());
+        assert!(eth72_size_limit_2mb.exceeds(3 * 1024 * 1024));
     }
 }

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -2,7 +2,7 @@
 
 use super::constants::DEFAULT_MAX_TX_INPUT_BYTES;
 use crate::{
-    blobstore::{BlobStore, PooledBlobSidecar},
+    blobstore::{BlobStore, BlobTxCellSidecar, PooledBlobSidecar},
     error::{
         Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
     },
@@ -811,15 +811,18 @@ where
                     // is stripped from the transaction and not included in a block.
                     // check if the blob is in the store, if it's included we previously validated
                     // it and inserted it
-                    if self.blob_store.contains(*transaction.hash()).is_ok_and(|c| c) {
-                        // validated transaction is already in the store
+                    if let Ok(Some(stored)) =
+                        self.blob_store.get_pooled_sidecar(*transaction.hash())
+                    {
+                        transaction.set_blob_sidecar(stored.as_ref().clone());
+                        transaction.take_blob();
                     } else {
                         return Err(InvalidPoolTransactionError::Eip4844(
                             Eip4844PoolTransactionError::MissingEip4844BlobSidecar,
                         ))
                     }
                 }
-                EthBlobTransactionSidecar::Present(sidecar) => {
+                EthBlobTransactionSidecar::Present(mut sidecar) => {
                     let now = Instant::now();
 
                     // EIP-7594 sidecar version handling
@@ -845,12 +848,33 @@ where
                         }
                     }
 
+                    if sidecar.cells().is_none() &&
+                        let Some(full) = sidecar.as_eip7594()
+                    {
+                        let cells = BlobTxCellSidecar::from_full(full, self.kzg_settings.get())
+                            .map_err(|err| {
+                                InvalidPoolTransactionError::Eip4844(
+                                    Eip4844PoolTransactionError::InvalidEip4844Blob(err),
+                                )
+                            })?;
+                        sidecar = PooledBlobSidecar::from_cells(cells);
+                    }
                     // validate the blob
-                    if let Err(err) = transaction.validate_blob(&sidecar, self.kzg_settings.get()) {
+                    let validation = if let Some(cells) = sidecar.cells() {
+                        cells.validate(
+                            transaction.blob_versioned_hashes().unwrap_or_default(),
+                            self.kzg_settings.get(),
+                        )
+                    } else {
+                        transaction.validate_blob(&sidecar, self.kzg_settings.get())
+                    };
+                    if let Err(err) = validation {
                         return Err(InvalidPoolTransactionError::Eip4844(
                             Eip4844PoolTransactionError::InvalidEip4844Blob(err),
                         ))
                     }
+                    transaction.set_blob_sidecar(sidecar.clone());
+                    transaction.take_blob();
                     // Record the duration of successful blob validation as histogram
                     self.validation_metrics.blob_validation_duration.record(now.elapsed());
                     // store the extracted blob

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -226,6 +226,11 @@ Networking:
 
           [default: 4096]
 
+      --blob-fetch-probability <BLOB_FETCH_PROBABILITY>
+          Percentage of blob transactions fetched in full. Use 100 to disable sparse sampling
+
+          [default: 15]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.
@@ -641,6 +646,16 @@ TxPool:
 
       --txpool.blob-cache-size <BLOB_CACHE_SIZE>
           Max number of entries for the in memory cache of the blob store
+
+      --txpool.blob-storage-size <BLOB_STORAGE_SIZE>
+          Soft cap for stored blob cells across all subpools, in MiB
+
+          [default: 2560]
+
+      --txpool.blocked-blob-storage-percent <BLOCKED_BLOB_STORAGE_PERCENT>
+          Maximum percentage of blob storage occupied by nonce suffixes blocked on missing cells
+
+          [default: 50]
 
       --txpool.disable-blobs-support
           Disable EIP-4844 blob transaction support

--- a/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/body.mdx
@@ -166,6 +166,11 @@ Networking:
 
           [default: 4096]
 
+      --blob-fetch-probability <BLOB_FETCH_PROBABILITY>
+          Percentage of blob transactions fetched in full. Use 100 to disable sparse sampling
+
+          [default: 15]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
+++ b/docs/vocs/docs/pages/cli/reth/p2p/header.mdx
@@ -166,6 +166,11 @@ Networking:
 
           [default: 4096]
 
+      --blob-fetch-probability <BLOB_FETCH_PROBABILITY>
+          Percentage of blob transactions fetched in full. Use 100 to disable sparse sampling
+
+          [default: 15]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -325,6 +325,11 @@ Networking:
 
           [default: 4096]
 
+      --blob-fetch-probability <BLOB_FETCH_PROBABILITY>
+          Percentage of blob transactions fetched in full. Use 100 to disable sparse sampling
+
+          [default: 15]
+
       --pooled-tx-response-soft-limit <BYTES>
           Experimental, for usage in research. Sets the max accumulated byte size of transactions
           to pack in one response.


### PR DESCRIPTION
Enable ETH/72 with independent body/cell fetching, per-peer verification, custody sampling, and persisted `BlobTxCellSidecar` storage. Add availability-aware propagation and payload selection, lazy reconstruction for full-blob consumers, restart/reorg handling, bounded caches, and blocked-suffix storage limits.

Reuses Soubhik’s response work from #26574; includes #27090 and #27095 until they merge.
