### PR TITLE
test(storage): benchmark 32-page MDBX residency queries

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c
@@ -21656,6 +21656,10 @@ __cold int env_close(MDBX_env *env, bool resurrect_after_fork) {
  * Проверка размещения/расположения отображенных страниц БД в ОЗУ (mem-in-core),
  * с кешированием этой информации. */
 
+/* Query width in max(DB page size, OS page size) units. Keep the shared
+ * 64-bit masks unchanged so this experiment does not alter lock-file layout. */
+enum { MINCORE_CACHE_UNITS = 32 };
+
 static inline bool bit_tas(uint64_t *field, char bit) {
   const uint64_t m = UINT64_C(1) << bit;
   const bool r = (*field & m) != 0;
@@ -21667,7 +21671,7 @@ static bool mincore_fetch(MDBX_env *const env, const size_t unit_begin) {
   lck_t *const lck = env->lck;
   for (size_t i = 1; i < ARRAY_LENGTH(lck->mincore_cache.begin); ++i) {
     const ptrdiff_t dist = unit_begin - lck->mincore_cache.begin[i];
-    if (likely(dist >= 0 && dist < 64)) {
+    if (likely(dist >= 0 && dist < MINCORE_CACHE_UNITS)) {
       const pgno_t tmp_begin = lck->mincore_cache.begin[i];
       const uint64_t tmp_mask = lck->mincore_cache.mask[i];
       do {
@@ -21680,7 +21684,7 @@ static bool mincore_fetch(MDBX_env *const env, const size_t unit_begin) {
     }
   }
 
-  size_t pages = 64;
+  size_t pages = MINCORE_CACHE_UNITS;
   unsigned unit_log = globals.sys_pagesize_ln2;
   unsigned shift = 0;
   if (env->ps > globals.sys_pagesize) {
@@ -21733,7 +21737,7 @@ MDBX_MAYBE_UNUSED static inline bool mincore_probe(MDBX_env *const env, const pg
   const size_t unit_begin = offset_aligned >> unit_log2;
   eASSERT(env, (unit_begin << unit_log2) == offset_aligned);
   const ptrdiff_t dist = unit_begin - env->lck->mincore_cache.begin[0];
-  if (likely(dist >= 0 && dist < 64))
+  if (likely(dist >= 0 && dist < MINCORE_CACHE_UNITS))
     return bit_tas(env->lck->mincore_cache.mask, (char)dist);
   return mincore_fetch(env, unit_begin);
 #else

--- a/crates/storage/libmdbx-rs/mdbx-sys/tests/mincore_cache.c
+++ b/crates/storage/libmdbx-rs/mdbx-sys/tests/mincore_cache.c
@@ -43,11 +43,56 @@ int main(void) {
   assert(mincore_probe(env, 64));
   assert(lock.pgops.mincore.weak == 6);
 
+  /* Both the newest and older entries must reject offset 32, while 31 hits. */
+  mincore_clean_cache(env);
+  lock.pgops.mincore.weak = 0;
+  assert(mincore_probe(env, 0));
+  assert(mincore_probe(env, 31));
+  assert(lock.pgops.mincore.weak == 1);
+  assert(mincore_probe(env, 96));
+  assert(mincore_probe(env, 32));
+  assert(lock.pgops.mincore.weak == 3);
+  assert(mincore_probe(env, 63));
+  assert(mincore_probe(env, 31));
+  assert(lock.pgops.mincore.weak == 3);
+  assert(mincore_probe(env, 64));
+  assert(lock.pgops.mincore.weak == 4);
+
+  /* A query at the mapping tail is clipped to one page. */
+  mincore_clean_cache(env);
+  assert(mincore_probe(env, 319));
+
+  /* Mixed residency and the optimistic bit update still work. */
+  assert(madvise(env->dxb_mmap.base, length, MADV_DONTNEED) == 0);
+  ((volatile char *)env->dxb_mmap.base)[31 * env->ps] = 1;
+  mincore_clean_cache(env);
+  lock.pgops.mincore.weak = 0;
+  assert(!mincore_probe(env, 0));
+  assert(mincore_probe(env, 0));
+  assert(mincore_probe(env, 31));
+  assert(!mincore_probe(env, 32));
+  assert(lock.pgops.mincore.weak == 2);
+
+  /* A DB page spanning two OS pages is resident only if both are resident. */
+  assert(madvise(env->dxb_mmap.base, length, MADV_DONTNEED) == 0);
+  env->ps *= 2;
+  env->ps2ln += 1;
+  ((volatile char *)env->dxb_mmap.base)[30 * env->ps] = 1;
+  ((volatile char *)env->dxb_mmap.base)[31 * env->ps] = 1;
+  ((volatile char *)env->dxb_mmap.base)[31 * env->ps + globals.sys_pagesize] = 1;
+  mincore_clean_cache(env);
+  lock.pgops.mincore.weak = 0;
+  assert(!mincore_probe(env, 0));
+  assert(!mincore_probe(env, 30));
+  assert(mincore_probe(env, 31));
+  assert(!mincore_probe(env, 32));
+  assert(lock.pgops.mincore.weak == 2);
+
   assert(munmap(env->dxb_mmap.base, length) == 0);
   env->dxb_mmap.base = NULL;
   env->dxb_mmap.current = 0;
   env->lck = NULL;
   mdbx_env_close(env);
-  puts("PASS: four-window reuse, promotion, and least-recently-used eviction");
+  puts("PASS: four-window LRU, 32-unit boundaries, tail, mixed residency, and larger DB pages");
   return 0;
 }


### PR DESCRIPTION
Test 32-unit MDBX residency queries against the existing 64-unit queries, keeping four cache entries, prefault behavior, and the shared lock-file layout unchanged. This experiment is stacked on [the cache insertion fix #27168](https://github.com/paradigmxyz/reth/pull/27168); neither side includes the diagnostic instrumentation from [#27174](https://github.com/paradigmxyz/reth/pull/27174).

The [paired comparison](https://github.com/paradigmxyz/reth/actions/runs/34577573410) and [unchanged-code control](https://github.com/paradigmxyz/reth/actions/runs/34577575046) completed with 300M-gas blocks, three pairs of 60 measured blocks plus 7 warmup, no samply, and identical scoped Chrome tracing. Results are mixed: official MDBX save metric **-7.10% (good)** and persistence wait **-8.95% (good)**, but execution median **+4.42% (bad)**; execution mean **+1.46% (neutral)**. Full-replay save_blocks totals averaged **12.192 → 11.389 s (-6.59%)**, including commit **18.899 → 18.140 s (-4.02%)**; the control's save_blocks change was **+0.06%**, and its official save/execution verdicts were neutral.

Boundary, LRU, mixed-residency, mapping-tail, larger-DB-page, and ASAN/UBSAN tests pass (leak detection disabled), as do nightly formatting and targeted clippy. Keep this experimental: no overall performance win is established, the new hit rate was not measured, and 32-unit/64-unit writer binaries must not concurrently share the same cache.

Prompted by: @mediocregopher
