### PR TITLE
fix(cli): preserve transaction senders in migrate-v2 when the table is complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8062,6 +8062,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-tasks",
+ "reth-testing-utils",
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -109,6 +109,7 @@ proptest-arbitrary-interop = { workspace = true, optional = true }
 [dev-dependencies]
 reth-ethereum-cli.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
+reth-testing-utils.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/cli/commands/src/db/migrate_v2.rs
+++ b/crates/cli/commands/src/db/migrate_v2.rs
@@ -36,9 +36,10 @@ impl Command {
     /// Execute the full v1 → v2 migration:
     ///
     /// 1. Migrate changesets + receipts to static files
-    /// 2. Flip `StorageSettings` to v2
-    /// 3. Clear recomputable MDBX tables + reset stage checkpoints
-    /// 4. Compact MDBX
+    /// 2. Migrate transaction senders to static files (when the table is complete)
+    /// 3. Flip `StorageSettings` to v2
+    /// 4. Clear recomputable MDBX tables + reset stage checkpoints
+    /// 5. Compact MDBX
     pub async fn execute<N: CliNodeTypes>(
         self,
         provider_factory: ProviderFactory<NodeTypesWithDBAdapter<N, DatabaseEnv>>,
@@ -66,8 +67,11 @@ impl Command {
 
         let sf_provider = provider_factory.static_file_provider();
 
-        for segment in [StaticFileSegment::AccountChangeSets, StaticFileSegment::StorageChangeSets]
-        {
+        for segment in [
+            StaticFileSegment::AccountChangeSets,
+            StaticFileSegment::StorageChangeSets,
+            StaticFileSegment::TransactionSenders,
+        ] {
             if sf_provider.get_highest_static_file_block(segment).is_some() {
                 eyre::bail!(
                     "Static file segment {segment:?} already contains data. \
@@ -85,12 +89,20 @@ impl Command {
         // === Phase 2: Migrate receipts → static files ===
         Self::migrate_receipts::<NodeTypesWithDBAdapter<N, DatabaseEnv>>(&provider_factory, tip)?;
 
-        // === Phase 3: Migrate indices → RocksDB ===
+        // === Phase 3: Migrate transaction senders → static files ===
+        //
+        // Senders are normally recomputed by SenderRecovery, but not all senders are
+        // recoverable: OP mainnet pre-Bedrock OVM transactions (e.g. no-signature queue
+        // transactions) got their senders from `import-op` and cannot be re-derived. When the
+        // table holds one sender per transaction, move it instead of clearing it.
+        let senders_migrated = Self::migrate_transaction_senders(&provider_factory, tip)?;
+
+        // === Phase 4: Migrate indices → RocksDB ===
         Self::migrate_to_rocksdb::<_, tables::TransactionHashNumbers>(&provider_factory)?;
         Self::migrate_to_rocksdb::<_, tables::AccountsHistory>(&provider_factory)?;
         Self::migrate_to_rocksdb::<_, tables::StoragesHistory>(&provider_factory)?;
 
-        // === Phase 4: Flip metadata to v2 ===
+        // === Phase 5: Flip metadata to v2 ===
         info!(target: "reth::cli", "Writing StorageSettings v2 metadata");
         {
             let provider_rw = provider_factory.database_provider_rw()?;
@@ -99,10 +111,10 @@ impl Command {
         }
         info!(target: "reth::cli", "Storage settings updated to v2");
 
-        // === Phase 5: Clear migrated and recomputable MDBX tables ===
-        Self::clear_migrated_and_recomputable_tables(&provider_factory)?;
+        // === Phase 6: Clear migrated and recomputable MDBX tables ===
+        Self::clear_migrated_and_recomputable_tables(&provider_factory, senders_migrated)?;
 
-        // === Phase 6: Compact MDBX (before pipeline, so it runs on a smaller DB) ===
+        // === Phase 7: Compact MDBX (before pipeline, so it runs on a smaller DB) ===
         let db_path = provider_factory.db_ref().path();
         Self::compact_mdbx(provider_factory.db_ref())?;
 
@@ -112,7 +124,7 @@ impl Command {
         let compact_path = db_path.with_file_name("db_compact");
         Self::swap_compacted_db(&db_path, &compact_path)?;
 
-        // === Phase 7: Reopen DB and run pipeline ===
+        // === Phase 8: Reopen DB and run pipeline ===
         // The caller will reopen the environment and run the pipeline.
         // We return here — the pipeline step is handled in mod.rs after
         // reopening the database with the compacted copy.
@@ -276,6 +288,74 @@ impl Command {
         Ok(())
     }
 
+    /// Migrates the `TransactionSenders` MDBX table to static files, if it is complete.
+    ///
+    /// Senders are usually recomputed by the `SenderRecovery` stage after migration, but some
+    /// chains contain transactions whose sender cannot be recovered from the signature (e.g. OP
+    /// mainnet pre-Bedrock OVM transactions, imported with pre-computed senders via `import-op`).
+    /// When the table holds one sender per transaction, moving it is both safer and cheaper than
+    /// recomputing.
+    ///
+    /// Returns `true` if senders were migrated — the `SenderRecovery` checkpoint must then be
+    /// preserved — and `false` if the table is incomplete (e.g. pruned or bootstrapped without
+    /// pre-Bedrock bodies) and the stage should rebuild it.
+    fn migrate_transaction_senders<N: ProviderNodeTypes>(
+        factory: &ProviderFactory<N>,
+        tip: u64,
+    ) -> eyre::Result<bool> {
+        let provider = factory.provider()?.disable_long_read_transaction_safety();
+        let sf_provider = factory.static_file_provider();
+
+        let total_txs = sf_provider
+            .get_highest_static_file_tx(StaticFileSegment::Transactions)
+            .map_or(0, |tx| tx + 1);
+        let sender_entries = provider.tx_ref().entries::<tables::TransactionSenders>()? as u64;
+
+        if total_txs == 0 || sender_entries != total_txs {
+            info!(
+                target: "reth::cli",
+                sender_entries,
+                total_txs,
+                "TransactionSenders table is incomplete, senders will be rebuilt by SenderRecovery"
+            );
+            return Ok(false);
+        }
+
+        info!(target: "reth::cli", "Migrating TransactionSenders → static files");
+
+        let mut writer = sf_provider.latest_writer(StaticFileSegment::TransactionSenders)?;
+
+        let mut senders_cursor = provider.tx_ref().cursor_read::<tables::TransactionSenders>()?;
+        let mut senders = senders_cursor.walk(None)?;
+        let mut indices_cursor = provider.tx_ref().cursor_read::<tables::BlockBodyIndices>()?;
+
+        let mut count = 0u64;
+        for entry in indices_cursor.walk(None)? {
+            let (block, indices) = entry?;
+            if block > tip {
+                break;
+            }
+            writer.ensure_at_block(block)?;
+            for _ in 0..indices.tx_count {
+                let (tx_num, sender) = senders.next().ok_or_else(|| {
+                    eyre::eyre!("missing sender for transaction in block {block}")
+                })??;
+                if tx_num != count {
+                    eyre::bail!(
+                        "non-contiguous TransactionSenders table: expected tx {count}, got {tx_num}"
+                    );
+                }
+                writer.append_transaction_sender(tx_num, &sender)?;
+                count += 1;
+            }
+        }
+        writer.ensure_at_block(tip)?;
+        writer.commit()?;
+
+        info!(target: "reth::cli", count, "TransactionSenders migrated");
+        Ok(true)
+    }
+
     fn migrate_to_rocksdb<N: ProviderNodeTypes, T: Table>(
         factory: &ProviderFactory<N>,
     ) -> eyre::Result<()> {
@@ -306,6 +386,7 @@ impl Command {
     /// and resets only the recomputed stage checkpoints.
     fn clear_migrated_and_recomputable_tables<N: ProviderNodeTypes>(
         factory: &ProviderFactory<N>,
+        senders_migrated: bool,
     ) -> eyre::Result<()> {
         info!(target: "reth::cli", "Clearing migrated and recomputable MDBX tables");
         let db = factory.db_ref();
@@ -323,7 +404,7 @@ impl Command {
         clear_table!(tables::AccountChangeSets);
         clear_table!(tables::StorageChangeSets);
 
-        // Senders — rebuilt by SenderRecovery
+        // Senders — migrated to static files, or rebuilt by SenderRecovery
         clear_table!(tables::TransactionSenders);
 
         // Indices — migrated to RocksDB
@@ -339,16 +420,22 @@ impl Command {
         clear_table!(tables::AccountsTrie);
         clear_table!(tables::StoragesTrie);
 
-        // Reset stage checkpoints so the pipeline rebuilds everything
+        // Reset stage checkpoints so the pipeline rebuilds everything. The SenderRecovery
+        // checkpoint is preserved when senders were migrated to static files — nothing to
+        // rebuild, and pre-Bedrock OVM senders could not be recovered anyway.
         info!(target: "reth::cli", "Resetting stage checkpoints");
         let provider_rw = factory.database_provider_rw()?;
-        for stage in [StageId::SenderRecovery, StageId::MerkleExecute, StageId::MerkleUnwind] {
+        let mut stages_to_reset = vec![StageId::MerkleExecute, StageId::MerkleUnwind];
+        if !senders_migrated {
+            stages_to_reset.push(StageId::SenderRecovery);
+        }
+        for stage in stages_to_reset {
             provider_rw.save_stage_checkpoint(stage, StageCheckpoint::new(0))?;
             info!(target: "reth::cli", %stage, "Checkpoint reset to 0");
         }
         provider_rw.save_stage_checkpoint_progress(StageId::MerkleExecute, vec![])?;
 
-        if provider_rw.last_block_number()? > 0 {
+        if !senders_migrated && provider_rw.last_block_number()? > 0 {
             let first_indices_entry = provider_rw
                 .tx_ref()
                 .cursor_read::<tables::BlockBodyIndices>()?
@@ -437,5 +524,155 @@ impl Command {
 
         info!(target: "reth::cli", "Database compaction swap complete");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_db_api::models::StoredBlockBodyIndices;
+    use reth_provider::{
+        test_utils::{create_test_provider_factory, MockNodeTypesWithDB},
+        StorageSettingsCache, TransactionsProvider,
+    };
+    use reth_testing_utils::generators::{self, random_block_range, BlockRangeParams};
+
+    const TIP: u64 = 19;
+
+    fn expected_sender(tx_num: u64) -> Address {
+        Address::with_last_byte((tx_num % 200) as u8 + 1)
+    }
+
+    /// Seeds a v1-layout chain: transactions in static files, block body indices and senders
+    /// in MDBX. Returns the total transaction count.
+    fn seed_v1_chain(factory: &ProviderFactory<MockNodeTypesWithDB>) -> u64 {
+        let mut rng = generators::rng();
+        let blocks = random_block_range(
+            &mut rng,
+            0..=TIP,
+            BlockRangeParams { tx_count: 1..4, ..Default::default() },
+        );
+
+        let sf_provider = factory.static_file_provider();
+        let provider_rw = factory.database_provider_rw().unwrap();
+        let tx = provider_rw.tx_ref();
+
+        let mut next_tx_num = 0u64;
+        {
+            // Scope the static-file writer so it is dropped (releasing its lock) before the MDBX
+            // provider commits — otherwise the DB commit blocks on the still-held writer lock.
+            let mut tx_writer = sf_provider.latest_writer(StaticFileSegment::Transactions).unwrap();
+            for block in &blocks {
+                tx.put::<tables::BlockBodyIndices>(
+                    block.number,
+                    StoredBlockBodyIndices {
+                        first_tx_num: next_tx_num,
+                        tx_count: block.transaction_count() as u64,
+                    },
+                )
+                .unwrap();
+                for body_tx in &block.body().transactions {
+                    tx_writer.append_transaction(next_tx_num, body_tx).unwrap();
+                    tx.put::<tables::TransactionSenders>(next_tx_num, expected_sender(next_tx_num))
+                        .unwrap();
+                    next_tx_num += 1;
+                }
+                tx_writer.increment_block(block.number).unwrap();
+            }
+            tx_writer.commit().unwrap();
+        }
+        provider_rw.commit().unwrap();
+        next_tx_num
+    }
+
+    #[test]
+    fn migrates_complete_senders_table() {
+        let factory = create_test_provider_factory();
+        let total_txs = seed_v1_chain(&factory);
+        assert!(total_txs > 0);
+
+        let migrated = Command::migrate_transaction_senders(&factory, TIP).unwrap();
+        assert!(migrated);
+
+        let sf_provider = factory.static_file_provider();
+        assert_eq!(
+            sf_provider.get_highest_static_file_tx(StaticFileSegment::TransactionSenders),
+            Some(total_txs - 1)
+        );
+        assert_eq!(
+            sf_provider.get_highest_static_file_block(StaticFileSegment::TransactionSenders),
+            Some(TIP)
+        );
+
+        // Senders must read back from static files with the exact same values.
+        factory.set_storage_settings_cache(StorageSettings::v2());
+        let provider = factory.provider().unwrap();
+        for tx_num in 0..total_txs {
+            assert_eq!(
+                provider.transaction_sender(tx_num).unwrap(),
+                Some(expected_sender(tx_num)),
+                "sender mismatch for tx {tx_num}"
+            );
+        }
+    }
+
+    #[test]
+    fn incomplete_senders_table_falls_back() {
+        let factory = create_test_provider_factory();
+        let total_txs = seed_v1_chain(&factory);
+
+        // Remove one sender to make the table incomplete.
+        let provider_rw = factory.database_provider_rw().unwrap();
+        provider_rw.tx_ref().delete::<tables::TransactionSenders>(total_txs - 1, None).unwrap();
+        provider_rw.commit().unwrap();
+
+        let migrated = Command::migrate_transaction_senders(&factory, TIP).unwrap();
+        assert!(!migrated);
+        assert!(factory
+            .static_file_provider()
+            .get_highest_static_file_block(StaticFileSegment::TransactionSenders)
+            .is_none());
+    }
+
+    #[test]
+    fn clear_preserves_sender_recovery_checkpoint_when_migrated() {
+        let factory = create_test_provider_factory();
+        seed_v1_chain(&factory);
+
+        let provider_rw = factory.database_provider_rw().unwrap();
+        provider_rw
+            .save_stage_checkpoint(StageId::SenderRecovery, StageCheckpoint::new(TIP))
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        Command::clear_migrated_and_recomputable_tables(&factory, true).unwrap();
+
+        let provider = factory.provider().unwrap();
+        assert_eq!(
+            provider.get_stage_checkpoint(StageId::SenderRecovery).unwrap(),
+            Some(StageCheckpoint::new(TIP))
+        );
+        // The MDBX table is cleared either way once senders live in static files.
+        assert_eq!(provider.tx_ref().entries::<tables::TransactionSenders>().unwrap(), 0);
+    }
+
+    #[test]
+    fn clear_resets_sender_recovery_checkpoint_when_not_migrated() {
+        let factory = create_test_provider_factory();
+        seed_v1_chain(&factory);
+
+        let provider_rw = factory.database_provider_rw().unwrap();
+        provider_rw
+            .save_stage_checkpoint(StageId::SenderRecovery, StageCheckpoint::new(TIP))
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        Command::clear_migrated_and_recomputable_tables(&factory, false).unwrap();
+
+        let provider = factory.provider().unwrap();
+        assert_eq!(
+            provider.get_stage_checkpoint(StageId::SenderRecovery).unwrap(),
+            Some(StageCheckpoint::new(0))
+        );
     }
 }


### PR DESCRIPTION
`migrate-v2` clears the `TransactionSenders` table and lets `SenderRecovery` rebuild it on the next start. That breaks on an OP Mainnet archive that includes pre-Bedrock (OVM) blocks: those senders can't be recovered from a signature — we imported them via `import-op` when building the archive — so after migrating, the node fails at `SenderRecovery` on the first OVM block and unwinds.

When the senders table is complete (one entry per transaction), this moves it into the `TransactionSenders` static-file segment instead of clearing it, and keeps the `SenderRecovery` checkpoint. Incomplete tables (pruned / `--without-ovm`) keep the existing clear-and-rebuild behavior.

Tested by migrating a full OP Mainnet archive (~1.35B txs) from v1 to v2: pre-Bedrock `from` fields are preserved and the node starts without re-running sender recovery. It's been serving as a v2 archive for several days since, no issues.
