### PR TITLE
fix(rocksdb): preserve history across pending block saves

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3,7 +3,9 @@ use crate::{
     changesets_utils::StorageRevertsIter,
     providers::{
         database::{chain::ChainStorage, metrics, DatabaseProviderMetrics},
-        rocksdb::{PendingRocksDBBatches, RocksDBProvider, RocksDBWriteCtx},
+        rocksdb::{
+            PendingRocksDBBatches, PendingRocksDBHistoryCache, RocksDBProvider, RocksDBWriteCtx,
+        },
         static_file::{StaticFileWriteCtx, StaticFileWriter},
         NodeTypesForProvider, StaticFileProvider,
     },
@@ -209,6 +211,8 @@ pub struct DatabaseProvider<TX, N: NodeTypes> {
     db_path: PathBuf,
     /// Pending `RocksDB` batches to be committed at provider commit time.
     pending_rocksdb_batches: PendingRocksDBBatches,
+    /// Latest uncommitted history shards written by this provider transaction.
+    pending_rocksdb_history: PendingRocksDBHistoryCache,
     /// Commit order for database operations.
     commit_order: CommitOrder,
     /// Minimum distance from tip required for pruning
@@ -382,6 +386,7 @@ impl<TX: DbTxMut, N: NodeTypes> DatabaseProvider<TX, N> {
             runtime,
             db_path,
             pending_rocksdb_batches: Default::default(),
+            pending_rocksdb_history: Default::default(),
             commit_order,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             metrics,
@@ -515,6 +520,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             prune_tx_lookup: self.prune_modes.transaction_lookup,
             storage_settings: self.cached_storage_settings(),
             pending_batches: self.pending_rocksdb_batches.clone(),
+            pending_history: self.pending_rocksdb_history.clone(),
         }
     }
 
@@ -1030,6 +1036,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> DatabaseProvider<TX, N> {
             runtime,
             db_path,
             pending_rocksdb_batches: Default::default(),
+            pending_rocksdb_history: Default::default(),
             commit_order: CommitOrder::Normal,
             minimum_pruning_distance: MINIMUM_UNWIND_SAFE_DISTANCE,
             metrics,
@@ -3958,7 +3965,7 @@ mod tests {
         U256,
     };
     use reth_chain_state::{test_utils::TestBlockBuilder, ExecutedBlock};
-    use reth_db_api::models::StorageSettings;
+    use reth_db_api::models::{sharded_key::NUM_OF_INDICES_IN_SHARD, StorageSettings};
     use reth_ethereum_primitives::Receipt;
     use reth_execution_types::{AccountRevertInit, BlockExecutionOutput, BlockExecutionResult};
     use reth_primitives_traits::SealedBlock;
@@ -5559,6 +5566,157 @@ mod tests {
     #[test]
     fn test_save_blocks_v2_table_assertions() {
         run_save_blocks_and_verify(StorageMode::V2);
+    }
+
+    fn block_with_revert(
+        number: u64,
+        parent_hash: B256,
+        address: Address,
+        slot: U256,
+    ) -> ExecutedBlock {
+        use alloy_primitives::map::{FbBuildHasher, HashMap};
+
+        let bundle = BundleState::builder(number..=number)
+            .state_present_account_info(
+                address,
+                AccountInfo { nonce: number, balance: U256::from(number), ..Default::default() },
+            )
+            .revert_account_info(number, address, Some(None))
+            .state_storage(
+                address,
+                HashMap::<U256, (U256, U256), FbBuildHasher<32>>::from_iter([(
+                    slot,
+                    (U256::ZERO, U256::from(number)),
+                )]),
+            )
+            .revert_storage(number, address, vec![(slot, U256::ZERO)])
+            .build();
+        let hashed_state =
+            HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle.state()).into_sorted();
+        let block = SealedBlock::<reth_ethereum_primitives::Block>::seal_parts(
+            Header { number, parent_hash, difficulty: U256::from(1), ..Default::default() },
+            Default::default(),
+        );
+
+        ExecutedBlock::new(
+            Arc::new(block.try_recover().unwrap()),
+            Arc::new(BlockExecutionOutput {
+                result: BlockExecutionResult {
+                    receipts: vec![],
+                    requests: Default::default(),
+                    gas_used: 0,
+                    blob_gas_used: 0,
+                },
+                state: bundle,
+            }),
+            ComputedTrieData {
+                sorted: SortedTrieData::new(Arc::new(hashed_state), Default::default()),
+            },
+        )
+    }
+
+    #[test]
+    fn test_save_blocks_preserves_pending_rocksdb_history() {
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let genesis = ExecutedBlock::new(
+            Arc::new(
+                SealedBlock::<reth_ethereum_primitives::Block>::from_sealed_parts(
+                    SealedHeader::new(
+                        Header { number: 0, difficulty: U256::from(1), ..Default::default() },
+                        B256::ZERO,
+                    ),
+                    Default::default(),
+                )
+                .try_recover()
+                .unwrap(),
+            ),
+            Arc::new(BlockExecutionOutput {
+                result: BlockExecutionResult {
+                    receipts: vec![],
+                    requests: Default::default(),
+                    gas_used: 0,
+                    blob_gas_used: 0,
+                },
+                state: Default::default(),
+            }),
+            ComputedTrieData::default(),
+        );
+        let provider_rw = factory.provider_rw().unwrap();
+        save_genesis(&provider_rw, &genesis).unwrap();
+        provider_rw.commit().unwrap();
+
+        let address = Address::with_last_byte(1);
+        let slot = U256::from(1);
+        let block_1 = block_with_revert(1, B256::ZERO, address, slot);
+        let block_2 = block_with_revert(2, block_1.recovered_block().hash(), address, slot);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.save_blocks(&SaveBlocksInput::new(vec![block_1], 0, 0, 1, 1)).unwrap();
+        provider_rw.save_blocks(&SaveBlocksInput::new(vec![block_2], 1, 1, 2, 2)).unwrap();
+        provider_rw.commit().unwrap();
+
+        let rocksdb = factory.rocksdb_provider();
+        let account_indices: Vec<_> = rocksdb
+            .account_history_shards(address)
+            .unwrap()
+            .into_iter()
+            .flat_map(|(_, shard)| shard.iter().collect::<Vec<_>>())
+            .collect();
+        assert_eq!(account_indices, [1, 2]);
+
+        let storage_indices: Vec<_> = rocksdb
+            .storage_history_shards(address, B256::from(slot))
+            .unwrap()
+            .into_iter()
+            .flat_map(|(_, shard)| shard.iter().collect::<Vec<_>>())
+            .collect();
+        assert_eq!(storage_indices, [1, 2]);
+    }
+
+    #[test]
+    fn test_rocksdb_history_preserves_pending_shard_after_split() {
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let address = Address::with_last_byte(1);
+        let slot = U256::from(1);
+        let block = block_with_revert(1, B256::ZERO, address, slot);
+        let provider_rw = factory.provider_rw().unwrap();
+        let rocksdb = factory.rocksdb_provider();
+        let runtime = reth_tasks::Runtime::test();
+        let blocks = vec![block.clone(); NUM_OF_INDICES_IN_SHARD];
+        let tx_nums = vec![0; NUM_OF_INDICES_IN_SHARD];
+
+        rocksdb
+            .write_blocks_data(&blocks, &tx_nums, provider_rw.rocksdb_write_ctx(1), &runtime)
+            .unwrap();
+        rocksdb
+            .write_blocks_data(
+                std::slice::from_ref(&block),
+                &[0],
+                provider_rw.rocksdb_write_ctx(NUM_OF_INDICES_IN_SHARD as u64 + 1),
+                &runtime,
+            )
+            .unwrap();
+        provider_rw.commit_pending_rocksdb_batches().unwrap();
+
+        let account_shards = rocksdb.account_history_shards(address).unwrap();
+        assert_eq!(account_shards.len(), 2);
+        assert_eq!(account_shards[0].1.len(), NUM_OF_INDICES_IN_SHARD as u64);
+        assert_eq!(
+            account_shards[1].1.iter().collect::<Vec<_>>(),
+            [NUM_OF_INDICES_IN_SHARD as u64 + 1]
+        );
+
+        let storage_shards = rocksdb.storage_history_shards(address, B256::from(slot)).unwrap();
+        assert_eq!(storage_shards.len(), 2);
+        assert_eq!(storage_shards[0].1.len(), NUM_OF_INDICES_IN_SHARD as u64);
+        assert_eq!(
+            storage_shards[1].1.iter().collect::<Vec<_>>(),
+            [NUM_OF_INDICES_IN_SHARD as u64 + 1]
+        );
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/rocksdb/mod.rs
+++ b/crates/storage/provider/src/providers/rocksdb/mod.rs
@@ -4,7 +4,7 @@ mod invariants;
 mod metrics;
 mod provider;
 
-pub(crate) use provider::{PendingRocksDBBatches, RocksDBWriteCtx};
+pub(crate) use provider::{PendingRocksDBBatches, PendingRocksDBHistoryCache, RocksDBWriteCtx};
 pub use provider::{
     PruneShardOutcome, PrunedIndices, RocksDBBatch, RocksDBBuilder, RocksDBIter, RocksDBProvider,
     RocksDBRawIter, RocksDBStats, RocksDBTableStats, RocksReadSnapshot, RocksTx,

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -49,6 +49,17 @@ fn synced_write_options() -> WriteOptions {
 /// Pending `RocksDB` batches type alias.
 pub(crate) type PendingRocksDBBatches = Arc<Mutex<Vec<WriteBatchWithTransaction<true>>>>;
 
+/// Latest uncommitted history shards, shared by all `save_blocks` calls in one provider
+/// transaction.
+#[derive(Debug, Default)]
+pub(crate) struct PendingRocksDBHistory {
+    account_shards: BTreeMap<Address, BlockNumberList>,
+    storage_shards: BTreeMap<(Address, B256), BlockNumberList>,
+}
+
+/// Pending history cache type alias.
+pub(crate) type PendingRocksDBHistoryCache = Arc<Mutex<PendingRocksDBHistory>>;
+
 /// Raw key-value result from a `RocksDB` iterator.
 type RawKVResult = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
@@ -93,6 +104,8 @@ pub(crate) struct RocksDBWriteCtx {
     pub storage_settings: StorageSettings,
     /// Pending batches to push to after writing.
     pub pending_batches: PendingRocksDBBatches,
+    /// Latest history shards written by earlier `save_blocks` calls in this transaction.
+    pub pending_history: PendingRocksDBHistoryCache,
 }
 
 impl fmt::Debug for RocksDBWriteCtx {
@@ -102,6 +115,7 @@ impl fmt::Debug for RocksDBWriteCtx {
             .field("prune_tx_lookup", &self.prune_tx_lookup)
             .field("storage_settings", &self.storage_settings)
             .field("pending_batches", &"<pending batches>")
+            .field("pending_history", &"<pending history shards>")
             .finish()
     }
 }
@@ -1485,9 +1499,19 @@ impl RocksDBProvider {
             }
         }
 
-        // Write account history using proper shard append logic
+        let mut pending_history = ctx.pending_history.lock();
         for (address, indices) in account_history {
-            batch.append_account_history_shard(address, indices)?;
+            let last_shard = match pending_history.account_shards.get(&address) {
+                Some(shard) => Some(shard.clone()),
+                None => self.get::<tables::AccountsHistory>(ShardedKey::new(address, u64::MAX))?,
+            };
+            let shards = self.account_history_shards_to_put(address, last_shard, indices)?;
+            let last_shard =
+                shards.last().expect("non-empty indices produce a sentinel shard").1.clone();
+            for (key, shard) in shards {
+                batch.put::<tables::AccountsHistory>(key, &shard)?;
+            }
+            pending_history.account_shards.insert(address, last_shard);
         }
         ctx.pending_batches.lock().push(batch.into_inner());
         Ok(())
@@ -1526,26 +1550,69 @@ impl RocksDBProvider {
         let shard_puts = storage_history
             .into_par_iter()
             .map(|((address, slot), indices)| {
-                self.storage_history_shards_to_put(address, slot, indices)
+                let last_shard =
+                    ctx.pending_history.lock().storage_shards.get(&(address, slot)).cloned();
+                let last_shard = match last_shard {
+                    Some(shard) => Some(shard),
+                    None => {
+                        self.get::<tables::StoragesHistory>(StorageShardedKey::last(address, slot))?
+                    }
+                };
+                self.storage_history_shards_to_put(address, slot, last_shard, indices)
+                    .map(|shards| ((address, slot), shards))
             })
             .collect::<ProviderResult<Vec<_>>>()?;
 
         let mut batch = self.batch();
-        for shards in shard_puts {
+        let mut pending_history = ctx.pending_history.lock();
+        for ((address, slot), shards) in shard_puts {
+            let last_shard =
+                shards.last().expect("non-empty indices produce a sentinel shard").1.clone();
             for (key, shard) in shards {
                 batch.put::<tables::StoragesHistory>(key, &shard)?;
             }
+            pending_history.storage_shards.insert((address, slot), last_shard);
         }
         ctx.pending_batches.lock().push(batch.into_inner());
         Ok(())
     }
 
-    /// Prepares storage history shard writes by reading the current last shard and appending
-    /// indices.
+    /// Prepares account history shard writes from the last committed or pending shard.
+    fn account_history_shards_to_put(
+        &self,
+        address: Address,
+        last_shard: Option<BlockNumberList>,
+        indices: Vec<u64>,
+    ) -> ProviderResult<Vec<(ShardedKey<Address>, BlockNumberList)>> {
+        let mut last_shard = last_shard.unwrap_or_else(BlockNumberList::empty);
+        last_shard.append(indices).map_err(ProviderError::other)?;
+
+        if last_shard.len() <= NUM_OF_INDICES_IN_SHARD as u64 {
+            return Ok(vec![(ShardedKey::new(address, u64::MAX), last_shard)]);
+        }
+
+        let chunks = last_shard.iter().chunks(NUM_OF_INDICES_IN_SHARD);
+        let mut chunks = chunks.into_iter().peekable();
+        let mut shards = Vec::new();
+        while let Some(chunk) = chunks.next() {
+            let shard = BlockNumberList::new_pre_sorted(chunk);
+            let highest_block_number = if chunks.peek().is_some() {
+                shard.iter().next_back().expect("chunks do not return empty lists")
+            } else {
+                u64::MAX
+            };
+            shards.push((ShardedKey::new(address, highest_block_number), shard));
+        }
+
+        Ok(shards)
+    }
+
+    /// Prepares storage history shard writes from the last committed or pending shard.
     fn storage_history_shards_to_put(
         &self,
         address: Address,
         storage_key: B256,
+        last_shard: Option<BlockNumberList>,
         indices: Vec<u64>,
     ) -> ProviderResult<Vec<(StorageShardedKey, BlockNumberList)>> {
         if indices.is_empty() {
@@ -1558,14 +1625,12 @@ impl RocksDBProvider {
             indices
         );
 
-        let last_key = StorageShardedKey::last(address, storage_key);
-        let last_shard_opt = self.get::<tables::StoragesHistory>(last_key.clone())?;
-        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
+        let mut last_shard = last_shard.unwrap_or_else(BlockNumberList::empty);
 
         last_shard.append(indices).map_err(ProviderError::other)?;
 
         if last_shard.len() <= NUM_OF_INDICES_IN_SHARD as u64 {
-            return Ok(vec![(last_key, last_shard)]);
+            return Ok(vec![(StorageShardedKey::last(address, storage_key), last_shard)]);
         }
 
         let chunks = last_shard.iter().chunks(NUM_OF_INDICES_IN_SHARD);
@@ -1983,34 +2048,12 @@ impl<'a> RocksDBBatch<'a> {
             indices
         );
 
-        let last_key = ShardedKey::new(address, u64::MAX);
-        let last_shard_opt = self.provider.get::<tables::AccountsHistory>(last_key.clone())?;
-        let mut last_shard = last_shard_opt.unwrap_or_else(BlockNumberList::empty);
-
-        last_shard.append(indices).map_err(ProviderError::other)?;
-
-        // Fast path: all indices fit in one shard
-        if last_shard.len() <= NUM_OF_INDICES_IN_SHARD as u64 {
-            self.put::<tables::AccountsHistory>(last_key, &last_shard)?;
-            return Ok(());
-        }
-
-        // Slow path: rechunk into multiple shards
-        let chunks = last_shard.iter().chunks(NUM_OF_INDICES_IN_SHARD);
-        let mut chunks_peekable = chunks.into_iter().peekable();
-
-        while let Some(chunk) = chunks_peekable.next() {
-            let shard = BlockNumberList::new_pre_sorted(chunk);
-            let highest_block_number = if chunks_peekable.peek().is_some() {
-                shard.iter().next_back().expect("`chunks` does not return empty list")
-            } else {
-                u64::MAX
-            };
-
-            self.put::<tables::AccountsHistory>(
-                ShardedKey::new(address, highest_block_number),
-                &shard,
-            )?;
+        let last_shard =
+            self.provider.get::<tables::AccountsHistory>(ShardedKey::new(address, u64::MAX))?;
+        for (key, shard) in
+            self.provider.account_history_shards_to_put(address, last_shard, indices)?
+        {
+            self.put::<tables::AccountsHistory>(key, &shard)?;
         }
 
         Ok(())
@@ -2034,10 +2077,16 @@ impl<'a> RocksDBBatch<'a> {
         indices: impl IntoIterator<Item = u64>,
     ) -> ProviderResult<()> {
         let indices: Vec<u64> = indices.into_iter().collect();
+        let last_shard = self
+            .provider
+            .get::<tables::StoragesHistory>(StorageShardedKey::last(address, storage_key))?;
 
-        for (key, shard) in
-            self.provider.storage_history_shards_to_put(address, storage_key, indices)?
-        {
+        for (key, shard) in self.provider.storage_history_shards_to_put(
+            address,
+            storage_key,
+            last_shard,
+            indices,
+        )? {
             self.put::<tables::StoragesHistory>(key, &shard)?;
         }
 


### PR DESCRIPTION
Fixes RocksDB account and storage history writes when multiple `save_blocks` calls share one provider transaction.
RocksDB batches do not expose pending writes to subsequent reads, so later saves could rebuild a history shard from stale committed state and overwrite earlier uncommitted indices. Track each key’s pending sentinel shard and append subsequent indices to it.