### PR TITLE
perf(trie): skip historical trie changesets with complete overlays

### DIFF
--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1080,6 +1080,173 @@ mod tests {
         sync::Arc,
     };
 
+    #[test]
+    fn historical_proofs_complete_masked_trie_rows() -> eyre::Result<()> {
+        use crate::{StaticFileProviderFactory, StaticFileSegment, StaticFileWriter};
+        use reth_storage_api::{StorageSettings, StorageSettingsCache, TrieWriter};
+        use reth_trie::{test_utils::TrieTestHarness, MultiProofTargets, MultiProofTargetsV2};
+        use revm::state::AccountInfo;
+
+        let address = Address::with_last_byte(1);
+        let other_address = Address::with_last_byte(2);
+        let hashed_address = keccak256(address);
+        let account = Account { balance: U256::from(1), ..Default::default() };
+        // Branches 00, 01 and 02 share the cached row at 0. The first two change
+        // in different blocks; the third keeps proof-v2's branch-collapse path inactive.
+        let slots: Vec<B256> = (0..=2u8)
+            .flat_map(|prefix| {
+                (0..u64::MAX)
+                    .map(|slot| B256::from(U256::from(slot)))
+                    .filter(move |slot| keccak256(slot)[0] == prefix)
+                    .take(2)
+            })
+            .collect();
+        let mut storage: BTreeMap<_, _> = slots.iter().map(|&slot| (slot, U256::from(1))).collect();
+        let mut trie = TrieTestHarness::new(
+            storage.iter().map(|(slot, value)| (keccak256(slot), *value)).collect(),
+        );
+        let mut blocks = Vec::<ExecutedBlock>::new();
+        let mut storage_roots = Vec::new();
+        for number in 0..=2 {
+            let mut output = (*ExecutedBlock::<reth_ethereum_primitives::EthPrimitives>::default()
+                .execution_output)
+                .clone();
+            let (state, storage_updates) = if number == 0 {
+                (
+                    HashedPostState::default()
+                        .with_accounts([
+                            (hashed_address, Some(account)),
+                            (keccak256(other_address), Some(account)),
+                        ])
+                        .with_storages([(
+                            hashed_address,
+                            HashedStorage::from_iter(trie.storage().iter().map(|(k, v)| (*k, *v))),
+                        )]),
+                    trie.storage_trie_updates().clone(),
+                )
+            } else {
+                let slot = slots[(number as usize - 1) * 2];
+                let value = U256::from(number + 1);
+                let changes = BTreeMap::from([(keccak256(slot), value)]);
+                let (_, updates) = trie.get_root_with_updates(&changes);
+                trie.apply_changeset(changes);
+                storage.insert(slot, value);
+                let info = AccountInfo::from_balance(account.balance);
+                output.state = BundleState::builder(number..=number)
+                    .state_original_account_info(address, info.clone())
+                    .state_present_account_info(address, info)
+                    .state_storage(
+                        address,
+                        std::iter::once((U256::from_be_bytes(slot.0), (U256::from(1), value)))
+                            .collect(),
+                    )
+                    .revert_storage(
+                        number,
+                        address,
+                        vec![(U256::from_be_bytes(slot.0), U256::from(1))],
+                    )
+                    .build();
+                (
+                    HashedPostState::from_hashed_storage(
+                        hashed_address,
+                        HashedStorage::from_iter([(keccak256(slot), value)]),
+                    ),
+                    updates,
+                )
+            };
+            let mut updates = TrieUpdates::default();
+            updates.storage_tries.insert(hashed_address, storage_updates);
+            let state_root = reth_trie::test_utils::state_root([
+                (address, (account, storage.clone())),
+                (other_address, (account, BTreeMap::new())),
+            ]);
+            storage_roots.push(reth_trie::test_utils::storage_root(storage.clone()));
+            let block = Block {
+                header: alloy_consensus::Header {
+                    number,
+                    parent_hash: blocks
+                        .last()
+                        .map(|b| b.recovered_block().hash())
+                        .unwrap_or_default(),
+                    state_root,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            blocks.push(ExecutedBlock::new(
+                Arc::new(RecoveredBlock::new_unhashed(block, vec![])),
+                Arc::new(output),
+                ComputedTrieData::new(
+                    Arc::new(state.into_sorted()),
+                    Arc::new(updates.into_sorted()),
+                ),
+            ));
+        }
+
+        for settings in [StorageSettings::v1(), StorageSettings::v2()] {
+            let factory = create_test_provider_factory();
+            factory.set_storage_settings_cache(settings);
+            let writer = factory.provider_rw()?;
+            writer.insert_block(blocks[0].recovered_block())?;
+            writer.write_hashed_state(blocks[0].hashed_state_ref())?;
+            writer.write_trie_updates_sorted(blocks[0].trie_updates_ref())?;
+            writer.commit()?;
+            let static_files = factory.static_file_provider();
+            static_files.get_writer(0, StaticFileSegment::Receipts)?.increment_block(0)?;
+            if settings.is_v2() {
+                static_files
+                    .get_writer(0, StaticFileSegment::AccountChangeSets)?
+                    .append_account_changeset(vec![], 0)?;
+                static_files
+                    .get_writer(0, StaticFileSegment::StorageChangeSets)?
+                    .append_storage_changeset(vec![], 0)?;
+            }
+            static_files.commit()?;
+            let writer = factory.provider_rw()?;
+            writer.save_blocks(&SaveBlocksInput::new(blocks[1..].to_vec(), 0, 0, 2, 1))?;
+            writer.commit()?;
+            factory.overlay_manager().insert_block(blocks[2].clone());
+            let provider = BlockchainProvider::new(factory)?;
+
+            for number in [1, 2] {
+                let state =
+                    provider.history_by_block_hash(blocks[number].recovered_block().hash())?;
+                let root = blocks[number].recovered_block().state_root;
+                state
+                    .multiproof_v2(
+                        Default::default(),
+                        MultiProofTargetsV2 {
+                            account_targets: vec![keccak256(other_address).into()],
+                            ..Default::default()
+                        },
+                    )?
+                    .account_proof(other_address, &[])?
+                    .verify(root)?;
+                assert_eq!(state.state_root(HashedPostState::default())?, root);
+                state.proof(Default::default(), other_address, &[])?.verify(root)?;
+                state
+                    .multiproof(
+                        Default::default(),
+                        MultiProofTargets::account(keccak256(other_address)),
+                    )?
+                    .account_proof(other_address, &[])?
+                    .verify(root)?;
+                assert_eq!(
+                    state.storage_root(address, HashedStorage::default())?,
+                    storage_roots[number]
+                );
+                state
+                    .storage_proof(address, slots[2], HashedStorage::default())?
+                    .verify(storage_roots[number])?;
+                let proof =
+                    state.storage_multiproof(address, &[slots[2]], HashedStorage::default())?;
+                assert_eq!(proof.root, storage_roots[number]);
+                proof.storage_proof(slots[2])?.verify(storage_roots[number])?;
+            }
+        }
+        Ok(())
+    }
+
     const TEST_BLOCKS_COUNT: usize = 5;
 
     const TEST_TRANSACTIONS_COUNT: u8 = 4;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1084,7 +1084,7 @@ mod tests {
     fn historical_proofs_complete_masked_trie_rows() -> eyre::Result<()> {
         use crate::{StaticFileProviderFactory, StaticFileSegment, StaticFileWriter};
         use reth_storage_api::{StorageSettings, StorageSettingsCache, TrieWriter};
-        use reth_trie::{test_utils::TrieTestHarness, MultiProofTargets, MultiProofTargetsV2};
+        use reth_trie::{test_utils::TrieTestHarness, MultiProofTargetsV2};
         use revm::state::AccountInfo;
 
         let address = Address::with_last_byte(1);
@@ -1219,14 +1219,6 @@ mod tests {
                 .account_proof(other_address, &[])?
                 .verify(root)?;
             assert_eq!(state.state_root(HashedPostState::default())?, root);
-            state.proof(Default::default(), other_address, &[])?.verify(root)?;
-            state
-                .multiproof(
-                    Default::default(),
-                    MultiProofTargets::account(keccak256(other_address)),
-                )?
-                .account_proof(other_address, &[])?
-                .verify(root)?;
             assert_eq!(
                 state.storage_root(address, HashedStorage::default())?,
                 storage_roots[number]

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1183,66 +1183,60 @@ mod tests {
             ));
         }
 
-        for settings in [StorageSettings::v1(), StorageSettings::v2()] {
-            let factory = create_test_provider_factory();
-            factory.set_storage_settings_cache(settings);
-            let writer = factory.provider_rw()?;
-            writer.insert_block(blocks[0].recovered_block())?;
-            writer.write_hashed_state(blocks[0].hashed_state_ref())?;
-            writer.write_trie_updates_sorted(blocks[0].trie_updates_ref())?;
-            writer.commit()?;
-            let static_files = factory.static_file_provider();
-            static_files.get_writer(0, StaticFileSegment::Receipts)?.increment_block(0)?;
-            if settings.is_v2() {
-                static_files
-                    .get_writer(0, StaticFileSegment::AccountChangeSets)?
-                    .append_account_changeset(vec![], 0)?;
-                static_files
-                    .get_writer(0, StaticFileSegment::StorageChangeSets)?
-                    .append_storage_changeset(vec![], 0)?;
-            }
-            static_files.commit()?;
-            let writer = factory.provider_rw()?;
-            writer.save_blocks(&SaveBlocksInput::new(blocks[1..].to_vec(), 0, 0, 2, 1))?;
-            writer.commit()?;
-            factory.overlay_manager().insert_block(blocks[2].clone());
-            let provider = BlockchainProvider::new(factory)?;
+        let factory = create_test_provider_factory();
+        factory.set_storage_settings_cache(StorageSettings::v2());
+        let writer = factory.provider_rw()?;
+        writer.insert_block(blocks[0].recovered_block())?;
+        writer.write_hashed_state(blocks[0].hashed_state_ref())?;
+        writer.write_trie_updates_sorted(blocks[0].trie_updates_ref())?;
+        writer.commit()?;
+        let static_files = factory.static_file_provider();
+        static_files.get_writer(0, StaticFileSegment::Receipts)?.increment_block(0)?;
+        static_files
+            .get_writer(0, StaticFileSegment::AccountChangeSets)?
+            .append_account_changeset(vec![], 0)?;
+        static_files
+            .get_writer(0, StaticFileSegment::StorageChangeSets)?
+            .append_storage_changeset(vec![], 0)?;
+        static_files.commit()?;
+        let writer = factory.provider_rw()?;
+        writer.save_blocks(&SaveBlocksInput::new(blocks[1..].to_vec(), 0, 0, 2, 1))?;
+        writer.commit()?;
+        factory.overlay_manager().insert_block(blocks[2].clone());
+        let provider = BlockchainProvider::new(factory)?;
 
-            for number in [1, 2] {
-                let state =
-                    provider.history_by_block_hash(blocks[number].recovered_block().hash())?;
-                let root = blocks[number].recovered_block().state_root;
-                state
-                    .multiproof_v2(
-                        Default::default(),
-                        MultiProofTargetsV2 {
-                            account_targets: vec![keccak256(other_address).into()],
-                            ..Default::default()
-                        },
-                    )?
-                    .account_proof(other_address, &[])?
-                    .verify(root)?;
-                assert_eq!(state.state_root(HashedPostState::default())?, root);
-                state.proof(Default::default(), other_address, &[])?.verify(root)?;
-                state
-                    .multiproof(
-                        Default::default(),
-                        MultiProofTargets::account(keccak256(other_address)),
-                    )?
-                    .account_proof(other_address, &[])?
-                    .verify(root)?;
-                assert_eq!(
-                    state.storage_root(address, HashedStorage::default())?,
-                    storage_roots[number]
-                );
-                state
-                    .storage_proof(address, slots[2], HashedStorage::default())?
-                    .verify(storage_roots[number])?;
-                let proof =
-                    state.storage_multiproof(address, &[slots[2]], HashedStorage::default())?;
-                assert_eq!(proof.root, storage_roots[number]);
-                proof.storage_proof(slots[2])?.verify(storage_roots[number])?;
-            }
+        for number in [1, 2] {
+            let state = provider.history_by_block_hash(blocks[number].recovered_block().hash())?;
+            let root = blocks[number].recovered_block().state_root;
+            state
+                .multiproof_v2(
+                    Default::default(),
+                    MultiProofTargetsV2 {
+                        account_targets: vec![keccak256(other_address).into()],
+                        ..Default::default()
+                    },
+                )?
+                .account_proof(other_address, &[])?
+                .verify(root)?;
+            assert_eq!(state.state_root(HashedPostState::default())?, root);
+            state.proof(Default::default(), other_address, &[])?.verify(root)?;
+            state
+                .multiproof(
+                    Default::default(),
+                    MultiProofTargets::account(keccak256(other_address)),
+                )?
+                .account_proof(other_address, &[])?
+                .verify(root)?;
+            assert_eq!(
+                state.storage_root(address, HashedStorage::default())?,
+                storage_roots[number]
+            );
+            state
+                .storage_proof(address, slots[2], HashedStorage::default())?
+                .verify(storage_roots[number])?;
+            let proof = state.storage_multiproof(address, &[slots[2]], HashedStorage::default())?;
+            assert_eq!(proof.root, storage_roots[number]);
+            proof.storage_proof(slots[2])?.verify(storage_roots[number])?;
         }
         Ok(())
     }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -153,11 +153,9 @@ impl<Provider: DBProvider + StorageSettingsCache> StorageRootProvider
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.0, |A| {
-            let input = TrieInputSorted::from_unsorted(TrieInput::from_state(
-                HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
-                ),
+            let input = TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
+                alloy_primitives::keccak256(address),
+                hashed_storage,
             ));
             <DbStorageRoot<'_, _, A>>::overlay_root(self.tx(), address, input)
                 .map_err(|err| ProviderError::Database(err.into()))
@@ -188,11 +186,9 @@ impl<Provider: DBProvider + StorageSettingsCache> StorageRootProvider
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
         reth_trie_db::with_adapter!(self.0, |A| {
-            let input = TrieInputSorted::from_unsorted(TrieInput::from_state(
-                HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
-                ),
+            let input = TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
+                alloy_primitives::keccak256(address),
+                hashed_storage,
             ));
             <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(self.tx(), address, slots, input)
                 .map_err(ProviderError::from)

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -188,13 +188,14 @@ impl<Provider: DBProvider + StorageSettingsCache> StorageRootProvider
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
         reth_trie_db::with_adapter!(self.0, |A| {
-            <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(
-                self.tx(),
-                address,
-                slots,
-                hashed_storage,
-            )
-            .map_err(ProviderError::from)
+            let input = TrieInputSorted::from_unsorted(TrieInput::from_state(
+                HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                ),
+            ));
+            <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(self.tx(), address, slots, input)
+                .map_err(ProviderError::from)
         })
     }
 }

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -153,10 +153,13 @@ impl<Provider: DBProvider + StorageSettingsCache> StorageRootProvider
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.0, |A| {
-            let input = TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
-                alloy_primitives::keccak256(address),
-                hashed_storage,
-            ));
+            let input = TrieInputSorted::from_state(
+                HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )
+                .into_sorted(),
+            );
             <DbStorageRoot<'_, _, A>>::overlay_root(self.tx(), address, input)
                 .map_err(|err| ProviderError::Database(err.into()))
         })
