### PR TITLE
refactor: delegate fee calculations to Alloy

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,7 +1,7 @@
 use crate::{ChainSpec, DepositContract};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_chains::Chain;
-use alloy_eips::{calc_next_block_base_fee, eip1559::BaseFeeParams, eip7840::BlobParams};
+use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_genesis::Genesis;
 use alloy_primitives::{B256, U256};
 use core::fmt::{Debug, Display};
@@ -63,14 +63,9 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     /// Returns the final total difficulty if the Paris hardfork is known.
     fn final_paris_total_difficulty(&self) -> Option<U256>;
 
-    /// See [`calc_next_block_base_fee`].
+    /// See [`AlloyBlockHeader::next_block_base_fee`].
     fn next_block_base_fee(&self, parent: &Self::Header, target_timestamp: u64) -> Option<u64> {
-        Some(calc_next_block_base_fee(
-            parent.gas_used(),
-            parent.gas_limit(),
-            parent.base_fee_per_gas()?,
-            self.base_fee_params_at_timestamp(target_timestamp),
-        ))
+        parent.next_block_base_fee(self.base_fee_params_at_timestamp(target_timestamp))
     }
 }
 

--- a/crates/rpc/rpc-eth-types/src/fee_history.rs
+++ b/crates/rpc/rpc-eth-types/src/fee_history.rs
@@ -396,21 +396,14 @@ where
     ///
     /// See also [`Self::next_block_excess_blob_gas`]
     pub fn next_block_blob_fee(&self) -> Option<u128> {
-        self.next_block_excess_blob_gas()
-            .and_then(|excess_blob_gas| Some(self.blob_params?.calc_blob_fee(excess_blob_gas)))
+        self.header.maybe_next_block_blob_fee(self.blob_params)
     }
 
     /// Calculate excess blob gas for the next block according to the EIP-4844 spec.
     ///
     /// Returns a `None` if no excess blob gas is set, no EIP-4844 support
     pub fn next_block_excess_blob_gas(&self) -> Option<u64> {
-        self.header.excess_blob_gas().and_then(|excess_blob_gas| {
-            Some(self.blob_params?.next_block_excess_blob_gas_osaka(
-                excess_blob_gas,
-                self.header.blob_gas_used()?,
-                self.header.base_fee_per_gas()?,
-            ))
-        })
+        self.header.maybe_next_block_excess_blob_gas(self.blob_params)
     }
 }
 


### PR DESCRIPTION
Delegates the existing base-fee and blob-fee helpers to Alloy’s `BlockHeader` methods, removing duplicate calculations while keeping the Reth APIs.
