### PR TITLE
test(bench): compare shard pool without mincore

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/build.rs
+++ b/crates/storage/libmdbx-rs/mdbx-sys/build.rs
@@ -28,6 +28,9 @@ fn main() {
         // which works correctly on all filesystems.
         .define("MDBX_USE_FALLOCATE", "0");
 
+    // Benchmark residency probes independently of the existing prefault writes.
+    cc.define("MDBX_USE_MINCORE", "0");
+
     // Enable debugging on debug builds
     #[cfg(debug_assertions)]
     cc.define("MDBX_DEBUG", "1").define("MDBX_ENABLE_PROFGC", "1");


### PR DESCRIPTION
Benchmark-only mincore-disabled variant of #27162 at `af99d401a56f1cd6c642903c843077adb1d36ce1`; prefault writes and durability settings are unchanged. This is a stacked experiment, not a recommendation to merge.

The [comparison](https://github.com/paradigmxyz/reth/actions/runs/34591844203) and [unchanged-code control](https://github.com/paradigmxyz/reth/actions/runs/34591828280) use 60 measured blocks, 7 warmup blocks, six pairs, 1G target gas, BAL enabled, and no Tracy, samply, Chrome tracing, or OTLP. Official results: validation +0.13% (neutral), persistence wait −10.33% (good), MDBX save_blocks −4.63% (neutral); control validation +1.22% (neutral).

Client replay elapsed time decreased 31.823 → 30.346 seconds (−4.64%, descriptive, not the summary's latency-sum “wall clock”). All canonical block hashes match, but mincore-on logs hit the shutdown timeout during the final five-block save, so equal-work fully durable completion is not verified and full persistence totals must not be compared.

Validation: `cargo test -p reth-libmdbx --locked` (46 tests and one doctest), `cargo +nightly fmt -p reth-mdbx-sys --check`, and `cargo +nightly clippy -p reth-mdbx-sys --locked -- -D warnings` passed.

Prompted by: @mattsse