@@ -186,10 +189,13 @@ impl<Provider: DBProvider + StorageSettingsCache> StorageRootProvider
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
         reth_trie_db::with_adapter!(self.0, |A| {
-            let input = TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
-                alloy_primitives::keccak256(address),
-                hashed_storage,
-            ));
+            let input = TrieInputSorted::from_state(
+                HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                )
+                .into_sorted(),
+            );
             <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(self.tx(), address, slots, input)
                 .map_err(ProviderError::from)
         })

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -153,7 +153,13 @@ impl<Provider: DBProvider + StorageSettingsCache> StorageRootProvider
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.0, |A| {
-            <DbStorageRoot<'_, _, A>>::overlay_root(self.tx(), address, hashed_storage)
+            let input = TrieInputSorted::from_unsorted(TrieInput::from_state(
+                HashedPostState::from_hashed_storage(
+                    alloy_primitives::keccak256(address),
+                    hashed_storage,
+                ),
+            ));
+            <DbStorageRoot<'_, _, A>>::overlay_root(self.tx(), address, input)
                 .map_err(|err| ProviderError::Database(err.into()))
         })
     }

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -20,6 +20,7 @@ mod tests {
     use reth_trie::{
         test_utils::{state_root, storage_root_prehashed},
         HashedPostState, HashedStorage, StateRoot, StorageRoot, StorageRootProgress,
+        TrieInput, TrieInputSorted,
     };
     use reth_trie_db::{DatabaseStateRoot, DatabaseStorageRoot, LegacyKeyAdapter, PackedKeyAdapter};
     use revm::database::{
@@ -1186,18 +1187,23 @@ mod tests {
             reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
         >;
         let is_v2 = provider_rw.cached_storage_settings().is_v2();
+        let input = TrieInputSorted::from_unsorted(TrieInput::from_state(
+            HashedPostState::from_hashed_storage(hashed_address, updated_storage.clone()),
+        ));
         let storage_root = if is_v2 {
             TestStorageRoot::<_, _, PackedKeyAdapter>::overlay_root(
                 tx,
                 address,
-                updated_storage.clone(),
+                input,
             )
             .unwrap()
         } else {
             TestStorageRoot::<_, _, LegacyKeyAdapter>::overlay_root(
                 tx,
                 address,
-                updated_storage.clone(),
+                TrieInputSorted::from_unsorted(TrieInput::from_state(
+                    HashedPostState::from_hashed_storage(hashed_address, updated_storage.clone()),
+                )),
             )
             .unwrap()
         };

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -20,7 +20,7 @@ mod tests {
     use reth_trie::{
         test_utils::{state_root, storage_root_prehashed},
         HashedPostState, HashedStorage, StateRoot, StorageRoot, StorageRootProgress,
-        TrieInput, TrieInputSorted,
+        TrieInputSorted,
     };
     use reth_trie_db::{DatabaseStateRoot, DatabaseStorageRoot, LegacyKeyAdapter, PackedKeyAdapter};
     use revm::database::{
@@ -1187,8 +1187,9 @@ mod tests {
             reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
         >;
         let is_v2 = provider_rw.cached_storage_settings().is_v2();
-        let input = TrieInputSorted::from_unsorted(TrieInput::from_state(
-            HashedPostState::from_hashed_storage(hashed_address, updated_storage.clone()),
+        let input = TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
+            hashed_address,
+            updated_storage.clone(),
         ));
         let storage_root = if is_v2 {
             TestStorageRoot::<_, _, PackedKeyAdapter>::overlay_root(
@@ -1201,8 +1202,9 @@ mod tests {
             TestStorageRoot::<_, _, LegacyKeyAdapter>::overlay_root(
                 tx,
                 address,
-                TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(hashed_address, updated_storage.clone()),
+                TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
+                    hashed_address,
+                    updated_storage.clone(),
                 )),
             )
             .unwrap()

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -1190,7 +1190,7 @@ mod tests {
         let input = TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
             hashed_address,
             updated_storage.clone(),
-        ));
+        ).into_sorted());
         let storage_root = if is_v2 {
             TestStorageRoot::<_, _, PackedKeyAdapter>::overlay_root(
                 tx,
@@ -1205,7 +1205,7 @@ mod tests {
                 TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
                     hashed_address,
                     updated_storage.clone(),
-                )),
+                ).into_sorted()),
             )
             .unwrap()
         };

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -1,4 +1,7 @@
-use crate::{manager::OverlayCacheConfig, OverlayManager};
+use crate::{
+    manager::{OverlayCacheConfig, StateTrieOverlayError},
+    OverlayManager,
+};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{
     map::{AddressMap, AddressSet, B256Map, U256Map},
@@ -477,14 +480,30 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         )?;
                     retrieve_trie_reverts_duration = start.elapsed();
                     accumulated_reverts
+                } else if state_trie_tip_block == finish_tip_block {
+                    retrieve_trie_reverts_duration = Duration::ZERO;
+                    Arc::default()
                 } else {
                     // Revert prefixes describe changes since the anchor, not stale hashes in
                     // masked DB rows. Complete the trie at Finish before applying those prefixes.
                     let start = Instant::now();
+                    let finish_state = self
+                        .overlay_manager
+                        .block_state(finish_tip_block.hash)
+                        .ok_or_else(|| {
+                            ProviderError::other(StateTrieOverlayError {
+                                tip_hash: finish_tip_block.hash,
+                                anchor_hash: state_trie_tip_block.hash,
+                            })
+                        })?;
                     let (nodes, _) = self
                         .overlay_manager
-                        .overlay_builder(finish_tip_block.hash)
-                        .resolve_state_trie_overlays(state_trie_tip_block.hash)?;
+                        .overlay_for_parent(
+                            &finish_state,
+                            state_trie_tip_block.hash,
+                            OverlayCacheConfig::default(),
+                        )
+                        .map_err(ProviderError::other)?;
                     retrieve_trie_reverts_duration = start.elapsed();
                     nodes
                 };

