### PR TITLE
refactor(execution): narrow cached state providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8909,7 +8909,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
- "reth-trie",
  "revm",
  "tracing",
 ]

--- a/crates/engine/execution-cache/Cargo.toml
+++ b/crates/engine/execution-cache/Cargo.toml
@@ -19,9 +19,7 @@ parking_lot.workspace = true
 reth-errors.workspace = true
 reth-metrics = { workspace = true, features = ["common"] }
 reth-primitives-traits = { workspace = true, features = ["std"] }
-reth-provider.workspace = true
 reth-revm.workspace = true
-reth-trie.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
@@ -34,6 +32,4 @@ revm.workspace = true
 test-utils = [
     "reth-primitives-traits/test-utils",
     "reth-revm/test-utils",
-    "reth-provider/test-utils",
-    "reth-trie/test-utils",
 ]

--- a/crates/engine/execution-cache/src/cached_state.rs
+++ b/crates/engine/execution-cache/src/cached_state.rs
@@ -10,15 +10,7 @@ use parking_lot::Once;
 use reth_errors::ProviderResult;
 use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, Bytecode};
-use reth_provider::{
-    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
-    StateProvider, StateRootProvider, StorageRootProvider,
-};
-use reth_revm::db::BundleState;
-use reth_trie::{
-    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
-    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
-};
+use reth_revm::{database::EvmStateProvider, db::BundleState};
 use std::{
     cell::Cell,
     fmt,
@@ -844,7 +836,12 @@ impl<K: PartialEq, V> StatsHandler<K, V> for CacheStatsHandler {
     }
 }
 
