### PR TITLE
docs: point eth-wire TransactionSigned at primitives lib.rs

### DIFF
--- a/docs/crates/eth-wire.md
+++ b/docs/crates/eth-wire.md
@@ -128,35 +128,13 @@ pub struct Transactions<T = TransactionSigned>(
 
 And the corresponding transaction type is defined here:
 
-[File: crates/ethereum/primitives/src/transaction.rs](../../crates/ethereum/primitives/src/transaction.rs)
-```rust, ignore
-#[reth_codec]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, AsRef, Deref, Default, Serialize, Deserialize)]
-pub struct TransactionSigned {
-    pub hash: TxHash,
-    pub signature: Signature,
-    #[deref]
-    #[as_ref]
-    pub transaction: Transaction,
-}
+[File: crates/ethereum/primitives/src/lib.rs](../../crates/ethereum/primitives/src/lib.rs)
+```rust,ignore
+/// Typed Transaction type without a signature
+pub type Transaction = alloy_consensus::EthereumTypedTransaction<TxEip4844>;
 
-impl Encodable for TransactionSigned {
-    fn encode(&self, out: &mut dyn bytes::BufMut) {
-        self.encode_inner(out, true);
-    }
-
-    fn length(&self) -> usize {
-        let len = self.payload_len();
-        len + length_of_length(len)
-    }
-}
-
-impl Decodable for TransactionSigned {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        // Implementation omitted for brevity
-        //...
-    }
-}
+/// Signed transaction.
+pub type TransactionSigned = alloy_consensus::EthereumTxEnvelope<TxEip4844>;
 ```
 Now that we know how the types work, let's take a look at how these are utilized in the network.
 


### PR DESCRIPTION
## Summary
`docs/crates/eth-wire.md` still links `crates/ethereum/primitives/src/transaction.rs` and shows an obsolete `TransactionSigned` struct. That path 404s on tip; `TransactionSigned` is now a type alias in `lib.rs`.

## Repro
1. Tip `docs/crates/eth-wire.md` links `../../crates/ethereum/primitives/src/transaction.rs`
2. `crates/ethereum/primitives/src/transaction.rs` → 404 (tree has `lib.rs` + `receipt.rs`)
3. Tip `crates/ethereum/primitives/src/lib.rs` defines `pub type TransactionSigned = alloy_consensus::EthereumTxEnvelope<TxEip4844>;`

## Change
Point the doc at `lib.rs` and replace the stale struct snippet with the current type aliases.
