### PR TITLE
fix(trie): revert changeset avoidance for read-only overlays

### DIFF
--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -16,7 +16,7 @@ use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, PruneCheckpointReader, StageCheckpointReader,
     StorageChangeSetReader, StorageSettingsCache,
 };
-use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted, TrieInputSorted};
+use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted};
 use reth_trie_db::DatabaseHashedPostState;
 use revm::{bytecode::Bytecode, database::BundleState, state::AccountInfo};
 use std::{
@@ -29,28 +29,28 @@ use tracing::{debug, debug_span, instrument};
 /// Contains the trie and hashed-state data required to initialize an overlay state provider.
 #[derive(Debug, Clone)]
 pub struct StateTrieOverlay {
-    input: TrieInputSorted,
+    /// Trie updates overlay.
+    pub trie_updates: Arc<TrieUpdatesSorted>,
+    /// Hashed state overlay.
+    pub hashed_post_state: Arc<HashedPostStateSorted>,
     /// Whether construction was skipped because a reused sparse trie covers this range.
     skipped_for_reused_sparse_trie: bool,
 }
 
 impl StateTrieOverlay {
-    pub(crate) const fn new(input: TrieInputSorted) -> Self {
-        Self { input, skipped_for_reused_sparse_trie: false }
+    pub(crate) const fn new(
+        trie_updates: Arc<TrieUpdatesSorted>,
+        hashed_post_state: Arc<HashedPostStateSorted>,
+    ) -> Self {
+        Self { trie_updates, hashed_post_state, skipped_for_reused_sparse_trie: false }
     }
 
     fn empty() -> Self {
-        Self { input: TrieInputSorted::default(), skipped_for_reused_sparse_trie: true }
-    }
-
-    /// Returns the trie input represented by this overlay.
-    pub const fn input(&self) -> &TrieInputSorted {
-        &self.input
-    }
-
-    /// Consumes the overlay and returns its trie input.
-    pub fn into_input(self) -> TrieInputSorted {
-        self.input
+        Self {
+            trie_updates: Arc::new(TrieUpdatesSorted::default()),
+            hashed_post_state: Arc::new(HashedPostStateSorted::default()),
+            skipped_for_reused_sparse_trie: true,
+        }
     }
 
     pub(crate) const fn skipped_for_reused_sparse_trie(&self) -> bool {
@@ -393,17 +393,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Builds the effective state trie overlay for the given provider.
-    ///
-    /// Set `trie_changesets` only for consumers that produce [`TrieUpdates`], such as
-    /// [`StateRootProvider::state_root_with_updates`]. Other consumers, including roots, proofs,
-    /// multiproofs, and witnesses, should leave it false: reverts are then represented by
-    /// hashed-state prefix sets instead of querying trie changesets.
     #[cfg(test)]
     #[instrument(level = "debug", target = "storage::overlay", skip_all)]
     fn build_state_trie_overlay<Provider>(
         &self,
         provider: &Provider,
-        trie_changesets: bool,
     ) -> ProviderResult<StateTrieOverlay>
     where
         Provider: StageCheckpointReader
@@ -415,12 +409,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             + StorageSettingsCache,
     {
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(provider)?;
-        self.build_state_trie_overlay_at_frontiers(
-            provider,
-            state_trie_tip_block,
-            finish_tip_block,
-            trie_changesets,
-        )
+        self.build_state_trie_overlay_at_frontiers(provider, state_trie_tip_block, finish_tip_block)
     }
 
     /// Builds the effective state trie overlay using frontiers already read from the provider.
@@ -437,7 +426,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         provider: &Provider,
         state_trie_tip_block: BlockNumHash,
         finish_tip_block: BlockNumHash,
-        trie_changesets: bool,
     ) -> ProviderResult<StateTrieOverlay>
     where
         Provider: ChangeSetReader
@@ -457,7 +445,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             self.anchor_at_parent_with_frontiers(provider, state_trie_tip_block, finish_tip_block)?;
 
         // Collect any reverts which are required to bring the DB view back to the anchor hash.
-        let (trie_updates, hashed_post_state, prefix_sets) = match &anchor_for_parent {
+        let (trie_updates, hashed_post_state) = match &anchor_for_parent {
             AnchorForParent::RevertsRequired { anchor, .. } => {
                 let revert_blocks =
                     self.revert_blocks(&anchor_for_parent)?.expect("reverts are required");
@@ -469,7 +457,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     "Collecting trie reverts for overlay state provider"
                 );
 
-                let trie_reverts = if trie_changesets {
+                let trie_reverts = {
                     let _guard = debug_span!(target: "storage::overlay", "retrieving_trie_reverts")
                         .entered();
                     let start = Instant::now();
@@ -482,9 +470,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         )?;
                     retrieve_trie_reverts_duration = start.elapsed();
                     accumulated_reverts
-                } else {
-                    retrieve_trie_reverts_duration = Duration::ZERO;
-                    Arc::default()
                 };
 
                 let mut hashed_state_reverts = {
@@ -495,12 +480,6 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     let res = HashedPostStateSorted::from_reverts(provider, revert_blocks)?;
                     retrieve_hashed_state_reverts_duration = start.elapsed();
                     res
-                };
-
-                let prefix_sets = if trie_changesets {
-                    Default::default()
-                } else {
-                    hashed_state_reverts.construct_prefix_sets()
                 };
 
                 // Resolve overlays and extend reverts with them. If reverts are empty, use overlays
@@ -538,7 +517,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     "Reverted to anchor block",
                 );
 
-                (trie_updates, hashed_state_updates, prefix_sets)
+                (trie_updates, hashed_state_updates)
             }
             AnchorForParent::NoReverts { anchor } => {
                 // If no reverts are needed, use the manager overlay directly unless the reused
@@ -569,7 +548,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     "Built overlay directly from durable frontier"
                 );
 
-                (trie_updates, hashed_post_state, Default::default())
+                (trie_updates, hashed_post_state)
             }
         };
 
@@ -582,11 +561,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         self.metrics.trie_updates_size.record(trie_updates_total_len as f64);
         self.metrics.hashed_state_size.record(hashed_state_updates_total_len as f64);
 
-        Ok(StateTrieOverlay::new(TrieInputSorted::new(
-            trie_updates,
-            hashed_post_state,
-            prefix_sets,
-        )))
+        Ok(StateTrieOverlay::new(trie_updates, hashed_post_state))
     }
 
     /// Returns the in-memory execution overlay and the block for historical fallback reads.
