### PR TITLE
test(storage): instrument MDBX residency cache

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/build.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/build.rs
@@ -8,6 +8,7 @@ fn main() {
     let mdbx = manifest_dir.join("libmdbx");
 
     println!("cargo:rerun-if-changed={}", mdbx.display());
+    println!("cargo:rerun-if-changed=mincore_diagnostics.h");
 
     let bindings = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("bindings.rs");
     generate_bindings(&mdbx, &bindings);
@@ -22,6 +23,8 @@ fn main() {
     let flags = format!("{:?}", cc.get_compiler().cflags_env());
     cc.define("MDBX_BUILD_FLAGS", flags.as_str())
         .define("MDBX_TXN_CHECKOWNER", "0")
+        // Experimental branch: aggregate residency-cache diagnostics per write transaction.
+        .define("MDBX_MINCORE_DIAGNOSTICS", "1")
         // Disable posix_fallocate() usage. On filesystems that do not support fallocate (e.g. ZFS),
         // glibc's posix_fallocate() emulates it by writing zeros, which can spuriously fail with
         // ENOSPC even when sufficient disk space is available. The fallback path uses ftruncate()

--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
@@ -4367,6 +4367,13 @@ enum env_flags {
   ENV_USABLE_FLAGS = ENV_CHANGEABLE_FLAGS | ENV_CHANGELESS_FLAGS
 };
 
+#ifndef MDBX_MINCORE_DIAGNOSTICS
+#define MDBX_MINCORE_DIAGNOSTICS 0
+#endif
+#if MDBX_USE_MINCORE && MDBX_MINCORE_DIAGNOSTICS
+#include "../mincore_diagnostics.h"
+#endif
+
 /* The database environment. */
 struct MDBX_env {
   /* ----------------------------------------------------- mostly static part */
@@ -4381,6 +4388,12 @@ struct MDBX_env {
 #endif                  /* Windows */
   osal_mmap_t lck_mmap; /* The lock file */
   lck_t *lck;
+#if MDBX_USE_MINCORE && MDBX_MINCORE_DIAGNOSTICS
+  /* Process-local: preserve the shared lock-file format. The pointer allows
+   * existing const-env cache invalidation paths to update their diagnostics. */
+  mincore_diagnostics_t mincore_diagnostics_storage;
+  mincore_diagnostics_t *mincore_diagnostics;
+#endif
 
   uint16_t leaf_nodemax;   /* max size of a leaf-node */
   uint16_t branch_nodemax; /* max size of a branch-node */
@@ -9583,6 +9596,9 @@ __cold int mdbx_env_create(MDBX_env **penv) {
   MDBX_env *env = osal_calloc(1, sizeof(MDBX_env));
   if (unlikely(!env))
     return LOG_IFERR(MDBX_ENOMEM);
+#if MDBX_USE_MINCORE && MDBX_MINCORE_DIAGNOSTICS
+  env->mincore_diagnostics = &env->mincore_diagnostics_storage;
+#endif
 
   env->max_readers = DEFAULT_READERS;
   env->max_dbi = env->n_dbi = CORE_DBS;
@@ -21670,6 +21686,10 @@ static bool mincore_fetch(MDBX_env *const env, const size_t unit_begin) {
     if (likely(dist >= 0 && dist < 64)) {
       const pgno_t tmp_begin = lck->mincore_cache.begin[i];
       const uint64_t tmp_mask = lck->mincore_cache.mask[i];
+#if MDBX_MINCORE_DIAGNOSTICS
+      mincore_diag_hit(env->mincore_diagnostics, i, tmp_begin, (unsigned)dist,
+                       (tmp_mask & (UINT64_C(1) << dist)) != 0);
+#endif
       do {
         lck->mincore_cache.begin[i] = lck->mincore_cache.begin[i - 1];
         lck->mincore_cache.mask[i] = lck->mincore_cache.mask[i - 1];
@@ -21699,8 +21719,14 @@ static bool mincore_fetch(MDBX_env *const env, const size_t unit_begin) {
 #if MDBX_ENABLE_PGOP_STAT
   env->lck->pgops.mincore.weak += 1;
 #endif /* MDBX_ENABLE_PGOP_STAT */
+#if MDBX_MINCORE_DIAGNOSTICS
+  mincore_diag_miss(env->mincore_diagnostics, unit_begin);
+#endif
   uint8_t *const vector = alloca(pages);
   if (unlikely(mincore(ptr_disp(env->dxb_mmap.base, offset), length, (void *)vector))) {
+#if MDBX_MINCORE_DIAGNOSTICS
+    ++env->mincore_diagnostics->errors;
+#endif
     NOTICE("mincore(+%zu, %zu), err %d", offset, length, errno);
     return false;
   }
@@ -21722,6 +21748,9 @@ static bool mincore_fetch(MDBX_env *const env, const size_t unit_begin) {
   }
 
   lck->mincore_cache.mask[0] = ~mask;
+#if MDBX_MINCORE_DIAGNOSTICS
+  mincore_diag_fetch(env->mincore_diagnostics, unit_begin, pages, shift, vector, mask);
+#endif
   return bit_tas(lck->mincore_cache.mask, 0);
 }
 #endif /* MDBX_USE_MINCORE */
@@ -21733,6 +21762,12 @@ MDBX_MAYBE_UNUSED static inline bool mincore_probe(MDBX_env *const env, const pg
   const size_t unit_begin = offset_aligned >> unit_log2;
   eASSERT(env, (unit_begin << unit_log2) == offset_aligned);
   const ptrdiff_t dist = unit_begin - env->lck->mincore_cache.begin[0];
+#if MDBX_MINCORE_DIAGNOSTICS
+  ++env->mincore_diagnostics->probes;
+  if (likely(dist >= 0 && dist < 64))
+    mincore_diag_hit(env->mincore_diagnostics, 0, env->lck->mincore_cache.begin[0], (unsigned)dist,
+                     (env->lck->mincore_cache.mask[0] & (UINT64_C(1) << dist)) != 0);
+#endif
   if (likely(dist >= 0 && dist < 64))
     return bit_tas(env->lck->mincore_cache.mask, (char)dist);
   return mincore_fetch(env, unit_begin);
@@ -26111,6 +26146,9 @@ __cold int lck_setup(MDBX_env *env, mdbx_mode_t mode) {
 }
 
 void mincore_clean_cache(const MDBX_env *const env) {
+#if MDBX_USE_MINCORE && MDBX_MINCORE_DIAGNOSTICS
+  mincore_diag_clear(env->mincore_diagnostics);
+#endif
   memset(env->lck->mincore_cache.begin, -1, sizeof(env->lck->mincore_cache.begin));
 }
 /// \copyright SPDX-License-Identifier: Apache-2.0
@@ -37002,6 +37040,9 @@ int txn_end(MDBX_txn *txn, unsigned mode) {
       if (!(env->flags & MDBX_WRITEMAP))
         dpl_release_shadows(txn);
       /* The writer mutex was locked in mdbx_txn_begin. */
+#if MDBX_USE_MINCORE && MDBX_MINCORE_DIAGNOSTICS
+      mincore_diag_report(env->mincore_diagnostics, txn->txnid, mode & TXN_END_OPMASK, env->ps, globals.sys_pagesize);
+#endif
       lck_txn_unlock(env);
     } else {
       eASSERT(env, txn->parent != nullptr);

--- a/crates/storage/libmdbx-rs/mdbx-sys/mincore_diagnostics.h
+++ b/crates/storage/libmdbx-rs/mdbx-sys/mincore_diagnostics.h
@@ -1,0 +1,153 @@
+/* Experimental, process-local residency-cache diagnostics. The caller must use
+ * the same writer serialization as the cache. No atomics, allocation, clocks,
+ * or logging occur per probe. Window units are max(DB page size, OS page size).
+ * This observes one writer environment; it does not simulate alternative LRU
+ * caches or validate the freshness of cached residency answers. */
+#ifndef RETH_MINCORE_DIAGNOSTICS_H
+#define RETH_MINCORE_DIAGNOSTICS_H
+
+typedef struct {
+  uint64_t begin, used;
+  unsigned units;
+} mincore_diag_window_t;
+
+typedef struct {
+  uint64_t probes, hits[4], misses, errors, resident_hits, nonresident_hits;
+  uint64_t resident_misses, nonresident_misses, repeated_hits, untracked_hits;
+  uint64_t queried_os_pages, resident_os_pages, queried_units;
+  uint64_t all_resident, none_resident, mixed, clipped_queries;
+  uint64_t evictions, invalidated_windows, clears;
+  uint64_t completed_windows, completed_units, used_units;
+  uint64_t usage_hist[65], offset_hits[64], ghost_hits[16], ghost_misses;
+  mincore_diag_window_t windows[4], ghosts[16];
+  unsigned ghost_next;
+} mincore_diagnostics_t;
+
+static unsigned mincore_diag_popcount(uint64_t bits) {
+  return (unsigned)__builtin_popcountll(bits);
+}
+
+static void mincore_diag_finish(mincore_diagnostics_t *d, size_t slot) {
+  mincore_diag_window_t *w = &d->windows[slot];
+  if (w->units) {
+    const unsigned used = mincore_diag_popcount(w->used);
+    ++d->completed_windows;
+    d->completed_units += w->units;
+    d->used_units += used;
+    ++d->usage_hist[used];
+    w->units = 0;
+  }
+}
+
+static void mincore_diag_clear(mincore_diagnostics_t *d) {
+  if (!d)
+    return;
+  ++d->clears;
+  for (size_t i = 0; i < 4; ++i) {
+    d->invalidated_windows += d->windows[i].units != 0;
+    mincore_diag_finish(d, i);
+  }
+  /* Old residency answers cannot survive an explicit cache invalidation. */
+  memset(d->ghosts, 0, sizeof(d->ghosts));
+  d->ghost_next = 0;
+}
+
+static void mincore_diag_hit(mincore_diagnostics_t *d, size_t slot, uint64_t begin,
+                             unsigned offset, bool resident) {
+  ++d->hits[slot];
+  ++d->offset_hits[offset];
+  d->resident_hits += resident;
+  d->nonresident_hits += !resident;
+  mincore_diag_window_t *w = &d->windows[slot];
+  if (w->units && w->begin == begin && offset < w->units) {
+    const uint64_t bit = UINT64_C(1) << offset;
+    d->repeated_hits += (w->used & bit) != 0;
+    w->used |= bit;
+  } else {
+    ++d->untracked_hits;
+  }
+  const mincore_diag_window_t hit = *w;
+  for (size_t i = slot; i > 0; --i)
+    d->windows[i] = d->windows[i - 1];
+  d->windows[0] = hit;
+}
+
+static void mincore_diag_miss(mincore_diagnostics_t *d, uint64_t begin) {
+  ++d->misses;
+  /* Search recently evicted query windows, newest first. A match indicates
+   * potential capacity reuse, not the hit rate of a larger simulated cache. */
+  for (unsigned age = 0; age < 16; ++age) {
+    const mincore_diag_window_t *w = &d->ghosts[(d->ghost_next + 15 - age) % 16];
+    if (w->units && begin >= w->begin && begin - w->begin < w->units) {
+      ++d->ghost_hits[age];
+      return;
+    }
+  }
+  ++d->ghost_misses;
+}
+
+static void mincore_diag_fetch(mincore_diagnostics_t *d, uint64_t begin, size_t pages,
+                               unsigned shift, const uint8_t *vector, uint64_t nonresident) {
+  mincore_diag_window_t evicted = d->windows[3];
+  if (evicted.units) {
+    ++d->evictions;
+    d->ghosts[d->ghost_next] = evicted;
+    d->ghost_next = (d->ghost_next + 1) % 16;
+  }
+  mincore_diag_finish(d, 3);
+  for (size_t i = 3; i > 0; --i)
+    d->windows[i] = d->windows[i - 1];
+  const unsigned units = (unsigned)((pages + ((size_t)1 << shift) - 1) >> shift);
+  d->windows[0] = (mincore_diag_window_t){begin, 1, units};
+  d->queried_os_pages += pages;
+  d->queried_units += units;
+  d->clipped_queries += units < 64;
+  for (size_t i = 0; i < pages; ++i)
+    d->resident_os_pages += vector[i] & 1;
+  const unsigned absent = mincore_diag_popcount(nonresident);
+  d->all_resident += absent == 0;
+  d->none_resident += absent == units;
+  d->mixed += absent != 0 && absent != units;
+  d->resident_misses += (nonresident & 1) == 0;
+  d->nonresident_misses += (nonresident & 1) != 0;
+}
+
+/* Cumulative snapshots include still-live windows, without evicting them.
+ * Emit after each top-level write transaction so graceful env teardown is not
+ * required. Consumers must difference snapshots, never sum cumulative rows. */
+static void mincore_diag_report(const mincore_diagnostics_t *d, uint64_t txnid,
+                                unsigned mode, unsigned db_page_size, unsigned os_page_size) {
+  if (!d || !d->probes)
+    return;
+  mincore_diagnostics_t snapshot = *d;
+  for (size_t i = 0; i < 4; ++i)
+    mincore_diag_finish(&snapshot, i);
+  char buffer[16384]; /* All fields and arrays fit even with 20-digit counters. */
+  size_t used = 0;
+#define MC_APPEND(...) used += (size_t)snprintf(buffer + used, sizeof(buffer) - used, __VA_ARGS__)
+#define MC_FIELD(name) MC_APPEND(",\"" #name "\":%" PRIu64, snapshot.name)
+#define MC_ARRAY(name)                                                                                                 \
+  do {                                                                                                                \
+    MC_APPEND(",\"" #name "\":[");                                                                                       \
+    for (size_t i = 0; i < sizeof(snapshot.name) / sizeof(snapshot.name[0]); ++i)                                       \
+      MC_APPEND("%s%" PRIu64, i ? "," : "", snapshot.name[i]);                                                         \
+    MC_APPEND("]");                                                                                                   \
+  } while (0)
+  MC_APPEND("MDBX_MINCORE_DIAG {\"txnid\":%" PRIu64 ",\"end_mode\":%u,\"db_page_size\":%u,\"os_page_size\":%u",
+            txnid, mode, db_page_size, os_page_size);
+  MC_FIELD(probes); MC_ARRAY(hits); MC_FIELD(misses); MC_FIELD(errors);
+  MC_FIELD(resident_hits); MC_FIELD(nonresident_hits); MC_FIELD(resident_misses); MC_FIELD(nonresident_misses);
+  MC_FIELD(repeated_hits); MC_FIELD(untracked_hits);
+  MC_FIELD(queried_os_pages); MC_FIELD(resident_os_pages); MC_FIELD(queried_units);
+  MC_FIELD(all_resident); MC_FIELD(none_resident); MC_FIELD(mixed); MC_FIELD(clipped_queries);
+  MC_FIELD(evictions); MC_FIELD(invalidated_windows); MC_FIELD(clears);
+  MC_FIELD(completed_windows); MC_FIELD(completed_units); MC_FIELD(used_units);
+  MC_ARRAY(usage_hist); MC_ARRAY(offset_hits); MC_ARRAY(ghost_hits); MC_FIELD(ghost_misses);
+  MC_APPEND("}\n");
+  assert(used < sizeof(buffer));
+  fputs(buffer, stderr);
+#undef MC_ARRAY
+#undef MC_FIELD
+#undef MC_APPEND
+}
+#endif

--- a/crates/storage/libmdbx-rs/mdbx-sys/mincore_diagnostics.md
+++ b/crates/storage/libmdbx-rs/mdbx-sys/mincore_diagnostics.md
@@ -1,0 +1,73 @@
+# Residency-cache experiment
+
+This draft enables `MDBX_MINCORE_DIAGNOSTICS=1` in `build.rs`, on top of the
+four-entry cache insertion fix. It leaves cache capacity, query shape, returned
+residency decisions, and the lock-file layout unchanged. This is diagnostic code,
+not a proposal to enable transaction logging in production.
+
+Counters are process-local, serialized with the existing cache operations, and
+intended for one writer environment per database. Other processes can mutate the
+shared cache without updating this environment's diagnostic metadata; do not use
+the utilization/ghost results for multi-writer-environment experiments.
+
+There are no per-probe allocations, atomics, timers, or log messages. A hit updates
+counters and a four-entry shadow usage mask. On a miss, diagnostics search at most
+16 recently evicted ranges and count residency bits in the returned vector. That
+additional work is measured against an uninstrumented baseline in the benchmark.
+
+Each completed or aborted top-level write transaction emits one cumulative JSON
+snapshot prefixed `MDBX_MINCORE_DIAG` to stderr. It includes commit-time GC probes.
+The final snapshot covers startup, warmup, measured blocks, and any subsequent
+write transactions. Do not sum snapshots or describe them as measured-window-only.
+Read-only transactions emit nothing. No block numbers or keys are logged.
+
+Fields:
+
+- `probes`, `hits[0..3]`, `misses`, `errors`: hit position before promotion; misses
+  are syscall attempts, including errors. `probes = sum(hits) + misses`.
+- `resident_hits`, `nonresident_hits`: cached decision before the existing
+  optimistic promotion of that bit to resident. `resident_misses` and
+  `nonresident_misses` describe the requested unit from a successful syscall.
+  These are hints, not independently verified cache accuracy.
+- `repeated_hits`: probes of a bit already visited in that cached window.
+  `untracked_hits` should be zero in the single-environment experiment.
+- `queried_os_pages`, `resident_os_pages`: successful queries only, counting OS
+  pages even when one DB page spans several OS pages. `queried_units` counts
+  max(DB page size, OS page size) units. Repeated queries count again.
+- `all_resident`, `none_resident`, `mixed`: classify returned window unit masks.
+  A unit is resident only if all of its OS pages are resident. `clipped_queries`
+  counts queries shorter than 64 units at the mapping tail.
+- `evictions`, `invalidated_windows`, `clears`: replacement versus explicit cache
+  clearing, including clears with no live window.
+- `completed_windows`, `completed_units`, `used_units`, `usage_hist[0..64]`:
+  observed query-window lifetimes. Snapshots also account for live windows without
+  evicting or otherwise changing them. `usage_hist[n]` counts windows where exactly
+  n distinct bits have been requested. This is usage before eviction/clear or as
+  of the snapshot, not a global count of unique DB pages. Live histogram buckets
+  can move between snapshots, so histogram deltas can be negative.
+- `offset_hits[0..63]`: cached probes by relative position in the query window;
+  excludes the initial miss at offset zero, includes repeated hits.
+- `ghost_hits[0..15]`: misses falling in a recently evicted query range, indexed
+  by eviction age (zero is newest). `ghost_misses` means no match. Ghosts clear on
+  invalidation. This is a capacity-reuse indicator, **not** a simulated larger
+  cache's hit rate: real query windows, overlap, and replacement would change.
+
+Run standalone Linux tests from this directory:
+
+```sh
+cc -O1 -pthread tests/mincore_cache.c -o /tmp/mincore_cache_test
+/tmp/mincore_cache_test
+cc -O1 -pthread tests/mincore_diagnostics.c -o /tmp/mincore_diagnostics_test
+/tmp/mincore_diagnostics_test
+```
+
+Summarize the last snapshot in each benchmark node log:
+
+```sh
+uv run summarize_mincore.py /path/to/bench-results/feature-*/node.log
+```
+
+Use observed hit positions and ghost reuse to select capacity experiments, and
+window utilization plus hit offsets to select query-size experiments. Each
+candidate still requires an uninstrumented paired `save_blocks` benchmark; these
+metrics cannot predict the syscall-cost/write-avoidance tradeoff by themselves.

--- a/crates/storage/libmdbx-rs/mdbx-sys/summarize_mincore.py
+++ b/crates/storage/libmdbx-rs/mdbx-sys/summarize_mincore.py
@@ -1,0 +1,61 @@
+"""Summarize cumulative diagnostic snapshots from one-writer benchmark logs."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def summarize(path):
+    snapshots = []
+    for line in path.read_text().splitlines():
+        if "MDBX_MINCORE_DIAG " in line:
+            snapshots.append(json.loads(line.split("MDBX_MINCORE_DIAG ", 1)[1]))
+    if not snapshots:
+        raise ValueError(f"No residency-cache snapshots in {path}")
+    d = snapshots[-1]
+    hits = sum(d["hits"])
+    queries = d["misses"] - d["errors"]
+    assert d["probes"] == hits + d["misses"]
+    assert hits == d["resident_hits"] + d["nonresident_hits"]
+    assert queries == d["resident_misses"] + d["nonresident_misses"]
+    assert queries == d["all_resident"] + d["none_resident"] + d["mixed"]
+    assert d["misses"] == sum(d["ghost_hits"]) + d["ghost_misses"]
+    assert d["completed_windows"] == queries == sum(d["usage_hist"])
+    assert d["used_units"] == sum(i * n for i, n in enumerate(d["usage_hist"]))
+    assert d["completed_units"] == d["queried_units"]
+    assert sum(d["offset_hits"]) == hits
+    assert d["untracked_hits"] == 0
+    pct = lambda n, denominator: round(100 * n / denominator, 4) if denominator else None
+    return {
+        "log": str(path),
+        "snapshots": len(snapshots),
+        "probes": d["probes"],
+        "syscalls": d["misses"],
+        "errors": d["errors"],
+        "hit_pct": pct(hits, d["probes"]),
+        "hit_position_pct_of_probes": [pct(n, d["probes"]) for n in d["hits"]],
+        "nonresident_decision_pct": pct(d["nonresident_hits"] + d["nonresident_misses"], d["probes"]),
+        "requested_unit_resident_on_miss_pct": pct(d["resident_misses"], queries),
+        "queried_os_pages": d["queried_os_pages"],
+        "queried_resident_os_pages_pct": pct(d["resident_os_pages"], d["queried_os_pages"]),
+        "all_resident_query_pct": pct(d["all_resident"], queries),
+        "none_resident_query_pct": pct(d["none_resident"], queries),
+        "mixed_query_pct": pct(d["mixed"], queries),
+        "mean_unique_units_used_per_query": round(d["used_units"] / queries, 4) if queries else None,
+        "query_utilization_pct": pct(d["used_units"], d["queried_units"]),
+        "one_unit_only_query_pct": pct(d["usage_hist"][1], queries),
+        "repeated_hit_pct_of_hits": pct(d["repeated_hits"], hits),
+        "hit_offset_below_8_pct": pct(sum(d["offset_hits"][:8]), hits),
+        "hit_offset_below_16_pct": pct(sum(d["offset_hits"][:16]), hits),
+        "hit_offset_below_32_pct": pct(sum(d["offset_hits"][:32]), hits),
+        "recent_4_evictions_match_pct_of_misses": pct(sum(d["ghost_hits"][:4]), d["misses"]),
+        "recent_16_evictions_match_pct_of_misses": pct(sum(d["ghost_hits"]), d["misses"]),
+        "evictions": d["evictions"],
+        "invalidated_windows": d["invalidated_windows"],
+        "clears": d["clears"],
+        "raw": d,
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps([summarize(Path(p)) for p in sys.argv[1:]], indent=2))

--- a/crates/storage/libmdbx-rs/mdbx-sys/tests/mincore_diagnostics.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/tests/mincore_diagnostics.c
@@ -1,0 +1,84 @@
+/* Linux: cc -O1 -pthread tests/mincore_diagnostics.c -o /tmp/mincore_diagnostics_test */
+#define MDBX_MINCORE_DIAGNOSTICS 1
+#define MDBX_ENABLE_PGOP_STAT 1
+#define MDBX_BUILD_FLAGS "standalone mincore diagnostics regression test"
+#include "../libmdbx/mdbx.c"
+#include <assert.h>
+
+int main(void) {
+  MDBX_env *env = NULL;
+  assert(mdbx_env_create(&env) == MDBX_SUCCESS);
+  lck_t lock = {0};
+  env->lck = &lock;
+  env->ps = globals.sys_pagesize;
+  env->ps2ln = globals.sys_pagesize_ln2;
+  const size_t length = 320 * env->ps;
+  env->dxb_mmap.base = mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(env->dxb_mmap.base != MAP_FAILED);
+  env->dxb_mmap.current = length;
+  mincore_clean_cache(env);
+  mincore_diagnostics_t *d = env->mincore_diagnostics;
+
+  /* Untouched anonymous pages are nonresident. The cache optimistically marks
+   * a probed bit resident even though this test does not perform a write. */
+  assert(!mincore_probe(env, 0));
+  assert(mincore_probe(env, 0));
+  assert(!mincore_probe(env, 1));
+  assert(mincore_probe(env, 1));
+  assert(d->probes == 4 && d->hits[0] == 3 && d->misses == 1);
+  assert(d->resident_hits == 2 && d->nonresident_hits == 1 && d->nonresident_misses == 1);
+  assert(d->repeated_hits == 2 && d->windows[0].used == 3);
+  assert(d->queried_os_pages == 64 && d->resident_os_pages == 0 && d->none_resident == 1);
+
+  /* Promotion keeps the usage bitmap attached to the matching cache entry. */
+  assert(!mincore_probe(env, 64));
+  assert(!mincore_probe(env, 128));
+  assert(!mincore_probe(env, 192));
+  assert(mincore_probe(env, 64));
+  assert(d->hits[2] == 1 && d->windows[0].begin == 64 && d->windows[3].used == 3);
+  assert(!mincore_probe(env, 256));
+  assert(d->evictions == 1 && d->completed_windows == 1 && d->usage_hist[2] == 1);
+  assert(!mincore_probe(env, 0));
+  assert(d->ghost_hits[0] == 1);
+
+  /* Explicit invalidation closes live windows and forgets stale ghost ranges. */
+  mincore_clean_cache(env);
+  assert(d->invalidated_windows == 4 && d->completed_windows == 6);
+  assert(d->used_units == 7 && d->completed_units == 384);
+  for (size_t i = 0; i < 16; ++i)
+    assert(!d->ghosts[i].units);
+  assert(!mincore_probe(env, 318));
+  assert(d->clipped_queries == 1 && d->windows[0].units == 2);
+
+  /* Residency classification and grouping when one DB page spans two OS pages. */
+  mincore_clean_cache(env);
+  memset(env->dxb_mmap.base, 0, length);
+  env->ps *= 2;
+  ++env->ps2ln;
+  assert(mincore_probe(env, 0));
+  assert(d->all_resident == 1 && d->resident_os_pages == 128 && d->resident_misses == 1);
+  assert(d->windows[0].units == 64);
+  mincore_clean_cache(env);
+  assert(madvise(env->dxb_mmap.base, globals.sys_pagesize, MADV_DONTNEED) == 0);
+  assert(!mincore_probe(env, 0));
+  assert(d->mixed == 1 && d->resident_os_pages == 255);
+  const uint64_t completed = d->completed_windows;
+  mincore_diag_report(d, 0, 0, env->ps, globals.sys_pagesize);
+  assert(d->completed_windows == completed && d->windows[0].units == 64);
+
+  /* Failed syscalls count as misses/errors, not successful query windows. */
+  mincore_clean_cache(env);
+  assert(munmap(env->dxb_mmap.base, length) == 0);
+  const uint64_t queried = d->queried_os_pages;
+  assert(!mincore_probe(env, 0));
+  assert(d->errors == 1 && d->queried_os_pages == queried && !d->windows[0].units);
+  assert(d->probes == d->misses + d->hits[0] + d->hits[1] + d->hits[2] + d->hits[3]);
+  assert(d->misses == d->errors + d->resident_misses + d->nonresident_misses);
+  assert(d->untracked_hits == 0);
+  mincore_diag_report(d, 1, 0, env->ps, globals.sys_pagesize);
+  env->dxb_mmap.base = NULL;
+  env->dxb_mmap.current = 0;
+  env->lck = NULL;
+  mdbx_env_close(env);
+  puts("PASS: hit positions, repeated probes, utilization, eviction, clear, tail, page-size grouping, errors");
+}


### PR DESCRIPTION
## Summary

- Add experimental process-local MDBX residency-cache counters, one cumulative JSON snapshot per top-level write transaction, a log reducer, and standalone tests. No per-probe allocation, atomics, timers, or logging. Misses additionally inspect 16 recently evicted windows and count returned residency bits.
- Stacked on [the cache insertion fix #27168](https://github.com/paradigmxyz/reth/pull/27168). Cache capacity, query geometry, residency decisions, and shared lock-file layout are unchanged. Diagnostic logging is enabled for this draft, not proposed as a production default.
- Instrumented versus uninstrumented cache-fixed baseline: full-replay `save_blocks` 11.981 → 12.195 s (+1.79%); including commit 18.161 → 18.249 s (+0.49%). Official measured-window MDBX save metric +5.99%, execution mean +0.006%: both **neutral**. This is an instrumentation experiment, not an optimization win or proof of zero overhead.

## Profile and tuning evidence

Three instrumented replays show:

- 31.91–33.02% lookup hit rate, with only **52 hits in the older three cache slots out of 2,453,526 total hits**.
- Only **68 of 5,147,762 misses** match any of the last 16 evicted windows (0.00132%). This is a reuse indicator, not a simulated larger-cache hit rate.
- **1.47–1.49 distinct answers consumed per 64-page query** (2.29–2.33% utilization); 64.89–65.73% of queries only supply the initial requested answer.
- On a miss, the requested page is resident 83.20–83.60% of the time, versus 4.51–4.57% residency across all queried pages. These are page-status checks, not physical disk-read counts.
- Hits are spread across the query: about 12% / 25% / 50% fall in its first 8 / 16 / 32 positions. Smaller queries could reduce kernel residency lookup work but would lose reuse and increase syscall count.

The evidence makes a smaller-query sweep more promising than increasing entry count. No query-size change has been benchmarked in this PR, and these counters do not prove an improvement. Counters cover startup, warmup, commit-time GC, and subsequent write transactions through the final snapshot, not just the measured block window. DB and OS page sizes are both 4 KiB in this benchmark.

## Verification

- [Instrumented comparison](https://github.com/paradigmxyz/reth/actions/runs/34572179865): cache-fixed `a662a22f7947b097a0eb5e1d430a151b01fdf111` versus instrumented `c0efa9a0432afd5c388aa8056ac0883f388fb8d6`.
- [Unchanged-code control](https://github.com/paradigmxyz/reth/actions/runs/34572187449): `a662a22f7947b097a0eb5e1d430a151b01fdf111` on both sides.
- Both workflows: 300M gas, engine mode, BAL enabled, three pairs, 60 measured blocks plus 7 warmup per replay, samply disabled, matching scoped persistence/database Chrome tracing. Each replay has nine completed `save_blocks` calls totaling 67 blocks.
- Comparison `summary.json`: execution mean 102.528 → 102.534 ms, neutral; measured-window MDBX save metric 147.44 → 156.27 ms/block, +5.99%, neutral, reported confidence half-width 10.27%; persistence wait +5.07%, neutral. Scrape-normalized measured-window metrics and full-replay trace totals have different boundaries.
- Control completed successfully: full-replay `save_blocks` 12.158 → 12.096 s (-0.51%); including commit 18.814 → 18.679 s (-0.72%). Official MDBX save metric +0.56%, neutral; execution mean -0.67%, neutral. Identical-code p90 was labeled good (-4.25%), illustrating variability. The instrumented +1.79% save-span change is larger than the control's shift; do not claim the instrumentation is cost-free.
- Original cache regression test and new real-mincore diagnostic tests pass: `cc -O1 -pthread tests/mincore_cache.c -o /tmp/mincore_cache_test` and `cc -O1 -pthread tests/mincore_diagnostics.c -o /tmp/mincore_diagnostics_test`, followed by running both executables from `crates/storage/libmdbx-rs/mdbx-sys`.
- ASAN/UBSAN diagnostic test passes with leak detection disabled; LeakSanitizer cannot attach to threads in the sandbox.
- `cargo +nightly fmt --all --check`, `cargo +nightly clippy -p reth-mdbx-sys --all-targets -- -D warnings`, and `git diff --check` pass.
- All three feature logs pass `summarize_mincore.py` accounting invariants; zero mincore errors, untracked hits, or clipped queries. See the workflow `bench-results` artifact's `feature-*/node.log` for raw cumulative snapshots.

Diagnostics assume one writer environment; another environment can alter the shared cache without updating these process-local shadow counters. Added counter work and environment layout changes can perturb timing. Future performance candidates should be compared with instrumentation disabled.

Prompted by: @mediocregopher
