### PR TITLE
perf(trie): collect sparse trie updates only from touched tries

### DIFF
--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -92,6 +92,9 @@ struct ArenaTrieBuffers {
     /// Trie updates built up directly during hashing and structural changes. `Some` when
     /// tracking updates, `None` otherwise. Initialized alongside `updates` in `set_updates`.
     updates: Option<SparseTrieUpdates>,
+    /// Set while this trie (or, for the upper trie, any of its subtries) may hold recorded
+    /// updates. Only ever set while `updates` is `Some`, and reset when updates are taken.
+    updates_recorded: bool,
     /// Reusable buffer for RLP encoding.
     rlp_buf: Vec<u8>,
     /// Reusable buffer for child `RlpNode`s during hashing.
@@ -103,6 +106,7 @@ impl ArenaTrieBuffers {
         if let Some(updates) = self.updates.as_mut() {
             updates.clear();
         }
+        self.updates_recorded = false;
         self.rlp_buf.clear();
         self.rlp_node_buf.clear();
     }
@@ -752,7 +756,7 @@ impl ArenaParallelSparseTrie {
         let ArenaSparseNode::Subtrie(mut subtrie) = node else {
             unreachable!("recycle_subtrie called on non-Subtrie node")
         };
-        Self::merge_subtrie_updates(&mut self.buffers.updates, &mut subtrie.buffers.updates);
+        Self::merge_subtrie_updates(&mut self.buffers, &mut subtrie.buffers);
     }
 
     /// Removes a [`ArenaSparseNode::Subtrie`] from the upper arena at `idx` and recycles it.
@@ -872,10 +876,7 @@ impl ArenaParallelSparseTrie {
                     subtrie.root,
                     Some(child_idx),
                 );
-                Self::merge_subtrie_updates(
-                    &mut self.buffers.updates,
-                    &mut subtrie.buffers.updates,
-                );
+                Self::merge_subtrie_updates(&mut self.buffers, &mut subtrie.buffers);
 
                 // The migrated subtrie root may be a branch whose children now live in
                 // the upper arena at or beyond the subtrie boundary depth. Re-wrap any
@@ -887,30 +888,28 @@ impl ArenaParallelSparseTrie {
     }
 
     /// Merges updates from a subtrie's buffer into the parent's buffer.
-    /// Both `dst` and `src` must be `Some` when updates are being tracked.
+    /// Both buffers must have `updates` set when updates are being tracked.
     ///
     /// Source removals cancel destination insertions (and vice versa) so that
     /// updates accumulated across multiple `root()` calls within a single block
     /// stay consistent.
-    fn merge_subtrie_updates(
-        dst: &mut Option<SparseTrieUpdates>,
-        src: &mut Option<SparseTrieUpdates>,
-    ) {
-        if let Some(dst_updates) = dst.as_mut() {
-            let src_updates = src.as_mut().expect("updates are enabled");
+    fn merge_subtrie_updates(dst: &mut ArenaTrieBuffers, src: &mut ArenaTrieBuffers) {
+        let Some(dst_updates) = dst.updates.as_mut() else { return };
+        let src_updates = src.updates.as_mut().expect("updates are enabled");
 
-            // Source insertions cancel destination removals.
-            for path in src_updates.updated_nodes.keys() {
-                dst_updates.removed_nodes.remove(path);
-            }
-            dst_updates.updated_nodes.extend(src_updates.updated_nodes.drain());
-
-            // Source removals cancel destination insertions.
-            for path in &src_updates.removed_nodes {
-                dst_updates.updated_nodes.remove(path);
-            }
-            dst_updates.removed_nodes.extend(src_updates.removed_nodes.drain());
+        // Source insertions cancel destination removals.
+        for path in src_updates.updated_nodes.keys() {
+            dst_updates.removed_nodes.remove(path);
         }
+        dst_updates.updated_nodes.extend(src_updates.updated_nodes.drain());
+
+        // Source removals cancel destination insertions.
+        for path in &src_updates.removed_nodes {
+            dst_updates.updated_nodes.remove(path);
+        }
+        dst_updates.removed_nodes.extend(src_updates.removed_nodes.drain());
+
+        dst.updates_recorded |= mem::take(&mut src.updates_recorded);
     }
 
     /// Right-pads a nibble path with zeros and packs it into a [`B256`].
@@ -966,6 +965,7 @@ impl ArenaParallelSparseTrie {
         let rlp_buf = &mut buffers.rlp_buf;
         let rlp_node_buf = &mut buffers.rlp_node_buf;
         let updates = &mut buffers.updates;
+        let updates_recorded = &mut buffers.updates_recorded;
 
         rlp_node_buf.clear();
 
@@ -1137,10 +1137,12 @@ impl ArenaParallelSparseTrie {
                     if !prev_branch_masks.is_empty() && new_branch_masks.is_empty() {
                         trie_updates.updated_nodes.remove(&logical_path);
                         trie_updates.removed_nodes.insert(logical_path);
+                        *updates_recorded = true;
                     } else if !new_branch_masks.is_empty() {
                         let compact = arena[head_idx].branch_ref().branch_node_compact(arena);
                         trie_updates.updated_nodes.insert(logical_path, compact);
                         trie_updates.removed_nodes.remove(&logical_path);
+                        *updates_recorded = true;
                     }
                 }
             }
@@ -2090,7 +2092,27 @@ impl ArenaParallelSparseTrie {
             subtrie.update_cached_rlp(new_epoch);
         }
 
-        Self::merge_subtrie_updates(&mut self.buffers.updates, &mut subtrie.buffers.updates);
+        Self::merge_subtrie_updates(&mut self.buffers, &mut subtrie.buffers);
+    }
+
+    /// Asserts that nothing was written into an update buffer without marking the trie as
+    /// having recorded updates, which would make `take_updates` drop them.
+    #[cfg(debug_assertions)]
+    fn debug_assert_no_pending_updates(&self) {
+        fn is_empty(buffers: &ArenaTrieBuffers) -> bool {
+            buffers.updates.as_ref().is_none_or(SparseTrieUpdates::is_empty)
+        }
+
+        debug_assert!(is_empty(&self.buffers), "upper trie holds unrecorded updates");
+        for (_, node) in &self.upper_arena {
+            if let Some(subtrie) = node.as_subtrie() {
+                debug_assert!(
+                    is_empty(&subtrie.buffers),
+                    "subtrie {:?} holds unrecorded updates",
+                    subtrie.path,
+                );
+            }
+        }
     }
 }
 
@@ -2153,6 +2175,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         } else {
             self.buffers.updates = None;
         }