--- a/crates/storage/storage-overlay/src/builder.rs
+++ b/crates/storage/storage-overlay/src/builder.rs
@@ -16,7 +16,7 @@ use reth_storage_api::{
     BlockNumReader, ChangeSetReader, DBProvider, PruneCheckpointReader, StageCheckpointReader,
     StorageChangeSetReader, StorageSettingsCache,
 };
-use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted};
+use reth_trie::{updates::TrieUpdatesSorted, HashedPostStateSorted, TrieInputSorted};
 use reth_trie_db::DatabaseHashedPostState;
 use revm::{bytecode::Bytecode, database::BundleState, state::AccountInfo};
 use std::{
@@ -29,28 +29,23 @@ use tracing::{debug, debug_span, instrument};
 /// Contains the trie and hashed-state data required to initialize an overlay state provider.
 #[derive(Debug, Clone)]
 pub struct StateTrieOverlay {
-    /// Trie updates overlay.
-    pub trie_updates: Arc<TrieUpdatesSorted>,
-    /// Hashed state overlay.
-    pub hashed_post_state: Arc<HashedPostStateSorted>,
+    input: TrieInputSorted,
     /// Whether construction was skipped because a reused sparse trie covers this range.
     skipped_for_reused_sparse_trie: bool,
 }
 
 impl StateTrieOverlay {
-    pub(crate) const fn new(
-        trie_updates: Arc<TrieUpdatesSorted>,
-        hashed_post_state: Arc<HashedPostStateSorted>,
-    ) -> Self {
-        Self { trie_updates, hashed_post_state, skipped_for_reused_sparse_trie: false }
+    pub(crate) const fn new(input: TrieInputSorted) -> Self {
+        Self { input, skipped_for_reused_sparse_trie: false }
     }
 
     fn empty() -> Self {
-        Self {
-            trie_updates: Arc::new(TrieUpdatesSorted::default()),
-            hashed_post_state: Arc::new(HashedPostStateSorted::default()),
-            skipped_for_reused_sparse_trie: true,
-        }
+        Self { input: TrieInputSorted::default(), skipped_for_reused_sparse_trie: true }
+    }
+
+    /// Returns the trie input represented by this overlay.
+    pub const fn input(&self) -> &TrieInputSorted {
+        &self.input
     }
 
     pub(crate) const fn skipped_for_reused_sparse_trie(&self) -> bool {
@@ -393,11 +388,17 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
     }
 
     /// Builds the effective state trie overlay for the given provider.
+    ///
+    /// Set `trie_changesets` only for consumers that produce [`TrieUpdates`], such as
+    /// [`StateRootProvider::state_root_with_updates`]. Other consumers, including roots, proofs,
+    /// multiproofs, and witnesses, should leave it false: complete the cached trie at Finish and
+    /// invalidate hashed-state revert prefixes instead of querying trie changesets.
     #[cfg(test)]
     #[instrument(level = "debug", target = "storage::overlay", skip_all)]
     fn build_state_trie_overlay<Provider>(
         &self,
         provider: &Provider,
+        trie_changesets: bool,
     ) -> ProviderResult<StateTrieOverlay>
     where
         Provider: StageCheckpointReader
@@ -409,7 +410,12 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             + StorageSettingsCache,
     {
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(provider)?;
-        self.build_state_trie_overlay_at_frontiers(provider, state_trie_tip_block, finish_tip_block)
+        self.build_state_trie_overlay_at_frontiers(
+            provider,
+            state_trie_tip_block,
+            finish_tip_block,
+            trie_changesets,
+        )
     }
 
     /// Builds the effective state trie overlay using frontiers already read from the provider.
@@ -426,6 +432,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         provider: &Provider,
         state_trie_tip_block: BlockNumHash,
         finish_tip_block: BlockNumHash,
+        trie_changesets: bool,
     ) -> ProviderResult<StateTrieOverlay>
     where
         Provider: ChangeSetReader
@@ -445,7 +452,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
             self.anchor_at_parent_with_frontiers(provider, state_trie_tip_block, finish_tip_block)?;
 
         // Collect any reverts which are required to bring the DB view back to the anchor hash.
-        let (trie_updates, hashed_post_state) = match &anchor_for_parent {
+        let (trie_updates, hashed_post_state, prefix_sets) = match &anchor_for_parent {
             AnchorForParent::RevertsRequired { anchor, .. } => {
                 let revert_blocks =
                     self.revert_blocks(&anchor_for_parent)?.expect("reverts are required");
@@ -457,7 +464,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     "Collecting trie reverts for overlay state provider"
                 );
 
-                let trie_reverts = {
+                let trie_reverts = if trie_changesets {
                     let _guard = debug_span!(target: "storage::overlay", "retrieving_trie_reverts")
                         .entered();
                     let start = Instant::now();
@@ -470,6 +477,16 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                         )?;
                     retrieve_trie_reverts_duration = start.elapsed();
                     accumulated_reverts
+                } else {
+                    // Revert prefixes describe changes since the anchor, not stale hashes in
+                    // masked DB rows. Complete the trie at Finish before applying those prefixes.
+                    let start = Instant::now();
+                    let (nodes, _) = self
+                        .overlay_manager
+                        .overlay_builder(finish_tip_block.hash)
+                        .resolve_state_trie_overlays(state_trie_tip_block.hash)?;
+                    retrieve_trie_reverts_duration = start.elapsed();
+                    nodes
                 };
 
                 let mut hashed_state_reverts = {
@@ -480,6 +497,12 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     let res = HashedPostStateSorted::from_reverts(provider, revert_blocks)?;
                     retrieve_hashed_state_reverts_duration = start.elapsed();
                     res
+                };
+
+                let prefix_sets = if trie_changesets {
+                    Default::default()
+                } else {
+                    hashed_state_reverts.construct_prefix_sets()
                 };
 
                 // Resolve overlays and extend reverts with them. If reverts are empty, use overlays
@@ -517,7 +540,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     "Reverted to anchor block",
                 );
 
-                (trie_updates, hashed_state_updates)
+                (trie_updates, hashed_state_updates, prefix_sets)
             }
             AnchorForParent::NoReverts { anchor } => {
                 // If no reverts are needed, use the manager overlay directly unless the reused
@@ -548,7 +571,7 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
                     "Built overlay directly from durable frontier"
                 );
 
-                (trie_updates, hashed_post_state)
+                (trie_updates, hashed_post_state, Default::default())
             }
         };
 