@@ -917,11 +892,11 @@ mod tests {
     }
 
     fn account_keys(overlay: &StateTrieOverlay) -> Vec<B256> {
-        overlay.input().state.accounts.iter().map(|(key, _)| *key).collect()
+        overlay.hashed_post_state.accounts.iter().map(|(key, _)| *key).collect()
     }
 
     fn account_node_paths(overlay: &StateTrieOverlay) -> Vec<Nibbles> {
-        overlay.input().nodes.account_nodes_ref().iter().map(|(path, _)| *path).collect()
+        overlay.trie_updates.account_nodes_ref().iter().map(|(path, _)| *path).collect()
     }
 
     #[test]
@@ -1038,7 +1013,7 @@ mod tests {
         for (parent_index, expected_ids) in [(3, vec![3, 4]), (4, vec![3, 4, 5])] {
             let overlay = manager
                 .overlay_builder(blocks[parent_index].recovered_block().hash())
-                .build_state_trie_overlay(&provider, true)
+                .build_state_trie_overlay(&provider)
                 .unwrap();
 
             assert_eq!(
@@ -1066,11 +1041,11 @@ mod tests {
         let overlay = manager
             .overlay_builder(blocks[4].recovered_block().hash())
             .with_skip_overlay_for_reused_sparse_trie(blocks[3].recovered_block().hash())
-            .build_state_trie_overlay(&provider, true)
+            .build_state_trie_overlay(&provider)
             .unwrap();
 
-        assert!(overlay.input().state.is_empty());
-        assert!(overlay.input().nodes.is_empty());
+        assert!(overlay.hashed_post_state.is_empty());
+        assert!(overlay.trie_updates.is_empty());
     }
 
     #[test]
@@ -1081,7 +1056,7 @@ mod tests {
         let builder = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(blocks[1].recovered_block().hash())
             .with_no_reverts();
-        let error = builder.build_state_trie_overlay(&provider, true).unwrap_err();
+        let error = builder.build_state_trie_overlay(&provider).unwrap_err();
 
         assert!(error.to_string().contains("reverts are disabled"));
     }
@@ -1102,35 +1077,9 @@ mod tests {
             Err(ProviderError::BlockHashNotFound(hash)) if hash == parent_hash
         ));
         assert!(matches!(
-            builder.build_state_trie_overlay(&provider, true),
+            builder.build_state_trie_overlay(&provider),
             Err(ProviderError::BlockHashNotFound(hash)) if hash == parent_hash
         ));
-    }
-
-    #[test]
-    fn state_trie_overlay_uses_revert_prefix_sets_without_trie_changesets() {
-        let (factory, blocks) = setup_frontiers(2, 3);
-        let provider_rw = factory.provider_rw().unwrap();
-        provider_rw
-            .tx_ref()
-            .put::<tables::AccountChangeSets>(
-                3,
-                AccountBeforeTx {
-                    address: Address::with_last_byte(1),
-                    info: Some(Account::default()),
-                },
-            )
-            .unwrap();
-        provider_rw.commit().unwrap();
-
-        let provider = factory.provider().unwrap();
-        let overlay = OverlayManager::<EthPrimitives>::default()
-            .overlay_builder(blocks[1].recovered_block().hash())
-            .build_state_trie_overlay(&provider, false)
-            .unwrap();
-
-        assert!(overlay.input().nodes.is_empty());
-        assert!(!overlay.input().prefix_sets.is_empty());
     }
 
     #[test]
@@ -1327,7 +1276,7 @@ mod tests {
         let provider = factory.provider().unwrap();
         let error = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(blocks[3].recovered_block().hash())
-            .build_state_trie_overlay(&provider, true)
+            .build_state_trie_overlay(&provider)
             .unwrap_err();
 
         assert!(
@@ -1343,7 +1292,7 @@ mod tests {
         let parent_hash = blocks[3].recovered_block().hash();
         let error = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(parent_hash)
-            .build_state_trie_overlay(&provider, true)
+            .build_state_trie_overlay(&provider)
             .unwrap_err();
 
         assert!(error.to_string().contains("is after partial state trie frontier"));

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -403,7 +403,7 @@ impl ChangesetCache {
         let overlay = overlay_manager
             .overlay_builder(finish.hash)
             .with_no_reverts()
-            .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish, true)?;
+            .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish)?;
         let state_trie_provider = OverlayStateProvider::<&P, N>::new_with_state_trie(
             provider,
             overlay,
@@ -644,7 +644,7 @@ mod tests {
     }
 
     fn empty_overlay() -> StateTrieOverlay {
-        StateTrieOverlay::new(TrieInputSorted::default())
+        StateTrieOverlay::new(Arc::default(), Arc::default())
     }
 
     fn insert_test_changesets(

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -52,7 +52,7 @@ pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
     factory: F,
     /// Overlay builder containing the configuration and overlay calculation logic.
     overlay_builder: OverlayBuilder<N>,
-    /// A cache mapping `(state_trie_tip, finish_tip, trie_changesets)` to [`StateTrieOverlay`].
+    /// A cache mapping `(state_trie_tip, finish_tip)` to [`StateTrieOverlay`].
     ///
     /// Under partial persistence the overlay depends on both durable frontiers, so both hashes are
     /// part of the cache key.
@@ -129,7 +129,6 @@ pub struct OverlayStateProvider<Provider, N: NodePrimitives = EthPrimitives> {
     state_trie_overlay_cache: StateTrieOverlayCache,
     metrics: OverlayStateProviderFactoryMetrics,
     state_trie_overlay: OnceCell<StateTrieOverlay>,
-    state_trie_overlay_with_trie_changesets: OnceCell<StateTrieOverlay>,
     execution_overlay: OnceCell<CachedExecutionOverlay>,
     is_v2: bool,
 }
@@ -163,7 +162,6 @@ impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, 
             state_trie_overlay_cache,
             metrics,
             state_trie_overlay: OnceCell::new(),
-            state_trie_overlay_with_trie_changesets: OnceCell::new(),
             execution_overlay: OnceCell::new(),
             is_v2,
         }
@@ -181,7 +179,6 @@ impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, 
             state_trie_overlay_cache: Default::default(),
             metrics: Default::default(),
             state_trie_overlay: OnceCell::new(),
-            state_trie_overlay_with_trie_changesets: OnceCell::new(),
             execution_overlay: OnceCell::from(CachedExecutionOverlay {
                 overlay: execution_overlay,
                 historical_fallback: None,
@@ -204,7 +201,6 @@ impl<'a, Provider, N: NodePrimitives> OverlayStateProvider<&'a Provider, N> {
             state_trie_overlay_cache: Default::default(),
             metrics: Default::default(),
             state_trie_overlay: OnceCell::new(),
-            state_trie_overlay_with_trie_changesets: OnceCell::new(),
             execution_overlay: OnceCell::new(),
             is_v2,
         }
@@ -220,8 +216,7 @@ impl<'a, Provider, N: NodePrimitives> OverlayStateProvider<&'a Provider, N> {
             overlay_builder: None,
             state_trie_overlay_cache: Default::default(),
             metrics: Default::default(),
-            state_trie_overlay: OnceCell::from(state_trie_overlay.clone()),
-            state_trie_overlay_with_trie_changesets: OnceCell::from(state_trie_overlay),
+            state_trie_overlay: OnceCell::from(state_trie_overlay),
             execution_overlay: OnceCell::new(),
             is_v2,
         }
@@ -237,7 +232,7 @@ where
         &self.provider
     }
 
-    fn state_trie_overlay(&self, trie_changesets: bool) -> ProviderResult<&StateTrieOverlay>
+    fn state_trie_overlay(&self) -> ProviderResult<&StateTrieOverlay>
     where
         Provider::Target: StageCheckpointReader
             + PruneCheckpointReader
@@ -247,17 +242,15 @@ where
             + BlockNumReader
             + StorageSettingsCache,
     {
-        let state_trie_overlay = self.state_trie_overlay_mut(trie_changesets);
-        if let Some(overlay) = state_trie_overlay.get() {
+        if let Some(overlay) = self.state_trie_overlay.get() {
             return Ok(overlay)
         }
 
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
-        let overlay = match self.state_trie_overlay_cache.entry((
-            state_trie_tip_block.hash,
-            finish_tip_block.hash,
-            trie_changesets,
-        )) {
+        let overlay = match self
+            .state_trie_overlay_cache
+            .entry((state_trie_tip_block.hash, finish_tip_block.hash))
+        {
             dashmap::Entry::Occupied(entry) => entry.get().clone(),
             dashmap::Entry::Vacant(entry) => {
                 self.metrics.state_trie_overlay_cache_misses.increment(1);
@@ -269,7 +262,6 @@ where
                         self.provider(),
                         state_trie_tip_block,
                         finish_tip_block,
-                        trie_changesets,
                     )?;
                 if !overlay.skipped_for_reused_sparse_trie() {
                     entry.insert(overlay.clone());
@@ -277,23 +269,11 @@ where
                 overlay
             }
         };
-        let _ = state_trie_overlay.set(overlay);
-        Ok(state_trie_overlay.get().expect("state trie overlay was just initialized"))
+        let _ = self.state_trie_overlay.set(overlay);
+        Ok(self.state_trie_overlay.get().expect("state trie overlay was just initialized"))
     }
 
-    const fn state_trie_overlay_mut(&self, trie_changesets: bool) -> &OnceCell<StateTrieOverlay> {
-        if trie_changesets {
-            &self.state_trie_overlay_with_trie_changesets
-        } else {
-            &self.state_trie_overlay
-        }
-    }
-
-    fn build_overlay(
-        &self,
-        input: TrieInputSorted,
-        trie_changesets: bool,
-    ) -> ProviderResult<TrieInputSorted>
+    fn build_overlay(&self, input: TrieInputSorted) -> ProviderResult<TrieInputSorted>
     where
         Provider::Target: StageCheckpointReader
             + PruneCheckpointReader
@@ -303,14 +283,13 @@ where
             + BlockNumReader
             + StorageSettingsCache,
     {
-        let overlay = self.state_trie_overlay(trie_changesets)?;
+        let overlay = self.state_trie_overlay()?;
         if overlay.skipped_for_reused_sparse_trie() {
             return Err(ProviderError::UnsupportedProvider)
         }
-        let TrieInputSorted { nodes: input_nodes, state: input_state, mut prefix_sets } = input;
-        let overlay_input = overlay.input();
-        let mut nodes = Arc::clone(&overlay_input.nodes);
-        let mut state = Arc::clone(&overlay_input.state);
+        let TrieInputSorted { nodes: input_nodes, state: input_state, prefix_sets } = input;
+        let mut nodes = Arc::clone(&overlay.trie_updates);
+        let mut state = Arc::clone(&overlay.hashed_post_state);
 
         if !input_nodes.is_empty() {
             Arc::make_mut(&mut nodes).extend_ref_and_sort(&input_nodes);
@@ -319,7 +298,6 @@ where
             Arc::make_mut(&mut state).extend_ref_and_sort(&input_state);
         }
 
-        prefix_sets.extend_ref(&overlay_input.prefix_sets);
         Ok(TrieInputSorted::new(nodes, state, prefix_sets))
     }
 
@@ -533,17 +511,16 @@ where
 {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
-                false,
-            )?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(hashed_state),
+            ))?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.provider().tx(), input)?)
         })
     }
 
     fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
             Ok(<DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes(
                 self.provider().tx(),
                 input,
@@ -556,10 +533,9 @@ where
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
-                true,
-            )?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(hashed_state),
+            ))?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(
                 self.provider().tx(),
                 input,
@@ -572,7 +548,7 @@ where
         input: TrieInput,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(input), true)?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
             Ok(
                 <DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes_with_updates(
                     self.provider().tx(),
@@ -600,15 +576,12 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(
-                        alloy_primitives::keccak256(address),
-                        hashed_storage,
-                    ),
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
                 )),
