### PR TITLE
test(bench): capture Tracy for mincore diagnosis

### DIFF
--- a/.github/scripts/bench-txgen-build.sh
+++ b/.github/scripts/bench-txgen-build.sh
@@ -30,17 +30,19 @@ fi
 
 build_node_binary() {
   local features_arg=""
-  local workspace_arg=""
+  local tracy_packages=""
 
   cd "$SOURCE_DIR"
   if [ -n "$EXTRA_FEATURES" ]; then
     features_arg="--features ${EXTRA_FEATURES}"
-    workspace_arg="--workspace"
+    # Select the feature-owning packages without building unrelated workspace
+    # binaries. reth-bb does not itself expose a tracy feature.
+    tracy_packages="-p reth-tracing -p reth-ethereum-cli -p reth-node-core"
   fi
 
   # shellcheck disable=SC2086
   RUSTFLAGS="-C target-cpu=native${EXTRA_RUSTFLAGS}" \
-    cargo build --locked --profile profiling $NODE_PKG $workspace_arg $features_arg
+    cargo build --locked --profile profiling $NODE_PKG $tracy_packages $features_arg
 }
 
 case "$MODE" in

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -328,6 +328,11 @@ else
 fi
 
 SUDO_ENV=()
+if [ "${BENCH_TRACY:-off}" = "on" ]; then
+  SUDO_ENV+=("TRACY_NO_SYS_TRACE=1")
+elif [ "${BENCH_TRACY:-off}" = "full" ]; then
+  SUDO_ENV+=("TRACY_NO_SYS_TRACE=0" "TRACY_SAMPLING_HZ=${BENCH_TRACY_SAMPLING_HZ:-1000}")
+fi
 if [ -n "${OTEL_RESOURCE_ATTRIBUTES:-}" ]; then
   SUDO_ENV+=("OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES}")
   SUDO_ENV+=("OTEL_BSP_MAX_QUEUE_SIZE=65536" "OTEL_BLRP_MAX_QUEUE_SIZE=65536")
@@ -558,9 +563,13 @@ fi
 
 if [ "${BENCH_TRACY:-off}" != "off" ]; then
   echo "Starting tracy-capture..."
-  tracy-capture -f -o "$OUTPUT_DIR/tracy-profile.tracy" &
+  tracy-capture -f -o "$OUTPUT_DIR/tracy-profile.tracy" > "$OUTPUT_DIR/tracy-capture.log" 2>&1 &
   TRACY_PID=$!
   sleep 0.5
+  if ! kill -0 "$TRACY_PID" 2>/dev/null; then
+    echo "::error::Tracy capture exited before block replay"
+    exit 1
+  fi
 fi
 
 # TODO(txgen): expose microsecond client-side FCU latency to avoid ms rounding.

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -622,12 +622,16 @@ if [ "${BENCH_TLB_TRACE:-false}" = "true" ]; then
   test "${#PERF_TIDS[@]}" -eq 3
   PERF_TID_LIST=$(IFS=,; echo "${PERF_TIDS[*]}")
   sudo sh -c 'echo $$ > "$1"; shift; exec "$@"' sh "$OUTPUT_DIR/tlb-perf.pid" \
-    perf record --clockid mono_raw -m 1024 -t "$PERF_TID_LIST" \
+    perf record --clockid CLOCK_MONOTONIC_RAW -m 1024 -t "$PERF_TID_LIST" \
     "${PERF_ARGS[@]}" -o "$OUTPUT_DIR/tlb-perf.data" \
     > "$OUTPUT_DIR/tlb-perf.log" 2>&1 &
   TLB_WRAPPER_PID=$!
   sleep 0.5
-  kill -0 "$TLB_WRAPPER_PID"
+  if ! kill -0 "$TLB_WRAPPER_PID" 2>/dev/null; then
+    cat "$OUTPUT_DIR/tlb-perf.log"
+    echo "::error::TLB/IPI recorder exited before block replay"
+    exit 1
+  fi
 fi
 
 # TODO(txgen): expose microsecond client-side FCU latency to avoid ms rounding.

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -13,7 +13,7 @@
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
 #               BENCH_TRACING_CHROME, BENCH_TRACY,
-#               BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ, BENCH_TLB_TRACE,
+#               BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ, BENCH_TLB_TRACE, BENCH_IO_TRACE,
 #               BENCH_POST_WARMUP_SLEEP_SECONDS,
 #               TXGEN_PAYLOADS_DIR (pre-extracted payloads; skips extraction),
 #               BENCH_TARGET_METRICS_SCRAPE_INTERVAL_MS (optional txgen override)
