### PR TITLE
chore(rpc): increase default transaction hash cache to 100k

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -1222,7 +1222,7 @@ mod tests {
                 max_headers: 1000,
                 max_bals: 1000,
                 max_concurrent_db_requests: 512,
-                max_cached_tx_hashes: 30_000,
+                max_cached_tx_hashes: 100_000,
             },
             gas_price_oracle: GasPriceOracleArgs {
                 blocks: 20,

--- a/crates/rpc/rpc-server-types/src/constants.rs
+++ b/crates/rpc/rpc-server-types/src/constants.rs
@@ -130,5 +130,5 @@ pub mod cache {
     pub const DEFAULT_CONCURRENT_DB_REQUESTS: usize = 512;
 
     /// Default maximum number of transaction hashes to cache for lookups.
-    pub const DEFAULT_MAX_CACHED_TX_HASHES: u32 = 30_000;
+    pub const DEFAULT_MAX_CACHED_TX_HASHES: u32 = 100_000;
 }

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -557,7 +557,7 @@ RPC State Cache:
       --rpc-cache.max-cached-tx-hashes <MAX_CACHED_TX_HASHES>
           Maximum number of transaction hashes to cache for transaction lookups
 
-          [default: 30000]
+          [default: 100000]
 
 Gas Price Oracle:
       --gpo.blocks <BLOCKS>


### PR DESCRIPTION
Raises the default RPC transaction-hash cache from 30,000 to 100,000 entries, providing capacity for 50 blocks at 2,000 transactions per block. Updates the CLI default expectation and regenerates the CLI reference.
