### PR TITLE
refactor(rpc): use Alloy message signing helper

### DIFF
--- a/crates/rpc/rpc/src/eth/helpers/signer.rs
+++ b/crates/rpc/rpc/src/eth/helpers/signer.rs
@@ -2,7 +2,7 @@
 
 use alloy_dyn_abi::TypedData;
 use alloy_eips::eip2718::Decodable2718;
-use alloy_primitives::{eip191_hash_message, map::AddressMap, Address, Signature, B256};
+use alloy_primitives::{map::AddressMap, Address, Signature, B256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner};
 use reth_rpc_convert::SignableTxRequest;
@@ -82,10 +82,7 @@ impl<T: Decodable2718, TxReq: SignableTxRequest<T>> EthSigner<T, TxReq> for DevS
     }
 
     async fn sign(&self, address: Address, message: &[u8]) -> Result<Signature> {
-        // Hash message according to EIP 191:
-        // https://ethereum.org/es/developers/docs/apis/json-rpc/#eth_sign
-        let hash = eip191_hash_message(message);
-        self.sign_hash(hash, address)
+        self.get_key(address)?.sign_message_sync(message).map_err(|_| SignError::CouldNotSign)
     }
 
     async fn sign_transaction(&self, request: TxReq, address: &Address) -> Result<T> {


### PR DESCRIPTION
Uses Alloy’s `sign_message_sync` for EIP-191 message signing in `DevSigner`, preserving the existing error mapping.