@@ -561,7 +584,11 @@ impl<N: NodePrimitives> OverlayBuilder<N> {
         self.metrics.trie_updates_size.record(trie_updates_total_len as f64);
         self.metrics.hashed_state_size.record(hashed_state_updates_total_len as f64);
 
-        Ok(StateTrieOverlay::new(trie_updates, hashed_post_state))
+        Ok(StateTrieOverlay::new(TrieInputSorted::new(
+            trie_updates,
+            hashed_post_state,
+            prefix_sets,
+        )))
     }
 
     /// Returns the in-memory execution overlay and the block for historical fallback reads.
@@ -892,11 +919,11 @@ mod tests {
     }
 
     fn account_keys(overlay: &StateTrieOverlay) -> Vec<B256> {
-        overlay.hashed_post_state.accounts.iter().map(|(key, _)| *key).collect()
+        overlay.input().state.accounts.iter().map(|(key, _)| *key).collect()
     }
 
     fn account_node_paths(overlay: &StateTrieOverlay) -> Vec<Nibbles> {
-        overlay.trie_updates.account_nodes_ref().iter().map(|(path, _)| *path).collect()
+        overlay.input().nodes.account_nodes_ref().iter().map(|(path, _)| *path).collect()
     }
 
     #[test]
@@ -1013,7 +1040,7 @@ mod tests {
         for (parent_index, expected_ids) in [(3, vec![3, 4]), (4, vec![3, 4, 5])] {
             let overlay = manager
                 .overlay_builder(blocks[parent_index].recovered_block().hash())
-                .build_state_trie_overlay(&provider)
+                .build_state_trie_overlay(&provider, true)
                 .unwrap();
 
             assert_eq!(
@@ -1041,11 +1068,11 @@ mod tests {
         let overlay = manager
             .overlay_builder(blocks[4].recovered_block().hash())
             .with_skip_overlay_for_reused_sparse_trie(blocks[3].recovered_block().hash())
-            .build_state_trie_overlay(&provider)
+            .build_state_trie_overlay(&provider, true)
             .unwrap();
 
-        assert!(overlay.hashed_post_state.is_empty());
-        assert!(overlay.trie_updates.is_empty());
+        assert!(overlay.input().state.is_empty());
+        assert!(overlay.input().nodes.is_empty());
     }
 
     #[test]
@@ -1056,7 +1083,7 @@ mod tests {
         let builder = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(blocks[1].recovered_block().hash())
             .with_no_reverts();
-        let error = builder.build_state_trie_overlay(&provider).unwrap_err();
+        let error = builder.build_state_trie_overlay(&provider, true).unwrap_err();
 
         assert!(error.to_string().contains("reverts are disabled"));
     }
@@ -1077,9 +1104,35 @@ mod tests {
             Err(ProviderError::BlockHashNotFound(hash)) if hash == parent_hash
         ));
         assert!(matches!(
-            builder.build_state_trie_overlay(&provider),
+            builder.build_state_trie_overlay(&provider, true),
             Err(ProviderError::BlockHashNotFound(hash)) if hash == parent_hash
         ));
+    }
+
+    #[test]
+    fn state_trie_overlay_uses_revert_prefix_sets_without_trie_changesets() {
+        let (factory, blocks) = setup_frontiers(3, 3);
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw
+            .tx_ref()
+            .put::<tables::AccountChangeSets>(
+                3,
+                AccountBeforeTx {
+                    address: Address::with_last_byte(1),
+                    info: Some(Account::default()),
+                },
+            )
+            .unwrap();
+        provider_rw.commit().unwrap();
+
+        let provider = factory.provider().unwrap();
+        let overlay = OverlayManager::<EthPrimitives>::default()
+            .overlay_builder(blocks[1].recovered_block().hash())
+            .build_state_trie_overlay(&provider, false)
+            .unwrap();
+
+        assert!(overlay.input().nodes.is_empty());
+        assert!(!overlay.input().prefix_sets.is_empty());
     }
 
     #[test]
@@ -1276,7 +1329,7 @@ mod tests {
         let provider = factory.provider().unwrap();
         let error = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(blocks[3].recovered_block().hash())
-            .build_state_trie_overlay(&provider)
+            .build_state_trie_overlay(&provider, true)
             .unwrap_err();
 
         assert!(
@@ -1292,7 +1345,7 @@ mod tests {
         let parent_hash = blocks[3].recovered_block().hash();
         let error = OverlayManager::<EthPrimitives>::default()
             .overlay_builder(parent_hash)
-            .build_state_trie_overlay(&provider)
+            .build_state_trie_overlay(&provider, true)
             .unwrap_err();
 
         assert!(error.to_string().contains("is after partial state trie frontier"));

--- a/crates/storage/storage-overlay/src/changeset_cache.rs
+++ b/crates/storage/storage-overlay/src/changeset_cache.rs
@@ -403,7 +403,7 @@ impl ChangesetCache {
         let overlay = overlay_manager
             .overlay_builder(finish.hash)
             .with_no_reverts()
-            .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish)?;
+            .build_state_trie_overlay_at_frontiers(provider, partial_state_trie, finish, true)?;
         let state_trie_provider = OverlayStateProvider::<&P, N>::new_with_state_trie(
             provider,
             overlay,
@@ -644,7 +644,7 @@ mod tests {
     }
 
     fn empty_overlay() -> StateTrieOverlay {
-        StateTrieOverlay::new(Arc::default(), Arc::default())
+        StateTrieOverlay::new(TrieInputSorted::default())
     }
 
     fn insert_test_changesets(

--- a/crates/storage/storage-overlay/src/manager.rs
+++ b/crates/storage/storage-overlay/src/manager.rs
@@ -99,7 +99,7 @@ impl<N: NodePrimitives> OverlayManager<N> {
         OverlayBuilder::new(parent_hash, self.block_state(parent_hash), self.clone())
     }
 
-    fn block_state(&self, parent_hash: B256) -> Option<BlockState<N>> {
+    pub(crate) fn block_state(&self, parent_hash: B256) -> Option<BlockState<N>> {
         let mut blocks = self.parent_chain(parent_hash).collect::<Vec<_>>();
         blocks.pop().map(|oldest| {
             blocks.into_iter().rev().fold(BlockState::new(oldest), |parent, block| {
@@ -675,9 +675,9 @@ impl Default for OverlayCacheConfig {
 #[derive(Debug)]
 pub(crate) struct StateTrieOverlayError {
     /// Requested in-memory tip hash.
-    tip_hash: B256,
+    pub(crate) tip_hash: B256,
     /// Requested anchor hash.
-    anchor_hash: B256,
+    pub(crate) anchor_hash: B256,
 }
 
 impl fmt::Display for StateTrieOverlayError {

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -35,8 +35,9 @@ use reth_trie::{
 };
 use reth_trie_db::{
     DatabaseAccountTrieCursor, DatabaseHashedCursorFactory, DatabaseProof, DatabaseStateRoot,
-    DatabaseStorageRoot, DatabaseStorageTrieCursor, DatabaseTrieCursorFactory, LegacyKeyAdapter,
-    PackedAccountsTrie, PackedKeyAdapter, PackedStoragesTrie,
+    DatabaseStorageProof, DatabaseStorageRoot, DatabaseStorageTrieCursor,
+    DatabaseTrieCursorFactory, LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter,
+    PackedStoragesTrie,
 };
 use std::{cell::OnceCell, fmt, ops::Deref, sync::Arc, time::Instant};
 use tracing::instrument;
@@ -630,27 +631,18 @@ where
     ) -> ProviderResult<StorageMultiProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let hashed_address = alloy_primitives::keccak256(address);
-            let mut input = self.build_overlay(
+            let input = self.build_overlay(
                 TrieInputSorted::from_unsorted(TrieInput::from_state(
                     HashedPostState::from_hashed_storage(hashed_address, hashed_storage),
                 )),
                 false,
             )?;
-            TrieStorageProof::new_hashed(
-                InMemoryTrieCursorFactory::new(
-                    DatabaseTrieCursorFactory::<_, A>::new(self.provider().tx()),
-                    input.nodes.as_ref(),
-                ),
-                HashedPostStateCursorFactory::new(
-                    DatabaseHashedCursorFactory::new(self.provider().tx()),
-                    input.state.as_ref(),
-                ),
-                hashed_address,
+            <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(
+                self.provider().tx(),
+                address,
+                slots,
+                input,
             )
-            .with_prefix_set_mut(
-                input.prefix_sets.storage_prefix_sets.remove(&hashed_address).unwrap_or_default(),
-            )
-            .storage_multiproof(slots.iter().map(alloy_primitives::keccak256).collect())
             .map_err(ProviderError::from)
         })
     }
@@ -1007,6 +999,11 @@ type DbStateRoot<'a, TX, A> =
     StateRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
 type DbStorageRoot<'a, TX, A> =
     StorageRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
+type DbStorageProof<'a, TX, A> = TrieStorageProof<
+    'static,
+    DatabaseTrieCursorFactory<&'a TX, A>,
+    DatabaseHashedCursorFactory<&'a TX>,
+>;
 type DbProof<'a, TX, A> =
     Proof<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
 

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -35,9 +35,8 @@ use reth_trie::{
 };
 use reth_trie_db::{
     DatabaseAccountTrieCursor, DatabaseHashedCursorFactory, DatabaseProof, DatabaseStateRoot,
-    DatabaseStorageProof, DatabaseStorageRoot, DatabaseStorageTrieCursor,
-    DatabaseTrieCursorFactory, LegacyKeyAdapter, PackedAccountsTrie, PackedKeyAdapter,
-    PackedStoragesTrie,
+    DatabaseStorageRoot, DatabaseStorageTrieCursor, DatabaseTrieCursorFactory, LegacyKeyAdapter,
+    PackedAccountsTrie, PackedKeyAdapter, PackedStoragesTrie,
 };
 use std::{cell::OnceCell, fmt, ops::Deref, sync::Arc, time::Instant};
 use tracing::instrument;
@@ -52,7 +51,7 @@ pub struct OverlayStateProviderFactory<F, N: NodePrimitives = EthPrimitives> {
     factory: F,
     /// Overlay builder containing the configuration and overlay calculation logic.
     overlay_builder: OverlayBuilder<N>,
-    /// A cache mapping `(state_trie_tip, finish_tip)` to [`StateTrieOverlay`].
+    /// A cache mapping `(state_trie_tip, finish_tip, trie_changesets)` to [`StateTrieOverlay`].
     ///
     /// Under partial persistence the overlay depends on both durable frontiers, so both hashes are
     /// part of the cache key.
@@ -129,6 +128,7 @@ pub struct OverlayStateProvider<Provider, N: NodePrimitives = EthPrimitives> {
     state_trie_overlay_cache: StateTrieOverlayCache,
     metrics: OverlayStateProviderFactoryMetrics,
     state_trie_overlay: OnceCell<StateTrieOverlay>,
+    state_trie_overlay_with_trie_changesets: OnceCell<StateTrieOverlay>,
     execution_overlay: OnceCell<CachedExecutionOverlay>,
     is_v2: bool,
 }
@@ -162,6 +162,7 @@ impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, 
             state_trie_overlay_cache,
             metrics,
             state_trie_overlay: OnceCell::new(),
+            state_trie_overlay_with_trie_changesets: OnceCell::new(),
             execution_overlay: OnceCell::new(),
             is_v2,
         }
@@ -179,6 +180,7 @@ impl<Provider, N: NodePrimitives> OverlayStateProvider<OwnedProvider<Provider>, 
             state_trie_overlay_cache: Default::default(),
             metrics: Default::default(),
             state_trie_overlay: OnceCell::new(),
+            state_trie_overlay_with_trie_changesets: OnceCell::new(),
             execution_overlay: OnceCell::from(CachedExecutionOverlay {
                 overlay: execution_overlay,
                 historical_fallback: None,
@@ -201,6 +203,7 @@ impl<'a, Provider, N: NodePrimitives> OverlayStateProvider<&'a Provider, N> {
             state_trie_overlay_cache: Default::default(),
             metrics: Default::default(),
             state_trie_overlay: OnceCell::new(),
+            state_trie_overlay_with_trie_changesets: OnceCell::new(),
             execution_overlay: OnceCell::new(),
             is_v2,
         }
@@ -216,7 +219,8 @@ impl<'a, Provider, N: NodePrimitives> OverlayStateProvider<&'a Provider, N> {
             overlay_builder: None,
             state_trie_overlay_cache: Default::default(),
             metrics: Default::default(),
-            state_trie_overlay: OnceCell::from(state_trie_overlay),
+            state_trie_overlay: OnceCell::from(state_trie_overlay.clone()),
+            state_trie_overlay_with_trie_changesets: OnceCell::from(state_trie_overlay),
             execution_overlay: OnceCell::new(),
             is_v2,
         }
@@ -232,7 +236,7 @@ where
         &self.provider
     }
 
-    fn state_trie_overlay(&self) -> ProviderResult<&StateTrieOverlay>
+    fn state_trie_overlay(&self, trie_changesets: bool) -> ProviderResult<&StateTrieOverlay>
     where
         Provider::Target: StageCheckpointReader
             + PruneCheckpointReader
@@ -242,15 +246,17 @@ where
             + BlockNumReader
             + StorageSettingsCache,
     {
-        if let Some(overlay) = self.state_trie_overlay.get() {
+        let state_trie_overlay = self.state_trie_overlay_mut(trie_changesets);
+        if let Some(overlay) = state_trie_overlay.get() {
             return Ok(overlay)
         }
 
         let (state_trie_tip_block, finish_tip_block) = database_state_frontiers(self.provider())?;
-        let overlay = match self
-            .state_trie_overlay_cache
-            .entry((state_trie_tip_block.hash, finish_tip_block.hash))
-        {
+        let overlay = match self.state_trie_overlay_cache.entry((
+            state_trie_tip_block.hash,
+            finish_tip_block.hash,
+            trie_changesets,
+        )) {
             dashmap::Entry::Occupied(entry) => entry.get().clone(),
             dashmap::Entry::Vacant(entry) => {
                 self.metrics.state_trie_overlay_cache_misses.increment(1);
@@ -262,6 +268,7 @@ where
                         self.provider(),
                         state_trie_tip_block,
                         finish_tip_block,
+                        trie_changesets,
                     )?;
                 if !overlay.skipped_for_reused_sparse_trie() {
                     entry.insert(overlay.clone());
@@ -269,11 +276,23 @@ where
                 overlay
             }
         };
-        let _ = self.state_trie_overlay.set(overlay);
-        Ok(self.state_trie_overlay.get().expect("state trie overlay was just initialized"))
+        let _ = state_trie_overlay.set(overlay);
+        Ok(state_trie_overlay.get().expect("state trie overlay was just initialized"))
     }
 
-    fn build_overlay(&self, input: TrieInputSorted) -> ProviderResult<TrieInputSorted>
+    const fn state_trie_overlay_mut(&self, trie_changesets: bool) -> &OnceCell<StateTrieOverlay> {
+        if trie_changesets {
+            &self.state_trie_overlay_with_trie_changesets
+        } else {
+            &self.state_trie_overlay
+        }
+    }
+
+    fn build_overlay(
+        &self,
+        input: TrieInputSorted,
+        trie_changesets: bool,
+    ) -> ProviderResult<TrieInputSorted>
     where
         Provider::Target: StageCheckpointReader
             + PruneCheckpointReader
@@ -283,13 +302,14 @@ where
             + BlockNumReader
             + StorageSettingsCache,
     {
-        let overlay = self.state_trie_overlay()?;
+        let overlay = self.state_trie_overlay(trie_changesets)?;
         if overlay.skipped_for_reused_sparse_trie() {
             return Err(ProviderError::UnsupportedProvider)
         }
-        let TrieInputSorted { nodes: input_nodes, state: input_state, prefix_sets } = input;
-        let mut nodes = Arc::clone(&overlay.trie_updates);
-        let mut state = Arc::clone(&overlay.hashed_post_state);
+        let TrieInputSorted { nodes: input_nodes, state: input_state, mut prefix_sets } = input;
+        let overlay_input = overlay.input();
+        let mut nodes = Arc::clone(&overlay_input.nodes);
+        let mut state = Arc::clone(&overlay_input.state);
 
         if !input_nodes.is_empty() {
             Arc::make_mut(&mut nodes).extend_ref_and_sort(&input_nodes);
@@ -298,6 +318,7 @@ where
             Arc::make_mut(&mut state).extend_ref_and_sort(&input_state);
         }
 
+        prefix_sets.extend_ref(&overlay_input.prefix_sets);
         Ok(TrieInputSorted::new(nodes, state, prefix_sets))
     }
 
@@ -511,16 +532,17 @@ where
 {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(hashed_state),
-            ))?;
+            let input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
+                false,
+            )?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.provider().tx(), input)?)
         })
     }
 
     fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             Ok(<DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes(
                 self.provider().tx(),
                 input,
@@ -533,9 +555,10 @@ where
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(hashed_state),
-            ))?;
+            let input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
+                true,
+            )?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(
                 self.provider().tx(),
                 input,
@@ -548,7 +571,7 @@ where
         input: TrieInput,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+            let input = self.build_overlay(TrieInputSorted::from_unsorted(input), true)?;
             Ok(
                 <DbStateRoot<'_, _, A> as DatabaseStateRoot<_>>::overlay_root_from_nodes_with_updates(
                     self.provider().tx(),
@@ -576,20 +599,31 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
+            let hashed_address = alloy_primitives::keccak256(address);
+            let mut input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(
+                    HashedPostState::from_hashed_storage(hashed_address, hashed_storage),
                 )),
-            ))?;
-            let hashed_storage = input
-                .state
-                .account_storages()
-                .get(&alloy_primitives::keccak256(address))
-                .cloned()
-                .unwrap_or_default()
-                .into();
-            <DbStorageRoot<'_, _, A>>::overlay_root(self.provider().tx(), address, hashed_storage)
+                false,
+            )?;
+            <DbStorageRoot<'_, _, A>>::from_tx(self.provider().tx(), address)
+                .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
+                    DatabaseTrieCursorFactory::<_, A>::new(self.provider().tx()),
+                    input.nodes.as_ref(),
+                ))
+                .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
+                    DatabaseHashedCursorFactory::new(self.provider().tx()),
+                    input.state.as_ref(),
+                ))
+                .with_prefix_set(
+                    input
+                        .prefix_sets
+                        .storage_prefix_sets
+                        .remove(&hashed_address)
+                        .unwrap_or_default()
+                        .freeze(),
+                )
+                .root()
                 .map_err(|err| ProviderError::Database(err.into()))
         })
     }
