### PR TITLE
perf(trie): hash sparse branches in a single child pass

### DIFF
--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -1,8 +1,9 @@
 use super::{
-    branch_child_idx::{BranchChildIdx, BranchChildIter},
-    ArenaSparseNode, ArenaSparseNodeBranchChild, ArenaSparseNodeState, Index, NodeArena,
+    branch_child_idx::BranchChildIdx, ArenaSparseNode, ArenaSparseNodeBranchChild,
+    ArenaSparseNodeState, Index, NodeArena,
 };
 use alloc::vec::Vec;
+use alloy_trie::TrieMask;
 use reth_trie_common::Nibbles;
 use tracing::{instrument, trace};
 
@@ -15,9 +16,9 @@ pub(super) struct ArenaCursorStackEntry {
     pub(super) index: Index,
     /// The absolute path of this node in the trie (not including its `short_key`).
     pub(super) path: Nibbles,
-    /// The dense index at which to resume child iteration in [`ArenaCursor::next`].
-    /// Only meaningful when this entry's node is a branch.
-    pub(super) next_dense_idx: usize,
+    /// The nibble at which to resume child iteration in [`ArenaCursor::next`]. Only meaningful
+    /// when this entry's node is a branch. `16` means all children have been visited.
+    pub(super) next_nibble: u8,
 }
 
 /// Result of [`ArenaCursor::seek`] describing the state at the deepest ancestor node.
@@ -106,7 +107,7 @@ impl ArenaCursor {
     /// Pushes an entry onto the stack for the node at the given index and path.
     fn push(&mut self, arena: &NodeArena, idx: Index, path: Nibbles) {
         debug_assert!(arena.contains_key(idx), "push called with invalid arena index");
-        self.stack.push(ArenaCursorStackEntry { index: idx, path, next_dense_idx: 0 });
+        self.stack.push(ArenaCursorStackEntry { index: idx, path, next_nibble: 0 });
         trace!(target: TRACE_TARGET, entry = ?self.stack.last().expect("just pushed"), "Pushed stack entry");
     }
 
@@ -143,6 +144,20 @@ impl ArenaCursor {
                 *arena[parent.index].state_mut() = ArenaSparseNodeState::Dirty;
             }
         }
+
+        entry
+    }
+
+    /// Pops the top entry from the stack without propagating dirty state to the parent.
+    fn pop_clean(&mut self, arena: &NodeArena) -> ArenaCursorStackEntry {
+        let entry = self.stack.pop().expect("pop can't be called on empty stack");
+
+        debug_assert!(
+            !arena
+                .get(entry.index)
+                .is_some_and(|node| matches!(node.state_ref(), Some(ArenaSparseNodeState::Dirty))),
+            "pop_clean called on a dirty node: {entry:?}",
+        );
 
         entry
     }
