### PR TITLE
feat(txpool): add nonce bound check hook

### DIFF
--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1491,6 +1491,14 @@ pub trait PoolTransaction:
         }
     }
 
+    /// Whether the transaction's nonce must be below [`u64::MAX`] according to EIP-2681.
+    ///
+    /// Defaults to `true`. Transactions with alternative nonce semantics can override this
+    /// independently of the sender nonce check in [`Self::requires_nonce_check`].
+    fn requires_nonce_bound_check(&self) -> bool {
+        true
+    }
+
     /// Allows to communicate to the pool that the transaction doesn't require a nonce check.
     fn requires_nonce_check(&self) -> bool {
         true

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -487,8 +487,7 @@ where
         };
 
         // Reject transactions with a nonce equal to U64::max according to EIP-2681
-        let tx_nonce = transaction.nonce();
-        if tx_nonce == u64::MAX {
+        if transaction.requires_nonce_bound_check() && transaction.nonce() == u64::MAX {
             return Err(InvalidPoolTransactionError::Eip2681)
         }
 
@@ -1700,6 +1699,34 @@ mod tests {
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
 
         assert!(outcome.is_valid());
+    }
+
+    #[test]
+    fn validates_nonce_bound() {
+        let provider = MockEthProvider::default().with_genesis_block();
+        let validator = EthTransactionValidatorBuilder::new(provider, test_evm_config())
+            .build(InMemoryBlobStore::default());
+        let transaction = |nonce| {
+            EthPooledTransaction::try_from_consensus(
+                TransactionBuilder::default()
+                    .chain_id(validator.chain_id())
+                    .nonce(nonce)
+                    .gas_limit(21_000)
+                    .to(Address::ZERO)
+                    .into_eip1559()
+                    .try_into_recovered()
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+
+        assert!(validator
+            .validate_stateless(TransactionOrigin::External, &transaction(u64::MAX - 1))
+            .is_ok());
+        assert!(matches!(
+            validator.validate_stateless(TransactionOrigin::External, &transaction(u64::MAX)),
+            Err(InvalidPoolTransactionError::Eip2681)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Add `PoolTransaction::requires_nonce_bound_check()` (defaulting to `true`) and gate the EIP-2681 check on it, so downstream chains can override nonce bounds independently of sender nonce validation. This enables Tempo's expiring nonce handling discussed in [tempoxyz/tempo#7610](https://github.com/tempoxyz/tempo/pull/7610), while preserving Ethereum's existing behavior.

Includes a regression test for Ethereum's `u64::MAX - 1` and `u64::MAX` nonce boundary.

Prompted by: @shekhirin