@@ -600,28 +634,9 @@ where
         slot: B256,
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageProof> {
-        reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
-                )),
-            ))?;
-            let hashed_storage = input
-                .state
-                .account_storages()
-                .get(&alloy_primitives::keccak256(address))
-                .cloned()
-                .unwrap_or_default()
-                .into();
-            <DbStorageProof<'_, _, A>>::overlay_storage_proof(
-                self.provider().tx(),
-                address,
-                slot,
-                hashed_storage,
-            )
+        self.storage_multiproof(address, &[slot], hashed_storage)?
+            .storage_proof(slot)
             .map_err(ProviderError::from)
-        })
     }
 
     fn storage_multiproof(
@@ -631,25 +646,28 @@ where
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_unsorted(
-                TrieInput::from_state(HashedPostState::from_hashed_storage(
-                    alloy_primitives::keccak256(address),
-                    hashed_storage,
+            let hashed_address = alloy_primitives::keccak256(address);
+            let mut input = self.build_overlay(
+                TrieInputSorted::from_unsorted(TrieInput::from_state(
+                    HashedPostState::from_hashed_storage(hashed_address, hashed_storage),
                 )),
-            ))?;
-            let hashed_storage = input
-                .state
-                .account_storages()
-                .get(&alloy_primitives::keccak256(address))
-                .cloned()
-                .unwrap_or_default()
-                .into();
-            <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(
-                self.provider().tx(),
-                address,
-                slots,
-                hashed_storage,
+                false,
+            )?;
+            TrieStorageProof::new_hashed(
+                InMemoryTrieCursorFactory::new(
+                    DatabaseTrieCursorFactory::<_, A>::new(self.provider().tx()),
+                    input.nodes.as_ref(),
+                ),
+                HashedPostStateCursorFactory::new(
+                    DatabaseHashedCursorFactory::new(self.provider().tx()),
+                    input.state.as_ref(),
+                ),
+                hashed_address,
             )
+            .with_prefix_set_mut(
+                input.prefix_sets.storage_prefix_sets.remove(&hashed_address).unwrap_or_default(),
+            )
+            .storage_multiproof(slots.iter().map(alloy_primitives::keccak256).collect())
             .map_err(ProviderError::from)
         })
     }