@@ -587,18 +587,11 @@ if [ "${BENCH_TRACY:-off}" != "off" ]; then
   fi
 fi
 
-if [ "${BENCH_TLB_TRACE:-false}" = "true" ]; then
+if [ "${BENCH_TLB_TRACE:-false}" = "true" ] || [ "${BENCH_IO_TRACE:-false}" = "true" ]; then
   # Attach only to the benchmark's engine, trie and transaction-manager threads.
   # sched_switch provides clock-alignment anchors for the matching Tracy capture.
   PERF_EVENTS=(tlb:tlb_flush irq_vectors:call_function_entry irq_vectors:call_function_exit
     irq_vectors:call_function_single_entry irq_vectors:call_function_single_exit sched:sched_switch)
-  PERF_ARGS=()
-  for event in "${PERF_EVENTS[@]}"; do
-    event_path="${event/:/\/}"
-    sudo test -r "/sys/kernel/tracing/events/$event_path/id"
-    sudo cat "/sys/kernel/tracing/events/$event_path/format" >> "$OUTPUT_DIR/tlb-event-formats.txt"
-    PERF_ARGS+=(-e "$event")
-  done
   RETH_CGROUP=$(sudo systemctl show "$RETH_SCOPE" -p ControlGroup --value)
   test -n "$RETH_CGROUP"
   RETH_PID=
@@ -621,15 +614,32 @@ if [ "${BENCH_TLB_TRACE:-false}" = "true" ]; then
   done
   test "${#PERF_TIDS[@]}" -eq 3
   PERF_TID_LIST=$(IFS=,; echo "${PERF_TIDS[*]}")
+  PERF_SCOPE=(-t "$PERF_TID_LIST")
+  if [ "${BENCH_IO_TRACE:-false}" = "true" ]; then
+    # Completion runs on interrupt/worker contexts, so task-scoped recording
+    # would omit it. Keep the shared artifact names for collector compatibility.
+    PERF_SCOPE=(-a)
+    PERF_EVENTS=(block:block_rq_issue block:block_rq_complete block:block_rq_requeue
+      syscalls:sys_enter_msync syscalls:sys_exit_msync)
+    lsblk -o NAME,MAJ:MIN,SIZE,TYPE,MOUNTPOINTS > "$OUTPUT_DIR/block-devices.txt"
+    findmnt -T "$DATADIR" > "$OUTPUT_DIR/datadir-mount.txt"
+  fi
+  PERF_ARGS=()
+  for event in "${PERF_EVENTS[@]}"; do
+    event_path="${event/:/\/}"
+    sudo test -r "/sys/kernel/tracing/events/$event_path/id"
+    sudo cat "/sys/kernel/tracing/events/$event_path/format" >> "$OUTPUT_DIR/tlb-event-formats.txt"
+    PERF_ARGS+=(-e "$event")
+  done
   sudo sh -c 'echo $$ > "$1"; shift; exec "$@"' sh "$OUTPUT_DIR/tlb-perf.pid" \
-    perf record --clockid CLOCK_MONOTONIC_RAW -m 1024 -t "$PERF_TID_LIST" \
+    perf record --clockid CLOCK_MONOTONIC_RAW -m 4096 "${PERF_SCOPE[@]}" \
     "${PERF_ARGS[@]}" -o "$OUTPUT_DIR/tlb-perf.data" \
     > "$OUTPUT_DIR/tlb-perf.log" 2>&1 &
   TLB_WRAPPER_PID=$!
   sleep 0.5
   if ! kill -0 "$TLB_WRAPPER_PID" 2>/dev/null; then
     cat "$OUTPUT_DIR/tlb-perf.log"
-    echo "::error::TLB/IPI recorder exited before block replay"
+    echo "::error::Kernel event recorder exited before block replay"
     exit 1
   fi
 fi

--- a/.github/scripts/bench-txgen-run.sh
+++ b/.github/scripts/bench-txgen-run.sh
@@ -13,7 +13,7 @@
 #               BENCH_FEATURE_ARGS, BENCH_OTLP_TRACES_ENDPOINT,
 #               BENCH_OTLP_LOGS_ENDPOINT, BENCH_OTLP_DISABLED,
 #               BENCH_TRACING_CHROME, BENCH_TRACY,
-#               BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ,
+#               BENCH_TRACY_FILTER, BENCH_TRACY_SAMPLING_HZ, BENCH_TLB_TRACE,
 #               BENCH_POST_WARMUP_SLEEP_SECONDS,
 #               TXGEN_PAYLOADS_DIR (pre-extracted payloads; skips extraction),
 #               BENCH_TARGET_METRICS_SCRAPE_INTERVAL_MS (optional txgen override)