-                false,
-            )?;
+            ))?;
             let hashed_storage = input
                 .state
                 .account_storages()
@@ -628,15 +601,12 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(
-                        alloy_primitives::keccak256(address),
-                        hashed_storage,
-                    ),
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
                 )),
-                false,
-            )?;
+            ))?;
             let hashed_storage = input
                 .state
                 .account_storages()
@@ -661,15 +631,12 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(
-                        alloy_primitives::keccak256(address),
-                        hashed_storage,
-                    ),
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(
+                TrieInput::from_state(HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
                 )),
-                false,
-            )?;
+            ))?;
             let hashed_storage = input
                 .state
                 .account_storages()
@@ -707,7 +674,7 @@ where
     ) -> ProviderResult<AccountProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -725,7 +692,7 @@ where
     ) -> ProviderResult<MultiProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -743,7 +710,7 @@ where
     ) -> ProviderResult<DecodedMultiProofV2> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -762,7 +729,7 @@ where
     ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
             let witness = TrieWitness::new(
                 InMemoryTrieCursorFactory::new(
                     DatabaseTrieCursorFactory::<_, A>::new(self.provider().tx()),
@@ -811,7 +778,7 @@ where
             return Ok(hashed_state)
         }
 
-        let overlay_state = self.build_overlay(TrieInputSorted::default(), false)?.state;
+        let overlay_state = self.build_overlay(TrieInputSorted::default())?.state;
         zero_destroyed_account_storage(
             &HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(self.provider().tx()),
@@ -926,7 +893,7 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
             Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
                 self.provider().tx().cursor_read::<PackedAccountsTrie>()?,
@@ -936,14 +903,14 @@ where
                 self.provider().tx().cursor_read::<tables::AccountsTrie>()?,
             ))
         };
