### PR TITLE
refactor(rpc): use Alloy BlockId display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10379,7 +10379,6 @@ dependencies = [
 name = "reth-rpc-server-types"
 version = "2.5.2"
 dependencies = [
- "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -14,7 +14,7 @@ use reth_primitives_traits::transaction::{error::InvalidTransactionError, signed
 use reth_revm::db::bal::EvmDatabaseError;
 use reth_rpc_convert::{CallFeesError, EthTxEnvError, TransactionConversionError};
 use reth_rpc_server_types::result::{
-    block_id_to_str, internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code,
+    internal_rpc_err, invalid_params_rpc_err, rpc_err, rpc_error_with_code,
 };
 use reth_transaction_pool::error::{
     Eip4844PoolTransactionError, Eip7702PoolTransactionError, InvalidPoolTransactionError,
@@ -337,16 +337,12 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::HeaderNotFound(id) | EthApiError::ReceiptsNotFound(id) => {
                 rpc_error_with_code(
                     EthRpcErrorCode::ResourceNotFound.code(),
-                    format!("block not found: {}", block_id_to_str(id)),
+                    format!("block not found: {id}"),
                 )
             }
             EthApiError::HeaderRangeNotFound(start_id, end_id) => rpc_error_with_code(
                 EthRpcErrorCode::ResourceNotFound.code(),
-                format!(
-                    "{error}: start block: {}, end block: {}",
-                    block_id_to_str(start_id),
-                    block_id_to_str(end_id),
-                ),
+                format!("{error}: start block: {start_id}, end block: {end_id}"),
             ),
             err @ EthApiError::TransactionConfirmationTimeout { .. } => rpc_error_with_code(
                 EthRpcErrorCode::TransactionConfirmationTimeout.code(),

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -23,7 +23,7 @@ use reth_primitives_traits::{
     BlockBody as _, BlockTy, NodePrimitives, Recovered, RecoveredBlock, SealedHeader,
 };
 use reth_rpc_convert::{RpcBlock, RpcConvert, RpcTxReq};
-use reth_rpc_server_types::result::{block_id_to_str, rpc_err};
+use reth_rpc_server_types::result::rpc_err;
 use reth_storage_api::{noop::NoopProvider, StateProvider};
 use revm::{
     context::Block,
@@ -61,7 +61,7 @@ pub enum EthSimulateError {
     #[error("Client adjustable limit reached")]
     GasLimitReached,
     /// Base block for the simulation was not found.
-    #[error("block not found: {}", block_id_to_str(*block))]
+    #[error("block not found: {block}")]
     BlockNotFound {
         /// The block id that was requested.
         block: BlockId,

--- a/crates/rpc/rpc-server-types/Cargo.toml
+++ b/crates/rpc/rpc-server-types/Cargo.toml
@@ -18,7 +18,6 @@ reth-network-api.workspace = true
 # ethereum
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
-alloy-eips.workspace = true
 
 # rpc
 jsonrpsee-core.workspace = true

--- a/crates/rpc/rpc-server-types/src/result.rs
+++ b/crates/rpc/rpc-server-types/src/result.rs
@@ -2,7 +2,6 @@
 
 use std::fmt;
 
-use alloy_eips::BlockId;
 use alloy_rpc_types_engine::PayloadError;
 use jsonrpsee_core::RpcResult;
 use reth_errors::ConsensusError;
@@ -150,20 +149,6 @@ pub fn rpc_err(
                 .expect("serializing String can't fail")
         }),
     )
-}
-
-/// Formats a [`BlockId`] into an error message.
-pub fn block_id_to_str(id: BlockId) -> String {
-    match id {
-        BlockId::Hash(h) => {
-            if h.require_canonical == Some(true) {
-                format!("canonical hash {}", h.block_hash)
-            } else {
-                format!("hash {}", h.block_hash)
-            }
-        }
-        BlockId::Number(n) => format!("{n}"),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Removes `block_id_to_str` and formats block IDs directly using Alloy’s `Display` implementation, preserving the existing RPC error messages. Also removes the unused `alloy-eips` dependency from `reth-rpc-server-types`.