@@ -181,6 +181,20 @@ call_reth_jit() {
 
 cleanup() {
   kill "${TAIL_PID:-}" 2>/dev/null || true
+  if [ -n "${TLB_WRAPPER_PID:-}" ]; then
+    if [ -s "$OUTPUT_DIR/tlb-perf.pid" ]; then
+      TLB_PERF_PID=$(<"$OUTPUT_DIR/tlb-perf.pid")
+      sudo kill -INT "$TLB_PERF_PID" 2>/dev/null || true
+      for i in $(seq 1 30); do
+        sudo kill -0 "$TLB_PERF_PID" 2>/dev/null || break
+        sleep 1
+      done
+      sudo kill -KILL "$TLB_PERF_PID" 2>/dev/null || true
+    fi
+    wait "$TLB_WRAPPER_PID" 2>/dev/null || true
+    sudo perf script --ns -i "$OUTPUT_DIR/tlb-perf.data" \
+      > "$OUTPUT_DIR/tlb-events.txt" 2> "$OUTPUT_DIR/tlb-decode.log" || true
+  fi
   if [ -n "${TRACY_PID:-}" ] && kill -0 "$TRACY_PID" 2>/dev/null; then
     echo "Stopping tracy-capture..."
     kill -INT "$TRACY_PID" 2>/dev/null || true
@@ -219,6 +233,7 @@ cleanup() {
 }
 TAIL_PID=
 TRACY_PID=
+TLB_WRAPPER_PID=
 trap cleanup EXIT
 
 sudo systemctl stop "$RETH_SCOPE" 2>/dev/null || true
@@ -570,6 +585,49 @@ if [ "${BENCH_TRACY:-off}" != "off" ]; then
     echo "::error::Tracy capture exited before block replay"
     exit 1
   fi
+fi
+
+if [ "${BENCH_TLB_TRACE:-false}" = "true" ]; then
+  # Attach only to the benchmark's engine, trie and transaction-manager threads.
+  # sched_switch provides clock-alignment anchors for the matching Tracy capture.
+  PERF_EVENTS=(tlb:tlb_flush irq_vectors:call_function_entry irq_vectors:call_function_exit
+    irq_vectors:call_function_single_entry irq_vectors:call_function_single_exit sched:sched_switch)
+  PERF_ARGS=()
+  for event in "${PERF_EVENTS[@]}"; do
+    event_path="${event/:/\/}"
+    sudo test -r "/sys/kernel/tracing/events/$event_path/id"
+    sudo cat "/sys/kernel/tracing/events/$event_path/format" >> "$OUTPUT_DIR/tlb-event-formats.txt"
+    PERF_ARGS+=(-e "$event")
+  done
+  RETH_CGROUP=$(sudo systemctl show "$RETH_SCOPE" -p ControlGroup --value)
+  test -n "$RETH_CGROUP"
+  RETH_PID=
+  while read -r candidate; do
+    if [ "$(sudo readlink "/proc/$candidate/exe")" = "$(realpath "$BINARY")" ]; then
+      RETH_PID="$candidate"
+      break
+    fi
+  done < <(sudo cat "/sys/fs/cgroup$RETH_CGROUP/cgroup.procs")
+  test -n "$RETH_PID"
+  PERF_TIDS=()
+  for task in /proc/"$RETH_PID"/task/*; do
+    task_name=$(<"$task/comm")
+    case "$task_name" in
+      engine|sparse-trie|mdbx-rs-txn-mgr)
+        PERF_TIDS+=("${task##*/}")
+        printf '%s\t%s\n' "${task##*/}" "$task_name" >> "$OUTPUT_DIR/tlb-thread-names.tsv"
+        ;;
+    esac
+  done
+  test "${#PERF_TIDS[@]}" -eq 3
+  PERF_TID_LIST=$(IFS=,; echo "${PERF_TIDS[*]}")
+  sudo sh -c 'echo $$ > "$1"; shift; exec "$@"' sh "$OUTPUT_DIR/tlb-perf.pid" \
+    perf record --clockid mono_raw -m 1024 -t "$PERF_TID_LIST" \
+    "${PERF_ARGS[@]}" -o "$OUTPUT_DIR/tlb-perf.data" \
+    > "$OUTPUT_DIR/tlb-perf.log" 2>&1 &
+  TLB_WRAPPER_PID=$!
+  sleep 0.5
+  kill -0 "$TLB_WRAPPER_PID"
 fi
 
 # TODO(txgen): expose microsecond client-side FCU latency to avoid ms rounding.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,6 +90,15 @@ on:
         required: false
         default: "false"
         type: boolean
+      tracy:
+        description: "Tracy capture: zones only (on) or zones plus system tracing (full)"
+        required: false
+        default: "off"
+        type: choice
+        options:
+          - "off"
+          - "on"
+          - "full"
       cores:
         description: "Limit reth to N CPU cores (0 = all available)"
         required: false
@@ -803,6 +812,9 @@ jobs:
       BENCH_WARMUP_BLOCKS: ${{ needs.bench-ack.outputs.warmup }}
       BENCH_SAMPLY: ${{ needs.bench-ack.outputs.samply }}
       BENCH_TRACING_CHROME: ${{ needs.bench-ack.outputs.tracing-chrome }}
+      BENCH_TRACY: ${{ inputs.tracy || 'off' }}
+      BENCH_TRACY_FILTER: debug
+      BENCH_TRACY_SAMPLING_HZ: "1000"
       BENCH_CORES: ${{ needs.bench-ack.outputs.cores }}
       BENCH_BIG_BLOCKS: ${{ needs.bench-ack.outputs.big-blocks }}
       BENCH_BIG_BLOCKS_TARGET_GAS: ${{ needs.bench-ack.outputs.big-blocks-target-gas }}
@@ -1008,6 +1020,21 @@ jobs:
             cargo install samply --git https://github.com/DaniPopes/samply --branch edge --locked
             sudo install "$HOME/.cargo/bin/samply" /usr/local/bin/
           fi
+
+      - name: Install matching Tracy capture
+        if: env.BENCH_TRACY != 'off'
+        run: |
+          sudo apt-get install -y --no-install-recommends cmake ninja-build pkg-config libfreetype6-dev libcurl4-openssl-dev libpugixml-dev
+          TRACY_BUILD_ROOT="$(mktemp -d /tmp/reth-tracy-build.XXXXXX)"
+          git init "$TRACY_BUILD_ROOT/source"
+          git -C "$TRACY_BUILD_ROOT/source" remote add origin https://github.com/wolfpld/tracy.git
+          # Tracy 0.13.1, matching the pinned tracy-client-sys 0.28.0.
+          git -C "$TRACY_BUILD_ROOT/source" fetch --depth 1 origin 05cceee0df3b8d7c6fa87e9638af311dbabc63cb
+          git -C "$TRACY_BUILD_ROOT/source" checkout --detach FETCH_HEAD
+          cmake -S "$TRACY_BUILD_ROOT/source/capture" -B "$TRACY_BUILD_ROOT/build" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DNO_FILESELECTOR=ON -DUSE_WAYLAND=ON
+          cmake --build "$TRACY_BUILD_ROOT/build" --target tracy-capture -j 4
+          echo "$TRACY_BUILD_ROOT/build" >> "$GITHUB_PATH"
 
       # Verify all required tools are available
       - name: Check dependencies
@@ -1353,6 +1380,12 @@ jobs:
           {"benchmark_run":"${run_label}","run_type":"${run_type}","git_ref":"${ref}","bench_sha":"${ref}","benchmark_id":"${BENCH_ID}","run_start_epoch":"${LAST_RUN_START}","reference_epoch":"${BENCH_REFERENCE_EPOCH}"}
           LABELS
             taskset -c 0 .github/scripts/bench-txgen-run.sh "$run_type" "$binary" "$BENCH_WORK_DIR/${run_label}"
+            if [ "${BENCH_TRACY:-off}" != "off" ]; then
+              test -s "$BENCH_WORK_DIR/${run_label}/tracy-profile.tracy" || {
+                echo "::error::Missing Tracy capture for ${run_label}"
+                exit 1
+              }
+            fi
           done
 
           .github/scripts/bench-update-status.sh "Finalizing results..."

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -91,7 +91,7 @@ on:
         default: "false"
         type: boolean
       tracy:
-        description: "Tracy capture: zones only (on) or zones plus system tracing (full)"
+        description: "Tracy capture: zones (on), system tracing (full), or system tracing plus TLB/IPI events (full-tlb)"
         required: false
         default: "off"
         type: choice
@@ -99,6 +99,7 @@ on:
           - "off"
           - "on"
           - "full"
+          - "full-tlb"
       cores:
         description: "Limit reth to N CPU cores (0 = all available)"
         required: false
@@ -812,7 +813,8 @@ jobs:
       BENCH_WARMUP_BLOCKS: ${{ needs.bench-ack.outputs.warmup }}
       BENCH_SAMPLY: ${{ needs.bench-ack.outputs.samply }}
       BENCH_TRACING_CHROME: ${{ needs.bench-ack.outputs.tracing-chrome }}
-      BENCH_TRACY: ${{ inputs.tracy || 'off' }}
+      BENCH_TRACY: ${{ inputs.tracy == 'full-tlb' && 'full' || inputs.tracy || 'off' }}
+      BENCH_TLB_TRACE: ${{ inputs.tracy == 'full-tlb' && 'true' || 'false' }}
       BENCH_TRACY_FILTER: debug
       BENCH_TRACY_SAMPLING_HZ: "1000"
       BENCH_CORES: ${{ needs.bench-ack.outputs.cores }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -91,7 +91,7 @@ on:
         default: "false"
         type: boolean
       tracy:
-        description: "Tracy capture: zones (on), system tracing (full), or system tracing plus TLB/IPI events (full-tlb)"
+        description: "Tracy capture: zones (on), system tracing (full), plus TLB/IPI (full-tlb) or block I/O (full-io)"
         required: false
         default: "off"
         type: choice
@@ -100,6 +100,7 @@ on:
           - "on"
           - "full"
           - "full-tlb"
+          - "full-io"
       cores:
         description: "Limit reth to N CPU cores (0 = all available)"
         required: false
@@ -813,8 +814,9 @@ jobs:
       BENCH_WARMUP_BLOCKS: ${{ needs.bench-ack.outputs.warmup }}
       BENCH_SAMPLY: ${{ needs.bench-ack.outputs.samply }}
       BENCH_TRACING_CHROME: ${{ needs.bench-ack.outputs.tracing-chrome }}
-      BENCH_TRACY: ${{ inputs.tracy == 'full-tlb' && 'full' || inputs.tracy || 'off' }}
+      BENCH_TRACY: ${{ (inputs.tracy == 'full-tlb' || inputs.tracy == 'full-io') && 'full' || inputs.tracy || 'off' }}
       BENCH_TLB_TRACE: ${{ inputs.tracy == 'full-tlb' && 'true' || 'false' }}
+      BENCH_IO_TRACE: ${{ inputs.tracy == 'full-io' && 'true' || 'false' }}
       BENCH_TRACY_FILTER: debug
       BENCH_TRACY_SAMPLING_HZ: "1000"
       BENCH_CORES: ${{ needs.bench-ack.outputs.cores }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1155,6 +1155,12 @@ jobs:
 
           .github/scripts/bench-txgen-install.sh
 
+          if [ "${BENCH_TRACY:-off}" != "off" ]; then
+            CARGO_BUILD_JOBS=8 .github/scripts/bench-txgen-build.sh baseline "${BASELINE_DIR}" "${{ steps.refs.outputs.baseline-ref }}"
+            CARGO_BUILD_JOBS=8 .github/scripts/bench-txgen-build.sh feature "${FEATURE_DIR}" "${{ steps.refs.outputs.feature-ref }}"
+            exit 0
+          fi
+
           .github/scripts/bench-txgen-build.sh baseline "${BASELINE_DIR}" "${{ steps.refs.outputs.baseline-ref }}" &
           PID_BASELINE=$!
           .github/scripts/bench-txgen-build.sh feature "${FEATURE_DIR}" "${{ steps.refs.outputs.feature-ref }}" &


### PR DESCRIPTION
Adds opt-in matching-version Tracy capture and optional kernel-event sidecars, with scoped benchmark builds and startup/output checks; production defaults and node behavior are unchanged.

Tracy/MCP plus loss-audited block-I/O traces identify earlier commit writeback overlapping more proof reads, longer read completion latency, and amplified pending-leaf retries; the first flush still writes approximately 648 MiB on both sides, and disabling synchronous flushing removes the doubled read-wait effect.

The final 60-block, two-pair [mincore-off comparison](https://github.com/paradigmxyz/reth/actions/runs/34588842198) reports +2.8391% mean validation (bad), versus −0.3012% in the [unchanged-code control](https://github.com/paradigmxyz/reth/actions/runs/34588843651) (neutral); the earlier [six-pair comparison](https://github.com/paradigmxyz/reth/actions/runs/34585256193) was neutral at +1.0113%, so the whole-run magnitude varies with instrumentation/repeats.

Verified shell syntax, workflow YAML, diff checks, successful end-to-end captures, MCP wait accounting, request-matching tests, and raw perf loss accounting; exact I/O claims use the intact first five seconds, before late recorder loss.

Prompted by: @mediocregopher