@@ -674,7 +692,7 @@ where
     ) -> ProviderResult<AccountProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -692,7 +710,7 @@ where
     ) -> ProviderResult<MultiProof> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -710,7 +728,7 @@ where
     ) -> ProviderResult<DecodedMultiProofV2> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             let input = TrieInput::new(
                 Arc::unwrap_or_clone(nodes).into(),
                 Arc::unwrap_or_clone(state).into(),
@@ -729,7 +747,7 @@ where
     ) -> ProviderResult<Vec<alloy_primitives::Bytes>> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let TrieInputSorted { nodes, state, prefix_sets } =
-                self.build_overlay(TrieInputSorted::from_unsorted(input))?;
+                self.build_overlay(TrieInputSorted::from_unsorted(input), false)?;
             let witness = TrieWitness::new(
                 InMemoryTrieCursorFactory::new(
                     DatabaseTrieCursorFactory::<_, A>::new(self.provider().tx()),
@@ -778,7 +796,7 @@ where
             return Ok(hashed_state)
         }
 
-        let overlay_state = self.build_overlay(TrieInputSorted::default())?.state;
+        let overlay_state = self.build_overlay(TrieInputSorted::default(), false)?.state;
         zero_destroyed_account_storage(
             &HashedPostStateCursorFactory::new(
                 DatabaseHashedCursorFactory::new(self.provider().tx()),
@@ -893,7 +911,7 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
         let cursor: Box<dyn TrieCursor + Send> = if self.is_v2 {
             Box::new(DatabaseAccountTrieCursor::<_, PackedKeyAdapter>::new(
                 self.provider().tx().cursor_read::<PackedAccountsTrie>()?,
@@ -903,14 +921,14 @@ where
                 self.provider().tx().cursor_read::<tables::AccountsTrie>()?,
             ))
         };
-        Ok(InMemoryTrieCursor::new_account(cursor, &overlay.trie_updates))
+        Ok(InMemoryTrieCursor::new_account(cursor, &overlay.input().nodes))
     }
 
     fn storage_trie_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
         let cursor: Box<dyn TrieStorageCursor + Send> = if self.is_v2 {
             Box::new(DatabaseStorageTrieCursor::<_, PackedKeyAdapter>::new(
                 self.provider().tx().cursor_dup_read::<PackedStoragesTrie>()?,
@@ -922,7 +940,7 @@ where
                 hashed_address,
             ))
         };
-        Ok(InMemoryTrieCursor::new_storage(cursor, &overlay.trie_updates, hashed_address))
+        Ok(InMemoryTrieCursor::new_storage(cursor, &overlay.input().nodes, hashed_address))
     }
 }
 
