### PR TITLE
test(net): cover eth/72 announcements in the rlp roundtrip fuzz

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -824,7 +824,10 @@ impl proptest::prelude::Arbitrary for NewPooledTransactionHashes72 {
                 // Map the usize values to the range 0..131072(0x20000)
                 let sizes_vec = vec(proptest::num::usize::ANY.prop_map(|x| x % 131072), len..=len);
                 let hashes_vec = vec(any::<B256>(), len..=len);
-                let cell_mask = any::<Option<B128>>();
+                // A zero mask is spelled `None`, so generating `Some(ZERO)` would produce a
+                // value that cannot survive its own encoding.
+                let cell_mask =
+                    any::<Option<B128>>().prop_map(|mask| mask.filter(|mask| !mask.is_zero()));
 
                 (types_vec, sizes_vec, hashes_vec, cell_mask)
             })
@@ -1667,6 +1670,26 @@ mod tests {
         for vector in vectors {
             test_encoding_vector(vector);
         }
+    }
+
+    #[test]
+    fn eth_72_zero_cell_mask_decodes_as_none() {
+        // The wire cannot tell a zero mask from an absent one, so `None` is the only
+        // representation that survives a round trip.
+        let zero = NewPooledTransactionHashes72 {
+            types: vec![],
+            sizes: vec![],
+            hashes: vec![],
+            cell_mask: Some(B128::ZERO),
+        };
+
+        let mut encoded = Vec::new();
+        zero.encode(&mut encoded);
+
+        let decoded = NewPooledTransactionHashes72::decode(&mut &encoded[..]).unwrap();
+
+        assert_eq!(decoded.cell_mask, None);
+        assert_eq!(encoded, hex!("d480c0c09000000000000000000000000000000000"));
     }
 
     #[test]

--- a/crates/net/eth-wire/tests/fuzz_roundtrip.rs
+++ b/crates/net/eth-wire/tests/fuzz_roundtrip.rs
@@ -54,8 +54,8 @@ pub mod fuzz_rlp {
     use reth_eth_wire::{
         BlockBodies, BlockHeaders, DisconnectReason, GetBlockBodies, GetBlockHeaders, GetNodeData,
         GetPooledTransactions, GetReceipts, HelloMessage, NewBlock, NewBlockHashes,
-        NewPooledTransactionHashes66, NewPooledTransactionHashes68, NodeData, P2PMessage,
-        PooledTransactions, Receipts, Status, Transactions,
+        NewPooledTransactionHashes66, NewPooledTransactionHashes68, NewPooledTransactionHashes72,
+        NodeData, P2PMessage, PooledTransactions, Receipts, Status, Transactions,
     };
     use serde::{Deserialize, Serialize};
     use test_fuzz::test_fuzz;
@@ -154,6 +154,7 @@ pub mod fuzz_rlp {
     fuzz_type_and_name!(NewBlock, fuzz_NewBlock);
     fuzz_type_and_name!(NewPooledTransactionHashes66, fuzz_NewPooledTransactionHashes66);
     fuzz_type_and_name!(NewPooledTransactionHashes68, fuzz_NewPooledTransactionHashes68);
+    fuzz_type_and_name!(NewPooledTransactionHashes72, fuzz_NewPooledTransactionHashes72);
     fuzz_type_and_name!(GetPooledTransactions, fuzz_GetPooledTransactions);
     fuzz_type_and_name!(PooledTransactions, fuzz_PooledTransactions);
     fuzz_type_and_name!(GetNodeData, fuzz_GetNodeData);


### PR DESCRIPTION
`NewPooledTransactionHashes72` was the only announcement version missing from the
rlp roundtrip fuzz harness, even though it has the hand-written `Decodable` impl
of the three — 66 and 68 are both registered.

Registering it needs one change first. The wire format cannot distinguish an
absent cell mask from a zero one (go-ethereum decodes into a non-optional
`[16]byte`), so the decoder normalizes a zero mask to `None`. That makes
`Some(B128::ZERO)` a value that cannot survive its own encoding, and `test-fuzz`
persists its corpus — a single such entry would fail the test permanently. The
arbitrary impl no longer generates it.

A random 16-byte mask is zero with probability 2^-128, so fuzzing would never
reach that case on its own; a deterministic test pins the normalization instead.
