### PR TITLE
feat(net): prepare eth72 pooled responses and announcement sizes

### DIFF
--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -20,7 +20,10 @@ use reth_evm::{
 use reth_evm_ethereum::factory::RethEvmFactory;
 #[cfg(feature = "jit")]
 use reth_evm_ethereum::factory::{JitBackend, JitMode, RevmcMetrics, RuntimeConfig, RuntimeTuning};
-use reth_network::{primitives::BasicNetworkPrimitives, NetworkHandle, PeersInfo};
+use reth_network::{
+    primitives::BasicNetworkPrimitives, types::EncodableEth72PooledTransaction, NetworkHandle,
+    PeersInfo,
+};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, HeaderTy, NodeAddOns, NodePrimitives,
     PayloadAttributesBuilder, PrimitivesTy, TxTy,
@@ -772,6 +775,7 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
+    PoolPooledTx<Pool>: EncodableEth72PooledTransaction,
 {
     type Network =
         NetworkHandle<BasicNetworkPrimitives<PrimitivesTy<Node::Types>, PoolPooledTx<Pool>>>;

--- a/crates/net/eth-wire-types/src/message.rs
+++ b/crates/net/eth-wire-types/src/message.rs
@@ -10,7 +10,7 @@ use super::{
     broadcast::NewBlockHashes, BlockAccessLists, BlockBodies, BlockHeaders, GetBlockAccessLists,
     GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts,
     GetReceipts70, NewPooledTransactionHashes66, NewPooledTransactionHashes68, NodeData,
-    PooledTransactions, Receipts, Status, StatusEth69, Transactions,
+    PooledTransactions, PooledTransactionsEth72, Receipts, Status, StatusEth69, Transactions,
 };
 use crate::{
     status::StatusMessage, BlockRangeUpdate, BroadcastPoolTransactions, Cells,
@@ -152,9 +152,15 @@ impl<N: NetworkPrimitives> ProtocolMessage<N> {
                 EthMessage::GetPooledTransactions(RequestPair::decode(buf)?)
             }
             EthMessageID::PooledTransactions => {
-                EthMessage::PooledTransactions(RequestPair::decode_with(buf, |buf| {
-                    PooledTransactions::decode_with_memory_budget(buf, tx_memory_budget)
-                })?)
+                if version >= EthVersion::Eth72 {
+                    EthMessage::PooledTransactionsEth72(RequestPair::decode_with(buf, |buf| {
+                        PooledTransactionsEth72::decode_with_memory_budget(buf, tx_memory_budget)
+                    })?)
+                } else {
+                    EthMessage::PooledTransactions(RequestPair::decode_with(buf, |buf| {
+                        PooledTransactions::decode_with_memory_budget(buf, tx_memory_budget)
+                    })?)
+                }
             }
             EthMessageID::GetNodeData => {
                 if version >= EthVersion::Eth67 {
@@ -358,6 +364,12 @@ pub enum EthMessage<N: NetworkPrimitives = EthNetworkPrimitives> {
         serde(bound = "N::PooledTransaction: serde::Serialize + serde::de::DeserializeOwned")
     )]
     PooledTransactions(RequestPair<PooledTransactions<N::PooledTransaction>>),
+    /// Represents an eth/72 `PooledTransactions` response.
+    ///
+    /// This is kept separate from [`Self::PooledTransactions`] only to select the eth/72 wire
+    /// encoding. It uses the same protocol message ID and is normalized back to the regular typed
+    /// response after decoding.
+    PooledTransactionsEth72(RequestPair<PooledTransactionsEth72<N::PooledTransaction>>),
     /// Represents a `GetNodeData` request-response pair.
     GetNodeData(RequestPair<GetNodeData>),
     /// Represents a `NodeData` request-response pair.
@@ -426,7 +438,9 @@ impl<N: NetworkPrimitives> EthMessage<N> {
             Self::GetBlockBodies(_) => EthMessageID::GetBlockBodies,
             Self::BlockBodies(_) => EthMessageID::BlockBodies,
             Self::GetPooledTransactions(_) => EthMessageID::GetPooledTransactions,
-            Self::PooledTransactions(_) => EthMessageID::PooledTransactions,
+            Self::PooledTransactions(_) | Self::PooledTransactionsEth72(_) => {
+                EthMessageID::PooledTransactions
+            }
             Self::GetNodeData(_) => EthMessageID::GetNodeData,
             Self::NodeData(_) => EthMessageID::NodeData,
             Self::GetReceipts(_) | Self::GetReceipts70(_) => EthMessageID::GetReceipts,
@@ -460,6 +474,7 @@ impl<N: NetworkPrimitives> EthMessage<N> {
         matches!(
             self,
             Self::PooledTransactions(_) |
+                Self::PooledTransactionsEth72(_) |
                 Self::Receipts(_) |
                 Self::Receipts69(_) |
                 Self::Receipts70(_) |
@@ -481,6 +496,15 @@ impl<N: NetworkPrimitives> EthMessage<N> {
         // user-facing `PeerRequest` API unchanged.
         if version >= EthVersion::Eth70 {
             return match self {
+                Self::PooledTransactions(pair) if version >= EthVersion::Eth72 => {
+                    // The request/response API remains version-neutral. Only the final wire
+                    // representation changes for an eth/72 peer.
+                    let RequestPair { request_id, message } = pair;
+                    Self::PooledTransactionsEth72(RequestPair {
+                        request_id,
+                        message: PooledTransactionsEth72::from_transactions(message),
+                    })
+                }
                 Self::GetReceipts(pair) => {
                     let RequestPair { request_id, message } = pair;
                     let req = RequestPair {
@@ -516,6 +540,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::BlockBodies(bodies) => bodies.encode(out),
             Self::GetPooledTransactions(request) => request.encode(out),
             Self::PooledTransactions(transactions) => transactions.encode(out),
+            Self::PooledTransactionsEth72(transactions) => transactions.encode(out),
             Self::GetNodeData(request) => request.encode(out),
             Self::NodeData(data) => data.encode(out),
             Self::GetReceipts(request) => request.encode(out),
@@ -546,6 +571,7 @@ impl<N: NetworkPrimitives> Encodable for EthMessage<N> {
             Self::BlockBodies(bodies) => bodies.length(),
             Self::GetPooledTransactions(request) => request.length(),
             Self::PooledTransactions(transactions) => transactions.length(),
+            Self::PooledTransactionsEth72(transactions) => transactions.length(),
             Self::GetNodeData(request) => request.length(),
             Self::NodeData(data) => data.length(),
             Self::GetReceipts(request) => request.length(),

--- a/crates/net/eth-wire-types/src/primitives.rs
+++ b/crates/net/eth-wire-types/src/primitives.rs
@@ -1,6 +1,6 @@
 //! Abstraction over primitive types in network messages.
 
-use crate::NewBlockPayload;
+use crate::{EncodableEth72PooledTransaction, NewBlockPayload};
 use alloy_consensus::{RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt};
 use alloy_rlp::{Decodable, Encodable};
 use core::fmt::Debug;
@@ -53,7 +53,10 @@ pub trait NetworkPrimitives: Send + Sync + Unpin + Clone + Debug + 'static {
     /// For EIP-4844 blob transactions, this includes the full blob sidecar with
     /// KZG commitments and proofs that are needed for validation but are not
     /// included in the consensus block format.
-    type PooledTransaction: SignedTransaction + TryFrom<Self::BroadcastedTransaction> + 'static;
+    type PooledTransaction: SignedTransaction
+        + TryFrom<Self::BroadcastedTransaction>
+        + EncodableEth72PooledTransaction
+        + 'static;
 
     /// The transaction type which peers return in `GetReceipts` messages.
     type Receipt: TxReceipt
@@ -102,7 +105,7 @@ pub struct BasicNetworkPrimitives<N: NodePrimitives, Pooled, NewBlock = crate::N
 impl<N, Pooled, NewBlock> NetworkPrimitives for BasicNetworkPrimitives<N, Pooled, NewBlock>
 where
     N: NodePrimitives,
-    Pooled: SignedTransaction + TryFrom<N::SignedTx> + 'static,
+    Pooled: SignedTransaction + TryFrom<N::SignedTx> + EncodableEth72PooledTransaction + 'static,
     NewBlock: NewBlockPayload<Block = N::Block>,
 {
     type BlockHeader = N::BlockHeader;

--- a/crates/net/eth-wire-types/src/transactions.rs
+++ b/crates/net/eth-wire-types/src/transactions.rs
@@ -2,12 +2,22 @@
 
 use crate::broadcast::decode_list_with_memory_budget;
 use alloc::vec::Vec;
-use alloy_consensus::transaction::{PooledTransaction, TxHashRef};
-use alloy_eips::eip7594::{BlobCellMask, Cell};
+use alloy_consensus::{
+    transaction::{PooledTransaction, RlpEcdsaEncodableTx, TxEip4844WithSidecar, TxHashRef},
+    Signed,
+};
+use alloy_eips::{
+    eip4844::Blob,
+    eip7594::{BlobCellMask, BlobTransactionSidecarVariant, Cell, EIP_7594_WRAPPER_VERSION},
+};
 use alloy_primitives::{B128, B256};
-use alloy_rlp::{Decodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
+use alloy_rlp::{
+    BufMut, Decodable, Encodable, Header, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
+    RlpEncodableWrapper,
+};
 use derive_more::{Constructor, Deref, IntoIterator};
 use reth_codecs_derive::add_arbitrary_tests;
+use reth_ethereum_primitives::PooledTransactionVariant;
 use reth_primitives_traits::InMemorySize;
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
@@ -69,6 +79,158 @@ pub struct PooledTransactions<T = PooledTransaction>(
     /// The transaction bodies, each of which should correspond to a requested hash.
     pub Vec<T>,
 );
+
+/// An eth/72 `PooledTransactions` response.
+///
+/// Eth/72 elides the blob list from type-3 transactions because blob data is fetched separately
+/// with `GetCells`. The transactions remain typed here; a borrowed type-3 encoding view elides
+/// the blob list. This is still the same `PooledTransactions` message (`0x0a`) on the wire, not a
+/// new protocol message.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PooledTransactionsEth72<T = PooledTransaction>(pub Vec<T>);
+
+/// Encodes a pooled transaction for an eth/72 response.
+pub trait EncodableEth72PooledTransaction: Encodable {
+    /// Writes this transaction using the eth/72 representation.
+    fn encode_eth72(&self, out: &mut dyn BufMut);
+
+    /// Returns the encoded length of the eth/72 representation.
+    fn eth72_length(&self) -> usize;
+}
+
+impl EncodableEth72PooledTransaction for PooledTransactionVariant {
+    fn encode_eth72(&self, out: &mut dyn BufMut) {
+        Eth72Pooled(self).encode(out);
+    }
+
+    fn eth72_length(&self) -> usize {
+        Eth72Pooled(self).length()
+    }
+}
+
+impl<T> PooledTransactionsEth72<T> {
+    /// Converts a regular pooled transaction response into the eth/72 response view.
+    pub fn from_transactions(transactions: PooledTransactions<T>) -> Self {
+        Self(transactions.0)
+    }
+}
+
+impl<T> From<PooledTransactionsEth72<T>> for PooledTransactions<T> {
+    fn from(transactions: PooledTransactionsEth72<T>) -> Self {
+        Self(transactions.0)
+    }
+}
+
+impl<T: Decodable + InMemorySize> PooledTransactionsEth72<T> {
+    /// Decodes an eth/72 response while applying the same memory budget as the regular response.
+    pub fn decode_with_memory_budget(
+        buf: &mut &[u8],
+        memory_budget: usize,
+    ) -> alloy_rlp::Result<Self> {
+        decode_list_with_memory_budget(buf, memory_budget).map(Self)
+    }
+}
+
+impl<T: EncodableEth72PooledTransaction> Encodable for PooledTransactionsEth72<T> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let payload_length = self.0.iter().map(T::eth72_length).sum();
+        Header { list: true, payload_length }.encode(out);
+        for transaction in &self.0 {
+            transaction.encode_eth72(out);
+        }
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.0.iter().map(T::eth72_length).sum();
+        Header { list: true, payload_length }.length_with_payload()
+    }
+}
+
+/// Borrowed eth/72 view of a pooled transaction.
+struct Eth72Pooled<'a>(&'a PooledTransactionVariant);
+
+impl Encodable for Eth72Pooled<'_> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self.0 {
+            PooledTransactionVariant::Eip4844(transaction) => {
+                Eth72PooledEip4844(transaction).encode(out)
+            }
+            transaction => transaction.encode(out),
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self.0 {
+            PooledTransactionVariant::Eip4844(transaction) => {
+                Eth72PooledEip4844(transaction).length()
+            }
+            transaction => transaction.length(),
+        }
+    }
+}
+
+/// Borrowed eth/72 view of a type-3 transaction.
+struct Eth72PooledEip4844<'a>(&'a Signed<TxEip4844WithSidecar<BlobTransactionSidecarVariant>>);
+
+impl Encodable for Eth72PooledEip4844<'_> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: false, payload_length: self.typed_length() }.encode(out);
+        out.put_u8(3);
+        Header { list: true, payload_length: self.payload_length() }.encode(out);
+        self.0.tx().tx.rlp_encode_signed(self.0.signature(), out);
+        Eth72BlobSidecar(&self.0.tx().sidecar).encode(out);
+    }
+
+    fn length(&self) -> usize {
+        Header { list: false, payload_length: self.typed_length() }.length_with_payload()
+    }
+}
+
+impl Eth72PooledEip4844<'_> {
+    fn payload_length(&self) -> usize {
+        self.0.tx().tx.rlp_encoded_length_with_signature(self.0.signature()) +
+            Eth72BlobSidecar(&self.0.tx().sidecar).length()
+    }
+
+    fn typed_length(&self) -> usize {
+        1 + Header { list: true, payload_length: self.payload_length() }.length_with_payload()
+    }
+}
+
+/// Borrowed sidecar view that writes an empty blob vector and preserves metadata.
+struct Eth72BlobSidecar<'a>(&'a BlobTransactionSidecarVariant);
+
+impl Encodable for Eth72BlobSidecar<'_> {
+    fn encode(&self, out: &mut dyn BufMut) {
+        match self.0 {
+            BlobTransactionSidecarVariant::Eip4844(sidecar) => {
+                Vec::<Blob>::new().encode(out);
+                sidecar.commitments.encode(out);
+                sidecar.proofs.encode(out);
+            }
+            BlobTransactionSidecarVariant::Eip7594(sidecar) => {
+                out.put_u8(EIP_7594_WRAPPER_VERSION);
+                Vec::<Blob>::new().encode(out);
+                sidecar.commitments.encode(out);
+                sidecar.cell_proofs.encode(out);
+            }
+        }
+    }
+
+    fn length(&self) -> usize {
+        match self.0 {
+            BlobTransactionSidecarVariant::Eip4844(sidecar) => {
+                Vec::<Blob>::new().length() + sidecar.commitments.length() + sidecar.proofs.length()
+            }
+            BlobTransactionSidecarVariant::Eip7594(sidecar) => {
+                1 + Vec::<Blob>::new().length() +
+                    sidecar.commitments.length() +
+                    sidecar.cell_proofs.length()
+            }
+        }
+    }
+}
 
 impl<T: Decodable + InMemorySize> PooledTransactions<T> {
     /// Decodes the RLP list of transactions, stopping once the cumulative
@@ -161,6 +323,66 @@ mod tests {
     use reth_chainspec::MIN_TRANSACTION_GAS;
     use reth_ethereum_primitives::{Transaction, TransactionSigned};
     use std::str::FromStr;
+
+    #[test]
+    fn eth72_response_elides_blobs_and_preserves_metadata() {
+        use super::PooledTransactionsEth72;
+        use crate::{EthMessage, EthNetworkPrimitives, EthVersion, ProtocolMessage};
+        use alloy_consensus::{SignableTransaction, TxEip4844, TxEip4844WithSidecar};
+        use alloy_eips::{
+            eip4844::{Blob, Bytes48},
+            eip7594::BlobTransactionSidecarEip7594,
+        };
+        use alloy_primitives::B256;
+        use reth_ethereum_primitives::PooledTransactionVariant;
+
+        let sidecar = BlobTransactionSidecarEip7594::new(
+            vec![Blob::default()],
+            vec![Bytes48::ZERO],
+            vec![Bytes48::ZERO; 128],
+        );
+        let tx = TxEip4844WithSidecar {
+            tx: TxEip4844 { blob_versioned_hashes: vec![B256::ZERO], ..Default::default() },
+            sidecar: sidecar.clone().into(),
+        }
+        .into_signed(Signature::test_signature());
+        let transactions = vec![PooledTransactionVariant::Eip4844(tx)];
+        let response = EthMessage::<EthNetworkPrimitives>::PooledTransactions(RequestPair {
+            request_id: 42,
+            message: PooledTransactions(transactions),
+        });
+        assert_eq!(response.clone().map_versioned(EthVersion::Eth71), response);
+        let elided = response.clone().map_versioned(EthVersion::Eth72);
+        let encoded = alloy_rlp::encode(&elided);
+        assert_eq!(encoded.len(), elided.length());
+        assert!(encoded.len() < response.length());
+        assert!(matches!(
+            &elided,
+            EthMessage::PooledTransactionsEth72(RequestPair {
+                message: PooledTransactionsEth72(_),
+                ..
+            })
+        ));
+        let mut packet = vec![elided.message_id().to_u8()];
+        packet.extend(encoded);
+        let mut input = packet.as_slice();
+        let decoded =
+            ProtocolMessage::<EthNetworkPrimitives>::decode_message(EthVersion::Eth72, &mut input)
+                .unwrap()
+                .message;
+        assert!(input.is_empty());
+        let EthMessage::PooledTransactionsEth72(decoded) = decoded else {
+            panic!("eth72 response")
+        };
+        assert_eq!(decoded.request_id, 42);
+        let PooledTransactionVariant::Eip4844(decoded) = &decoded.message.0[0] else {
+            panic!("blob transaction")
+        };
+        let decoded = decoded.tx().sidecar.as_eip7594().unwrap();
+        assert!(decoded.blobs.is_empty());
+        assert_eq!(decoded.commitments, sidecar.commitments);
+        assert_eq!(decoded.cell_proofs, sidecar.cell_proofs);
+    }
 
     #[test]
     // Test vector from: https://eips.ethereum.org/EIPS/eip-2481

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -34,7 +34,7 @@ use reth_eth_wire::{
 };
 use reth_eth_wire_types::{
     message::RequestPair, snap::SnapProtocolMessage, NewPooledTransactionHashes,
-    RawCapabilityMessage,
+    PooledTransactions, RawCapabilityMessage,
 };
 use reth_metrics::common::mpsc::MeteredPollSender;
 use reth_network_api::{PeerRequest, RequestMessage};
@@ -358,6 +358,12 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
             EthMessage::PooledTransactions(resp) => {
                 on_response!(resp, GetPooledTransactions)
             }
+            EthMessage::PooledTransactionsEth72(resp) => {
+                // Keep the existing transaction fetcher and request correlation version-neutral;
+                // the eth/72 wrapper only describes how this response was encoded on the wire.
+                let resp = resp.map(PooledTransactions::from);
+                on_response!(resp, GetPooledTransactions)
+            }
             EthMessage::GetNodeData(req) => {
                 on_request!(req, NodeData, GetNodeData)
             }
@@ -588,7 +594,7 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
     fn handle_outgoing_response(&mut self, id: u64, resp: PeerResponseResult<N>) {
         match resp.try_into_message(id) {
             Ok(RequestMessage::Eth(msg)) => {
-                self.queued_outgoing.push_back(msg.into());
+                self.queued_outgoing.push_back(msg.map_versioned(self.conn.version()).into());
             }
             Ok(RequestMessage::Snap(msg)) => {
                 self.queued_outgoing.push_back(OutgoingMessage::Snap(msg));

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -1204,12 +1204,14 @@ where
             return
         }
         if let Some(peer) = self.peers.get_mut(&peer_id) {
-            let transactions = self.pool.get_pooled_transaction_elements(
-                request.0,
-                GetPooledTransactionLimit::ResponseSizeSoftLimit(
-                    self.transaction_fetcher.info.soft_limit_byte_size_pooled_transactions_response,
-                ),
-            );
+            let response_size_limit =
+                self.transaction_fetcher.info.soft_limit_byte_size_pooled_transactions_response;
+            let limit = if peer.version() >= EthVersion::Eth72 {
+                GetPooledTransactionLimit::Eth72ResponseSizeSoftLimit(response_size_limit)
+            } else {
+                GetPooledTransactionLimit::ResponseSizeSoftLimit(response_size_limit)
+            };
+            let transactions = self.pool.get_pooled_transaction_elements(request.0, limit);
             trace!(target: "net::tx::propagation", sent_txs=?transactions.iter().map(|tx| tx.tx_hash()), "Sending requested transactions to peer");
 
             // we sent a response at which point we assume that the peer is aware of the
@@ -1829,13 +1831,18 @@ impl PropagationMode {
 #[derive(Debug, Clone)]
 struct PropagateTransaction {
     is_broadcastable_in_full: bool,
-    /// Size advertised in `NewPooledTransactionHashes` metadata and used for full broadcast
-    /// soft-limit accounting.
+    /// Size advertised to pre-eth/72 peers in `NewPooledTransactionHashes` metadata and used for
+    /// full broadcast soft-limit accounting.
     ///
     /// This is the network encoded transaction size. For pool-backed blob transactions, this is
     /// the pool's cached encoded length, which includes the sidecar returned by
     /// `PooledTransactions`.
     propagation_size: usize,
+    /// Size advertised to eth/72 peers in `NewPooledTransactionHashes` metadata.
+    ///
+    /// Type-3 transactions omit blob payloads in eth/72 `PooledTransactions` responses, so this
+    /// must match that blob-elided representation rather than [`Self::propagation_size`].
+    eth72_propagation_size: usize,
     transaction: LazyEncodedTransaction,
 }
 
@@ -1852,6 +1859,7 @@ impl PropagateTransaction {
         Self {
             is_broadcastable_in_full,
             propagation_size,
+            eth72_propagation_size: propagation_size,
             transaction: LazyEncoded::new(transaction),
         }
     }
@@ -1864,9 +1872,11 @@ impl PropagateTransaction {
     fn pool_tx<P: PoolTransaction>(tx: Arc<ValidPoolTransaction<P>>) -> Self {
         let is_broadcastable_in_full = tx.transaction.consensus_ref().is_broadcastable_in_full();
         let propagation_size = tx.encoded_length();
+        let eth72_propagation_size = tx.transaction.eth72_encoded_length();
         Self {
             is_broadcastable_in_full,
             propagation_size,
+            eth72_propagation_size,
             transaction: LazyEncoded::new(PropagatePooledTransactionEncoder::new(tx)),
         }
     }
@@ -1878,6 +1888,11 @@ impl PropagateTransaction {
     /// Returns the network encoded size used for propagation limits and hash metadata.
     const fn propagation_size(&self) -> usize {
         self.propagation_size
+    }
+
+    /// Returns the size advertised to an eth/72 peer.
+    const fn eth72_propagation_size(&self) -> usize {
+        self.eth72_propagation_size
     }
 
     fn tx_type(&self) -> u8 {
@@ -2105,7 +2120,7 @@ impl PooledTransactionsHashesBuilder {
             }
             Self::Eth72(msg) => {
                 msg.hashes.push(*pooled_tx.hash());
-                msg.sizes.push(pooled_tx.encoded_length());
+                msg.sizes.push(pooled_tx.transaction.eth72_encoded_length());
                 let ty = pooled_tx.transaction.ty();
                 msg.types.push(ty);
                 if ty == EIP4844_TX_TYPE_ID {
@@ -2151,7 +2166,7 @@ impl PooledTransactionsHashesBuilder {
             }
             Self::Eth72(msg) => {
                 msg.hashes.push(*tx.tx_hash());
-                msg.sizes.push(tx.propagation_size());
+                msg.sizes.push(tx.eth72_propagation_size());
                 let ty = tx.tx_type();
                 msg.types.push(ty);
                 if ty == EIP4844_TX_TYPE_ID {
@@ -3237,6 +3252,29 @@ mod tests {
         let tx = PropagateTransaction::new(tx);
 
         assert_eq!(tx.propagation_size(), expected_size);
+        assert_eq!(tx.eth72_propagation_size(), expected_size);
+    }
+
+    #[test]
+    fn test_eth72_hash_announcement_uses_blob_elided_size() {
+        let mut tx_gen = TransactionGenerator::new(rand::rng());
+        let mut tx = tx_gen.gen_eip4844_pooled();
+        tx.encoded_length = 100;
+        tx.eth72_encoded_length = 10;
+
+        let tx = valid_eth_pool_transaction(tx);
+        let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
+        builder.push_pooled(tx.clone());
+
+        let PooledTransactionsHashesBuilder::Eth72(message) = builder else { unreachable!() };
+        assert_eq!(message.sizes, vec![10]);
+
+        let tx = PropagateTransaction::pool_tx(tx);
+        let mut builder = PooledTransactionsHashesBuilder::new(EthVersion::Eth72);
+        builder.push(&tx);
+
+        let PooledTransactionsHashesBuilder::Eth72(message) = builder else { unreachable!() };
+        assert_eq!(message.sizes, vec![10]);
     }
 
     #[test]

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -416,7 +416,11 @@ where
         let transactions = self.get_all_propagatable(tx_hashes);
         let mut size = 0;
         for transaction in transactions {
-            let encoded_len = transaction.encoded_length();
+            let encoded_len = if limit.is_eth72() {
+                transaction.transaction.eth72_encoded_length()
+            } else {
+                transaction.encoded_length()
+            };
             let Some(pooled) = self.to_pooled_transaction(transaction) else {
                 continue;
             };

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -76,7 +76,7 @@ use alloy_primitives::{
     Address, Bytes, TxHash, TxKind, B256, U256,
 };
 use futures_util::{ready, Stream};
-use reth_eth_wire_types::HandleMempoolData;
+use reth_eth_wire_types::{EncodableEth72PooledTransaction, HandleMempoolData};
 use reth_ethereum_primitives::{PooledTransactionVariant, TransactionSigned};
 use reth_execution_types::ChangedAccount;
 use reth_primitives_traits::{Block, InMemorySize, Recovered, SealedBlock, SignedTransaction};
@@ -1473,6 +1473,14 @@ pub trait PoolTransaction:
     /// Note: Implementations should cache this value.
     fn encoded_length(&self) -> usize;
 
+    /// Returns the encoded transaction length advertised to an eth/72 peer.
+    ///
+    /// The default matches the regular pooled transaction encoding. Ethereum blob transactions
+    /// override this with their blob-elided eth/72 encoding length.
+    fn eth72_encoded_length(&self) -> usize {
+        self.encoded_length()
+    }
+
     /// Ensures that the transaction's code size does not exceed the provided `max_init_code_size`.
     ///
     /// This is specifically relevant for contract creation transactions ([`TxKind::Create`]),
@@ -1545,6 +1553,7 @@ pub trait EthPoolTransaction: PoolTransaction {
 /// - `cost`: Pre-calculated max cost (gas * price + value + blob costs)
 /// - `encoded_length`: Cached RLP encoding length for size limits
 /// - `in_memory_size`: Cached transaction size for subpool memory accounting
+/// - `eth72_encoded_length`: Cached blob-elided RLP encoding length for eth/72 announcements
 /// - `blob_sidecar`: Blob data state (None/Missing/Present)
 /// - `blob_cell_availability`: Cached blob cell availability for eth/72 announcements
 ///
@@ -1568,6 +1577,9 @@ pub struct EthPooledTransaction<T = TransactionSigned> {
     ///
     /// Must be updated if `transaction` is modified or replaced.
     pub in_memory_size: usize,
+    /// This is the RLP length of the blob-elided transaction representation used by eth/72
+    /// pooled transaction responses and announcements.
+    pub eth72_encoded_length: usize,
 
     /// The blob side car for this transaction
     pub blob_sidecar: EthBlobTransactionSidecar,
@@ -1613,6 +1625,7 @@ impl<T: SignedTransaction> EthPooledTransaction<T> {
             cost,
             encoded_length,
             in_memory_size,
+            eth72_encoded_length: encoded_length,
             blob_sidecar,
             blob_cell_availability,
         }
@@ -1650,6 +1663,7 @@ impl PoolTransaction for EthPooledTransaction {
 
     fn from_pooled(tx: Recovered<Self::Pooled>) -> Self {
         let encoded_length = tx.encode_2718_len();
+        let eth72_encoded_length = tx.eth72_length();
         let (tx, signer) = tx.into_parts();
         match tx {
             PooledTransactionVariant::Eip4844(tx) => {
@@ -1660,6 +1674,7 @@ impl PoolTransaction for EthPooledTransaction {
                 let tx = TransactionSigned::from(tx);
                 let tx = Recovered::new_unchecked(tx, signer);
                 let mut pooled = Self::new(tx, encoded_length);
+                pooled.eth72_encoded_length = eth72_encoded_length;
                 if let Some(availability) = pooled.blob_cell_availability.clone() {
                     pooled.blob_sidecar = EthBlobTransactionSidecar::Present(
                         PooledBlobSidecar::new(blob, availability),
@@ -1670,7 +1685,9 @@ impl PoolTransaction for EthPooledTransaction {
             tx => {
                 // no blob sidecar
                 let tx = Recovered::new_unchecked(tx.into(), signer);
-                Self::new(tx, encoded_length)
+                let mut pooled = Self::new(tx, encoded_length);
+                pooled.eth72_encoded_length = eth72_encoded_length;
+                pooled
             }
         }
     }
@@ -1703,6 +1720,10 @@ impl PoolTransaction for EthPooledTransaction {
     /// Returns the length of the rlp encoded object
     fn encoded_length(&self) -> usize {
         self.encoded_length
+    }
+
+    fn eth72_encoded_length(&self) -> usize {
+        self.eth72_encoded_length
     }
 }
 
@@ -1938,6 +1959,11 @@ pub enum GetPooledTransactionLimit {
     None,
     /// Enforce a size limit on the returned transactions, for example 2MB
     ResponseSizeSoftLimit(usize),
+    /// Enforce a size limit on an eth/72 pooled transaction response.
+    ///
+    /// Type-3 transactions omit their blob payload from this response, so its limit must be
+    /// measured against the blob-elided representation.
+    Eth72ResponseSizeSoftLimit(usize),
 }
 
 impl GetPooledTransactionLimit {
@@ -1946,8 +1972,16 @@ impl GetPooledTransactionLimit {
     pub const fn exceeds(&self, size: usize) -> bool {
         match self {
             Self::None => false,
-            Self::ResponseSizeSoftLimit(limit) => size > *limit,
+            Self::ResponseSizeSoftLimit(limit) | Self::Eth72ResponseSizeSoftLimit(limit) => {
+                size > *limit
+            }
         }
+    }
+
+    /// Returns whether this limit applies to eth/72 blob-elided transaction responses.
+    #[inline]
+    pub const fn is_eth72(&self) -> bool {
+        matches!(self, Self::Eth72ResponseSizeSoftLimit(_))
     }
 }
 
@@ -2002,11 +2036,14 @@ mod tests {
     use super::*;
     use crate::{blobstore::BlobCellAvailability, test_utils::MockTransaction};
     use alloy_consensus::{
-        EthereumTxEnvelope, SignableTransaction, TxEip1559, TxEip2930, TxEip4844, TxEip7702,
-        TxEnvelope, TxLegacy,
+        BlobTransactionSidecar, EthereumTxEnvelope, SignableTransaction, TxEip1559, TxEip2930,
+        TxEip4844, TxEip4844WithSidecar, TxEip7702, TxEnvelope, TxLegacy,
     };
-    use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
-    use alloy_primitives::Signature;
+    use alloy_eips::{
+        eip4844::{Blob, Bytes48, DATA_GAS_PER_BLOB},
+        eip7594::{BlobCellMask, BlobTransactionSidecarVariant},
+    };
+    use alloy_primitives::{Signature, B256};
 
     #[test]
     fn test_mock_consensus_encoding() {
@@ -2160,6 +2197,32 @@ mod tests {
     }
 
     #[test]
+    fn test_eth_pooled_transaction_caches_eth72_blob_elided_length() {
+        let sidecar = BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar {
+            blobs: vec![Blob::default()],
+            commitments: vec![Bytes48::from([1; 48])],
+            proofs: vec![Bytes48::default()],
+        });
+        let transaction = TxEip4844WithSidecar::from_tx_and_sidecar(
+            TxEip4844 { blob_versioned_hashes: vec![B256::ZERO], ..Default::default() },
+            sidecar,
+        )
+        .into_signed(Signature::test_signature());
+        let transaction = PooledTransactionVariant::Eip4844(transaction);
+        let eth72_encoded_length = transaction.eth72_length();
+        let encoded_length = transaction.encode_2718_len();
+
+        let pooled = EthPooledTransaction::from_pooled(Recovered::new_unchecked(
+            transaction,
+            Default::default(),
+        ));
+
+        assert_eq!(pooled.encoded_length(), encoded_length);
+        assert_eq!(pooled.eth72_encoded_length(), eth72_encoded_length);
+        assert!(pooled.eth72_encoded_length() < pooled.encoded_length());
+    }
+
+    #[test]
     fn test_eth_pooled_transaction_new_eip7702() {
         // Init an EIP-7702 transaction with specific parameters
         let tx = EthereumTxEnvelope::<TxEip4844>::Eip7702(
@@ -2192,6 +2255,8 @@ mod tests {
 
         // Size limit of 2MB (2 * 1024 * 1024 bytes)
         let size_limit_2mb = GetPooledTransactionLimit::ResponseSizeSoftLimit(2 * 1024 * 1024);
+        let eth72_size_limit_2mb =
+            GetPooledTransactionLimit::Eth72ResponseSizeSoftLimit(2 * 1024 * 1024);
 
         // Test with size below the limit
         // 1MB is below 2MB, should return false
@@ -2204,5 +2269,8 @@ mod tests {
         // Test with size exceeding the limit
         // 3MB is above the 2MB limit, should return true
         assert!(size_limit_2mb.exceeds(3 * 1024 * 1024));
+        assert!(!size_limit_2mb.is_eth72());
+        assert!(eth72_size_limit_2mb.is_eth72());
+        assert!(eth72_size_limit_2mb.exceeds(3 * 1024 * 1024));
     }
 }


### PR DESCRIPTION
Encodes ETH/72 pooled responses with blob payloads elided and uses matching sizes for announcements and response limits, while preserving existing pool accounting and version-neutral request handling. ETH/72 remains disabled by default.

Extracted from #27097; adapts the response work from #26574.
