### PR TITLE
chore(trie): trace CPU work and worker waits during root calculation

### DIFF
--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -180,6 +180,10 @@ call_reth_jit() {
 }
 
 cleanup() {
+  if [ -n "${TRIE_ORIGINAL_SCHEDSTATS:-}" ]; then
+    sudo sysctl -w "kernel.sched_schedstats=${TRIE_ORIGINAL_SCHEDSTATS}" || true
+    TRIE_ORIGINAL_SCHEDSTATS=
+  fi
   kill "${TAIL_PID:-}" 2>/dev/null || true
   if [ -n "${TRACY_PID:-}" ] && kill -0 "$TRACY_PID" 2>/dev/null; then
     echo "Stopping tracy-capture..."
@@ -220,6 +224,16 @@ cleanup() {
 TAIL_PID=
 TRACY_PID=
 trap cleanup EXIT
+
+# Enable runnable-queue accounting on both sides of an activity capture. Restore the
+# runner's original setting in cleanup, including failed benchmark runs.
+TRIE_ORIGINAL_SCHEDSTATS=
+if [[ "${BENCH_BASELINE_ARGS:-} ${BENCH_FEATURE_ARGS:-}" == *"engine::tree::activity=trace"* ]] &&
+   [ -r /proc/sys/kernel/sched_schedstats ]; then
+  TRIE_ORIGINAL_SCHEDSTATS="$(cat /proc/sys/kernel/sched_schedstats)"
+  sudo sysctl -w kernel.sched_schedstats=1
+  cat /proc/sys/kernel/sched_schedstats > "$OUTPUT_DIR/scheduler-stats.txt"
+fi
 
 sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
 sudo systemctl reset-failed "$RETH_SCOPE" 2>/dev/null || true

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -372,7 +372,7 @@ if [ "${BENCH_SAMPLY:-false}" = "true" ]; then
   sudo systemd-run --quiet --scope --collect --unit="$RETH_SCOPE" \
     -p MemoryMax="$MEM_LIMIT" -p AllowedCPUs="$RETH_CPUS" \
     env "${SUDO_ENV[@]}" nice -n -20 \
-    "$SAMPLY" record --save-only --presymbolicate --rate 10000 \
+    "$SAMPLY" record --save-only --presymbolicate --rate 1000 \
     --output "$OUTPUT_DIR/samply-profile.json.gz" \
     -- "$BINARY" "${RETH_ARGS[@]}" \
     > "$LOG" 2>&1 &

--- a/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/execute.rs
@@ -106,8 +106,14 @@ where
     MakeDb: Fn(bool) -> Result<DB, BalExecutionError> + Sync + 'scope,
     ReceiptTy<Evm::Primitives>: Clone,
 {
+    let _body =
+        tracing::trace_span!(target: "engine::tree::critical", "bal_canonical_body").entered();
     let bal = input_bal.as_bal();
-    let input_bal_revm = convert_alloy_to_revm_bal(bal)?;
+    let input_bal_revm =
+        tracing::trace_span!(target: "engine::tree::critical", "bal_convert_input")
+            .in_scope(|| convert_alloy_to_revm_bal(bal))?;
+    let setup =
+        tracing::trace_span!(target: "engine::tree::critical", "bal_canonical_setup").entered();
 
     let block_gas_limit = evm_env.block_env.gas_limit();
     let enable_amsterdam_eip8037 = evm_env.cfg_env.enable_amsterdam_eip8037;
@@ -129,6 +135,7 @@ where
         let (result_tx, result_rx) = crossbeam_channel::unbounded();
         let (abort_guard, abort_rx) = AbortGuard::new();
 
+        tracing::trace!(target: "engine::tree::bal", "bal spawning workers");
         for _ in 0..worker_count {
             worker::spawn_worker(
                 scope,
@@ -142,6 +149,7 @@ where
                 ctx.clone(),
             );
         }
+        tracing::trace!(target: "engine::tree::bal", "bal workers spawned");
         drop(result_tx);
 
         let mut gas_tracker =
@@ -149,12 +157,22 @@ where
         let evm = evm_config.evm_with_env(&mut canonical_state, evm_env);
         let mut canonical_executor = evm_config.create_executor_with_state(evm, ctx.clone());
 
-        canonical_executor.apply_pre_execution_changes()?;
+        drop(setup);
+        tracing::trace_span!(target: "engine::tree::critical", "bal_canonical_pre")
+            .in_scope(|| canonical_executor.apply_pre_execution_changes())?;
         let mut senders = Vec::with_capacity(transaction_count);
         let mut last_sent_len = 0usize;
+        let loop_span =
+            tracing::trace_span!(target: "engine::tree::critical", "bal_commit_loop").entered();
         for output in ordered_worker_outputs(&result_rx, transaction_count) {
             let output = output?;
 
+            let _span = tracing::trace_span!(
+                target: "engine::tree::bal",
+                "bal_commit_transaction",
+                index = output.index,
+            )
+            .entered();
             gas_tracker.validate_tx_limit(output.tx_gas_limit)?;
             gas_tracker.record_result(output.result.result());
             canonical_executor.evm_mut().db_mut().bump_bal_index();
@@ -171,16 +189,20 @@ where
                 }
             }
         }
+        drop(loop_span);
         drop(abort_guard);
 
         canonical_executor.evm_mut().db_mut().bump_bal_index();
-        let block_result = canonical_executor.apply_post_execution_changes()?;
+        let block_result =
+            tracing::trace_span!(target: "engine::tree::critical", "bal_canonical_post")
+                .in_scope(|| canonical_executor.apply_post_execution_changes())?;
         (block_result, senders)
     };
 
     let built_bal = take_built_bal_and_log_divergence(&mut canonical_state, bal);
 
