### PR TITLE
chore(peers): replace EF bootnodes with NodeOps fleet

### DIFF
--- a/crates/net/peers/src/bootnodes.rs
+++ b/crates/net/peers/src/bootnodes.rs
@@ -6,20 +6,21 @@ use crate::NodeRecord;
 use alloc::vec::Vec;
 
 /// Ethereum Foundation Go Bootnodes
-pub static MAINNET_BOOTNODES: [&str; 4] = [
-    "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303",   // bootnode-aws-ap-southeast-1-001
-    "enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303",     // bootnode-aws-us-east-1-001
-    "enode://2b252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a823487071b5695317c8ccd085219c3a03af063495b2f1da8d18218da2d6a82981b45e6ffc@65.108.70.101:30303",   // bootnode-hetzner-hel
-    "enode://4aeb4ab6c14b23e2c4cfdce879c04b0748a20d8e9b59e25ded2a08143e265c6c25936e74cbc8e641e3312ca288673d91f2f93f8e277de3cfa444ecdaaf982052@157.90.35.166:30303",   // bootnode-hetzner-fsn
+pub static MAINNET_BOOTNODES: [&str; 5] = [
+    "enode://ca967418ba165105303cfbb733dfb92bfcab80d65009d5e5f158c8e9e5f2c90795ae396a28d2114d66b4001e123e8c2c0465b018aed619fff41faca2ab4d2e64@212.99.218.66:0?discport=20151", // nodeops-bootnode-dcl1-01
+    "enode://de4265bc38cba8508a14226356fabf480b88da880c19da49df57806a5b242f2ada08c25e54725c5ce1a762436c8f89e91781787c6b153ef9da72d00b62048170@129.212.166.61:0?discport=30303", // nodeops-bootnode-sfo3-01
+    "enode://0b75ce940a50f9b3f37cfa162120642d16a4584774317fdaa02d0eec8f8aaf11fac79ba9d4213f33da9d4c512a3e0716a286b1b8f715c0a2cf5ac630030e0672@144.126.252.24:0?discport=30303", // nodeops-bootnode-blr1-01
+    "enode://01472729e328876c6ccea993cf326b8a1ac969d4da4eac57ffa6b79d2d8338fa21012ff6c05b7ed78811a2f91768944219d9a3f0d33cb97ee0c128a8ed26386b@178.156.215.140:0?discport=30303", // nodeops-bootnode-ash-01
+    "enode://0c949a7bc8d71b95ab9889c11e481a4743314093d5a0de5871de27bd8294e884b8e3b230b7cecfaf421fa6617aeff897e414444d7b4bf5b249dc9604716077ba@5.223.94.81:0?discport=30303", // nodeops-bootnode-sin-01
 ];
 
 /// Ethereum Foundation Sepolia Bootnodes
 pub static SEPOLIA_BOOTNODES: [&str; 5] = [
-    "enode://4e5e92199ee224a01932a377160aa432f31d0b351f84ab413a8e0a42f4f36476f8fb1cbe914af0d9aef0d51665c214cf653c651c4bbd9d5550a934f241f1682b@138.197.51.181:30303", // sepolia-bootnode-1-nyc3
-    "enode://143e11fb766781d22d92a2e33f8f104cddae4411a122295ed1fdb6638de96a6ce65f5b7c964ba3763bba27961738fef7d3ecc739268f3e5e771fb4c87b6234ba@146.190.1.103:30303",  // sepolia-bootnode-1-sfo3
-    "enode://8b61dc2d06c3f96fddcbebb0efb29d60d3598650275dc469c22229d3e5620369b0d3dedafd929835fe7f489618f19f456fe7c0df572bf2d914a9f4e006f783a9@170.64.250.88:30303",  // sepolia-bootnode-1-syd1
-    "enode://10d62eff032205fcef19497f35ca8477bea0eadfff6d769a147e895d8b2b8f8ae6341630c645c30f5df6e67547c03494ced3d9c5764e8622a26587b083b028e8@139.59.49.206:30303",  // sepolia-bootnode-1-blr1
-    "enode://9e9492e2e8836114cc75f5b929784f4f46c324ad01daf87d956f98b3b6c5fcba95524d6e5cf9861dc96a2c8a171ea7105bb554a197455058de185fa870970c7c@138.68.123.152:30303", // sepolia-bootnode-1-ams3
+    "enode://4aff27bd8f1f667a56be304fcab797b4d7b630bf78581ffe6bc0d84852bb73362361ab2884ad396418abe25e7da621be0cadf5b02b6709b49d76b404813c9ddc@212.99.218.66:0?discport=20152", // nodeops-bootnode-dcl1-01
+    "enode://665565ef7b9734bafb27fda8234ca43ca51ea097d0f29d9c9340daee0437c9e1d409c8283d1ce135eedccc2850f94c39c3cc63c641ad5fb0bef9dd37bd0fa6c1@129.212.166.61:0?discport=30403", // nodeops-bootnode-sfo3-01
+    "enode://8e41eb6b03ef7b4c42d4cee19e8150f5fdc1ca28d9e33a627d09875e493a2bedfdea0bfe8c5bab778929a5334a311ca8d37e9016928fc6141c8fe52e708fbd98@144.126.252.24:0?discport=30403", // nodeops-bootnode-blr1-01
+    "enode://b1e27df0cb42adc27b990879a5c4c99ce1bd15bdf0b829afdfdec50fbe352ad602075607f488ca805781e7f127d9709117a8bf8763ebac6e769f7cf50ded3806@178.156.215.140:0?discport=30403", // nodeops-bootnode-ash-01
+    "enode://02dc5303f128bd0c8055a1fb126c9929bd74d401fca2f2aeba5d74208d1854b08cd5e7932d2db39e21891bf0347599b2cb63bedf14c96fac2bd92c77def82352@5.223.94.81:0?discport=30403", // nodeops-bootnode-sin-01
 ];
 
 /// Ethereum Foundation Holesky Bootnodes
@@ -30,10 +31,12 @@ pub static HOLESKY_BOOTNODES: [&str; 2] = [
 
 /// Ethereum Foundation Hoodi Bootnodes
 /// From: <https://github.com/eth-clients/hoodi/blob/main/metadata/enodes.yaml>
-pub static HOODI_BOOTNODES: [&str; 3] = [
-    "enode://2112dd3839dd752813d4df7f40936f06829fc54c0e051a93967c26e5f5d27d99d886b57b4ffcc3c475e930ec9e79c56ef1dbb7d86ca5ee83a9d2ccf36e5c240c@134.209.138.84:30303",
-    "enode://60203fcb3524e07c5df60a14ae1c9c5b24023ea5d47463dfae051d2c9f3219f309657537576090ca0ae641f73d419f53d8e8000d7a464319d4784acd7d2abc41@209.38.124.160:30303",
-    "enode://8ae4a48101b2299597341263da0deb47cc38aa4d3ef4b7430b897d49bfa10eb1ccfe1655679b1ed46928ef177fbf21b86837bd724400196c508427a6f41602cd@134.199.184.23:30303",
+pub static HOODI_BOOTNODES: [&str; 5] = [
+    "enode://70bab91175f9bbcebbfbf155644f46c03ed44ef4927d816e3601ba5fd32f7a240ffb8953e737dd8595cf3773a62230ca27dd5390d268570f980f7d47a40dd1a3@212.99.218.66:0?discport=20153", // nodeops-bootnode-dcl1-01
+    "enode://afd50407db4562c5049f3af489743a24b732cba6af2195e62205be59ae645aa0a4179da81515bfcfd20d3fd1f12ffdfcf5d4853ff1ad39189c3bb97132cd0986@129.212.166.61:0?discport=30503", // nodeops-bootnode-sfo3-01
+    "enode://f787af01c154fb0fe82798d5c72ca81e3f2a789798a476a6c93da7acbb3f58002e7494c916680035a5beed158092c10bb08b10917bbc3ac41784e7b01017b4a4@144.126.252.24:0?discport=30503", // nodeops-bootnode-blr1-01
+    "enode://71c400e99baa31e91d8ea7bda5850ef143b9da94b07413dbd4c1c84c4b5fc474806234c123bc5e1a97b7ae3162115cad9ccdf290319b0710f9d40d81b967153e@178.156.215.140:0?discport=30503", // nodeops-bootnode-ash-01
+    "enode://81aabd7223f345e713b7f355cc76680ba8ec3a7b098f100655a467e4049113586fb5ce052a6ef90033ec62b91ed63457c87aa49dd0f1338af963b85522176db7@5.223.94.81:0?discport=30503", // nodeops-bootnode-sin-01
 ];
 
 /// Returns parsed mainnet nodes


### PR DESCRIPTION
I am on the Ethereum Foundation's Node Infrastructure team (NodeOps). We run the bootnodes
that ship in this repository as the "EF" entries for mainnet, Sepolia and Hoodi. We are
replacing that fleet, and we would like the new records in a release before the Glamsterdam
client releases.

### What changes

- Add five new EF bootnodes per network. Every node serves all three networks.
- Remove the legacy EF entries. The new set is a replacement, not an addition.
- Third-party bootnodes and DNS discovery roots are untouched.

### The new fleet

Five bootnodes, each serving mainnet, Sepolia and Hoodi. They are geographically distributed,
multi-cloud, and dual stack (IPv4 + IPv6). Each node runs discv4 and discv5 on the EL port and
discv5 on the CL port, and the fleet spreads across several discovery implementations so one
implementation bug cannot take the whole set down.

### About the records

- The ENRs are generic bootnode records: no `eth2` field, no `tcp`, sequence number 1. Clients
  dial configured bootnodes regardless of fork, and a static list cannot be re-signed every
  fork, so we do not include fork data on purpose.
- Where an EL list accepts ENRs, we list the ENR. It covers discv4 and discv5 and carries the
  IPv6 endpoint. Enodes appear only where a list needs them, in the discovery-only form
  `enode://<pubkey>@<ip>:0?discport=<port>` (no RLPx listener).
- The records are derived from the node keys and are byte-identical across all the client
  PRs. The canonical copies are the eth-clients PRs (`metadata/bootstrap_nodes.yaml` and
  `metadata/enodes.yaml` for mainnet, sepolia and hoodi).

### Verification

- Each node answers discv4 and discv5 pings from the public internet on the advertised ports.
- The relevant tests in this repository pass with the new lists (details below).
- The legacy nodes stay online until client releases with the new records are widely deployed.
  We will announce the shutdown separately.

### Contact

Chase Wright, EF Node Infrastructure. Discord `MysticRyuujin` (ETH R&D and STEEL servers), or
chase.wright@ethereum.org.

### This repository

**Files:** `crates/net/peers/src/bootnodes.rs`.

**Semantics:** `MAINNET_BOOTNODES`, `SEPOLIA_BOOTNODES` and `HOODI_BOOTNODES` hold the five
discovery-only enodes per network (array length 4 / 5 / 3 → 5). These constants parse
`NodeRecord`, which does not take `enr:`, so this is the one EL list with enodes only. ENR
support in the built-in lists would let reth pick up the IPv6 endpoints.

**Tests:** `cargo test -p reth-network-peers`.