-impl<S: AccountReader> AccountReader for CachedStateProvider<S> {
+#[inline]
+fn nonzero_storage_value(value: StorageValue) -> Option<StorageValue> {
+    (!value.is_zero()).then_some(value)
+}
+
+impl<S: EvmStateProvider> EvmStateProvider for CachedStateProvider<S> {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         if let Some(snapshot) = &self.txpool_snapshot {
             if let Some(account) = snapshot.account(address) {
@@ -875,18 +872,7 @@ impl<S: AccountReader> AccountReader for CachedStateProvider<S> {
             self.state_provider.basic_account(address)
         }
     }
-}
 
-#[inline]
-fn nonzero_storage_value(value: StorageValue) -> Option<StorageValue> {
-    if value.is_zero() {
-        None
-    } else {
-        Some(value)
-    }
-}
-
-impl<S: StateProvider> StateProvider for CachedStateProvider<S> {
     fn storage(
         &self,
         account: Address,
@@ -921,9 +907,7 @@ impl<S: StateProvider> StateProvider for CachedStateProvider<S> {
             self.state_provider.storage(account, storage_key)
         }
     }
-}
 
-impl<S: BytecodeReader> BytecodeReader for CachedStateProvider<S> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         if let Some(snapshot) = &self.txpool_snapshot {
             if let Some(code) = snapshot.bytecode(code_hash) {
@@ -954,116 +938,9 @@ impl<S: BytecodeReader> BytecodeReader for CachedStateProvider<S> {
             self.state_provider.bytecode_by_hash(code_hash)
         }
     }
-}
 
-impl<S: StateRootProvider> StateRootProvider for CachedStateProvider<S> {
-    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
-        self.state_provider.state_root(hashed_state)
-    }
-
-    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
-        self.state_provider.state_root_from_nodes(input)
-    }
-
-    fn state_root_with_updates(
-        &self,
-        hashed_state: HashedPostState,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        self.state_provider.state_root_with_updates(hashed_state)
-    }
-
-    fn state_root_from_nodes_with_updates(
-        &self,
-        input: TrieInput,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        self.state_provider.state_root_from_nodes_with_updates(input)
-    }
-}
-
-impl<S: StateProofProvider> StateProofProvider for CachedStateProvider<S> {
-    fn proof(
-        &self,
-        input: TrieInput,
-        address: Address,
-        slots: &[B256],
-    ) -> ProviderResult<AccountProof> {
-        self.state_provider.proof(input, address, slots)
-    }
-
-    fn multiproof(
-        &self,
-        input: TrieInput,
-        targets: MultiProofTargets,
-    ) -> ProviderResult<MultiProof> {
-        self.state_provider.multiproof(input, targets)
-    }
-
-    fn multiproof_v2(
-        &self,
-        input: TrieInput,
-        targets: reth_trie::MultiProofTargetsV2,
-    ) -> ProviderResult<reth_trie::DecodedMultiProofV2> {
-        self.state_provider.multiproof_v2(input, targets)
-    }
-
-    fn witness(
-        &self,
-        input: TrieInput,
-        target: HashedPostState,
-        mode: reth_trie::ExecutionWitnessMode,
-    ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
-        self.state_provider.witness(input, target, mode)
-    }
-}
-
-impl<S: StorageRootProvider> StorageRootProvider for CachedStateProvider<S> {
-    fn storage_root(
-        &self,
-        address: Address,
-        hashed_storage: HashedStorage,
-    ) -> ProviderResult<B256> {
-        self.state_provider.storage_root(address, hashed_storage)
-    }
-
-    fn storage_proof(
-        &self,
-        address: Address,
-        slot: B256,
-        hashed_storage: HashedStorage,
-    ) -> ProviderResult<StorageProof> {
-        self.state_provider.storage_proof(address, slot, hashed_storage)
-    }
-
-    fn storage_multiproof(
-        &self,
-        address: Address,
-        slots: &[B256],
-        hashed_storage: HashedStorage,
-    ) -> ProviderResult<StorageMultiProof> {
-        self.state_provider.storage_multiproof(address, slots, hashed_storage)
-    }
-}
-
-impl<S: BlockHashReader> BlockHashReader for CachedStateProvider<S> {
     fn block_hash(&self, number: alloy_primitives::BlockNumber) -> ProviderResult<Option<B256>> {
         self.state_provider.block_hash(number)
-    }
-
-    fn canonical_hashes_range(
-        &self,
-        start: alloy_primitives::BlockNumber,
-        end: alloy_primitives::BlockNumber,
-    ) -> ProviderResult<Vec<B256>> {
-        self.state_provider.canonical_hashes_range(start, end)
-    }
-}
-
-impl<S: HashedPostStateProvider> HashedPostStateProvider for CachedStateProvider<S> {
-    fn hashed_post_state(
-        &self,
-        bundle_state: &reth_revm::db::BundleState,
-    ) -> ProviderResult<HashedPostState> {
-        self.state_provider.hashed_post_state(bundle_state)
     }
 }
 

--- a/crates/engine/tree/src/tree/instrumented_state.rs
+++ b/crates/engine/tree/src/tree/instrumented_state.rs
@@ -4,14 +4,7 @@ use metrics::{Gauge, Histogram};
 use reth_errors::ProviderResult;
 use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, Bytecode, FastInstant as Instant};