-    canonical_state.merge_transitions(BundleRetention::Reverts);
+    tracing::trace_span!(target: "engine::tree::critical", "bal_merge_transitions")
+        .in_scope(|| canonical_state.merge_transitions(BundleRetention::Reverts));
     Ok((
         BlockExecutionOutput { state: canonical_state.take_bundle(), result: block_result },
         senders,
@@ -213,7 +235,10 @@ fn take_built_bal_and_log_divergence<DB>(
 where
     DB: Database,
 {
-    let built_bal = canonical_state.take_built_alloy_bal().expect("with_bal_builder set");
+    let built_bal = tracing::trace_span!(target: "engine::tree::critical", "bal_rebuild")
+        .in_scope(|| canonical_state.take_built_alloy_bal().expect("with_bal_builder set"));
+    let _compare =
+        tracing::trace_span!(target: "engine::tree::critical", "bal_debug_compare").entered();
     if tracing::enabled!(target: "engine::tree::payload_processor::bal", tracing::Level::DEBUG) &&
         built_bal.as_slice() != received_bal.as_slice()
     {

--- a/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/ordered_outputs.rs
@@ -76,25 +76,35 @@ impl<R> Iterator for OrderedWorkerOutputs<'_, R> {
             return None;
         }
 
+        let _span = tracing::trace_span!(
+            target: "engine::tree::bal",
+            "bal_next_output",
+            index = self.next,
+        )
+        .entered();
         loop {
             if let Some(output) = self.pending[self.next].take() {
                 self.next += 1;
                 return Some(Ok(output));
             }
 
-            let output = match self.result_rx.recv() {
-                Ok(Ok(output)) => output,
-                Ok(Err(err)) => {
-                    self.failed = true;
-                    return Some(Err(err.into()));
-                }
-                Err(_) => {
-                    self.failed = true;
-                    return Some(Err(OrderedWorkerOutputError::ResultChannelClosed));
-                }
-            };
+            let output =
+                match tracing::trace_span!(target: "engine::tree::critical", "bal_result_recv")
+                    .in_scope(|| self.result_rx.recv())
+                {
+                    Ok(Ok(output)) => output,
+                    Ok(Err(err)) => {
+                        self.failed = true;
+                        return Some(Err(err.into()));
+                    }
+                    Err(_) => {
+                        self.failed = true;
+                        return Some(Err(OrderedWorkerOutputError::ResultChannelClosed));
+                    }
+                };
 
             let index = output.index;
+            tracing::trace!(target: "engine::tree::bal", index, next = self.next, "bal output received");
             assert!(
                 index < self.total,
                 "BAL worker returned out-of-bounds transaction index {index}; total={}",

--- a/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
+++ b/crates/engine/tree/src/tree/payload_processor/bal/worker.rs
@@ -69,6 +69,8 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
 {
     scope.spawn(move |_| {
         let worker_result = (|| -> Result<(), BalWorkerError> {
+            let setup =
+                tracing::trace_span!(target: "engine::tree::bal", "bal_worker_setup").entered();
             // Create a database with fill_on_miss=true ensuring misses
             // are inserted for the other workers.
             let database = make_db(true).map_err(BalWorkerError::Setup)?;
@@ -79,6 +81,7 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 .build();
             let evm = evm_config.evm_with_env(&mut worker_state, evm_env);
             let mut executor = evm_config.create_executor_with_state(evm, ctx.clone());
+            drop(setup);
 
             loop {
                 let (index, tx) = crossbeam_channel::select_biased! {
@@ -92,6 +95,12 @@ pub(super) fn spawn_worker<'scope, Evm, Tx, Err, DB, MakeDb>(
                 let signer = *tx.signer();
                 let tx_gas_limit = tx.tx().gas_limit();
 
+                let _span = tracing::trace_span!(
+                    target: "engine::tree::bal",
+                    "bal_execute_transaction",
+                    index,
+                )
+                .entered();
                 executor
                     .evm_mut()
                     .db_mut()

--- a/crates/engine/tree/src/tree/payload_processor/prewarm.rs
+++ b/crates/engine/tree/src/tree/payload_processor/prewarm.rs
@@ -374,6 +374,7 @@ where
 
         if let Some(hashed_update_stream) = hashed_update_stream {
             let ctx = ctx.clone();
+            trace!(target: "engine::tree::critical", phase = "bal_stream_queued");
             executor.bal_streaming_pool().spawn(move || {
                 let branch_span = debug_span!(
                     target: "engine::tree::payload_processor::prewarm",
@@ -692,6 +693,7 @@ where
 
             let mut hashed_state = reth_trie::HashedPostState::default();
             hashed_state.storages.insert(hashed_address, storage_map);
+            trace!(target: "engine::tree::critical", phase = "bal_storage_update_ready");
             hashed_update_stream.on_hashed_state_update(hashed_state);
         }
 
@@ -753,6 +755,7 @@ where
 
         let mut hashed_state = reth_trie::HashedPostState::default();
         hashed_state.accounts.insert(hashed_address, account);
+        trace!(target: "engine::tree::critical", phase = "bal_account_update_ready");
         hashed_update_stream.on_hashed_state_update(hashed_state);
     }
 }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -491,6 +491,7 @@ where
         V: PayloadValidator<T, Block = N::Block> + Clone,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
+        let setup = tracing::trace_span!(target: "engine::tree::critical", "np_setup").entered();
         let parent_hash = input.parent_hash();
         let _txpool_pause = self.txpool_prewarm.as_ref().map(txpool_prewarm::Handle::pause);
         let txpool_snapshot =
@@ -552,7 +553,9 @@ where
             parent_block.gas_limit().saturating_mul(MAX_EXPECTED_GAS_LIMIT_MULTIPLIER)
         {
             // Call `.get()` to await the pre-execution checks and exit early if they fail.
-            if validated_block.get().is_err() {
+            if tracing::trace_span!(target: "engine::tree::critical", "np_gas_guard_wait")
+                .in_scope(|| validated_block.get().is_err())
+            {
                 return Err(validated_block
                     .try_into_inner()
                     .expect("sole handle")
@@ -582,8 +585,11 @@ where
         // Extract the decoded BAL, if present. Undecodable block access list bytes invalidate the
         // payload.
         let decoded_bal =
-            ensure_ok!(input.try_decoded_access_list().map_err(BlockAccessListDecodeError::new))
-                .map(Arc::new);
+            ensure_ok!(tracing::trace_span!(target: "engine::tree::critical", "np_decode_bal")
+                .in_scope(|| input
+                    .try_decoded_access_list()
+                    .map_err(BlockAccessListDecodeError::new)))
+            .map(Arc::new);
 
         if let Some(decoded_bal) = decoded_bal.as_deref() {
             // Reject oversized BAL sidecars before executing the block.
@@ -719,6 +725,7 @@ where
         // Execute the block and handle any execution errors.
         // The receipt root task is spawned before execution and receives receipts incrementally
         // as transactions complete, allowing parallel computation during execution.
+        drop(setup);
         let execute_block_start = Instant::now();
         let execution_result = if parallel_bal_execution {
             self.execute_block_bal(env, &input, &handle, &make_state_provider)
@@ -774,7 +781,9 @@ where
                 }
             });
 
-        let block = validated_block.try_into_inner().expect("sole handle")?;
+        let block =
+            tracing::trace_span!(target: "engine::tree::critical", "np_wait_payload_conversion")
+                .in_scope(|| validated_block.try_into_inner().expect("sole handle"))?;
         let block = block.with_senders(senders);
 
         // Wait for the receipt root computation to complete.
@@ -827,7 +836,8 @@ where
 
         let root_start = Instant::now();
         let root_outcome = ensure_ok_post_block!(
-            state_root_job.finish(&block, output.clone(), &hashed_state),
+            tracing::trace_span!(target: "engine::tree::critical", "np_finish_root")
+                .in_scope(|| state_root_job.finish(&block, output.clone(), &hashed_state)),
             block
         );
         let root_elapsed = root_start.elapsed();
@@ -1521,10 +1531,12 @@ where
         // Create deferred handle and task that owns the unsorted inputs.
         // Resolve the lazy handle into Arc<HashedPostState>. By this point the hashed state has
         // already been computed and used for state root verification, so .get() returns instantly.
-        let hashed_state = match hashed_state.try_into_inner() {
-            Ok(state) => state,
-            Err(handle) => handle.get().clone(),
-        };
+        let hashed_state =
+            tracing::trace_span!(target: "engine::tree::critical", "np_wait_hashed_state")
+                .in_scope(|| match hashed_state.try_into_inner() {
+                    Ok(state) => state,
+                    Err(handle) => handle.get().clone(),
+                });
         let (deferred_trie_data, deferred_trie_task) =
             LazyTrieData::pending(hashed_state, trie_output);
         let block_validation_metrics = self.metrics.block_validation.clone();

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -1138,7 +1138,7 @@ where
         _hashed_state: &LazyHashedPostState,
     ) -> ProviderResult<StateRootJobOutcome> {
         if self.timeout.is_none() {
-            return match tracing::trace_span!(target: "engine::tree::critical", "np_wait_sparse_root").in_scope(|| self.handle.state_root()) {
+            return match tracing::trace_span!(target: "engine::tree::critical", "np_wait_sparse_root").in_scope(|| { let _activity = reth_trie_sparse::activity::ActivityGuard::new("engine_root_wait"); self.handle.state_root() }) {
                 Ok(outcome) => self.verified_sparse_outcome(block, &output, outcome),
                 Err(err) => {
                     debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");
@@ -1151,8 +1151,11 @@ where
         let task_rx = self.handle.take_state_root_rx();
         let fallback_rx =
             match tracing::trace_span!(target: "engine::tree::critical", "np_wait_sparse_root")
-                .in_scope(|| task_rx.recv_timeout(timeout))
-            {
+                .in_scope(|| {
+                    let _activity =
+                        reth_trie_sparse::activity::ActivityGuard::new("engine_root_wait");
+                    task_rx.recv_timeout(timeout)
+                }) {
                 Ok(Ok(outcome)) => return self.verified_sparse_outcome(block, &output, outcome),
                 Ok(Err(err)) => {
                     debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");

--- a/crates/engine/tree/src/tree/state_root_strategy/mod.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/mod.rs
@@ -1138,7 +1138,7 @@ where
         _hashed_state: &LazyHashedPostState,
     ) -> ProviderResult<StateRootJobOutcome> {
         if self.timeout.is_none() {
-            return match self.handle.state_root() {
+            return match tracing::trace_span!(target: "engine::tree::critical", "np_wait_sparse_root").in_scope(|| self.handle.state_root()) {
                 Ok(outcome) => self.verified_sparse_outcome(block, &output, outcome),
                 Err(err) => {
                     debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");
@@ -1149,34 +1149,37 @@ where
 
         let timeout = self.timeout.expect("checked above");
         let task_rx = self.handle.take_state_root_rx();
-        let fallback_rx = match task_rx.recv_timeout(timeout) {
-            Ok(Ok(outcome)) => return self.verified_sparse_outcome(block, &output, outcome),
-            Ok(Err(err)) => {
-                debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");
-                Self::serial_fallback(
-                    &self.executor,
-                    self.state_provider_factory.clone(),
-                    output.clone(),
-                )?
-            }
-            Err(RecvTimeoutError::Timeout) => {
-                warn!(target: "engine::tree::state_root_strategy", ?timeout, "State root task timed out, racing serial fallback");
-                self.metrics.state_root_task_timeout_total.increment(1);
-                Self::serial_fallback(
-                    &self.executor,
-                    self.state_provider_factory.clone(),
-                    output.clone(),
-                )?
-            }
-            Err(RecvTimeoutError::Disconnected) => {
-                debug!(target: "engine::tree::state_root_strategy", "State root task dropped, falling back to serial root");
-                Self::serial_fallback(
-                    &self.executor,
-                    self.state_provider_factory.clone(),
-                    output.clone(),
-                )?
-            }
-        };
+        let fallback_rx =
+            match tracing::trace_span!(target: "engine::tree::critical", "np_wait_sparse_root")
+                .in_scope(|| task_rx.recv_timeout(timeout))
+            {
+                Ok(Ok(outcome)) => return self.verified_sparse_outcome(block, &output, outcome),
+                Ok(Err(err)) => {
+                    debug!(target: "engine::tree::state_root_strategy", %err, "State root task failed, falling back to serial root");
+                    Self::serial_fallback(
+                        &self.executor,
+                        self.state_provider_factory.clone(),
+                        output.clone(),
+                    )?
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    warn!(target: "engine::tree::state_root_strategy", ?timeout, "State root task timed out, racing serial fallback");
+                    self.metrics.state_root_task_timeout_total.increment(1);
+                    Self::serial_fallback(
+                        &self.executor,
+                        self.state_provider_factory.clone(),
+                        output.clone(),
+                    )?
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    debug!(target: "engine::tree::state_root_strategy", "State root task dropped, falling back to serial root");
+                    Self::serial_fallback(
+                        &self.executor,
+                        self.state_provider_factory.clone(),
+                        output.clone(),
+                    )?
+                }
+            };
 
         loop {
             if let Ok(Ok(outcome)) = task_rx.try_recv() {

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1,5 +1,6 @@
 //! Sparse Trie task related functionality.
 
+use reth_trie_sparse::activity::ActivityGuard;
 use std::sync::Arc;
 
 use super::{evm_state_to_hashed_post_state, StateRootComputeOutcome, StateRootMessage};
@@ -262,6 +263,8 @@ where
         skip_all
     )]
     pub(super) fn run(&mut self) -> Result<StateRootComputeOutcome, StateRootTaskError> {
+        let _activity = ActivityGuard::new("task");
+
         let now = Instant::now();
 
         let mut total_idle_time = std::time::Duration::ZERO;
@@ -274,11 +277,13 @@ where
         // marker means they died without finishing the stream.
         while !self.finished_state_updates {
             let mut t = Instant::now();
+            let wait_activity = ActivityGuard::new("loop_receive");
             let wait = tracing::trace_span!(target: "engine::tree::critical", "trie_wait_stream")
                 .entered();
             crossbeam_channel::select_biased! {
                 recv(self.updates) -> message => {
                     drop(wait);
+                    drop(wait_activity);
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
                     self.metrics
@@ -295,6 +300,7 @@ where
                 }
                 recv(self.proof_result_rx) -> message => {
                     drop(wait);
+                    drop(wait_activity);
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
                     self.metrics
@@ -320,11 +326,13 @@ where
         // are ignored: with all updates known, prefetching has nothing left to help.
         while !done {
             let mut t = Instant::now();
+            let wait_activity = ActivityGuard::new("loop_receive");
             let wait = tracing::trace_span!(target: "engine::tree::critical", "trie_wait_proofs")
                 .entered();
             crossbeam_channel::select_biased! {
                 recv(self.proof_result_rx) -> message => {
                     drop(wait);
+                    drop(wait_activity);
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
                     self.metrics
@@ -349,6 +357,7 @@ where
         debug!(target: "engine::root", "All proofs processed, ending calculation");
 
         let start = Instant::now();
+        let final_activity = ActivityGuard::new("final_root_updates");
         let (state_root, trie_updates) = match self.trie.root_with_updates(self.new_epoch) {
             Ok(result) => result,
             Err(err)
@@ -369,6 +378,7 @@ where
             }
         };
 
+        drop(final_activity);
         let end = Instant::now();
         self.metrics.sparse_trie_final_update_duration_histogram.record(end.duration_since(start));
         self.metrics.sparse_trie_total_duration_histogram.record(end.duration_since(now));
@@ -403,6 +413,8 @@ where
         message: ProofResultMessage,
         t: &mut Instant,
     ) -> Result<(), StateRootTaskError> {
+        let _activity = ActivityGuard::new("proof_coalesce_reveal");
+
         let mut result = self.on_proof_result_message(message)?;
         while let Ok(next) = self.proof_result_rx.try_recv() {
             let res = self.on_proof_result_message(next)?;
@@ -415,7 +427,10 @@ where
             .record(phase_end.duration_since(*t));
         *t = phase_end;
 
-        self.on_proof_result(result)?;
+        {
+            let _activity = ActivityGuard::new("proof_reveal");
+            self.on_proof_result(result)?;
+        }
         self.metrics.sparse_trie_reveal_multiproof_duration_histogram.record(t.elapsed());
         Ok(())
     }
@@ -431,6 +446,8 @@ where
         name = "trie_make_progress"
     )]
     fn make_progress(&mut self) -> Result<bool, StateRootTaskError> {
+        let _activity = ActivityGuard::new("progress");
+
         let updates_queued = !self.finished_state_updates && !self.updates.is_empty();
 
         if !updates_queued && self.proof_result_rx.is_empty() {
@@ -452,7 +469,10 @@ where
             // If there's still no pending updates spend some time pre-computing the account
             // trie upper hashes
             if self.proof_result_rx.is_empty() {
-                self.trie.calculate_subtries(self.new_epoch);
+                {
+                    let _activity = ActivityGuard::new("account_subtries");
+                    self.trie.calculate_subtries(self.new_epoch);
+                }
             }
         } else if !updates_queued {
             // If we don't have any pending updates, apply them to the trie,
@@ -596,6 +616,8 @@ where
     }
 
     fn process_new_updates(&mut self) -> SparseTrieResult<()> {
+        let _activity = ActivityGuard::new("new_updates");
+
         if self.pending_updates == 0 {
             return Ok(());
         }
@@ -654,11 +676,14 @@ where
         skip_all
     )]
     fn process_leaf_updates(&mut self, new: bool) -> SparseTrieResult<()> {
+        let _activity = ActivityGuard::new("leaf_pass");
+
         let storage_updates =
             if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
 
         // Process all storage updates, skipping tries with no pending updates.
         let span = trace_span!(target: "engine::tree::critical", "process_storage_leaf_updates", new, attempted = tracing::field::Empty, applied = tracing::field::Empty, tries = tracing::field::Empty).entered();
+        let storage_activity = ActivityGuard::new("storage_leaves");
         let mut attempted = 0usize;
         let mut applied = 0usize;
         let mut tries = 0usize;
@@ -700,6 +725,7 @@ where
         span.record("attempted", attempted);
         span.record("applied", applied);
         span.record("tries", tries);
+        drop(storage_activity);
         drop(span);
 
         // Process account trie updates and fill the account targets.
@@ -717,6 +743,8 @@ where
         skip_all
     )]
     fn process_account_leaf_updates(&mut self, new: bool) -> SparseTrieResult<bool> {
+        let _activity = ActivityGuard::new("account_leaves");
+
         let account_updates =
             if new { &mut self.new_account_updates } else { &mut self.account_updates };
 
@@ -763,6 +791,8 @@ where
         name = "trie_compute_drained_storage_roots"
     )]
     fn compute_drained_storage_roots(&mut self) {
+        let activity = ActivityGuard::new("storage_batch");
+
         struct SendStorageTriePtr<S>(*mut RevealableSparseTrie<S>);
         // SAFETY: this wrapper only forwards the pointer across rayon; deref invariants are
         // documented at the use site below.
@@ -785,7 +815,11 @@ where
         let parent_span =
             debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
         let new_epoch = self.new_epoch;
+        let submitted = std::time::Instant::now();
+        let batch_id = activity.id();
         tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
+            let _activity =
+                ActivityGuard::job("storage_root_job", batch_id, 1, submitted.elapsed());
             let span = if tracing::enabled!(tracing::Level::TRACE) {
                 debug_span!(
                     target: "engine::tree::payload_processor::sparse_trie",
@@ -825,6 +859,8 @@ where
         name = "trie_promote_pending_account_updates"
     )]
     fn promote_pending_account_updates(&mut self) -> SparseTrieResult<()> {
+        let _activity = ActivityGuard::new("promotion");
+
         self.process_leaf_updates(false)?;
 
         if self.pending_account_updates.is_empty() {
@@ -904,6 +940,8 @@ where
         name = "trie_dispatch_pending_targets"
     )]
     fn dispatch_pending_targets(&mut self) -> Result<(), StateRootTaskError> {
+        let _activity = ActivityGuard::new("proof_dispatch");
+
         if self.pending_targets.is_empty() {
             return Ok(())
         }

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -277,7 +277,8 @@ where
         // marker means they died without finishing the stream.
         while !self.finished_state_updates {
             let mut t = Instant::now();
-            let wait_activity = ActivityGuard::new("loop_receive");
+            let wait_activity = (self.updates.is_empty() && self.proof_result_rx.is_empty())
+                .then(|| ActivityGuard::new("loop_receive"));
             let wait = tracing::trace_span!(target: "engine::tree::critical", "trie_wait_stream")
                 .entered();
             crossbeam_channel::select_biased! {
@@ -326,7 +327,8 @@ where
         // are ignored: with all updates known, prefetching has nothing left to help.
         while !done {
             let mut t = Instant::now();
-            let wait_activity = ActivityGuard::new("loop_receive");
+            let wait_activity =
+                self.proof_result_rx.is_empty().then(|| ActivityGuard::new("loop_receive"));
             let wait = tracing::trace_span!(target: "engine::tree::critical", "trie_wait_proofs")
                 .entered();
             crossbeam_channel::select_biased! {
@@ -446,8 +448,6 @@ where
         name = "trie_make_progress"
     )]
     fn make_progress(&mut self) -> Result<bool, StateRootTaskError> {
-        let _activity = ActivityGuard::new("progress");
-
         let updates_queued = !self.finished_state_updates && !self.updates.is_empty();
 
         if !updates_queued && self.proof_result_rx.is_empty() {

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -274,8 +274,11 @@ where
         // marker means they died without finishing the stream.
         while !self.finished_state_updates {
             let mut t = Instant::now();
+            let wait = tracing::trace_span!(target: "engine::tree::critical", "trie_wait_stream")
+                .entered();
             crossbeam_channel::select_biased! {
                 recv(self.updates) -> message => {
+                    drop(wait);
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
                     self.metrics
@@ -291,6 +294,7 @@ where
                     self.pending_updates += 1;
                 }
                 recv(self.proof_result_rx) -> message => {
+                    drop(wait);
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
                     self.metrics
@@ -316,8 +320,11 @@ where
         // are ignored: with all updates known, prefetching has nothing left to help.
         while !done {
             let mut t = Instant::now();
+            let wait = tracing::trace_span!(target: "engine::tree::critical", "trie_wait_proofs")
+                .entered();
             crossbeam_channel::select_biased! {
                 recv(self.proof_result_rx) -> message => {
+                    drop(wait);
                     let wake = Instant::now();
                     total_idle_time += wake.duration_since(idle_start);
                     self.metrics
@@ -385,6 +392,12 @@ where
 
     /// Handles a received proof result: coalesces everything already queued, reveals the
     /// proof in the trie, and records timing metrics.
+    #[tracing::instrument(
+        level = "trace",
+        target = "engine::tree::critical",
+        skip_all,
+        name = "trie_on_proof_results"
+    )]
     fn on_proof_results(
         &mut self,
         message: ProofResultMessage,
@@ -411,6 +424,12 @@ where
     ///
     /// Messages queued after the finish marker are best-effort hints and are not actionable.
     /// Returns `true` once the finish marker was received and all pending trie work is done.
+    #[tracing::instrument(
+        level = "trace",
+        target = "engine::tree::critical",
+        skip_all,
+        name = "trie_make_progress"
+    )]
     fn make_progress(&mut self) -> Result<bool, StateRootTaskError> {
         let updates_queued = !self.finished_state_updates && !self.updates.is_empty();
 
@@ -464,10 +483,12 @@ where
                 None
             }
             SparseTrieTaskMessage::HashedState(hashed_state) => {
+                tracing::trace!(target: "engine::tree::critical", phase = "trie_state_update_received");
                 self.on_hashed_state_update(hashed_state);
                 None
             }
             SparseTrieTaskMessage::FinishedStateUpdates => {
+                tracing::trace!(target: "engine::tree::critical", phase = "trie_state_stream_finished");
                 let hashed_state = Arc::new(core::mem::take(&mut self.final_hashed_state));
                 let _ = self.final_hashed_state_tx.take().unwrap().send(Arc::clone(&hashed_state));
                 self.finished_state_updates = true;
@@ -637,7 +658,10 @@ where
             if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
 
         // Process all storage updates, skipping tries with no pending updates.
-        let span = trace_span!("process_storage_leaf_updates").entered();
+        let span = trace_span!(target: "engine::tree::critical", "process_storage_leaf_updates", new, attempted = tracing::field::Empty, applied = tracing::field::Empty, tries = tracing::field::Empty).entered();
+        let mut attempted = 0usize;
+        let mut applied = 0usize;
+        let mut tries = 0usize;
         for (address, updates) in storage_updates {
             if updates.is_empty() {
                 continue;
@@ -662,6 +686,9 @@ where
                 }
             })?;
             let updates_len_after = updates.len();
+            attempted += updates_len_before;
+            applied += updates_len_before - updates_len_after;
+            tries += 1;
             self.storage_cache_hits += (updates_len_before - updates_len_after) as u64;
             self.storage_cache_misses += updates_len_after as u64;
 
@@ -670,6 +697,9 @@ where
             }
         }
 
+        span.record("attempted", attempted);
+        span.record("applied", applied);
+        span.record("tries", tries);
         drop(span);
 
         // Process account trie updates and fill the account targets.
@@ -691,6 +721,7 @@ where
             if new { &mut self.new_account_updates } else { &mut self.account_updates };
 
         let updates_len_before = account_updates.len();
+        let span = trace_span!(target: "engine::tree::critical", "process_account_leaf_updates_batch", new, attempted = updates_len_before, applied = tracing::field::Empty).entered();
 
         self.trie.trie_mut().update_leaves(account_updates, |target, parent| {
             match self.fetched_account_targets.entry(target) {
@@ -710,6 +741,7 @@ where
         })?;
 
         let updates_len_after = account_updates.len();
+        span.record("applied", updates_len_before - updates_len_after);
         self.account_cache_hits += (updates_len_before - updates_len_after) as u64;
         self.account_cache_misses += updates_len_after as u64;
 
@@ -724,6 +756,12 @@ where
     /// 3. but the storage root hasn't been updated yet,
     ///
     /// we trigger state root computation on a rayon pool.
+    #[tracing::instrument(
+        level = "trace",
+        target = "engine::tree::critical",
+        skip_all,
+        name = "trie_compute_drained_storage_roots"
+    )]
     fn compute_drained_storage_roots(&mut self) {
         struct SendStorageTriePtr<S>(*mut RevealableSparseTrie<S>);
         // SAFETY: this wrapper only forwards the pointer across rayon; deref invariants are
@@ -780,10 +818,11 @@ where
     /// Iterates through all storage tries for which all updates were processed, computes their
     /// storage roots, and promotes corresponding pending account updates into proper leaf updates
     /// for accounts trie.
-    #[instrument(
+    #[tracing::instrument(
         level = "trace",
-        target = "engine::tree::payload_processor::sparse_trie",
-        skip_all
+        target = "engine::tree::critical",
+        skip_all,
+        name = "trie_promote_pending_account_updates"
     )]
     fn promote_pending_account_updates(&mut self) -> SparseTrieResult<()> {
         self.process_leaf_updates(false)?;
@@ -795,7 +834,7 @@ where
         self.compute_drained_storage_roots();
 
         loop {
-            let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
+            let span = trace_span!(target: "engine::tree::critical", "promote_updates", pending = self.pending_account_updates.len(), promoted = tracing::field::Empty).entered();
             // Now handle pending account updates that can be upgraded to a proper update.
             let account_rlp_buf = &mut self.account_rlp_buf;
             let mut num_promoted = 0;
@@ -858,12 +897,19 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(
+        level = "trace",
+        target = "engine::tree::critical",
+        skip_all,
+        name = "trie_dispatch_pending_targets"
+    )]
     fn dispatch_pending_targets(&mut self) -> Result<(), StateRootTaskError> {
         if self.pending_targets.is_empty() {
             return Ok(())
         }
 
         let _span = trace_span!("dispatch_pending_targets").entered();
+        tracing::trace!(target: "engine::tree::critical", phase = "trie_proof_targets_ready", targets = self.pending_targets.len());
         let (targets, chunking_length) = self.pending_targets.take();
         let mut dispatch_error = None;
         dispatch_with_chunking(

--- a/crates/metrics/src/thread.rs
+++ b/crates/metrics/src/thread.rs
@@ -218,10 +218,10 @@ pub fn current_thread_runqueue_time() -> Option<Duration> {
         use std::{fs::File, os::unix::fs::FileExt};
         thread_local! {
             static SCHEDSTAT: Option<File> = (|| {
-                if std::fs::read_to_string("/proc/sys/kernel/sched_schedstats").ok()?.trim() != "1" {
-                    None
-                } else {
+                if std::fs::read_to_string("/proc/sys/kernel/sched_schedstats").ok()?.trim() == "1" {
                     File::open("/proc/thread-self/schedstat").ok()
+                } else {
+                    None
                 }
             })();
         }

--- a/crates/metrics/src/thread.rs
+++ b/crates/metrics/src/thread.rs
@@ -190,6 +190,54 @@ mod platform {
     }
 }
 
+/// Current thread CPU time with nanosecond resolution, when supported.
+#[allow(clippy::missing_const_for_fn)]
+pub fn current_thread_cpu_time() -> Option<Duration> {
+    #[cfg(target_os = "linux")]
+    {
+        let mut ts = std::mem::MaybeUninit::<libc::timespec>::uninit();
+        // SAFETY: ts is writable and is read only after clock_gettime succeeds.
+        if unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, ts.as_mut_ptr()) } != 0 {
+            return None;
+        }
+        // SAFETY: clock_gettime initialized ts on success.
+        let ts = unsafe { ts.assume_init() };
+        Some(Duration::new(ts.tv_sec.try_into().ok()?, ts.tv_nsec.try_into().ok()?))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Current thread time queued to run, only when Linux scheduler statistics are enabled.
+#[allow(clippy::missing_const_for_fn)]
+pub fn current_thread_runqueue_time() -> Option<Duration> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::{fs::File, os::unix::fs::FileExt};
+        thread_local! {
+            static SCHEDSTAT: Option<File> = (|| {
+                if std::fs::read_to_string("/proc/sys/kernel/sched_schedstats").ok()?.trim() != "1" {
+                    None
+                } else {
+                    File::open("/proc/thread-self/schedstat").ok()
+                }
+            })();
+        }
+        SCHEDSTAT.with(|file| {
+            let mut buf = [0u8; 128];
+            let n = file.as_ref()?.read_at(&mut buf, 0).ok()?;
+            let text = std::str::from_utf8(&buf[..n]).ok()?;
+            Some(Duration::from_nanos(text.split_whitespace().nth(1)?.parse().ok()?))
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/trie/parallel/src/proof_task.rs
+++ b/crates/trie/parallel/src/proof_task.rs
@@ -1059,6 +1059,7 @@ where
         *account_proofs_processed += 1;
 
         // Send result to SparseTrieCacheTask
+        trace!(target: "engine::tree::critical", phase = "trie_proof_result_ready");
         if result_tx.send(ProofResultMessage { result, elapsed: total_elapsed, state }).is_err() {
             trace!(
                 target: "trie::proof_task",

--- a/crates/trie/sparse/src/activity.rs
+++ b/crates/trie/sparse/src/activity.rs
@@ -4,7 +4,10 @@ use reth_metrics::thread::{
 };
 use std::{
     cell::Cell,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        LazyLock,
+    },
     time::{Duration, Instant},
 };
 use tracing::span::EnteredSpan;
@@ -47,9 +50,11 @@ impl ActivityGuard {
         if !tracing::enabled!(target: "engine::tree::activity", tracing::Level::TRACE) {
             return Self { active: None };
         }
+        let epoch = *EPOCH;
         let id = NEXT.fetch_add(1, Ordering::Relaxed);
         let span = tracing::trace_span!(target: "engine::tree::activity", "trie_activity",
             phase, id, parent_id = parent, units, queued_us = queued.as_secs_f64() * 1e6,
+            wall_start_ns = tracing::field::Empty, wall_end_ns = tracing::field::Empty,
             cpu_start_ns = tracing::field::Empty, cpu_end_ns = tracing::field::Empty,
             wall_us = tracing::field::Empty, cpu_us = tracing::field::Empty,
             queue_start_ns = tracing::field::Empty, queue_end_ns = tracing::field::Empty,
@@ -65,6 +70,7 @@ impl ActivityGuard {
                 previous,
                 span,
                 start: Instant::now(),
+                epoch,
                 cpu: current_thread_cpu_time(),
                 usage: ThreadResourceUsage::now(),
                 queue: scheduler.then(current_thread_runqueue_time).flatten(),
@@ -84,7 +90,12 @@ impl Drop for ActivityGuard {
         let queue = active.queue.and_then(|_| current_thread_runqueue_time());
         let usage = active.usage.elapsed();
         let cpu = current_thread_cpu_time();
-        active.span.record("wall_us", active.start.elapsed().as_secs_f64() * 1e6);
+        let end = Instant::now();
+        active.span.record("wall_us", end.duration_since(active.start).as_secs_f64() * 1e6);
+        active
+            .span
+            .record("wall_start_ns", active.start.duration_since(active.epoch).as_nanos() as u64);
+        active.span.record("wall_end_ns", end.duration_since(active.epoch).as_nanos() as u64);
         if let (Some(start), Some(end)) = (active.cpu, cpu) {
             active.span.record("cpu_start_ns", start.as_nanos() as u64);
             active.span.record("cpu_end_ns", end.as_nanos() as u64);
@@ -112,9 +123,11 @@ struct Active {
     previous: u64,
     span: EnteredSpan,
     start: Instant,
+    epoch: Instant,
     usage: ThreadResourceUsage,
     cpu: Option<Duration>,
     queue: Option<Duration>,
 }
+static EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
 static NEXT: AtomicU64 = AtomicU64::new(1);
 thread_local! { static PARENT: Cell<u64> = const { Cell::new(0) }; }

--- a/crates/trie/sparse/src/activity.rs
+++ b/crates/trie/sparse/src/activity.rs
@@ -21,8 +21,19 @@ impl ActivityGuard {
         Self::start(phase, PARENT.with(Cell::get), 0, Duration::ZERO, true)
     }
 
+    /// Measures a fine-grained phase only when detailed activity is explicitly enabled.
+    pub fn detail(phase: &'static str) -> Self {
+        if !tracing::enabled!(target: "engine::tree::detail_activity", tracing::Level::TRACE) {
+            return Self { active: None };
+        }
+        Self::new(phase)
+    }
+
     /// Measures one worker job and records its relation to the submitting batch.
     pub fn job(phase: &'static str, parent: u64, units: usize, queued: Duration) -> Self {
+        if !tracing::enabled!(target: "engine::tree::detail_activity", tracing::Level::TRACE) {
+            return Self { active: None };
+        }
         Self::start(phase, parent, units, queued, false)
     }
 

--- a/crates/trie/sparse/src/activity.rs
+++ b/crates/trie/sparse/src/activity.rs
@@ -41,6 +41,7 @@ impl ActivityGuard {
             phase, id, parent_id = parent, units, queued_us = queued.as_secs_f64() * 1e6,
             cpu_start_ns = tracing::field::Empty, cpu_end_ns = tracing::field::Empty,
             wall_us = tracing::field::Empty, cpu_us = tracing::field::Empty,
+            queue_start_ns = tracing::field::Empty, queue_end_ns = tracing::field::Empty,
             runqueue_us = tracing::field::Empty, voluntary = tracing::field::Empty,
             involuntary = tracing::field::Empty, minor_faults = tracing::field::Empty,
             major_faults = tracing::field::Empty, input_ops = tracing::field::Empty,
@@ -53,9 +54,9 @@ impl ActivityGuard {
                 previous,
                 span,
                 start: Instant::now(),
+                cpu: current_thread_cpu_time(),
                 usage: ThreadResourceUsage::now(),
                 queue: scheduler.then(current_thread_runqueue_time).flatten(),
-                cpu: current_thread_cpu_time(),
             }),
         }
     }
@@ -69,9 +70,9 @@ impl ActivityGuard {
 impl Drop for ActivityGuard {
     fn drop(&mut self) {
         let Some(active) = &self.active else { return };
-        let cpu = current_thread_cpu_time();
         let queue = active.queue.and_then(|_| current_thread_runqueue_time());
         let usage = active.usage.elapsed();
+        let cpu = current_thread_cpu_time();
         active.span.record("wall_us", active.start.elapsed().as_secs_f64() * 1e6);
         if let (Some(start), Some(end)) = (active.cpu, cpu) {
             active.span.record("cpu_start_ns", start.as_nanos() as u64);
@@ -79,6 +80,8 @@ impl Drop for ActivityGuard {
             active.span.record("cpu_us", end.saturating_sub(start).as_secs_f64() * 1e6);
         }
         if let (Some(start), Some(end)) = (active.queue, queue) {
+            active.span.record("queue_start_ns", start.as_nanos() as u64);
+            active.span.record("queue_end_ns", end.as_nanos() as u64);
             active.span.record("runqueue_us", end.saturating_sub(start).as_secs_f64() * 1e6);
         }
         if let Some(usage) = usage {

--- a/crates/trie/sparse/src/activity.rs
+++ b/crates/trie/sparse/src/activity.rs
@@ -1,0 +1,106 @@
+//! Diagnostic phase accounting. CPU and context-switch counters belong only to the calling thread.
+use reth_metrics::thread::{
+    current_thread_cpu_time, current_thread_runqueue_time, ThreadResourceUsage,
+};
+use std::{
+    cell::Cell,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+use tracing::span::EnteredSpan;
+
+/// Thread-bound measurement of a synchronous trie phase.
+#[derive(Debug)]
+pub struct ActivityGuard {
+    active: Option<Active>,
+}
+
+impl ActivityGuard {
+    /// Measures a phase, including scheduler counters when available.
+    pub fn new(phase: &'static str) -> Self {
+        Self::start(phase, PARENT.with(Cell::get), 0, Duration::ZERO, true)
+    }
+
+    /// Measures one worker job and records its relation to the submitting batch.
+    pub fn job(phase: &'static str, parent: u64, units: usize, queued: Duration) -> Self {
+        Self::start(phase, parent, units, queued, false)
+    }
+
+    fn start(
+        phase: &'static str,
+        parent: u64,
+        units: usize,
+        queued: Duration,
+        scheduler: bool,
+    ) -> Self {
+        if !tracing::enabled!(target: "engine::tree::activity", tracing::Level::TRACE) {
+            return Self { active: None };
+        }
+        let id = NEXT.fetch_add(1, Ordering::Relaxed);
+        let span = tracing::trace_span!(target: "engine::tree::activity", "trie_activity",
+            phase, id, parent_id = parent, units, queued_us = queued.as_secs_f64() * 1e6,
+            cpu_start_ns = tracing::field::Empty, cpu_end_ns = tracing::field::Empty,
+            wall_us = tracing::field::Empty, cpu_us = tracing::field::Empty,
+            runqueue_us = tracing::field::Empty, voluntary = tracing::field::Empty,
+            involuntary = tracing::field::Empty, minor_faults = tracing::field::Empty,
+            major_faults = tracing::field::Empty, input_ops = tracing::field::Empty,
+        )
+        .entered();
+        let previous = PARENT.with(|p| p.replace(id));
+        Self {
+            active: Some(Active {
+                id,
+                previous,
+                span,
+                start: Instant::now(),
+                usage: ThreadResourceUsage::now(),
+                queue: scheduler.then(current_thread_runqueue_time).flatten(),
+                cpu: current_thread_cpu_time(),
+            }),
+        }
+    }
+
+    /// Identifier for attaching worker jobs to this batch.
+    pub fn id(&self) -> u64 {
+        self.active.as_ref().map_or(0, |a| a.id)
+    }
+}
+
+impl Drop for ActivityGuard {
+    fn drop(&mut self) {
+        let Some(active) = &self.active else { return };
+        let cpu = current_thread_cpu_time();
+        let queue = active.queue.and_then(|_| current_thread_runqueue_time());
+        let usage = active.usage.elapsed();
+        active.span.record("wall_us", active.start.elapsed().as_secs_f64() * 1e6);
+        if let (Some(start), Some(end)) = (active.cpu, cpu) {
+            active.span.record("cpu_start_ns", start.as_nanos() as u64);
+            active.span.record("cpu_end_ns", end.as_nanos() as u64);
+            active.span.record("cpu_us", end.saturating_sub(start).as_secs_f64() * 1e6);
+        }
+        if let (Some(start), Some(end)) = (active.queue, queue) {
+            active.span.record("runqueue_us", end.saturating_sub(start).as_secs_f64() * 1e6);
+        }
+        if let Some(usage) = usage {
+            active.span.record("voluntary", usage.voluntary_context_switches);
+            active.span.record("involuntary", usage.involuntary_context_switches);
+            active.span.record("minor_faults", usage.minor_page_faults);
+            active.span.record("major_faults", usage.major_page_faults);
+            active.span.record("input_ops", usage.block_input_operations);
+        }
+        PARENT.with(|p| p.set(active.previous));
+    }
+}
+
+#[derive(Debug)]
+struct Active {
+    id: u64,
+    previous: u64,
+    span: EnteredSpan,
+    start: Instant,
+    usage: ThreadResourceUsage,
+    cpu: Option<Duration>,
+    queue: Option<Duration>,
+}
+static NEXT: AtomicU64 = AtomicU64::new(1);
+thread_local! { static PARENT: Cell<u64> = const { Cell::new(0) }; }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2267,7 +2267,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
             let parent_span = tracing::Span::current();
             #[cfg(feature = "metrics")]
-            let batch = crate::activity::ActivityGuard::new("reveal_subtrie_batch");
+            let batch = crate::activity::ActivityGuard::detail("reveal_subtrie_batch");
             #[cfg(feature = "metrics")]
             let batch_id = batch.id();
             #[cfg(feature = "metrics")]
@@ -2337,7 +2337,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
     fn update_subtrie_hashes(&mut self, new_epoch: TrieNodeEpoch) {
         #[cfg(feature = "metrics")]
-        let _activity = crate::activity::ActivityGuard::new("hash_subtries");
+        let _activity = crate::activity::ActivityGuard::detail("hash_subtries");
 
         trace!(target: TRACE_TARGET, "Updating subtrie hashes");
 
@@ -2377,7 +2377,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 #[cfg(feature = "metrics")]
                 let submitted = std::time::Instant::now();
                 #[cfg(feature = "metrics")]
-                let batch = crate::activity::ActivityGuard::new("hash_subtrie_batch");
+                let batch = crate::activity::ActivityGuard::detail("hash_subtrie_batch");
                 #[cfg(feature = "metrics")]
                 let batch_id = batch.id();
                 taken = taken
@@ -2640,14 +2640,14 @@ impl SparseTrie for ArenaParallelSparseTrie {
         mut proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
     ) -> SparseTrieResult<()> {
         #[cfg(feature = "metrics")]
-        let _activity = crate::activity::ActivityGuard::new("apply_leaves");
+        let _activity = crate::activity::ActivityGuard::detail("apply_leaves");
 
         if updates.is_empty() {
             return Ok(());
         }
 
         #[cfg(feature = "metrics")]
-        let sorting = crate::activity::ActivityGuard::new("leaf_sort");
+        let sorting = crate::activity::ActivityGuard::detail("leaf_sort");
         // Drain and sort updates lexicographically by nibbles path.
         let mut sorted: Vec<_> =
             updates.drain().map(|(key, update)| (key, Nibbles::unpack(key), update)).collect();
@@ -2655,7 +2655,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         #[cfg(feature = "metrics")]
         drop(sorting);
         #[cfg(feature = "metrics")]
-        let traversal = crate::activity::ActivityGuard::new("leaf_traversal");
+        let traversal = crate::activity::ActivityGuard::detail("leaf_traversal");
 
         let threshold = self.parallelism_thresholds.min_updates;
         let parallelize_distributed_updates = sorted.len() >= threshold.saturating_mul(4);
@@ -2866,7 +2866,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
             let parent_span = tracing::Span::current();
             #[cfg(feature = "metrics")]
-            let batch = crate::activity::ActivityGuard::new("apply_subtrie_batch");
+            let batch = crate::activity::ActivityGuard::detail("apply_subtrie_batch");
             #[cfg(feature = "metrics")]
             let batch_id = batch.id();
             #[cfg(feature = "metrics")]
@@ -2885,7 +2885,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         }
 
         #[cfg(feature = "metrics")]
-        let _restore = crate::activity::ActivityGuard::new("leaf_restore");
+        let _restore = crate::activity::ActivityGuard::detail("leaf_restore");
         // Collect subtrie paths before consuming `taken`, then restore subtries and
         // process required proofs.
         let taken_paths: Vec<Nibbles> = taken.iter().map(|(_, s, _)| s.path).collect();

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -2266,9 +2266,22 @@ impl SparseTrie for ArenaParallelSparseTrie {
             use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
             let parent_span = tracing::Span::current();
+            #[cfg(feature = "metrics")]
+            let batch = crate::activity::ActivityGuard::new("reveal_subtrie_batch");
+            #[cfg(feature = "metrics")]
+            let batch_id = batch.id();
+            #[cfg(feature = "metrics")]
+            let submitted = std::time::Instant::now();
             let results: Vec<SparseTrieResult<()>> = taken
                 .par_iter_mut()
                 .map(|(_, subtrie, node_vec)| {
+                    #[cfg(feature = "metrics")]
+                    let _job = crate::activity::ActivityGuard::job(
+                        "reveal_subtrie_job",
+                        batch_id,
+                        node_vec.len(),
+                        submitted.elapsed(),
+                    );
                     let _guard = parent_span.enter();
                     subtrie.reveal_nodes(node_vec)
                 })
@@ -2323,6 +2336,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
     fn update_subtrie_hashes(&mut self, new_epoch: TrieNodeEpoch) {
+        #[cfg(feature = "metrics")]
+        let _activity = crate::activity::ActivityGuard::new("hash_subtries");
+
         trace!(target: TRACE_TARGET, "Updating subtrie hashes");
 
         // Only descend if the root is a branch; otherwise there are no subtries.
@@ -2358,9 +2374,22 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
                 let parent_span = tracing::Span::current();
+                #[cfg(feature = "metrics")]
+                let submitted = std::time::Instant::now();
+                #[cfg(feature = "metrics")]
+                let batch = crate::activity::ActivityGuard::new("hash_subtrie_batch");
+                #[cfg(feature = "metrics")]
+                let batch_id = batch.id();
                 taken = taken
                     .into_par_iter()
                     .map(|(idx, mut subtrie)| {
+                        #[cfg(feature = "metrics")]
+                        let _job = crate::activity::ActivityGuard::job(
+                            "hash_subtrie_job",
+                            batch_id,
+                            subtrie.num_dirty_leaves as usize,
+                            submitted.elapsed(),
+                        );
                         let _guard = parent_span.enter();
                         subtrie.update_cached_rlp(new_epoch);
                         (idx, subtrie)
@@ -2610,14 +2639,23 @@ impl SparseTrie for ArenaParallelSparseTrie {
         updates: &mut B256Map<LeafUpdate>,
         mut proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
     ) -> SparseTrieResult<()> {
+        #[cfg(feature = "metrics")]
+        let _activity = crate::activity::ActivityGuard::new("apply_leaves");
+
         if updates.is_empty() {
             return Ok(());
         }
 
+        #[cfg(feature = "metrics")]
+        let sorting = crate::activity::ActivityGuard::new("leaf_sort");
         // Drain and sort updates lexicographically by nibbles path.
         let mut sorted: Vec<_> =
             updates.drain().map(|(key, update)| (key, Nibbles::unpack(key), update)).collect();
         sorted.sort_unstable_by_key(|entry| entry.1);
+        #[cfg(feature = "metrics")]
+        drop(sorting);
+        #[cfg(feature = "metrics")]
+        let traversal = crate::activity::ActivityGuard::new("leaf_traversal");
 
         let threshold = self.parallelism_thresholds.min_updates;
         let parallelize_distributed_updates = sorted.len() >= threshold.saturating_mul(4);
@@ -2817,6 +2855,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
             return Ok(());
         }
 
+        #[cfg(feature = "metrics")]
+        drop(traversal);
         // Apply updates to taken subtries, in parallel if more than one.
         if taken.len() == 1 {
             let (_, ref mut subtrie, ref range) = taken[0];
@@ -2825,12 +2865,27 @@ impl SparseTrie for ArenaParallelSparseTrie {
             use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
             let parent_span = tracing::Span::current();
+            #[cfg(feature = "metrics")]
+            let batch = crate::activity::ActivityGuard::new("apply_subtrie_batch");
+            #[cfg(feature = "metrics")]
+            let batch_id = batch.id();
+            #[cfg(feature = "metrics")]
+            let submitted = std::time::Instant::now();
             taken.par_iter_mut().for_each(|(_, subtrie, range)| {
+                #[cfg(feature = "metrics")]
+                let _job = crate::activity::ActivityGuard::job(
+                    "apply_subtrie_job",
+                    batch_id,
+                    range.len(),
+                    submitted.elapsed(),
+                );
                 let _guard = parent_span.enter();
                 subtrie.update_leaves(&sorted[range.clone()]);
             });
         }
 
+        #[cfg(feature = "metrics")]
+        let _restore = crate::activity::ActivityGuard::new("leaf_restore");
         // Collect subtrie paths before consuming `taken`, then restore subtries and
         // process required proofs.
         let taken_paths: Vec<Nibbles> = taken.iter().map(|(_, s, _)| s.path).collect();

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -33,3 +33,7 @@ pub mod errors {
         SparseTrieErrorKind, SparseTrieResult,
     };
 }
+
+/// Diagnostic wall/CPU accounting for trie phases.
+#[cfg(feature = "metrics")]
+pub mod activity;


### PR DESCRIPTION
Separates sparse-trie wall time, calling-thread CPU time, runnable-queue delay, and context switches to explain engine root wait. Optional worker tracing links jobs to parallel batches; shared monotonic timestamps keep accounting independent of tracer entry/exit overhead.

Diagnostic only, based on main `e63ec720` including #27093. The final 300M BAL capture measured 37.4 ms root wait: about 18.5 ms coordinator CPU, 0.45 ms runnable-queue delay, and 18.4 ms otherwise off CPU; only 0.19 ms was in the main-loop receive. Instrumentation changed mean server latency by +0.8% across three pairs.

[Full phase breakdown and profile findings](https://github.com/paradigmxyz/reth/pull/27134#issuecomment-5610364780).
