### PR TITLE
perf(net): amortize gossip recovery scheduling

### DIFF
--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1,7 +1,7 @@
 //! Transactions management for the p2p network.
 
 use alloy_consensus::{constants::EIP4844_TX_TYPE_ID, transaction::TxHashRef};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use smallvec::SmallVec;
 
 /// Aggregation on configurable parameters for [`TransactionsManager`].
@@ -1532,7 +1532,13 @@ where
             }
         };
 
-        let new_txs = transactions.into_par_iter().filter_map(recover).collect::<Vec<_>>();
+        // Avoid waking the global pool for small gossip batches and amortize work stealing
+        // over multiple recoveries for larger batches.
+        let new_txs = if txs_len < 16 {
+            transactions.into_iter().filter_map(recover).collect::<Vec<_>>()
+        } else {
+            transactions.into_par_iter().with_min_len(16).filter_map(recover).collect::<Vec<_>>()
+        };
 
         has_bad_transactions |= new_txs.len() != txs_len;
 


### PR DESCRIPTION
Recover gossip batches smaller than 16 transactions inline and keep larger Rayon splits at least 16 transactions. This reduces scheduling work for short batches while preserving sender recovery and cache behavior; follows up on #25085.