@@ -954,10 +972,10 @@ where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
         HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(self.provider().tx()),
-            &overlay.hashed_post_state,
+            &overlay.input().state,
         )
         .hashed_account_cursor()
     }
@@ -966,10 +984,10 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        let overlay = self.state_trie_overlay().map_err(into_database_error)?;
+        let overlay = self.state_trie_overlay(true).map_err(into_database_error)?;
         HashedPostStateCursorFactory::new(
             DatabaseHashedCursorFactory::new(self.provider().tx()),
-            &overlay.hashed_post_state,
+            &overlay.input().state,
         )
         .hashed_storage_cursor(hashed_address)
     }
@@ -987,7 +1005,7 @@ pub(crate) struct OverlayStateProviderFactoryMetrics {
     state_trie_overlay_cache_misses: Counter,
 }
 
-type StateTrieOverlayCache = Arc<DashMap<(BlockHash, BlockHash), StateTrieOverlay>>;
+type StateTrieOverlayCache = Arc<DashMap<(BlockHash, BlockHash, bool), StateTrieOverlay>>;
 
 #[derive(Clone, Debug)]
 struct CachedExecutionOverlay {
@@ -1006,11 +1024,6 @@ type DbStateRoot<'a, TX, A> =
     StateRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
 type DbStorageRoot<'a, TX, A> =
     StorageRoot<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
-type DbStorageProof<'a, TX, A> = TrieStorageProof<
-    'static,
-    DatabaseTrieCursorFactory<&'a TX, A>,
-    DatabaseHashedCursorFactory<&'a TX>,
->;
 type DbProof<'a, TX, A> =
     Proof<DatabaseTrieCursorFactory<&'a TX, A>, DatabaseHashedCursorFactory<&'a TX>>;
 
@@ -1122,11 +1135,11 @@ mod tests {
     }
 
     fn account_keys(overlay: &StateTrieOverlay) -> Vec<B256> {
-        overlay.hashed_post_state.accounts.iter().map(|(key, _)| *key).collect()
+        overlay.input().state.accounts.iter().map(|(key, _)| *key).collect()
     }
 
     fn account_node_paths(overlay: &StateTrieOverlay) -> Vec<Nibbles> {
-        overlay.trie_updates.account_nodes_ref().iter().map(|(path, _)| *path).collect()
+        overlay.input().nodes.account_nodes_ref().iter().map(|(path, _)| *path).collect()
     }
 
     #[test]
@@ -1142,7 +1155,7 @@ mod tests {
         );
 
         let provider = state_provider_factory.database_provider_ro().unwrap();
-        let first = provider.state_trie_overlay().unwrap().clone();
+        let first = provider.state_trie_overlay(false).unwrap().clone();
         assert_eq!(account_keys(&first), vec![B256::with_last_byte(3), B256::with_last_byte(4)]);
         drop(provider);
 
@@ -1158,7 +1171,7 @@ mod tests {
         provider_rw.commit().unwrap();
 
         let provider = state_provider_factory.database_provider_ro().unwrap();
-        let second = provider.state_trie_overlay().unwrap().clone();
+        let second = provider.state_trie_overlay(false).unwrap().clone();
         assert_eq!(account_keys(&second), vec![B256::with_last_byte(4)]);
         assert_eq!(account_node_paths(&second), vec![Nibbles::from_nibbles([4])]);
         assert_eq!(state_provider_factory.state_trie_overlay_cache.len(), 2);
@@ -1192,6 +1205,39 @@ mod tests {
     }
 
     #[test]
+    fn state_trie_overlay_cache_is_keyed_by_trie_changesets() {
+        let (factory, blocks) = setup_frontiers(1, 3);
+        let manager = OverlayManager::default();
+        for block in &blocks[2..=3] {
+            manager.insert_block(block.clone());
+        }
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            factory,
+            manager.overlay_builder(blocks[3].recovered_block().hash()),
+        );
+        let provider = state_provider_factory.database_provider_ro().unwrap();
+
+        provider.state_trie_overlay(false).unwrap();
+        provider.state_trie_overlay(true).unwrap();
+
+        assert_eq!(state_provider_factory.state_trie_overlay_cache.len(), 2);
+    }
+
+    #[test]
+    fn supplied_state_trie_overlay_is_available_in_both_modes() {
+        let (factory, _) = setup_frontiers(1, 1);
+        let provider = factory.provider().unwrap();
+        let provider = OverlayStateProvider::<&_, EthPrimitives>::new_with_state_trie(
+            &provider,
+            StateTrieOverlay::new(TrieInputSorted::default()),
+            false,
+        );
+
+        assert!(provider.state_trie_overlay(false).is_ok());
+        assert!(provider.state_trie_overlay(true).is_ok());
+    }
+
+    #[test]
     fn lazy_overlays_survive_manager_block_removal() {
         let (factory, blocks) = setup_frontiers(1, 1);
         let manager = OverlayManager::default();
@@ -1212,7 +1258,7 @@ mod tests {
             [blocks[2].recovered_block().num_hash(), blocks[3].recovered_block().num_hash()]
         );
         assert_eq!(
-            account_keys(provider.state_trie_overlay().unwrap()),
+            account_keys(provider.state_trie_overlay(false).unwrap()),
             vec![B256::with_last_byte(3), B256::with_last_byte(4)]
         );
     }
@@ -1230,7 +1276,7 @@ mod tests {
         );
 
         let provider = state_provider_factory.database_provider_ro().unwrap();
-        assert!(provider.state_trie_overlay().unwrap().skipped_for_reused_sparse_trie());
+        assert!(provider.state_trie_overlay(false).unwrap().skipped_for_reused_sparse_trie());
         assert!(state_provider_factory.state_trie_overlay_cache.is_empty());
         assert!(matches!(
             provider.state_root(HashedPostState::default()),

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -533,10 +533,7 @@ where
 {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
-                false,
-            )?;
+            let input = self.build_overlay(TrieInputSorted::from_state(hashed_state), false)?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.provider().tx(), input)?)
         })
     }
@@ -556,10 +553,7 @@ where
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(hashed_state)),
-                true,
-            )?;
+            let input = self.build_overlay(TrieInputSorted::from_state(hashed_state), true)?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(
                 self.provider().tx(),
                 input,
@@ -602,8 +596,9 @@ where
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let hashed_address = alloy_primitives::keccak256(address);
             let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(hashed_address, hashed_storage),
+                TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
+                    hashed_address,
+                    hashed_storage,
                 )),
                 false,
             )?;
@@ -632,8 +627,9 @@ where
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let hashed_address = alloy_primitives::keccak256(address);
             let input = self.build_overlay(
-                TrieInputSorted::from_unsorted(TrieInput::from_state(
-                    HashedPostState::from_hashed_storage(hashed_address, hashed_storage),
+                TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
+                    hashed_address,
+                    hashed_storage,
                 )),
                 false,
             )?;

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -600,30 +600,13 @@ where
     ) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let hashed_address = alloy_primitives::keccak256(address);
-            let mut input = self.build_overlay(
+            let input = self.build_overlay(
                 TrieInputSorted::from_unsorted(TrieInput::from_state(
                     HashedPostState::from_hashed_storage(hashed_address, hashed_storage),
                 )),
                 false,
             )?;
-            <DbStorageRoot<'_, _, A>>::from_tx(self.provider().tx(), address)
-                .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                    DatabaseTrieCursorFactory::<_, A>::new(self.provider().tx()),
-                    input.nodes.as_ref(),
-                ))
-                .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                    DatabaseHashedCursorFactory::new(self.provider().tx()),
-                    input.state.as_ref(),
-                ))
-                .with_prefix_set(
-                    input
-                        .prefix_sets
-                        .storage_prefix_sets
-                        .remove(&hashed_address)
-                        .unwrap_or_default()
-                        .freeze(),
-                )
-                .root()
+            <DbStorageRoot<'_, _, A>>::overlay_root(self.provider().tx(), address, input)
                 .map_err(|err| ProviderError::Database(err.into()))
         })
     }

--- a/crates/storage/storage-overlay/src/provider.rs
+++ b/crates/storage/storage-overlay/src/provider.rs
@@ -533,7 +533,8 @@ where
 {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_state(hashed_state), false)?;
+            let input =
+                self.build_overlay(TrieInputSorted::from_state(hashed_state.into_sorted()), false)?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes(self.provider().tx(), input)?)
         })
     }
