### PR TITLE
refactor(primitives): use Alloy receipt root calculation

### DIFF
--- a/crates/ethereum/primitives/Cargo.toml
+++ b/crates/ethereum/primitives/Cargo.toml
@@ -18,7 +18,6 @@ reth-primitives-traits.workspace = true
 
 # ethereum
 alloy-eips = { workspace = true, features = ["k256"] }
-alloy-primitives.workspace = true
 alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 
@@ -26,6 +25,7 @@ alloy-rpc-types-eth = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-primitives.workspace = true
 arbitrary.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -1,8 +1,5 @@
 use alloy_consensus::TxType;
 pub use alloy_consensus::{EthereumReceipt, TxTy};
-use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::B256;
-use reth_primitives_traits::proofs::ordered_trie_root_with_encoder;
 
 /// Raw ethereum receipt.
 pub type Receipt<T = TxType> = EthereumReceipt<T>;
@@ -10,15 +7,6 @@ pub type Receipt<T = TxType> = EthereumReceipt<T>;
 #[cfg(feature = "rpc")]
 /// Receipt representation for RPC.
 pub type RpcReceipt<T = TxType> = EthereumReceipt<T, alloy_rpc_types_eth::Log>;
-
-/// Calculates the receipt root for a header for the reference type of [`Receipt`].
-///
-/// NOTE: Prefer `proofs::calculate_receipt_root` if you have log blooms memoized.
-pub fn calculate_receipt_root_no_memo<T: TxTy>(receipts: &[Receipt<T>]) -> B256 {
-    ordered_trie_root_with_encoder(receipts, |r, buf| {
-        alloy_consensus::TxReceipt::with_bloom_ref(r).encode_2718(buf)
-    })
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -411,7 +411,7 @@ impl ExecutionOutcome {
     pub fn ethereum_receipts_root(&self, block_number: BlockNumber) -> Option<B256> {
         self.generic_receipts_root_slow(
             block_number,
-            reth_ethereum_primitives::calculate_receipt_root_no_memo,
+            reth_ethereum_primitives::Receipt::calculate_receipt_root_no_memo,
         )
     }
 }


### PR DESCRIPTION
Replaces the duplicate receipt-root helper with Alloy’s `Receipt::calculate_receipt_root_no_memo` and moves the now test-only `alloy-primitives` dependency to dev-dependencies.