@@ -241,52 +256,74 @@ impl ArenaCursor {
         arena: &mut NodeArena,
         should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
     ) -> NextResult {
+        self.advance::<true>(arena, should_descend)
+    }
+
+    /// Like [`Self::next`], but skips the dirty-state propagation when popping.
+    ///
+    /// Only for walks that leave every visited node clean, such as the hashing walk, which
+    /// caches each branch before the cursor pops it. Debug builds assert this.
+    pub(super) fn next_clean(
+        &mut self,
+        arena: &mut NodeArena,
+        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
+    ) -> NextResult {
+        self.advance::<false>(arena, should_descend)
+    }
+
+    fn advance<const PROPAGATE_DIRTY: bool>(
+        &mut self,
+        arena: &mut NodeArena,
+        should_descend: impl Fn(usize, &ArenaSparseNode) -> bool,
+    ) -> NextResult {
         if self.needs_pop {
-            self.pop(arena);
+            if PROPAGATE_DIRTY {
+                self.pop(arena);
+            } else {
+                self.pop_clean(arena);
+            }
             self.needs_pop = false;
         }
 
         loop {
-            let Some(head) = self.stack.last_mut() else {
+            let Some(head) = self.stack.last() else {
                 return NextResult::Done;
             };
             let head_idx = head.index;
+            let resume_nibble = head.next_nibble;
+            let child_depth = self.stack.len();
 
             let ArenaSparseNode::Branch(branch) = &arena[head_idx] else {
                 self.needs_pop = true;
                 return NextResult::NonBranch;
             };
 
-            let state_mask = branch.state_mask;
-            let start = head.next_dense_idx;
-            let child_depth = self.stack.len();
+            // Resume the scan by masking off the children that were already visited, so a branch
+            // with many dirty children isn't rescanned from nibble 0 on every descent.
+            let state_mask = branch.state_mask.get() as u32;
+            let visited = state_mask & ((1u32 << resume_nibble) - 1);
+            let remaining = TrieMask::new((state_mask & !visited) as u16);
 
-            let mut descended = false;
-            for (branch_child_idx, nibble) in BranchChildIter::new(state_mask) {
-                if branch_child_idx.get() < start {
-                    continue;
-                }
-
-                let child_idx = match &arena[head_idx].branch_ref().children[branch_child_idx] {
-                    ArenaSparseNodeBranchChild::Revealed(child_idx) => *child_idx,
-                    ArenaSparseNodeBranchChild::Blinded(_) => continue,
-                };
-
-                if should_descend(child_depth, &arena[child_idx]) {
-                    // Record where to resume iteration when we return to this entry.
-                    self.stack.last_mut().expect("head exists").next_dense_idx =
-                        branch_child_idx.get() + 1;
-                    let path = self.child_path(arena, nibble);
-                    self.push(arena, child_idx, path);
-                    descended = true;
+            let mut descended = None;
+            for (child, nibble) in
+                branch.children[visited.count_ones() as usize..].iter().zip(remaining.iter())
+            {
+                let ArenaSparseNodeBranchChild::Revealed(child_idx) = child else { continue };
+                if should_descend(child_depth, &arena[*child_idx]) {
+                    descended = Some((nibble, *child_idx));
                     break;
                 }
             }
 
-            if !descended {
+            let Some((nibble, child_idx)) = descended else {
                 self.needs_pop = true;
                 return NextResult::Branch;
-            }
+            };
+
+            // Record where to resume iteration when we return to this entry.
+            self.stack.last_mut().expect("head exists").next_nibble = nibble + 1;
+            let path = self.child_path(arena, nibble);
+            self.push(arena, child_idx, path);
         }
     }
 

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
 use alloy_primitives::{keccak256, map::B256Map, B256};
-use alloy_trie::TrieMask;
+use alloy_trie::{BranchNodeCompact, TrieMask};
 use core::{cmp::Reverse, mem};
 use reth_execution_errors::SparseTrieResult;
 use reth_trie_common::{
@@ -920,28 +920,6 @@ impl ArenaParallelSparseTrie {
         B256::from(bytes)
     }
 
-    /// Returns the [`BranchNodeMasks`] for a branch based on the status of its children.
-    fn get_branch_masks(arena: &NodeArena, branch: &ArenaSparseNodeBranch) -> BranchNodeMasks {
-        let mut masks = BranchNodeMasks::default();
-
-        for (nibble, child) in branch.child_iter() {
-            let (hash_bit, tree_bit) = match child {
-                ArenaSparseNodeBranchChild::Blinded(_) => (
-                    branch.branch_masks.hash_mask.is_bit_set(nibble),
-                    branch.branch_masks.tree_mask.is_bit_set(nibble),
-                ),
-                ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                    let child = &arena[*child_idx];
-                    (child.hash_mask_bit(), child.tree_mask_bit())
-                }
-            };
-
-            masks.set_child_bits(nibble, hash_bit, tree_bit);
-        }
-
-        masks
-    }
-
     /// Computes and caches `RlpNode` for all dirty nodes reachable from `root` in `arena`.
     ///
     /// Uses the cursor's stack to walk dirty branches depth-first. For each branch,
@@ -1001,11 +979,15 @@ impl ArenaParallelSparseTrie {
 
         cursor.reset(arena, root, base_path);
 
-        // Step 2: Walk dirty branches depth-first using `cursor.next`. Only dirty branches
+        // Scratch for the child hashes of the branch being encoded. A branch has at most 16
+        // children, so this never spills to the heap.
+        let mut hashes = SmallVec::<[B256; 16]>::new();
+
+        // Step 2: Walk dirty branches depth-first using `cursor.next_clean`. Only dirty branches
         // are descended into; all other children (leaves, cached branches, blinded, subtries)
         // are encoded when their parent branch is popped.
         loop {
-            let result = cursor.next(&mut *arena, |_, node| {
+            let result = cursor.next_clean(&mut *arena, |_, node| {
                 matches!(
                     node,
                     ArenaSparseNode::Branch(b) if matches!(b.state, ArenaSparseNodeState::Dirty)
@@ -1027,79 +1009,34 @@ impl ArenaParallelSparseTrie {
             // The branch at `head_idx` is exhausted. All its dirty child branches
             // have already been encoded and cached. Collect all children's RLP nodes
             // and encode the branch.
-            trace!(
-                target: TRACE_TARGET,
-                branch_path = ?head_path,
-                branch_short_key = ?arena[head_idx].short_key().expect("head is a branch"),
-                state_mask = ?arena[head_idx].branch_ref().state_mask,
-                "Calculating branch RlpNode",
-            );
-
-            rlp_node_buf.clear();
-            let mut node_epoch = TrieNodeEpoch::UNMODIFIED;
-            let state_mask = arena[head_idx].branch_ref().state_mask;
-            for (child_idx, _nibble) in BranchChildIter::new(state_mask) {
-                match &arena[head_idx].branch_ref().children[child_idx] {
-                    ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
-                        rlp_node_buf.push(rlp_node.clone());
-                    }
-                    ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                        let child_idx = *child_idx;
-                        match &arena[child_idx] {
-                            ArenaSparseNode::Leaf { .. } => {
-                                Self::encode_leaf(
-                                    arena,
-                                    child_idx,
-                                    rlp_buf,
-                                    rlp_node_buf,
-                                    new_epoch,
-                                );
-                            }
-                            ArenaSparseNode::Branch(child_b) => {
-                                let ArenaSparseNodeState::Cached { rlp_node, .. } = &child_b.state
-                                else {
-                                    panic!("child branch must be cached after DFS");
-                                };
-                                let rlp_node = rlp_node.clone();
-                                rlp_node_buf.push(rlp_node);
-                            }
-                            ArenaSparseNode::Subtrie(subtrie) => {
-                                let subtrie_root = &subtrie.arena[subtrie.root];
-                                match subtrie_root {
-                                    ArenaSparseNode::Branch(ArenaSparseNodeBranch {
-                                        state: ArenaSparseNodeState::Cached { rlp_node, .. },
-                                        ..
-                                    }) |
-                                    ArenaSparseNode::Leaf {
-                                        state: ArenaSparseNodeState::Cached { rlp_node, .. },
-                                        ..
-                                    } => {
-                                        rlp_node_buf.push(rlp_node.clone());
-                                    }
-                                    _ => panic!("subtrie root must be a cached Branch or Leaf"),
-                                }
-                            }
-                            ArenaSparseNode::TakenSubtrie | ArenaSparseNode::EmptyRoot { .. } => {
-                                unreachable!("Unexpected child {:?}", arena[child_idx]);
-                            }
-                        }
-                        let Some(ArenaSparseNodeState::Cached { epoch: child_epoch, .. }) =
-                            arena[child_idx].state_ref()
-                        else {
-                            panic!("revealed child must be cached after encoding");
-                        };
-                        node_epoch = node_epoch.max(*child_epoch);
-                    }
-                }
-            }
-
-            // Encode the branch, optionally wrapping in an extension if it has a short_key.
             let b = arena[head_idx].branch_ref();
             let short_key = b.short_key;
             let state_mask = b.state_mask;
             let prev_branch_masks = b.branch_masks;
-            let new_branch_masks = Self::get_branch_masks(arena, b);
             let was_dirty = matches!(b.state, ArenaSparseNodeState::Dirty);
+
+            trace!(
+                target: TRACE_TARGET,
+                branch_path = ?head_path,
+                branch_short_key = ?short_key,
+                ?state_mask,
+                "Calculating branch RlpNode",
+            );
+
+            // Child hashes are only needed for branches that end up in the trie updates, which
+            // requires the same conditions as the update recording below.
+            let record_hashes =
+                was_dirty && updates.is_some() && !(head_path.is_empty() && short_key.is_empty());
+            hashes.clear();
+
+            let (mut node_epoch, new_branch_masks) = Self::hash_branch_children(
+                arena,
+                head_idx,
+                rlp_buf,
+                rlp_node_buf,
+                record_hashes.then_some(&mut hashes),
+                new_epoch,
+            );
             if was_dirty {
                 node_epoch = node_epoch.max(new_epoch);
             }
@@ -1117,7 +1054,7 @@ impl ArenaParallelSparseTrie {
             trace!(
                 target: TRACE_TARGET,
                 path = ?head_path,
-                short_key = ?arena[head_idx].short_key(),
+                ?short_key,
                 children = ?state_mask.iter().zip(rlp_node_buf.iter()).collect::<Vec<_>>(),
                 rlp_node = ?rlp_node,
                 "Calculated branch RlpNode",
@@ -1138,7 +1075,13 @@ impl ArenaParallelSparseTrie {
                         trie_updates.updated_nodes.remove(&logical_path);
                         trie_updates.removed_nodes.insert(logical_path);
                     } else if !new_branch_masks.is_empty() {
-                        let compact = arena[head_idx].branch_ref().branch_node_compact(arena);
+                        let compact = BranchNodeCompact::new(
+                            state_mask,
+                            new_branch_masks.tree_mask,
+                            new_branch_masks.hash_mask,
+                            hashes.to_vec(),
+                            None,
+                        );
                         trie_updates.updated_nodes.insert(logical_path, compact);
                         trie_updates.removed_nodes.remove(&logical_path);
                     }
@@ -1150,6 +1093,130 @@ impl ArenaParallelSparseTrie {
             panic!("root must be cached after update_cached_rlp");
         };
         rlp_node.clone()
+    }
+
+    /// Walks the children of the branch at `head_idx` once, pushing each child's `RlpNode` onto
+    /// `rlp_node_buf` and returning the branch's epoch (the max epoch across its revealed
+    /// children) together with its recomputed [`BranchNodeMasks`]. When `hashes` is `Some`, the
+    /// hashes of the children selected by the new hash mask are appended to it in nibble order,
+    /// ready for the branch's [`BranchNodeCompact`].
+    ///
+    /// Dirty leaf children are encoded during the walk but their cached state is written back
+    /// afterwards, because the walk holds a shared borrow of the branch.
+    fn hash_branch_children(
+        arena: &mut NodeArena,
+        head_idx: Index,
+        rlp_buf: &mut Vec<u8>,
+        rlp_node_buf: &mut Vec<RlpNode>,
+        mut hashes: Option<&mut SmallVec<[B256; 16]>>,
+        new_epoch: TrieNodeEpoch,
+    ) -> (TrieNodeEpoch, BranchNodeMasks) {
+        let mut node_epoch = TrieNodeEpoch::UNMODIFIED;
+        let mut masks = BranchNodeMasks::default();
+        let mut encoded_leaves = SmallVec::<[(Index, RlpNode, TrieNodeEpoch); 16]>::new();
+
+        rlp_node_buf.clear();
+
+        let branch = arena[head_idx].branch_ref();
+        for (dense_idx, nibble) in BranchChildIter::new(branch.state_mask) {
+            let (hash_bit, tree_bit) = match &branch.children[dense_idx] {
+                ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
+                    rlp_node_buf.push(rlp_node.clone());
+                    (
+                        branch.branch_masks.hash_mask.is_bit_set(nibble),
+                        branch.branch_masks.tree_mask.is_bit_set(nibble),
+                    )
+                }
+                ArenaSparseNodeBranchChild::Revealed(child_idx) => {
+                    let child_idx = *child_idx;
+                    let (child_epoch, bits) = match &arena[child_idx] {
+                        ArenaSparseNode::Leaf { state, key, value } => {
+                            let epoch = match state {
+                                ArenaSparseNodeState::Cached { rlp_node, epoch } => {
+                                    rlp_node_buf.push(rlp_node.clone());
+                                    *epoch
+                                }
+                                ArenaSparseNodeState::Revealed | ArenaSparseNodeState::Dirty => {
+                                    let epoch = if matches!(state, ArenaSparseNodeState::Dirty) {
+                                        new_epoch
+                                    } else {
+                                        TrieNodeEpoch::UNMODIFIED
+                                    };
+                                    rlp_buf.clear();
+                                    let rlp_node = LeafNodeRef { key, value }.rlp(rlp_buf);
+                                    encoded_leaves.push((child_idx, rlp_node.clone(), epoch));
+                                    rlp_node_buf.push(rlp_node);
+                                    epoch
+                                }
+                            };
+                            (epoch, (false, false))
+                        }
+                        ArenaSparseNode::Branch(child_branch) => {
+                            let ArenaSparseNodeState::Cached { rlp_node, epoch } =
+                                &child_branch.state
+                            else {
+                                panic!("child branch must be cached after DFS");
+                            };
+                            let bits = (
+                                child_branch.short_key.is_empty() && rlp_node.is_hash(),
+                                !child_branch.branch_masks.is_empty(),
+                            );
+                            rlp_node_buf.push(rlp_node.clone());
+                            (*epoch, bits)
+                        }
+                        ArenaSparseNode::Subtrie(subtrie) => match &subtrie.arena[subtrie.root] {
+                            ArenaSparseNode::Branch(ArenaSparseNodeBranch {
+                                state: ArenaSparseNodeState::Cached { rlp_node, epoch },
+                                short_key,
+                                branch_masks,
+                                ..
+                            }) => {
+                                let bits = (
+                                    short_key.is_empty() && rlp_node.is_hash(),
+                                    !branch_masks.is_empty(),
+                                );
+                                rlp_node_buf.push(rlp_node.clone());
+                                (*epoch, bits)
+                            }
+                            ArenaSparseNode::Leaf {
+                                state: ArenaSparseNodeState::Cached { rlp_node, epoch },
+                                ..
+                            } => {
+                                rlp_node_buf.push(rlp_node.clone());
+                                (*epoch, (false, false))
+                            }
+                            _ => panic!("subtrie root must be a cached Branch or Leaf"),
+                        },
+                        node @ (ArenaSparseNode::TakenSubtrie |
+                        ArenaSparseNode::EmptyRoot { .. }) => {
+                            unreachable!("Unexpected child {node:?}");
+                        }
+                    };
+                    node_epoch = node_epoch.max(child_epoch);
+                    bits
+                }
+            };
+
+            masks.set_child_bits(nibble, hash_bit, tree_bit);
+
+            // A child only carries a hash mask bit if its `RlpNode` is a hash, so the hash for
+            // the branch's `BranchNodeCompact` is the node that was just pushed.
+            if hash_bit && let Some(hashes) = hashes.as_mut() {
+                hashes.push(
+                    rlp_node_buf
+                        .last()
+                        .expect("child RlpNode was just pushed")
+                        .as_hash()
+                        .expect("hash mask child must be a hash"),
+                );
+            }
+        }
+
+        for (child_idx, rlp_node, epoch) in encoded_leaves {
+            *arena[child_idx].state_mut() = ArenaSparseNodeState::Cached { rlp_node, epoch };
+        }
+
+        (node_epoch, masks)
     }
 
     /// Immutable traversal to find a leaf value at `full_path` starting from `root` in `arena`.

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -1,10 +1,9 @@
 use super::{
     branch_child_idx::{BranchChildIdx, BranchChildIter},
-    ArenaSparseSubtrie, Index, NodeArena,
+    ArenaSparseSubtrie, Index,
 };
 use alloc::{boxed::Box, vec::Vec};
-use alloy_primitives::{keccak256, B256};
-use alloy_trie::{BranchNodeCompact, TrieMask};
+use alloy_trie::TrieMask;
 use reth_trie_common::{BranchNodeMasks, Nibbles, ProofTrieNodeV2, RlpNode, TrieNodeV2};
 use smallvec::SmallVec;
 use strum::AsRefStr;
@@ -136,31 +135,6 @@ impl ArenaSparseNodeBranch {
     ) -> impl Iterator<Item = (u8, &ArenaSparseNodeBranchChild)> + '_ {
         BranchChildIter::new(self.state_mask).map(|(idx, nibble)| (nibble, &self.children[idx]))
     }
-
-    /// Returns a [`BranchNodeCompact`] from this branch's masks and children hashes.
-    pub(super) fn branch_node_compact(&self, arena: &NodeArena) -> BranchNodeCompact {
-        let mut hashes = Vec::with_capacity(self.branch_masks.hash_mask.count_bits() as usize);
-        for (nibble, child) in self.child_iter() {
-            if self.branch_masks.hash_mask.is_bit_set(nibble) {
-                let hash = match child {
-                    ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
-                        rlp_node.as_hash().expect("blinded child must be a hash")
-                    }
-                    ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                        arena[*child_idx].cached_hash()
-                    }
-                };
-                hashes.push(hash);
-            }
-        }
-        BranchNodeCompact::new(
-            self.state_mask,
-            self.branch_masks.tree_mask,
-            self.branch_masks.hash_mask,
-            hashes,
-            None,
-        )
-    }
 }
 
 /// A node in the arena-based sparse trie.
@@ -258,50 +232,6 @@ impl ArenaSparseNode {
             Self::Subtrie(s) => Some(s),
             _ => None,
         }
-    }
-
-    /// Returns the branch data if this node (or its subtrie root) is a branch, or `None`.
-    pub(super) fn as_branch(&self) -> Option<&ArenaSparseNodeBranch> {
-        match self {
-            Self::Branch(b) => Some(b),
-            Self::Subtrie(s) => s.arena[s.root].as_branch(),
-            _ => None,
-        }
-    }
-
-    /// Returns `true` if this node should contribute a set bit in its parent's `hash_mask`.
-    ///
-    /// That is, if the node is a branch with no short key (no extension) whose cached
-    /// RLP is a hash (>= 32 bytes). Small branches whose RLP is embedded don't get a
-    /// `hash_mask` bit.
-    pub(super) fn hash_mask_bit(&self) -> bool {
-        self.as_branch().is_some_and(|b| {
-            b.short_key.is_empty() &&
-                b.state.cached_rlp_node().expect("branch's RlpNode must be cached").is_hash()
-        })
-    }
-
-    /// Returns `true` if this node should contribute a set bit in its parent's `tree_mask`.
-    ///
-    /// That is, if the node is a branch with any non-empty `branch_masks`.
-    pub(super) fn tree_mask_bit(&self) -> bool {
-        self.as_branch().is_some_and(|b| !b.branch_masks.is_empty())
-    }
-
-    /// Returns the cached hash of this node. Panics if the node's state is not `Cached`.
-    ///
-    /// If the `RlpNode` is already a hash (>= 32 bytes encoded), returns it directly.
-    /// Otherwise keccak-hashes the RLP encoding to produce the hash. This handles the
-    /// case where a branch's RLP is small enough to be embedded rather than hashed.
-    pub(super) fn cached_hash(&self) -> B256 {
-        let rlp_node = match self {
-            Self::Branch(ArenaSparseNodeBranch { state, .. }) | Self::Leaf { state, .. } => state
-                .cached_rlp_node()
-                .expect("cached_hash called on non-Cached branch or leaf: {self:?}"),
-            Self::Subtrie(s) => return s.arena[s.root].cached_hash(),
-            _ => panic!("cached_hash called on {self:?}"),
-        };
-        rlp_node.as_hash().unwrap_or_else(|| keccak256(rlp_node.as_slice()))
     }
 }
 


### PR DESCRIPTION
`ArenaParallelSparseTrie::update_cached_rlp` walked the children of every dirty branch up to four times per hashing round: once to collect the child `RlpNode`s and epochs, once in `get_branch_masks`, once in `branch_node_compact`, and once in the cursor's descend scan, each of them re-indexing the arena for every child. The child `RlpNode`, the max child epoch, the hash and tree mask bits and the hashes for the `BranchNodeCompact` now all come out of a single pass that takes one borrow of the branch and one arena lookup per child. A child only carries a hash mask bit when its `RlpNode` is a hash, so the compact's hashes are read off the nodes the pass already collected rather than by walking the arena a third time. Dirty leaf children are encoded during the pass and their cached state is written back immediately after it, since the pass holds a shared borrow of the arena.

Two smaller things in the cursor: the depth-first scan resumes at the nibble it stopped at instead of rescanning from nibble zero on every descent, and the hashing walk pops without dirty-state propagation, which is a no-op there because every branch is cached before it is popped (debug builds assert it). As a side effect the hashing walk no longer emits the trace-level cursor spans.

Measured with a local harness that times `SparseTrie::root` per iteration and keeps the best of 200, since this machine is too busy for mean wall times to mean anything, with a single rayon thread on a 50k-leaf storage trie: 10k leaf updates 7.15 ms to 6.88 ms, 1k updates 1.54 ms to 1.49 ms, and the new code was faster in 8 of 8 alternating runs for the 10k case. 64 updates is unchanged, which is expected as almost none of that time is in the branch walk. `reveal_nodes` and `update_leaves` are unaffected, and with the default rayon pool the numbers were too noisy to say anything either way. The risk is that the fused pass has to reproduce the mask and update bookkeeping exactly; the arena proptest cross-checks roots and trie updates against `StorageRoot` over 1000 cases and covers that, along with the sparse trie suite and the engine `state_root_strategy` tests.