@@ -553,7 +554,8 @@ where
         hashed_state: HashedPostState,
     ) -> ProviderResult<(B256, TrieUpdates)> {
         reth_trie_db::with_adapter!(self.provider(), |A| {
-            let input = self.build_overlay(TrieInputSorted::from_state(hashed_state), true)?;
+            let input =
+                self.build_overlay(TrieInputSorted::from_state(hashed_state.into_sorted()), true)?;
             Ok(<DbStateRoot<'_, _, A>>::overlay_root_from_nodes_with_updates(
                 self.provider().tx(),
                 input,
@@ -596,10 +598,10 @@ where
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let hashed_address = alloy_primitives::keccak256(address);
             let input = self.build_overlay(
-                TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
-                    hashed_address,
-                    hashed_storage,
-                )),
+                TrieInputSorted::from_state(
+                    HashedPostState::from_hashed_storage(hashed_address, hashed_storage)
+                        .into_sorted(),
+                ),
                 false,
             )?;
             <DbStorageRoot<'_, _, A>>::overlay_root(self.provider().tx(), address, input)
@@ -627,10 +629,10 @@ where
         reth_trie_db::with_adapter!(self.provider(), |A| {
             let hashed_address = alloy_primitives::keccak256(address);
             let input = self.build_overlay(
-                TrieInputSorted::from_state(HashedPostState::from_hashed_storage(
-                    hashed_address,
-                    hashed_storage,
-                )),
+                TrieInputSorted::from_state(
+                    HashedPostState::from_hashed_storage(hashed_address, hashed_storage)
+                        .into_sorted(),
+                ),
                 false,
             )?;
             <DbStorageProof<'_, _, A>>::overlay_storage_multiproof(

--- a/crates/trie/common/src/input.rs
+++ b/crates/trie/common/src/input.rs
@@ -160,6 +160,13 @@ impl TrieInputSorted {
         Self { nodes, state, prefix_sets }
     }
 
+    /// Create new sorted trie input from in-memory state. The prefix sets will be constructed and
+    /// set automatically.
+    pub fn from_state(state: HashedPostState) -> Self {
+        let prefix_sets = state.construct_prefix_sets();
+        Self { nodes: Default::default(), state: Arc::new(state.into_sorted()), prefix_sets }
+    }
+
     /// Create from unsorted [`TrieInput`] by sorting.
     pub fn from_unsorted(input: TrieInput) -> Self {
         Self {

--- a/crates/trie/common/src/input.rs
+++ b/crates/trie/common/src/input.rs
@@ -160,11 +160,11 @@ impl TrieInputSorted {
         Self { nodes, state, prefix_sets }
     }
 
-    /// Create new sorted trie input from in-memory state. The prefix sets will be constructed and
-    /// set automatically.
-    pub fn from_state(state: HashedPostState) -> Self {
+    /// Create new sorted trie input from sorted in-memory state. The prefix sets will be
+    /// constructed and set automatically.
+    pub fn from_state(state: HashedPostStateSorted) -> Self {
         let prefix_sets = state.construct_prefix_sets();
-        Self { nodes: Default::default(), state: Arc::new(state.into_sorted()), prefix_sets }
+        Self { nodes: Default::default(), state: Arc::new(state), prefix_sets }
     }
 
     /// Create from unsorted [`TrieInput`] by sorting.

--- a/crates/trie/db/src/proof.rs
+++ b/crates/trie/db/src/proof.rs
@@ -7,7 +7,7 @@ use reth_trie::{
     proof::{Proof, StorageProof},
     trie_cursor::InMemoryTrieCursorFactory,
     AccountProof, DecodedMultiProofV2, HashedPostStateSorted, HashedStorage, MultiProof,
-    MultiProofTargets, MultiProofTargetsV2, StorageMultiProof, TrieInput,
+    MultiProofTargets, MultiProofTargetsV2, StorageMultiProof, TrieInput, TrieInputSorted,
 };
 
 /// Extends [`Proof`] with operations specific for working with a database transaction.
@@ -114,7 +114,7 @@ pub trait DatabaseStorageProof<'a, TX> {
         tx: &'a TX,
         address: Address,
         slots: &[B256],
-        storage: HashedStorage,
+        input: TrieInputSorted,
     ) -> Result<StorageMultiProof, StateProofError>;
 }
 
@@ -158,21 +158,21 @@ impl<'a, TX: DbTx, A: TrieTableAdapter> DatabaseStorageProof<'a, TX>
         tx: &'a TX,
         address: Address,
         slots: &[B256],
-        storage: HashedStorage,
+        mut input: TrieInputSorted,
     ) -> Result<StorageMultiProof, StateProofError> {
         let hashed_address = keccak256(address);
         let targets = slots.iter().map(keccak256).collect();
-        let prefix_set = storage.construct_prefix_set();
-        let state_sorted = HashedPostStateSorted::new(
-            Default::default(),
-            HashMap::from_iter([(hashed_address, storage.into_sorted())]),
-        );
         StorageProof::new(
-            DatabaseTrieCursorFactory::<_, A>::new(tx),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            InMemoryTrieCursorFactory::new(
+                DatabaseTrieCursorFactory::<_, A>::new(tx),
+                &input.nodes,
+            ),
+            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &input.state),
             address,
         )
-        .with_prefix_set_mut(prefix_set)
+        .with_prefix_set_mut(
+            input.prefix_sets.storage_prefix_sets.remove(&hashed_address).unwrap_or_default(),
+        )
         .storage_multiproof(targets)
     }
 }

--- a/crates/trie/db/src/storage.rs
+++ b/crates/trie/db/src/storage.rs
@@ -5,7 +5,8 @@ use reth_execution_errors::StorageRootError;
 use reth_storage_api::{BlockNumReader, StorageChangeSetReader};
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
-    hashed_cursor::HashedPostStateCursorFactory, HashedPostState, HashedStorage, StorageRoot,
+    hashed_cursor::HashedPostStateCursorFactory, trie_cursor::InMemoryTrieCursorFactory,
+    HashedStorage, StorageRoot, TrieInputSorted,
 };
 
 #[cfg(feature = "metrics")]
@@ -19,11 +20,11 @@ pub trait DatabaseStorageRoot<'a, TX> {
     /// Create a new storage root calculator from database transaction and hashed address.
     fn from_tx_hashed(tx: &'a TX, hashed_address: B256) -> Self;
 
-    /// Calculates the storage root for this [`HashedStorage`] and returns it.
+    /// Calculates the storage root with the given trie input.
     fn overlay_root(
         tx: &'a TX,
         address: Address,
-        hashed_storage: HashedStorage,
+        input: TrieInputSorted,
     ) -> Result<B256, StorageRootError>;
 }
 
@@ -85,16 +86,22 @@ impl<'a, TX: DbTx, A: TrieTableAdapter> DatabaseStorageRoot<'a, TX>
     fn overlay_root(
         tx: &'a TX,
         address: Address,
-        hashed_storage: HashedStorage,
+        mut input: TrieInputSorted,
     ) -> Result<B256, StorageRootError> {
-        let prefix_set = hashed_storage.construct_prefix_set().freeze();
-        let state_sorted =
-            HashedPostState::from_hashed_storage(keccak256(address), hashed_storage).into_sorted();
+        let hashed_address = keccak256(address);
         StorageRoot::new(
-            DatabaseTrieCursorFactory::<_, A>::new(tx),
-            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &state_sorted),
+            InMemoryTrieCursorFactory::new(
+                DatabaseTrieCursorFactory::<_, A>::new(tx),
+                &input.nodes,
+            ),
+            HashedPostStateCursorFactory::new(DatabaseHashedCursorFactory::new(tx), &input.state),
             address,
-            prefix_set,
+            input
+                .prefix_sets
+                .storage_prefix_sets
+                .remove(&hashed_address)
+                .unwrap_or_default()
+                .freeze(),
             #[cfg(feature = "metrics")]
             TrieRootMetrics::new(reth_trie::TrieType::Storage),
         )


### PR DESCRIPTION
Reimplements #26986 and fixes historical proofs against partially persisted trie rows.

- Avoids loading trie changesets for overlay operations that only calculate state roots, proofs, multiproofs, or witnesses; derives invalidation prefix sets from hashed reverts instead.
- Retains trie changesets for operations that return trie updates or create trie cursors.
- Caches read-only and trie-changeset overlays separately, including both durable frontiers in the cache key.
- Completes the partial-state-trie-to-Finish overlay before historical proof construction, so the proof calculator reads a coherent Finish view instead of masked database rows.
- Passes the full `TrieInputSorted` through storage-root and storage-multiproof calculation so their node overlays are preserved.
