### PR TITLE
chore(bench): temporary big-block BAL run for #27173

### DIFF
--- a/crates/ethereum/payload/src/validator.rs
+++ b/crates/ethereum/payload/src/validator.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::Block;
 use alloy_rpc_types_engine::{ExecutionData, PayloadError};
 use reth_chainspec::EthereumHardforks;
-use reth_payload_validator::{cancun, prague, shanghai};
+use reth_payload_validator::{amsterdam, cancun, prague, shanghai};
 use reth_primitives_traits::{Block as _, SealedBlock, SignedTransaction};
 use std::sync::Arc;
 
@@ -101,6 +101,11 @@ where
         sealed_block.body(),
         sidecar.prague(),
         chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp),
+    )?;
+
+    amsterdam::ensure_well_formed_fields(
+        &sealed_block,
+        chain_spec.is_amsterdam_active_at_timestamp(sealed_block.timestamp),
     )?;
 
     Ok(sealed_block)

--- a/crates/payload/validator/src/amsterdam.rs
+++ b/crates/payload/validator/src/amsterdam.rs
@@ -1,0 +1,71 @@
+//! Amsterdam rules for new payloads.
+
+use alloy_consensus::BlockHeader;
+use alloy_rpc_types_engine::PayloadError;
+use reth_primitives_traits::{Block, SealedBlock};
+
+/// Checks that Amsterdam header fields are present if Amsterdam is active and absent otherwise.
+#[inline]
+pub fn ensure_well_formed_fields<T: Block>(
+    block: &SealedBlock<T>,
+    is_amsterdam_active: bool,
+) -> Result<(), PayloadError> {
+    if is_amsterdam_active {
+        if block.block_access_list_hash().is_none() {
+            return Err(PayloadError::PostAmsterdamBlockWithoutBlockAccessList)
+        }
+        if block.slot_number().is_none() {
+            return Err(PayloadError::PostAmsterdamBlockWithoutSlotNumber)
+        }
+    } else {
+        if block.block_access_list_hash().is_some() {
+            return Err(PayloadError::PreAmsterdamBlockWithBlockAccessList)
+        }
+        if block.slot_number().is_some() {
+            return Err(PayloadError::PreAmsterdamBlockWithSlotNumber)
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{Block as AlloyBlock, Header, TxEnvelope};
+
+    fn block(
+        has_block_access_list: bool,
+        has_slot_number: bool,
+    ) -> SealedBlock<AlloyBlock<TxEnvelope>> {
+        let header = Header {
+            block_access_list_hash: has_block_access_list.then_some(Default::default()),
+            slot_number: has_slot_number.then_some(0),
+            ..Default::default()
+        };
+        AlloyBlock { header, body: Default::default() }.seal_slow()
+    }
+
+    #[test]
+    fn validates_amsterdam_fields() {
+        assert!(ensure_well_formed_fields(&block(true, true), true).is_ok());
+        assert!(ensure_well_formed_fields(&block(false, false), false).is_ok());
+
+        assert!(matches!(
+            ensure_well_formed_fields(&block(false, true), true),
+            Err(PayloadError::PostAmsterdamBlockWithoutBlockAccessList)
+        ));
+        assert!(matches!(
+            ensure_well_formed_fields(&block(true, false), true),
+            Err(PayloadError::PostAmsterdamBlockWithoutSlotNumber)
+        ));
+        assert!(matches!(
+            ensure_well_formed_fields(&block(true, false), false),
+            Err(PayloadError::PreAmsterdamBlockWithBlockAccessList)
+        ));
+        assert!(matches!(
+            ensure_well_formed_fields(&block(false, true), false),
+            Err(PayloadError::PreAmsterdamBlockWithSlotNumber)
+        ));
+    }
+}

--- a/crates/payload/validator/src/lib.rs
+++ b/crates/payload/validator/src/lib.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod amsterdam;
 pub mod cancun;
 pub mod prague;
 pub mod shanghai;


### PR DESCRIPTION
Temporary benchmark-only copy of #27173 at `5e5770bfd5d2147ac1d689c98aec661d0bcb7617`, preserving the original commits and authorship, to run Derek's big-block benchmark with BAL enabled.

Do not merge; the implementation remains tracked in #27173.