-        Ok(InMemoryTrieCursor::new_account(cursor, &overlay.input().nodes))
+        Ok(InMemoryTrieCursor::new_account(cursor, &overlay.trie_updates))
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
             Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
                 self.provider().tx().cursor_dup_read::<PackedStoragesTrie>()?,
@@ -955,7 +922,7 @@ where
                 hashed_address,
             ))
         };
-        Ok(InMemoryTrieCursor::new_storage(cursor, &overlay.input().nodes, hashed_address))
+        Ok(InMemoryTrieCursor::new_storage(cursor, &overlay.trie_updates, hashed_address))
     }
 }
 
@@ -987,10 +954,10 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(self.provider().tx()),
-            &overlay.input().state,
+            &overlay.hashed_post_state,
         )
         .hashed_account_cursor()
     }
@@ -999,10 +966,10 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
         HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(self.provider().tx()),
-            &overlay.input().state,
+            &overlay.hashed_post_state,
         )
         .hashed_storage_cursor(hashed_address)
     }
@@ -1020,7 +987,7 @@ pub(crate) struct OverlayStateProviderFactoryMetrics {
     state_trie_overlay_cache_misses: Counter,
 }
 
-type StateTrieOverlayCache = Arc<DashMap<(BlockHash, BlockHash, bool), StateTrieOverlay>>;
+type StateTrieOverlayCache = Arc<DashMap<(BlockHash, BlockHash), StateTrieOverlay>>;
 
 #[derive(Clone, Debug)]
 struct CachedExecutionOverlay {
@@ -1155,11 +1122,11 @@ mod tests {
     }
 
     fn account_keys(overlay: &StateTrieOverlay) -> Vec<B256> {
-        overlay.input().state.accounts.iter().map(|(key, _)| *key).collect()
+        overlay.hashed_post_state.accounts.iter().map(|(key, _)| *key).collect()
     }
 
     fn account_node_paths(overlay: &StateTrieOverlay) -> Vec<Nibbles> {
-        overlay.input().nodes.account_nodes_ref().iter().map(|(path, _)| *path).collect()
+        overlay.trie_updates.account_nodes_ref().iter().map(|(path, _)| *path).collect()
     }
 
     #[test]
@@ -1175,7 +1142,7 @@ mod tests {
         );
 
         let provider = state_provider_factory.database_provider_ro().unwrap();
-        let first = provider.state_trie_overlay(false).unwrap().clone();
+        let first = provider.state_trie_overlay().unwrap().clone();
         assert_eq!(account_keys(&first), vec![B256::with_last_byte(3), B256::with_last_byte(4)]);
         drop(provider);
 
@@ -1191,7 +1158,7 @@ mod tests {
         provider_rw.commit().unwrap();
 
         let provider = state_provider_factory.database_provider_ro().unwrap();
-        let second = provider.state_trie_overlay(false).unwrap().clone();
+        let second = provider.state_trie_overlay().unwrap().clone();
         assert_eq!(account_keys(&second), vec![B256::with_last_byte(4)]);
         assert_eq!(account_node_paths(&second), vec![Nibbles::from_nibbles([4])]);
         assert_eq!(state_provider_factory.state_trie_overlay_cache.len(), 2);
@@ -1225,39 +1192,6 @@ mod tests {
     }
 
     #[test]
-    fn state_trie_overlay_cache_is_keyed_by_trie_changesets() {
-        let (factory, blocks) = setup_frontiers(1, 3);
-        let manager = OverlayManager::default();
-        for block in &blocks[2..=3] {
-            manager.insert_block(block.clone());
-        }
-        let state_provider_factory = OverlayStateProviderFactory::new(
-            factory,
-            manager.overlay_builder(blocks[3].recovered_block().hash()),
-        );
-        let provider = state_provider_factory.database_provider_ro().unwrap();
-
-        provider.state_trie_overlay(false).unwrap();
-        provider.state_trie_overlay(true).unwrap();
-
-        assert_eq!(state_provider_factory.state_trie_overlay_cache.len(), 2);
-    }
-
-    #[test]
-    fn supplied_state_trie_overlay_is_available_in_both_modes() {
-        let (factory, _) = setup_frontiers(1, 1);
-        let provider = factory.provider().unwrap();
-        let provider = OverlayStateProvider::<&_, EthPrimitives>::new_with_state_trie(
-            &provider,
-            StateTrieOverlay::new(TrieInputSorted::default()),
-            false,
-        );
-
-        assert!(provider.state_trie_overlay(false).is_ok());
-        assert!(provider.state_trie_overlay(true).is_ok());
-    }
-
-    #[test]
     fn lazy_overlays_survive_manager_block_removal() {
         let (factory, blocks) = setup_frontiers(1, 1);
         let manager = OverlayManager::default();
@@ -1278,7 +1212,7 @@ mod tests {
             [blocks[2].recovered_block().num_hash(), blocks[3].recovered_block().num_hash()]
         );
         assert_eq!(
-            account_keys(provider.state_trie_overlay(false).unwrap()),
+            account_keys(provider.state_trie_overlay().unwrap()),
             vec![B256::with_last_byte(3), B256::with_last_byte(4)]
         );
     }
@@ -1296,7 +1230,7 @@ mod tests {
         );
 
         let provider = state_provider_factory.database_provider_ro().unwrap();
-        assert!(provider.state_trie_overlay(false).unwrap().skipped_for_reused_sparse_trie());
+        assert!(provider.state_trie_overlay().unwrap().skipped_for_reused_sparse_trie());
         assert!(state_provider_factory.state_trie_overlay_cache.is_empty());
         assert!(matches!(
             provider.state_root(HashedPostState::default()),


### PR DESCRIPTION
Reverts [#26986](https://github.com/paradigmxyz/reth/pull/26986).

Prompted by: @shekhirin
