### PR TITLE
fix(storage): preserve MDBX mincore cache entries on insertion

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
@@ -21705,7 +21705,7 @@ static bool mincore_fetch(MDBX_env *const env, const size_t unit_begin) {
     return false;
   }
 
-  for (size_t i = 1; i < ARRAY_LENGTH(lck->mincore_cache.begin); ++i) {
+  for (size_t i = ARRAY_LENGTH(lck->mincore_cache.begin) - 1; i > 0; --i) {
     lck->mincore_cache.begin[i] = lck->mincore_cache.begin[i - 1];
     lck->mincore_cache.mask[i] = lck->mincore_cache.mask[i - 1];
   }

--- a/crates/storage/libmdbx-rs/mdbx-sys/tests/mincore_cache.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/tests/mincore_cache.c
@@ -1,0 +1,53 @@
+/* Standalone Linux regression test for the internal residency cache.
+ * Run from mdbx-sys:
+ * cc -O1 -pthread tests/mincore_cache.c -o /tmp/mincore_cache_test
+ * /tmp/mincore_cache_test
+ */
+#define MDBX_ENABLE_PGOP_STAT 1
+#define MDBX_BUILD_FLAGS "standalone mincore cache regression test"
+#include "../libmdbx/mdbx.c"
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+  MDBX_env *env = NULL;
+  assert(mdbx_env_create(&env) == MDBX_SUCCESS);
+  lck_t lock = {0};
+  env->lck = &lock;
+  env->ps = globals.sys_pagesize;
+  env->ps2ln = globals.sys_pagesize_ln2;
+  const size_t length = 320 * env->ps;
+  env->dxb_mmap.base = mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(env->dxb_mmap.base != MAP_FAILED);
+  env->dxb_mmap.current = length;
+  memset(env->dxb_mmap.base, 0, length);
+  mincore_clean_cache(env);
+
+  /* Four disjoint windows fit. Revisiting each must avoid another syscall. */
+  for (pgno_t page = 0; page < 256; page += 64)
+    assert(mincore_probe(env, page));
+  assert(lock.pgops.mincore.weak == 4);
+  const pgno_t revisit[] = {64, 128, 0, 192};
+  for (size_t i = 0; i < ARRAY_LENGTH(revisit); ++i) {
+    assert(mincore_probe(env, revisit[i]));
+    assert(lock.pgops.mincore.weak == 4);
+  }
+
+  /* The fifth window evicts page 64, the least recently used window. */
+  assert(mincore_probe(env, 256));
+  assert(lock.pgops.mincore.weak == 5);
+  assert(mincore_probe(env, 128));
+  assert(mincore_probe(env, 0));
+  assert(mincore_probe(env, 192));
+  assert(lock.pgops.mincore.weak == 5);
+  assert(mincore_probe(env, 64));
+  assert(lock.pgops.mincore.weak == 6);
+
+  assert(munmap(env->dxb_mmap.base, length) == 0);
+  env->dxb_mmap.base = NULL;
+  env->dxb_mmap.current = 0;
+  env->lck = NULL;
+  mdbx_env_close(env);
+  puts("PASS: four-window reuse, promotion, and least-recently-used eviction");
+  return 0;
+}


### PR DESCRIPTION
Fix the MDBX residency-cache insertion loop: shifting forward replaces `[A,B,C,D]` with `[new,A,A,A]`, discarding useful windows and causing avoidable `mincore()` calls. Shift backward to preserve `[new,A,B,C]`; the standalone C regression test checks four-window reuse, promotion, and least-recently-used eviction.

Validation: the C regression fails before the fix and passes after it; all 49 `reth-libmdbx` tests/doctests, nightly formatting, targeted nightly Clippy, and whitespace checks pass. The standalone C test has its compile/run command at the top of the file.

[Big-block comparison](https://github.com/paradigmxyz/reth/actions/runs/34528199912) and [base-versus-base control](https://github.com/paradigmxyz/reth/actions/runs/34528100399) both completed: 300M gas, BAL enabled, 30 measured blocks plus 7 warmup, three AB run pairs, Samply and Chrome tracing enabled identically. Baseline is `040bef7b319c7ec145689e03fe78710e11986db6`; candidate is `a662a22f7947b097a0eb5e1d430a151b01fdf111`.

| Timing | Baseline | Fixed | Change | Control change |
| --- | ---: | ---: | ---: | ---: |
| `save_blocks` on persistence thread, total seconds/replay | 6.9203 | 6.9442 | +0.35% | +0.33% |
| `on_save_blocks`, including commit, total seconds/replay | 10.8762 | 10.9137 | +0.34% | +0.11% |
| MDBX `save_blocks`, benchmark-normalized ms/block | 146.894 | 146.643 | -0.17% | +1.99% |

Trace totals average three replays per side; each contains five persistence batches covering the same 37 blocks, including warmup and final persistence. Only persistence-thread spans are counted: the same `save_blocks` span is also entered on worker threads. The normalized MDBX row is the measured-window `reth_storage_providers_database_save_blocks_mdbx` result from `summary.json` (duration-counter increase divided by canonical block advancement).

No measured performance win: `summary.json` classifies the MDBX timing and every headline benchmark metric as neutral. The cache regression is fixed, but this workload does not demonstrate a speedup. Profiles and traces are linked in the benchmark result comment.

Prompted by: @mediocregopher