-use reth_provider::{
-    AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider, StateProofProvider,
-    StateProvider, StateRootProvider, StorageRootProvider,
-};
-use reth_trie::{
-    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
-    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
-};
+use reth_revm::database::EvmStateProvider;
 use std::{
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -69,7 +62,7 @@ pub struct InstrumentedStateProvider<S> {
 
 impl<S> InstrumentedStateProvider<S>
 where
-    S: StateProvider,
+    S: EvmStateProvider,
 {
     /// Creates a new [`InstrumentedStateProvider`] from a state provider with the provided label
     /// for metrics.
@@ -155,7 +148,7 @@ impl StateProviderMetrics {
     }
 }
 
-impl<S: AccountReader> AccountReader for InstrumentedStateProvider<S> {
+impl<S: EvmStateProvider> EvmStateProvider for InstrumentedStateProvider<S> {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         let start = Instant::now();
         let res = self.state_provider.basic_account(address);
@@ -165,9 +158,7 @@ impl<S: AccountReader> AccountReader for InstrumentedStateProvider<S> {
         self.stats.total_account_fetch_latency.add_duration(elapsed);
         res
     }
-}
 
-impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {
     fn storage(
         &self,
         account: Address,
@@ -181,9 +172,7 @@ impl<S: StateProvider> StateProvider for InstrumentedStateProvider<S> {
         self.stats.total_storage_fetch_latency.add_duration(elapsed);
         res
     }
-}
 
-impl<S: BytecodeReader> BytecodeReader for InstrumentedStateProvider<S> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         let start = Instant::now();
         let res = self.state_provider.bytecode_by_hash(code_hash);
@@ -200,116 +189,9 @@ impl<S: BytecodeReader> BytecodeReader for InstrumentedStateProvider<S> {
         );
         res
     }
-}
 
-impl<S: StateRootProvider> StateRootProvider for InstrumentedStateProvider<S> {
-    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
-        self.state_provider.state_root(hashed_state)
-    }
-
-    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
-        self.state_provider.state_root_from_nodes(input)
-    }
-
-    fn state_root_with_updates(
-        &self,
-        hashed_state: HashedPostState,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        self.state_provider.state_root_with_updates(hashed_state)
-    }
-
-    fn state_root_from_nodes_with_updates(
-        &self,
-        input: TrieInput,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        self.state_provider.state_root_from_nodes_with_updates(input)
-    }
-}
-
-impl<S: StateProofProvider> StateProofProvider for InstrumentedStateProvider<S> {
-    fn proof(
-        &self,
-        input: TrieInput,
-        address: Address,
-        slots: &[B256],
-    ) -> ProviderResult<AccountProof> {
-        self.state_provider.proof(input, address, slots)
-    }
-
-    fn multiproof(
-        &self,
-        input: TrieInput,
-        targets: MultiProofTargets,
-    ) -> ProviderResult<MultiProof> {
-        self.state_provider.multiproof(input, targets)
-    }
-
-    fn multiproof_v2(
-        &self,
-        input: TrieInput,
-        targets: reth_trie::MultiProofTargetsV2,
-    ) -> ProviderResult<reth_trie::DecodedMultiProofV2> {
-        self.state_provider.multiproof_v2(input, targets)
-    }
-
-    fn witness(
-        &self,
-        input: TrieInput,
-        target: HashedPostState,
-        mode: reth_trie::ExecutionWitnessMode,
-    ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
-        self.state_provider.witness(input, target, mode)
-    }
-}
-
-impl<S: StorageRootProvider> StorageRootProvider for InstrumentedStateProvider<S> {
-    fn storage_root(
-        &self,
-        address: Address,
-        hashed_storage: HashedStorage,
-    ) -> ProviderResult<B256> {
-        self.state_provider.storage_root(address, hashed_storage)
-    }
-
-    fn storage_proof(
-        &self,
-        address: Address,
-        slot: B256,
-        hashed_storage: HashedStorage,
-    ) -> ProviderResult<StorageProof> {
-        self.state_provider.storage_proof(address, slot, hashed_storage)
-    }
-
-    fn storage_multiproof(
-        &self,
-        address: Address,
-        slots: &[B256],
-        hashed_storage: HashedStorage,
-    ) -> ProviderResult<StorageMultiProof> {
-        self.state_provider.storage_multiproof(address, slots, hashed_storage)
-    }
-}
-
-impl<S: BlockHashReader> BlockHashReader for InstrumentedStateProvider<S> {
     fn block_hash(&self, number: alloy_primitives::BlockNumber) -> ProviderResult<Option<B256>> {
         self.state_provider.block_hash(number)
-    }
-
-    fn canonical_hashes_range(
-        &self,
-        start: alloy_primitives::BlockNumber,
-        end: alloy_primitives::BlockNumber,
-    ) -> ProviderResult<Vec<B256>> {
-        self.state_provider.canonical_hashes_range(start, end)
-    }
-}
-
-impl<S: HashedPostStateProvider> HashedPostStateProvider for InstrumentedStateProvider<S> {
-    fn hashed_post_state(
-        &self,
-        bundle_state: &reth_revm::db::BundleState,
-    ) -> ProviderResult<HashedPostState> {
-        self.state_provider.hashed_post_state(bundle_state)
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal_prewarm_pool.rs
@@ -2,9 +2,8 @@
 
 use alloy_primitives::{Address, StorageKey};
 use reth_execution_cache::{CachedStateProvider, ExecutionCache, TxPoolPrewarmCacheSnapshot};
-use reth_provider::{
-    AccountReader, BytecodeReader, ProviderResult, StateProvider, StateProviderBox,
-};
+use reth_provider::ProviderResult;
+use reth_revm::database::{EvmStateProvider, EvmStateProviderBox};
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -15,9 +14,9 @@ use std::{
 use tokio::sync::oneshot;
 use tracing::trace;
 
-/// Builds a fresh `StateProviderBox` over the block's parent state. Type-erased so the pool is not
+/// Builds a fresh EVM provider over the block's parent state. Type-erased so the pool is not
 /// generic over the provider factory; each worker builds its own per block.
-pub type BuildProviderFn = dyn Fn() -> ProviderResult<StateProviderBox> + Send + Sync;
+pub type BuildProviderFn = dyn Fn() -> ProviderResult<EvmStateProviderBox> + Send + Sync;
 
 /// A single warm request: a whole account (basic account + its bytecode) followed by a batch of
 /// its storage slots, or a batch of storage slots on their own.
@@ -161,7 +160,7 @@ const WARM_BATCH_SIZE: usize = 8;
 fn prewarm_loop(rx: crossbeam_channel::Receiver<PrewarmMsg>) {
     // The provider (and its MDBX read txn) held for the current block, between `BeginBlock` and
     // `EndBlock`. `None` while idle, so no read txn is pinned across the inter-block gap.
-    let mut provider: Option<CachedStateProvider<StateProviderBox>> = None;
+    let mut provider: Option<CachedStateProvider<EvmStateProviderBox>> = None;
 
     // Blocks when idle; the channel disconnects (and the loop ends) when the pool is dropped.
     while let Ok(msg) = rx.recv() {

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -27,11 +27,11 @@ use reth_evm::{execute::ExecutableTxFor, ConfigureEvm, Evm, EvmFor, RecoveredTx,
 use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, FastInstant as Instant, NodePrimitives};
 use reth_provider::{
-    AccountReader, BlockExecutionOutput, BlockNumReader, ChangeSetReader, DatabaseProviderFactory,
+    BlockExecutionOutput, BlockNumReader, ChangeSetReader, DatabaseProviderFactory,
     DatabaseProviderROFactory, HistoryReader, PruneCheckpointReader, StageCheckpointReader,
-    StateProviderBox, StorageChangeSetReader, StorageSettingsCache,
+    StorageChangeSetReader, StorageSettingsCache,
 };
-use reth_revm::database::StateProviderDatabase;
+use reth_revm::database::{EvmStateProvider, EvmStateProviderBox, StateProviderDatabase};
 use reth_storage_overlay::OverlayStateProviderFactory;
 use reth_tasks::{pool::WorkerPool, Runtime};
 use reth_trie_common::MultiProofTargetsV2;
@@ -386,8 +386,7 @@ where
 
                 stream_bal.as_bal().par_iter().for_each(|account_changes| {
                     WorkerPool::with_worker_mut(|worker| {
-                        let provider =
-                            worker.get_or_init::<Option<Box<dyn AccountReader>>>(|| None);
+                        let provider = worker.get_or_init::<Option<EvmStateProviderBox>>(|| None);
                         ctx.send_bal_hashed_state(
                             &parent_span,
                             provider,
@@ -423,9 +422,7 @@ where
             let caches = saved_cache.cache().clone();
             let state_provider_factory = ctx.provider.clone();
             let build = Arc::new(move || {
-                state_provider_factory
-                    .database_provider_ro()
-                    .map(|provider| Box::new(provider) as _)
+                state_provider_factory.database_provider_ro().map(EvmStateProviderBox::new)
             });
 
             pool.begin_block(build, caches, ctx.env.txpool_snapshot.clone());
@@ -569,8 +566,7 @@ where
 
 /// Per-thread EVM state initialised by [`PrewarmContext::evm_for_ctx`] and stored in
 /// [`WorkerPool`] workers via [`Worker::get_or_init`](reth_tasks::pool::Worker::get_or_init).
-type PrewarmEvmState<Evm> =
-    Option<EvmFor<Evm, StateProviderDatabase<reth_provider::StateProviderBox>>>;
+type PrewarmEvmState<Evm> = Option<EvmFor<Evm, StateProviderDatabase<EvmStateProviderBox>>>;
 
 impl<N, P, Evm> PrewarmContext<N, P, Evm>
 where
@@ -589,8 +585,8 @@ where
     /// Creates a per-thread EVM for prewarming.
     #[instrument(level = "debug", target = "engine::tree::payload_processor::prewarm", skip_all)]
     fn evm_for_ctx(&self) -> PrewarmEvmState<Evm> {
-        let mut state_provider: StateProviderBox = match self.provider.database_provider_ro() {
-            Ok(provider) => Box::new(provider),
+        let mut state_provider = match self.provider.database_provider_ro() {
+            Ok(provider) => EvmStateProviderBox::new(provider),
             Err(err) => {
                 trace!(
                     target: "engine::tree::payload_processor::prewarm",
@@ -604,7 +600,7 @@ where
         // Use the caches to create a new provider with caching
         if let Some(saved_cache) = &self.saved_cache {
             let caches = saved_cache.cache().clone();
-            state_provider = Box::new(
+            state_provider = EvmStateProviderBox::new(
                 CachedStateProvider::new_prewarm(state_provider, caches)
                     .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
             );
@@ -665,7 +661,7 @@ where
     fn send_bal_hashed_state(
         &self,
         parent_span: &Span,
-        provider: &mut Option<Box<dyn AccountReader>>,
+        provider: &mut Option<EvmStateProviderBox>,
         account_changes: &alloy_eip7928::AccountChanges,
         hashed_update_stream: &StateRootUpdateStream,
     ) {
@@ -717,17 +713,16 @@ where
                         return;
                     }
                 };
-                let boxed: Box<dyn AccountReader> =
-                    match (self.disable_bal_batch_io, &self.saved_cache) {
-                        (false, Some(saved)) => {
-                            let caches = saved.cache().clone();
-                            Box::new(
-                                CachedStateProvider::new_prewarm(inner, caches)
-                                    .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
-                            )
-                        }
-                        _ => Box::new(inner),
-                    };
+                let boxed = match (self.disable_bal_batch_io, &self.saved_cache) {
+                    (false, Some(saved)) => {
+                        let caches = saved.cache().clone();
+                        EvmStateProviderBox::new(
+                            CachedStateProvider::new_prewarm(inner, caches)
+                                .with_txpool_snapshot(self.env.txpool_snapshot.clone()),
+                        )
+                    }
+                    _ => EvmStateProviderBox::new(inner),
+                };
                 *provider = Some(boxed);
             }
             let account_reader = provider.as_ref().expect("provider just initialized");

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -154,11 +154,13 @@ use reth_primitives_traits::{
 use reth_provider::{
     BlockExecutionOutput, BlockHashReader, BlockReader, ChangeSetReader, DatabaseProviderFactory,
     DatabaseProviderROFactory, HashedPostStateProvider, HistoryReader, ProviderError,
-    PruneCheckpointReader, StageCheckpointReader, StateProvider, StateProviderBox,
-    StateProviderFactory, StateReader, StateRootProvider, StorageChangeSetReader,
-    StorageSettingsCache,
+    PruneCheckpointReader, StageCheckpointReader, StateProvider, StateProviderFactory, StateReader,
+    StateRootProvider, StorageChangeSetReader, StorageSettingsCache,
 };
-use reth_revm::db::{states::bundle_state::BundleRetention, BundleAccount, State};
+use reth_revm::{
+    database::{EvmStateProvider, EvmStateProviderBox},
+    db::{states::bundle_state::BundleRetention, BundleAccount, State},
+};
 use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
 use reth_trie::{
     hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory, updates::TrieUpdates,
@@ -677,15 +679,15 @@ where
         //
         // The second parameter `instrument_state_provider` controls whether we should
         // instrument the state provider with metrics.
-        let make_state_provider = |fill_on_miss: bool| -> ProviderResult<StateProviderBox> {
+        let make_state_provider = |fill_on_miss: bool| -> ProviderResult<EvmStateProviderBox> {
             let provider = state_provider_factory.database_provider_ro()?;
-            let mut provider = if let Some((caches, cache_metrics)) = &execution_cache {
+            let provider = if let Some((caches, cache_metrics)) = &execution_cache {
                 let fill_mode = if fill_on_miss {
                     CacheFillMode::FillOnMiss
                 } else {
                     CacheFillMode::LookupOnly
                 };
-                Box::new(
+                EvmStateProviderBox::new(
                     CachedStateProvider::new_with_mode(
                         provider,
                         caches.clone(),
@@ -694,24 +696,26 @@ where
                         cache_stats.clone(),
                     )
                     .with_txpool_snapshot(txpool_snapshot.clone()),
-                ) as StateProviderBox
+                )
             } else {
-                Box::new(provider) as StateProviderBox
+                EvmStateProviderBox::new(provider)
             };
 
-            if instrument_state_provider {
+            let provider = if instrument_state_provider {
                 let stats = state_provider_stats
                     .as_ref()
                     .expect("instrumented state provider requires shared stats");
                 let metrics = state_provider_metrics
                     .as_ref()
                     .expect("instrumented state provider requires metrics");
-                provider = Box::new(InstrumentedStateProvider::with_stats(
+                EvmStateProviderBox::new(InstrumentedStateProvider::with_stats(
                     provider,
                     metrics.clone(),
                     Arc::clone(stats),
-                ));
-            }
+                ))
+            } else {
+                provider
+            };
 
             Ok(provider)
         };
@@ -1017,7 +1021,7 @@ where
         InsertBlockErrorKind,
     >
     where
-        S: StateProvider + Send,
+        S: EvmStateProvider + Send,
         Err: core::error::Error + Send + Sync + 'static,
         V: PayloadValidator<T, Block = N::Block>,
         T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
@@ -1155,7 +1159,7 @@ where
     where
         Tx: ExecutableTxFor<Evm> + Send,
         Err: core::error::Error + Send + Sync + 'static,
-        MakeStateProvider: Fn(bool) -> ProviderResult<StateProviderBox> + Sync,
+        MakeStateProvider: Fn(bool) -> ProviderResult<EvmStateProviderBox> + Sync,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
         T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
         V: PayloadValidator<T, Block = N::Block>,

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -31,7 +31,10 @@ use reth_payload_builder::{BlobSidecars, EthBuiltPayload};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadAttributes;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
-use reth_revm::{database::StateProviderDatabase, db::State};
+use reth_revm::{
+    database::{EvmStateProviderBox, StateProviderDatabase},
+    db::State,
+};
 use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{
     error::{Eip4844PoolTransactionError, InvalidPoolTransactionError},
@@ -169,17 +172,22 @@ where
     let PayloadConfig { parent_header, attributes, payload_id, .. } = config;
     let skip_state_root = builder_config.skip_state_root;
 
-    let mut state_provider = client.state_by_block_hash(parent_header.hash())?;
-    if let Some(execution_cache) = execution_cache {
-        state_provider = Box::new(CachedStateProvider::new(
-            state_provider,
+    let state_provider = client.state_by_block_hash(parent_header.hash())?;
+    let cached_state_provider = execution_cache.map(|execution_cache| {
+        CachedStateProvider::new(
+            &state_provider,
             execution_cache.cache().clone(),
             // It's ok to recreate the cache every time, because it's cheap to do so for a vanilla
             // Ethereum builder every 12s.
             Some(CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder)),
-        ));
-    }
-    let state = StateProviderDatabase::new(state_provider.as_ref());
+        )
+    });
+    let state = StateProviderDatabase::new(
+        cached_state_provider
+            .as_ref()
+            .map(EvmStateProviderBox::from_ref)
+            .unwrap_or_else(|| EvmStateProviderBox::from_ref(&state_provider)),
+    );
     let chain_spec = client.chain_spec();
     let is_amsterdam = chain_spec.is_amsterdam_active_at_timestamp(attributes.timestamp());
     let mut db = State::builder()

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -1,4 +1,5 @@
 use crate::primitives::alloy_primitives::{BlockNumber, StorageKey, StorageValue};
+use alloc::boxed::Box;
 use alloy_primitives::{Address, B256, U256};
 use core::ops::{Deref, DerefMut};
 use reth_primitives_traits::Account;
@@ -31,6 +32,60 @@ pub trait EvmStateProvider {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>>;
+}
+
+/// Type-erased provider for EVM execution.
+pub struct EvmStateProviderBox<P: ?Sized = dyn EvmStateProvider + Send>(Box<P>);
+
+impl EvmStateProviderBox {
+    /// Boxes an EVM state provider.
+    pub fn new<T>(provider: T) -> Self
+    where
+        T: EvmStateProvider + Send + 'static,
+    {
+        Self(Box::new(provider))
+    }
+}
+
+impl<'a> EvmStateProviderBox<dyn EvmStateProvider + 'a> {
+    /// Boxes a borrowed EVM state provider.
+    pub fn from_ref<T>(provider: &'a T) -> Self
+    where
+        T: EvmStateProvider + ?Sized,
+    {
+        Self(Box::new(EvmStateProviderRef(provider)))
+    }
+}
+
+impl<P: ?Sized> core::fmt::Debug for EvmStateProviderBox<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EvmStateProviderBox").finish_non_exhaustive()
+    }
+}
+
+impl<P: EvmStateProvider + ?Sized> EvmStateProvider for EvmStateProviderBox<P> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        self.0.basic_account(address)
+    }
+
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        self.0.block_hash(number)
+    }
+
+    fn bytecode_by_hash(
+        &self,
+        code_hash: &B256,
+    ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+        self.0.bytecode_by_hash(code_hash)
+    }
+
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        self.0.storage(account, storage_key)
+    }
 }
 
 // Blanket implementation of EvmStateProvider for any type that implements StateProvider.
@@ -223,6 +278,33 @@ where
         code_hash: &B256,
     ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
         Ok(Some(reth_primitives_traits::Bytecode(self.0.code_by_hash_ref(*code_hash)?)))
+    }
+}
+
+struct EvmStateProviderRef<'a, P: ?Sized>(&'a P);
+
+impl<P: EvmStateProvider + ?Sized> EvmStateProvider for EvmStateProviderRef<'_, P> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        self.0.basic_account(address)
+    }
+
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        self.0.block_hash(number)
+    }
+
+    fn bytecode_by_hash(
+        &self,
+        code_hash: &B256,
+    ) -> ProviderResult<Option<reth_primitives_traits::Bytecode>> {
+        self.0.bytecode_by_hash(code_hash)
+    }
+
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        self.0.storage(account, storage_key)
     }
 }
 


### PR DESCRIPTION
Limits cached payload reads to the EVM execution surface and removes its unused state-root and proof delegation. Keeps payload finalization on the original full provider while sharing that provider with the cache through a borrowed EVM view.