+        self.buffers.updates_recorded = false;
     }
 
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all, fields(num_nodes = nodes.len()))]
@@ -2431,7 +2454,19 @@ impl SparseTrie for ArenaParallelSparseTrie {
             .map_or(Cow::Owned(SparseTrieUpdates::default()), Cow::Borrowed)
     }
 
+    fn has_updates(&self) -> bool {
+        self.buffers.updates_recorded
+    }
+
     fn take_updates(&mut self) -> SparseTrieUpdates {
+        if !self.buffers.updates_recorded {
+            #[cfg(debug_assertions)]
+            self.debug_assert_no_pending_updates();
+            return SparseTrieUpdates::default();
+        }
+
+        self.buffers.updates_recorded = false;
+
         match self.buffers.updates.take() {
             Some(updates) => {
                 self.buffers.updates = Some(SparseTrieUpdates::with_capacity(
@@ -2612,6 +2647,12 @@ impl SparseTrie for ArenaParallelSparseTrie {
     ) -> SparseTrieResult<()> {
         if updates.is_empty() {
             return Ok(());
+        }
+
+        // Every recorded update originates from a leaf update, so marking here covers the
+        // buffers of the subtries too, which record on their own during hashing and collapses.
+        if self.buffers.updates.is_some() {
+            self.buffers.updates_recorded = true;
         }
 
         // Drain and sort updates lexicographically by nibbles path.

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -374,21 +374,27 @@ where
 
     /// Returns storage trie updates for tries that have been revealed.
     ///
+    /// Tries that recorded nothing since the last call are skipped without taking their
+    /// updates, which keeps this cheap when many unchanged tries are retained across blocks.
+    ///
     /// Panics if any of the storage tries are not revealed.
     pub fn storage_trie_updates(&mut self) -> B256Map<StorageTrieUpdates> {
         self.storage
             .tries
             .iter_mut()
-            .map(|(address, trie)| {
+            .filter_map(|(address, trie)| {
                 let trie = trie.as_revealed_mut().unwrap();
+                if !trie.has_updates() {
+                    return None
+                }
+
                 let updates = trie.take_updates();
                 let updates = StorageTrieUpdates {
                     storage_nodes: updates.updated_nodes,
                     removed_nodes: updates.removed_nodes,
                 };
-                (*address, updates)
+                (!updates.is_empty()).then_some((*address, updates))
             })
-            .filter(|(_, updates)| !updates.is_empty())
             .collect()
     }
 

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -193,6 +193,12 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     /// If no updates have been made/recorded, returns an empty update set.
     fn updates_ref(&self) -> Cow<'_, SparseTrieUpdates>;
 
+    /// Returns whether [`Self::take_updates`] may return a non-empty update set.
+    ///
+    /// Implementations may over-report, but must never report `false` while updates are
+    /// pending. Callers holding many tries use this to skip untouched ones.
+    fn has_updates(&self) -> bool;
+
     /// Consumes and returns the currently accumulated trie updates.
     ///
     /// This is useful when you want to apply the updates to an external database

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -460,6 +460,11 @@ pub struct RlpNodeStackItem {
 }
 
 impl SparseTrieUpdates {
+    /// Returns `true` if no nodes were updated or removed.
+    pub fn is_empty(&self) -> bool {
+        self.updated_nodes.is_empty() && self.removed_nodes.is_empty()
+    }
+
     /// Clears the updates, but keeps the backing data structures allocated.
     pub fn clear(&mut self) {
         self.updated_nodes.clear();

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -272,6 +272,7 @@ sparse_trie_tests! {
     test_take_updates_contains_updated_and_removed_nodes,
     test_take_updates_no_duplicate_updated_and_removed_nodes,
     test_take_updates_cross_cancellation_across_root_calls,
+    test_has_updates_reports_pending_updates,
 
 
     // prune

--- a/crates/trie/sparse/tests/suite/take_updates.rs
+++ b/crates/trie/sparse/tests/suite/take_updates.rs
@@ -76,6 +76,48 @@ pub(super) fn test_take_updates_resets_after_take<T: SparseTrie>(new_trie: fn() 
     );
 }
 
+/// `has_updates` gates `take_updates`.
+///
+/// It must be set once a mutation was recorded and cleared by the take, so that callers
+/// holding many tries can skip the untouched ones.
+pub(super) fn test_has_updates_reports_pending_updates<T: SparseTrie>(new_trie: fn() -> T) {
+    let mut storage: BTreeMap<B256, U256> = BTreeMap::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10;
+        key.0[1] = i * 16;
+        storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let harness = SuiteTestHarness::new(storage);
+
+    let mut untracked: T = harness.init_trie_fully_revealed(false, new_trie);
+    let mut trie: T = harness.init_trie_fully_revealed(true, new_trie);
+    assert!(!trie.has_updates(), "a revealed trie without mutations has no updates");
+
+    let mut key = B256::ZERO;
+    key.0[0] = 0x10;
+    key.0[1] = 0xFF;
+    let changeset: BTreeMap<B256, U256> = BTreeMap::from([(key, U256::from(999))]);
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut untracked, &mut leaf_updates);
+    let _ = untracked.root(epoch(0));
+    assert!(!untracked.has_updates(), "a trie that does not track updates never has any");
+
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+    harness.reveal_and_update(&mut trie, &mut leaf_updates);
+    let _ = trie.root(epoch(0));
+    assert!(trie.has_updates(), "updating a leaf must mark the trie as having updates");
+
+    let updates = trie.take_updates();
+    assert!(
+        !updates.updated_nodes.is_empty() || !updates.removed_nodes.is_empty(),
+        "the take must return the recorded updates",
+    );
+    assert!(!trie.has_updates(), "the take must clear the pending updates");
+}
+
 /// `take_updates` contains both updated and removed nodes, mutually exclusive.
 ///
 /// Uses a 3-level branching structure so that intermediate branches are "real" DB nodes


### PR DESCRIPTION
The final root call collects trie updates by taking the update buffer of every retained storage trie. The preserved sparse trie keeps thousands of those across blocks while only the tries changed by the current block can hold anything, so most of that scan is overhead on the critical path; a samply profile of the sparse-trie coordinator attributes ~37% of `root_with_updates` to it. A trie now reports whether it recorded an update since the last take and `storage_trie_updates` skips the rest.

The marker is deliberately conservative: it is set when leaf updates are applied to a trie that retains updates and when a branch update is recorded during hashing, so it may report a trie whose recorded set turns out to be empty, but never the other way around. Behaviour of `take_updates` is otherwise unchanged. A debug assertion checks that no update buffer holds anything while the marker is unset, which the arena proptest and the sparse trie suite exercise.

Measured with 5000 revealed but untouched storage tries in a local harness, the scan drops from ~100us to ~45us per call. Production tries are larger and colder than that harness, so the effect on a real block should be bigger, but I have no local number for it.

# PR stack
Review in order:

1. perf(trie): collect sparse trie updates only from touched tries #27146 — this PR
2. perf(trie): collect updates from storage mutation candidates #27152
