### PR TITLE
perf(trie): gate collapse retries on the sibling reveal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10954,7 +10954,6 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-common",
- "slotmap",
  "smallvec",
  "strum 0.27.2",
  "tracing",
@@ -12199,15 +12198,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "small_btree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -526,7 +526,6 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_with = { version = "3", default-features = false, features = ["macros"] }
 sha2 = { version = "0.10", default-features = false }
 shlex = "1.3"
-slotmap = "1"
 smallvec = "1"
 strum = { version = "0.27", default-features = false }
 strum_macros = "0.27"

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -806,6 +806,7 @@ where
             let StorageSlot::Idle(work) = slot else {
                 unreachable!("an idle slot is only checked out from here")
             };
+
             if inline_round || work.is_target_only() {
                 let output = work.run(new_epoch, retain_updates);
                 self.apply_storage_output(address, output)?;
@@ -1300,21 +1301,19 @@ where
                 account_targets.len().saturating_sub(MAX_STALLED_PROOF_TARGETS_TO_LOG);
             account_targets.truncate(MAX_STALLED_PROOF_TARGETS_TO_LOG);
 
-            let mut storage_targets = self
-                .storage
-                .iter()
-                .filter_map(|(address, slot)| match slot {
-                    StorageSlot::Idle(work) => Some((address, work)),
-                    StorageSlot::InFlight(_) => None,
-                })
-                .flat_map(|(address, work)| {
-                    work.pending
-                        .keys()
-                        .copied()
-                        .chain(work.trie.blocked_updates().keys())
-                        .map(move |target| (*address, target, work.fetched.get(&target).copied()))
-                })
-                .collect::<Vec<_>>();
+            let mut storage_targets =
+                self.storage
+                    .iter()
+                    .filter_map(|(address, slot)| match slot {
+                        StorageSlot::Idle(work) => Some((address, work)),
+                        StorageSlot::InFlight(_) => None,
+                    })
+                    .flat_map(|(address, work)| {
+                        work.pending.keys().copied().chain(work.trie.blocked_updates().keys()).map(
+                            move |target| (*address, target, work.fetched.get(&target).copied()),
+                        )
+                    })
+                    .collect::<Vec<_>>();
             storage_targets.sort_unstable();
             let storage_targets_truncated =
                 storage_targets.len().saturating_sub(MAX_STALLED_PROOF_TARGETS_TO_LOG);

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -1,6 +1,10 @@
 //! Sparse Trie task related functionality.
 
-use std::sync::Arc;
+use std::{
+    any::Any,
+    panic::{self, AssertUnwindSafe},
+    sync::Arc,
+};
 
 use super::{evm_state_to_hashed_post_state, StateRootComputeOutcome, StateRootMessage};
 use alloy_primitives::{
@@ -119,9 +123,9 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// address has to treat it as unavailable until the job hands it back.
     in_flight_storage: B256Map<InFlightStorage>,
     /// Sender handed to storage jobs. Kept alive by the task so the receiver never disconnects.
-    storage_done_tx: CrossbeamSender<StorageTrieJobDone<S>>,
+    storage_done_tx: CrossbeamSender<StorageJobMessage<S>>,
     /// Receives storage tries coming back from jobs spawned by this task.
-    storage_done_rx: CrossbeamReceiver<StorageTrieJobDone<S>>,
+    storage_done_rx: CrossbeamReceiver<StorageJobMessage<S>>,
     /// Whether blocked storage leaf updates are worth retrying, see
     /// [`Self::process_leaf_updates`].
     storage_retry_armed: bool,
@@ -339,7 +343,7 @@ where
                     let Ok(returned) = message else {
                         unreachable!("we own the sender half")
                     };
-                    self.on_storage_trie_returned(returned)?;
+                    self.on_storage_job_message(returned)?;
                 },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
@@ -378,7 +382,7 @@ where
                     let Ok(returned) = message else {
                         unreachable!("we own the sender half")
                     };
-                    self.on_storage_trie_returned(returned)?;
+                    self.on_storage_job_message(returned)?;
                 },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
@@ -898,12 +902,31 @@ where
                 )
                 .entered();
                 for job in chunk {
-                    if storage_done_tx.send(job.run(new_epoch, retain_updates)).is_err() {
+                    let address = job.address;
+                    let message = match panic::catch_unwind(AssertUnwindSafe(|| {
+                        job.run(new_epoch, retain_updates)
+                    })) {
+                        Ok(done) => StorageJobMessage::Done(done),
+                        Err(payload) => StorageJobMessage::Panicked { address, payload },
+                    };
+                    if storage_done_tx.send(message).is_err() {
                         // Nobody is waiting for the result anymore, drop the rest here.
                         return;
                     }
                 }
             });
+        }
+    }
+
+    /// Handles a message from a storage job: puts a finished trie back, or resumes a panic that
+    /// happened on the job thread here, where it fails this task like an inline panic would.
+    fn on_storage_job_message(&mut self, message: StorageJobMessage<S>) -> SparseTrieResult<()> {
+        match message {
+            StorageJobMessage::Done(done) => self.on_storage_trie_returned(done),
+            StorageJobMessage::Panicked { address, payload } => {
+                self.in_flight_storage.remove(&address);
+                panic::resume_unwind(payload)
+            }
         }
     }
 
@@ -944,8 +967,8 @@ where
 
     /// Reinstates every storage trie whose job has already finished, without blocking.
     fn drain_returned_storage_tries(&mut self) -> SparseTrieResult<()> {
-        while let Ok(done) = self.storage_done_rx.try_recv() {
-            self.on_storage_trie_returned(done)?;
+        while let Ok(message) = self.storage_done_rx.try_recv() {
+            self.on_storage_job_message(message)?;
         }
 
         Ok(())
@@ -1207,6 +1230,21 @@ enum StorageJobKind {
     Root,
     /// Reveal these proof nodes into the trie.
     Reveal(Vec<ProofTrieNodeV2>),
+}
+
+/// What a spawned storage job sends back to the sparse trie task.
+enum StorageJobMessage<S> {
+    /// The job finished and hands its trie back.
+    Done(StorageTrieJobDone<S>),
+    /// The job panicked and its trie is lost. The global rayon pool has no panic handler, so a
+    /// panic escaping a spawned job would abort the process; it is caught and resumed on the task
+    /// thread instead, where it fails the state root calculation like an inline panic.
+    Panicked {
+        /// Hashed address of the trie the job owned.
+        address: B256,
+        /// The panic payload, resumed on the task thread.
+        payload: Box<dyn Any + Send>,
+    },
 }
 
 /// A storage trie coming back to the sparse trie task after its job finished.

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::{evm_state_to_hashed_post_state, StateRootComputeOutcome, StateRootMessage};
 use alloy_primitives::{
-    map::{hash_map::Entry, B256Map},
+    map::{hash_map::Entry, B256Map, B256Set},
     B256,
 };
 use alloy_rlp::{Decodable, Encodable};
@@ -28,8 +28,8 @@ use reth_trie_parallel::{
 };
 use reth_trie_sparse::{
     errors::{SparseStateTrieErrorKind, SparseTrieErrorKind, SparseTrieResult},
-    ArenaParallelSparseTrie, DeferredDrops, LeafUpdate, RevealableSparseTrie, SparseStateTrie,
-    SparseTrie, TrieNodeEpoch,
+    ArenaParallelSparseTrie, BlockedLeafUpdates, DeferredDrops, LeafUpdate, RevealableSparseTrie,
+    SparseStateTrie, SparseTrie, TrieNodeEpoch,
 };
 use tracing::{debug, debug_span, error, instrument, trace_span};
 
@@ -67,7 +67,15 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// Account trie updates.
     account_updates: B256Map<LeafUpdate>,
     /// Storage trie updates. hashed address -> slot -> update.
+    ///
+    /// A revealed trie takes ownership of the updates it could not apply, so entries only
+    /// remain here while the storage trie is still blind.
     storage_updates: B256Map<B256Map<LeafUpdate>>,
+    /// Storage tries that hold leaf updates they could not apply yet.
+    blocked_storage_updates: B256Set,
+    /// Storage tries whose blocked leaf updates may be applicable now, because the trie received
+    /// a proof or still holds updates that do not depend on one.
+    retry_storage_updates: B256Set,
 
     /// Account updates that are buffered but were not yet applied to the trie.
     new_account_updates: B256Map<LeafUpdate>,
@@ -79,7 +87,8 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// are revealed and/or calculated.
     ///
     /// Invariant: for each entry in `pending_account_updates` account must either be already
-    /// revealed in the trie or have an entry in `account_updates`.
+    /// revealed in the trie, have an entry in `account_updates`, or have a leaf update blocked
+    /// inside the accounts trie.
     ///
     /// Values can be either of:
     ///   - None: account had a storage update and is awaiting storage root calculation and/or
@@ -170,6 +179,8 @@ where
             max_targets_for_chunking: DEFAULT_MAX_TARGETS_FOR_CHUNKING,
             account_updates: Default::default(),
             storage_updates: Default::default(),
+            blocked_storage_updates: Default::default(),
+            retry_storage_updates: Default::default(),
             new_account_updates: Default::default(),
             new_storage_updates: Default::default(),
             pending_account_updates: Default::default(),
@@ -556,6 +567,8 @@ where
     }
 
     fn on_proof_result(&mut self, result: DecodedMultiProofV2) -> Result<(), StateRootTaskError> {
+        // Revealing these tries can unblock leaf updates they hold on to.
+        self.retry_storage_updates.extend(result.storage_proofs.keys().copied());
         self.trie
             .reveal_decoded_multiproof_v2(result)
             .map_err(|e| StateRootTaskError::Other(format!("could not reveal multiproof: {e:?}")))
@@ -633,47 +646,95 @@ where
         skip_all
     )]
     fn process_leaf_updates(&mut self, new: bool) -> SparseTrieResult<()> {
-        let storage_updates =
-            if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
-
-        // Process all storage updates, skipping tries with no pending updates.
         let span = trace_span!("process_storage_leaf_updates").entered();
-        for (address, updates) in storage_updates {
-            if updates.is_empty() {
-                continue;
-            }
-            let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
 
-            let trie = self.trie.get_or_create_storage_trie_mut(*address);
-            let fetched = self.fetched_storage_targets.entry(*address).or_default();
-            let mut targets = Vec::new();
-
-            let updates_len_before = updates.len();
-            trie.update_leaves(updates, |path, parent| match fetched.entry(path) {
-                Entry::Occupied(mut entry) => {
-                    if parent < *entry.get() {
-                        entry.insert(parent);
-                        targets.push(ProofV2Target::new(path).with_parent(parent));
+        let result = if new {
+            // Process all new storage updates, skipping tries with no pending updates.
+            let mut new_storage_updates = core::mem::take(&mut self.new_storage_updates);
+            let result = new_storage_updates
+                .iter_mut()
+                .filter(|(_, updates)| !updates.is_empty())
+                .try_for_each(|(address, updates)| {
+                    self.apply_storage_leaf_updates(*address, updates)
+                });
+            self.new_storage_updates = new_storage_updates;
+            result
+        } else {
+            // Only tries that received a proof or hold updates waiting on something else than a
+            // reveal can make progress, all other blocked updates would hit the same blinded
+            // node again.
+            let mut storage_updates = core::mem::take(&mut self.storage_updates);
+            let result = core::mem::take(&mut self.retry_storage_updates).into_iter().try_for_each(
+                |address| {
+                    let Some(updates) = storage_updates.get_mut(&address) else { return Ok(()) };
+                    if updates.is_empty() && !self.blocked_storage_updates.contains(&address) {
+                        return Ok(())
                     }
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(parent);
-                    targets.push(ProofV2Target::new(path).with_parent(parent));
-                }
-            })?;
-            let updates_len_after = updates.len();
-            self.storage_cache_hits += (updates_len_before - updates_len_after) as u64;
-            self.storage_cache_misses += updates_len_after as u64;
-
-            if !targets.is_empty() {
-                self.pending_targets.extend_storage_targets(address, targets);
-            }
-        }
+                    self.apply_storage_leaf_updates(address, updates)
+                },
+            );
+            self.storage_updates = storage_updates;
+            result
+        };
 
         drop(span);
+        result?;
 
         // Process account trie updates and fill the account targets.
         self.process_account_leaf_updates(new)?;
+
+        Ok(())
+    }
+
+    /// Applies the given leaf updates to the storage trie of `address` and queues the proof
+    /// targets they require.
+    fn apply_storage_leaf_updates(
+        &mut self,
+        address: B256,
+        updates: &mut B256Map<LeafUpdate>,
+    ) -> SparseTrieResult<()> {
+        let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", "storage_trie_leaf_updates", a=%address).entered();
+
+        let trie = self.trie.get_or_create_storage_trie_mut(address);
+        let fetched = self.fetched_storage_targets.entry(address).or_default();
+        let mut targets = Vec::new();
+
+        let pending_before = updates.len() + trie.blocked_updates().len();
+        trie.update_leaves(updates, |path, parent| match fetched.entry(path) {
+            Entry::Occupied(mut entry) => {
+                if parent < *entry.get() {
+                    entry.insert(parent);
+                    targets.push(ProofV2Target::new(path).with_parent(parent));
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(parent);
+                targets.push(ProofV2Target::new(path).with_parent(parent));
+            }
+        })?;
+
+        let blocked = trie.blocked_updates();
+        let pending_after = updates.len() + blocked.len();
+        let has_retryable = blocked.has_retryable();
+        let is_blocked = !blocked.is_empty();
+
+        self.storage_cache_hits += pending_before.saturating_sub(pending_after) as u64;
+        self.storage_cache_misses += pending_after as u64;
+
+        if is_blocked {
+            self.blocked_storage_updates.insert(address);
+        } else {
+            self.blocked_storage_updates.remove(&address);
+        }
+        if has_retryable {
+            // These updates wait on a node that is not on their own path, so no reveal will
+            // report them and the trie has to be visited again regardless.
+            self.retry_storage_updates.insert(address);
+        }
+
+        if !targets.is_empty() {
+            self.pending_targets.extend_storage_targets(&address, targets);
+        }
 
         Ok(())
     }
@@ -690,7 +751,7 @@ where
         let account_updates =
             if new { &mut self.new_account_updates } else { &mut self.account_updates };
 
-        let updates_len_before = account_updates.len();
+        let pending_before = account_updates.len() + self.trie.trie_mut().blocked_updates().len();
 
         self.trie.trie_mut().update_leaves(account_updates, |target, parent| {
             match self.fetched_account_targets.entry(target) {
@@ -709,11 +770,11 @@ where
             }
         })?;
 
-        let updates_len_after = account_updates.len();
-        self.account_cache_hits += (updates_len_before - updates_len_after) as u64;
-        self.account_cache_misses += updates_len_after as u64;
+        let pending_after = account_updates.len() + self.trie.trie_mut().blocked_updates().len();
+        self.account_cache_hits += pending_before.saturating_sub(pending_after) as u64;
+        self.account_cache_misses += pending_after as u64;
 
-        Ok(updates_len_after < updates_len_before)
+        Ok(pending_after < pending_before)
     }
 
     /// Computes storage roots for accounts whose storage updates are fully drained.
@@ -734,6 +795,7 @@ where
         for (address, updates) in &self.storage_updates {
             if updates.is_empty() &&
                 let Some(trie) = self.trie.storage_tries_mut().get_mut(address) &&
+                trie.blocked_updates().is_empty() &&
                 !trie.is_root_cached()
             {
                 tries_to_compute_roots.push((*address, SendStorageTriePtr(trie)));
@@ -801,7 +863,7 @@ where
             let mut num_promoted = 0;
             self.pending_account_updates.retain(|addr, account| {
                 if let Some(updates) = self.storage_updates.get(addr) {
-                    if !updates.is_empty() {
+                    if !updates.is_empty() || self.blocked_storage_updates.contains(addr) {
                         // If account has pending storage updates, it is still pending.
                         return true;
                     } else if let Some(account) = account.take() {
@@ -813,8 +875,16 @@ where
                     }
                 }
 
-                // Get the current account state either from the trie or from latest account update.
-                let trie_account = match self.account_updates.get(addr) {
+                // Get the current account state either from the trie or from latest account
+                // update, which the accounts trie may be holding on to until it is revealed.
+                let pending_update = match self.account_updates.get(addr) {
+                    Some(update) => Some(update),
+                    None => self
+                        .trie
+                        .state_trie_ref()
+                        .and_then(|trie| trie.blocked_updates().get(addr)),
+                };
+                let trie_account = match pending_update {
                     Some(LeafUpdate::Changed(encoded)) => {
                         Some(encoded).filter(|encoded| !encoded.is_empty())
                     }
@@ -907,8 +977,15 @@ where
 
     fn has_pending_sparse_trie_updates(&self) -> bool {
         !self.account_updates.is_empty() ||
+            !self.blocked_storage_updates.is_empty() ||
+            self.account_blocked_updates().is_some_and(|blocked| !blocked.is_empty()) ||
             self.storage_updates.values().any(|updates| !updates.is_empty()) ||
             !self.pending_account_updates.is_empty()
+    }
+
+    /// Returns the leaf updates the accounts trie could not apply yet, if it is revealed.
+    fn account_blocked_updates(&self) -> Option<&BlockedLeafUpdates> {
+        self.trie.state_trie_ref().map(SparseTrie::blocked_updates)
     }
 
     /// Errors when pending trie updates remain but nothing can deliver them: no update
@@ -932,7 +1009,9 @@ where
             let mut account_targets = self
                 .account_updates
                 .keys()
-                .map(|target| (*target, self.fetched_account_targets.get(target).copied()))
+                .copied()
+                .chain(self.account_blocked_updates().into_iter().flat_map(|b| b.keys()))
+                .map(|target| (target, self.fetched_account_targets.get(&target).copied()))
                 .collect::<Vec<_>>();
             account_targets.sort_unstable();
             let account_targets_truncated =
@@ -944,11 +1023,16 @@ where
                 .iter()
                 .flat_map(|(address, updates)| {
                     let fetched_targets = self.fetched_storage_targets.get(address);
-                    updates.keys().map(move |target| {
+                    let blocked = self
+                        .trie
+                        .storage_trie_ref(address)
+                        .into_iter()
+                        .flat_map(|trie| trie.blocked_updates().keys());
+                    updates.keys().copied().chain(blocked).map(move |target| {
                         (
                             *address,
-                            *target,
-                            fetched_targets.and_then(|targets| targets.get(target)).copied(),
+                            target,
+                            fetched_targets.and_then(|targets| targets.get(&target)).copied(),
                         )
                     })
                 })
@@ -1308,6 +1392,83 @@ mod tests {
         }
         assert_eq!(task.pending_updates, INITIAL_UPDATE_BATCH_SIZE);
         assert_eq!(task.new_account_updates.len(), INITIAL_UPDATE_BATCH_SIZE);
+        drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
+    }
+
+    #[test]
+    fn storage_leaves_retry_only_after_a_proof_for_their_trie() {
+        let runtime = reth_tasks::Runtime::test();
+        let provider_factory = create_test_provider_factory();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            provider_factory,
+            OverlayManager::<reth_chain_state::EthPrimitives>::default()
+                .overlay_builder(anchor_hash),
+        );
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(state_provider_factory),
+            false,
+            proof_result_tx.clone(),
+        );
+
+        let default_trie = RevealableSparseTrie::blind_from(ArenaParallelSparseTrie::default());
+        let trie = SparseStateTrie::default()
+            .with_accounts_trie(default_trie.clone())
+            .with_default_storage_trie(default_trie)
+            .with_updates(true);
+
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (_cancel_guard, cancel_rx) = crossbeam_channel::bounded::<()>(0);
+        let mut task = SparseTrieCacheTask::new_with_trie(
+            &runtime,
+            updates_rx,
+            cancel_rx,
+            std::sync::mpsc::channel().0,
+            proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
+            SparseTrieTaskMetrics::default(),
+            trie,
+            B256::from([0x55; 32]),
+            TrieNodeEpoch::UNMODIFIED,
+            1,
+        );
+
+        let first = B256::repeat_byte(0x11);
+        let second = B256::repeat_byte(0x22);
+        let slot = B256::repeat_byte(0x33);
+        task.on_prewarm_targets(MultiProofTargetsV2 {
+            storage_targets: B256Map::from_iter([
+                (first, vec![ProofV2Target::new(slot)]),
+                (second, vec![ProofV2Target::new(slot)]),
+            ]),
+            ..Default::default()
+        });
+        task.pending_updates = 1;
+        task.process_new_updates().unwrap();
+
+        let misses = task.storage_cache_misses;
+        task.process_leaf_updates(false).unwrap();
+        assert_eq!(task.storage_cache_misses, misses, "tries without a proof must not be visited");
+
+        // Revealing one storage trie must drain its pending touch without visiting the other.
+        task.on_proof_result(DecodedMultiProofV2 {
+            storage_proofs: B256Map::from_iter([(
+                first,
+                vec![reth_trie_common::ProofTrieNodeV2::empty()],
+            )]),
+            ..Default::default()
+        })
+        .unwrap();
+        task.process_leaf_updates(false).unwrap();
+        assert!(task.storage_updates[&first].is_empty());
+        assert_eq!(task.storage_updates[&second].len(), 1);
+        assert_eq!(task.storage_cache_misses, misses);
+
         drop(updates_tx);
         drop(task);
         drain_sparse_trie_tasks(&runtime);

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -105,6 +105,14 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// not applied yet. Promotion instead writes the value it just encoded, which is always the
     /// newest one.
     existing_accounts: B256Map<Option<TrieAccount>>,
+    /// Accounts from [`Self::pending_account_updates`] that may have become promotable.
+    ///
+    /// Promotion pops from here instead of scanning every pending account on every round. An
+    /// address is queued when its pending entry appears, when its storage trie drains and when
+    /// its account leaf update is applied, which are the only transitions that can unblock it.
+    /// Queuing an account that is not ready yet is harmless: it is dropped again and re-queued
+    /// by the transition that finally unblocks it.
+    promotable_accounts: Vec<B256>,
     /// Cache of account proof targets that were already fetched/requested from the proof workers.
     /// Account to the broadest requested parent context (an unknown parent sorts before every
     /// known parent).
@@ -197,6 +205,7 @@ where
             new_storage_updates: Default::default(),
             pending_account_updates: Default::default(),
             existing_accounts: Default::default(),
+            promotable_accounts: Default::default(),
             fetched_account_targets: Default::default(),
             fetched_storage_targets: Default::default(),
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
@@ -452,8 +461,18 @@ where
             self.promote_pending_account_updates()?;
             self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
 
-            if self.finished_state_updates && !self.has_pending_sparse_trie_updates() {
-                return Ok(true);
+            if self.finished_state_updates && !self.has_pending_leaf_updates() {
+                if self.pending_account_updates.is_empty() {
+                    return Ok(true);
+                }
+
+                // No leaf update is left that could unblock an account, so everything still
+                // pending must be promotable. Requeuing all of them turns a transition the
+                // ready queue missed into a full scan instead of a stalled task.
+                self.promote_all_pending_accounts()?;
+                if !self.has_pending_sparse_trie_updates() {
+                    return Ok(true);
+                }
             }
 
             self.dispatch_pending_targets()?;
@@ -566,7 +585,10 @@ where
 
             // Make sure account is tracked in `pending_account_updates` so that once storage root
             // is computed, it will be updated in the accounts trie.
-            self.pending_account_updates.entry(address).or_insert(None);
+            if let Entry::Vacant(entry) = self.pending_account_updates.entry(address) {
+                entry.insert(None);
+                self.promotable_accounts.push(address);
+            }
         }
 
         for (&address, &account) in &hashed_state_update.accounts {
@@ -578,7 +600,13 @@ where
 
             // Track account in `pending_account_updates` so that once storage root is computed,
             // it will be updated in the accounts trie.
-            self.pending_account_updates.insert(address, Some(account));
+            //
+            // A known account can be promoted as soon as its storage trie is drained, so an entry
+            // that only awaited a storage root has to be queued again.
+            if !matches!(self.pending_account_updates.insert(address, Some(account)), Some(Some(_)))
+            {
+                self.promotable_accounts.push(address);
+            }
         }
 
         self.final_hashed_state.extend(hashed_state_update);
@@ -743,6 +771,10 @@ where
             self.blocked_storage_updates.insert(address);
         } else {
             self.blocked_storage_updates.remove(&address);
+            if updates.is_empty() {
+                // The storage root is final now, so the account waiting for it can be promoted.
+                self.promotable_accounts.push(address);
+            }
         }
         if has_retryable {
             // These updates wait on a node that is not on their own path, so no reveal will
@@ -794,12 +826,15 @@ where
                     }
                 }
                 LeafUpdateEvent::Touched { key, value } => {
-                    if self.pending_account_updates.contains_key(&key) &&
-                        let Entry::Vacant(entry) = self.existing_accounts.entry(key)
-                    {
-                        entry.insert(
-                            value.filter(|value| !value.is_empty()).map(decode_trie_account),
-                        );
+                    if self.pending_account_updates.contains_key(&key) {
+                        // The account's own leaf update is applied, so nothing keeps it from
+                        // being promoted any more.
+                        self.promotable_accounts.push(key);
+                        if let Entry::Vacant(entry) = self.existing_accounts.entry(key) {
+                            entry.insert(
+                                value.filter(|value| !value.is_empty()).map(decode_trie_account),
+                            );
+                        }
                     }
                 }
             },
@@ -890,70 +925,28 @@ where
         }
 
         self.compute_drained_storage_roots();
+        self.drain_promotable_accounts()?;
 
+        #[cfg(debug_assertions)]
+        self.debug_assert_no_promotable_accounts();
+
+        Ok(())
+    }
+
+    /// Requeues every account still awaiting promotion and promotes what it can.
+    fn promote_all_pending_accounts(&mut self) -> SparseTrieResult<()> {
+        self.promotable_accounts.extend(self.pending_account_updates.keys().copied());
+        self.drain_promotable_accounts()
+    }
+
+    /// Promotes queued accounts until neither the queue nor the accounts trie makes progress.
+    fn drain_promotable_accounts(&mut self) -> SparseTrieResult<()> {
         loop {
             let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
-            // Now handle pending account updates that can be upgraded to a proper update.
-            let account_rlp_buf = &mut self.account_rlp_buf;
-            let existing_accounts = &mut self.existing_accounts;
-            let account_value_fallbacks = &mut self.account_value_fallbacks;
             let mut num_promoted = 0;
-            self.pending_account_updates.retain(|addr, account| {
-                if let Some(updates) = self.storage_updates.get(addr) {
-                    if !updates.is_empty() || self.blocked_storage_updates.contains(addr) {
-                        // If account has pending storage updates, it is still pending.
-                        return true;
-                    } else if let Some(account) = account.take() {
-                        let storage_root = self.trie.storage_root(addr, self.new_epoch).expect("updates are drained, storage trie should be revealed by now");
-                        promote_account_leaf(&mut self.account_updates, existing_accounts, account_rlp_buf, *addr, account, storage_root);
-                        num_promoted += 1;
-                        return false;
-                    }
-                }
-
-                // Get the current account state either from the trie or from latest account
-                // update, which the accounts trie may be holding on to until it is revealed.
-                let pending_update = match self.account_updates.get(addr) {
-                    Some(update) => Some(update),
-                    None => self
-                        .trie
-                        .state_trie_ref()
-                        .and_then(|trie| trie.blocked_updates().get(addr)),
-                };
-                let trie_account = match pending_update {
-                    Some(LeafUpdate::Changed(encoded)) => Some(encoded)
-                        .filter(|encoded| !encoded.is_empty())
-                        .map(|encoded| decode_trie_account(encoded)),
-                    // Needs to be revealed first
-                    Some(LeafUpdate::Touched) => return true,
-                    // The trie reports the value of every touched leaf it applies, so an
-                    // account whose update was already drained is normally cached here.
-                    None => match existing_accounts.get(addr) {
-                        Some(reported) => *reported,
-                        None => {
-                            *account_value_fallbacks += 1;
-                            self.trie.get_account_value(addr).map(|value| decode_trie_account(value))
-                        }
-                    },
-                };
-
-                let (account, storage_root) = if let Some(account) = account.take() {
-                    // If account is Some(_) here it means it didn't have any storage updates
-                    // and we can fetch the storage root directly from the account trie.
-                    //
-                    // If it did have storage updates, we would've had processed it above when iterating over storage tries.
-                    let storage_root = trie_account.map(|account| account.storage_root).unwrap_or(EMPTY_ROOT_HASH);
-
-                    (account, storage_root)
-                } else {
-                    (trie_account.map(Into::into), self.trie.storage_root(addr, self.new_epoch).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
-                };
-
-                promote_account_leaf(&mut self.account_updates, existing_accounts, account_rlp_buf, *addr, account, storage_root);
-                num_promoted += 1;
-
-                false
-            });
+            while let Some(addr) = self.promotable_accounts.pop() {
+                num_promoted += usize::from(self.promote_account(addr));
+            }
             span.record("promoted", num_promoted);
             drop(span);
 
@@ -967,6 +960,115 @@ where
         }
 
         Ok(())
+    }
+
+    /// Turns the pending update for `addr` into an accounts trie leaf update, if its storage
+    /// root and its current account fields are both known by now.
+    ///
+    /// Returns whether the account was promoted. An account that is not ready stays pending and
+    /// is queued again by whichever transition unblocks it.
+    fn promote_account(&mut self, addr: B256) -> bool {
+        let Some(mut pending) = self.pending_account_updates.get(&addr).copied() else {
+            return false
+        };
+
+        if let Some(updates) = self.storage_updates.get(&addr) {
+            if !updates.is_empty() || self.blocked_storage_updates.contains(&addr) {
+                // If account has pending storage updates, it is still pending.
+                return false;
+            } else if let Some(account) = pending.take() {
+                let storage_root = self
+                    .trie
+                    .storage_root(&addr, self.new_epoch)
+                    .expect("updates are drained, storage trie should be revealed by now");
+                self.write_account_leaf(addr, account, storage_root);
+                return true;
+            }
+        }
+
+        // Get the current account state either from the trie or from latest account
+        // update, which the accounts trie may be holding on to until it is revealed.
+        let pending_update = match self.account_updates.get(&addr) {
+            Some(update) => Some(update),
+            None => self.trie.state_trie_ref().and_then(|trie| trie.blocked_updates().get(&addr)),
+        };
+        let trie_account = match pending_update {
+            Some(LeafUpdate::Changed(encoded)) => Some(encoded)
+                .filter(|encoded| !encoded.is_empty())
+                .map(|encoded| decode_trie_account(encoded)),
+            // Needs to be revealed first
+            Some(LeafUpdate::Touched) => return false,
+            // The trie reports the value of every touched leaf it applies, so an account whose
+            // update was already drained is normally cached here.
+            None => match self.existing_accounts.get(&addr) {
+                Some(reported) => *reported,
+                None => {
+                    self.account_value_fallbacks += 1;
+                    self.trie.get_account_value(&addr).map(|value| decode_trie_account(value))
+                }
+            },
+        };
+
+        let (account, storage_root) = if let Some(account) = pending.take() {
+            // If account is Some(_) here it means it didn't have any storage updates
+            // and we can fetch the storage root directly from the account trie.
+            //
+            // If it did have storage updates, we would've had processed it above when iterating
+            // over storage tries.
+            (account, trie_account.map_or(EMPTY_ROOT_HASH, |account| account.storage_root))
+        } else {
+            (
+                trie_account.map(Into::into),
+                self.trie.storage_root(&addr, self.new_epoch).expect(
+                    "account had storage updates that were applied to its trie, storage root must be revealed by now",
+                ),
+            )
+        };
+
+        self.write_account_leaf(addr, account, storage_root);
+        true
+    }
+
+    /// Queues the promoted account leaf value for the accounts trie, records it as the trie's
+    /// value for `addr` so a later promotion does not have to read it back, and clears the
+    /// account's pending entry.
+    fn write_account_leaf(&mut self, addr: B256, account: Option<Account>, storage_root: B256) {
+        let encoded = encode_account_leaf_value(account, storage_root, &mut self.account_rlp_buf);
+        self.existing_accounts.insert(
+            addr,
+            (!encoded.is_empty())
+                .then(|| account.unwrap_or_default().into_trie_account(storage_root)),
+        );
+        self.account_updates.insert(addr, LeafUpdate::Changed(encoded));
+        self.pending_account_updates.remove(&addr);
+    }
+
+    /// Asserts the ready queue did not miss a transition: every account left pending must still
+    /// be waiting for its storage trie to drain or for its own leaf update to be applied.
+    #[cfg(debug_assertions)]
+    fn debug_assert_no_promotable_accounts(&self) {
+        for (addr, pending) in &self.pending_account_updates {
+            if self.storage_updates.get(addr).is_some_and(|updates| !updates.is_empty()) ||
+                self.blocked_storage_updates.contains(addr)
+            {
+                continue
+            }
+
+            assert!(
+                !(self.storage_updates.contains_key(addr) && pending.is_some()),
+                "account {addr:?} could be promoted from its drained storage trie but was not queued",
+            );
+            assert!(
+                self.account_updates
+                    .get(addr)
+                    .or_else(|| self
+                        .trie
+                        .state_trie_ref()
+                        .and_then(|trie| trie.blocked_updates().get(addr)))
+                    .is_some_and(LeafUpdate::is_touched),
+                "account {addr:?} could be promoted but was not queued",
+            );
+        }
     }
 
     fn dispatch_pending_targets(&mut self) -> Result<(), StateRootTaskError> {
@@ -1017,11 +1119,18 @@ where
     }
 
     fn has_pending_sparse_trie_updates(&self) -> bool {
+        self.has_pending_leaf_updates() || !self.pending_account_updates.is_empty()
+    }
+
+    /// Returns whether any leaf update is still waiting to be applied to one of the tries.
+    ///
+    /// While this is false no trie can change any more, so every account still waiting for
+    /// promotion already has everything it needs.
+    fn has_pending_leaf_updates(&self) -> bool {
         !self.account_updates.is_empty() ||
             !self.blocked_storage_updates.is_empty() ||
             self.account_blocked_updates().is_some_and(|blocked| !blocked.is_empty()) ||
-            self.storage_updates.values().any(|updates| !updates.is_empty()) ||
-            !self.pending_account_updates.is_empty()
+            self.storage_updates.values().any(|updates| !updates.is_empty())
     }
 
     /// Returns the leaf updates the accounts trie could not apply yet, if it is revealed.
@@ -1178,24 +1287,6 @@ fn dispatch_with_chunking<T, I>(
     }
 
     dispatch(items);
-}
-
-/// Queues the promoted account leaf value for the accounts trie and records it as the trie's
-/// value for `addr`, so a later promotion of the same account does not have to read it back.
-fn promote_account_leaf(
-    account_updates: &mut B256Map<LeafUpdate>,
-    existing_accounts: &mut B256Map<Option<TrieAccount>>,
-    account_rlp_buf: &mut Vec<u8>,
-    addr: B256,
-    account: Option<Account>,
-    storage_root: B256,
-) {
-    let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
-    existing_accounts.insert(
-        addr,
-        (!encoded.is_empty()).then(|| account.unwrap_or_default().into_trie_account(storage_root)),
-    );
-    account_updates.insert(addr, LeafUpdate::Changed(encoded));
 }
 
 /// Decodes an account trie leaf value.

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -3,7 +3,7 @@
 use std::{
     any::Any,
     panic::{self, AssertUnwindSafe},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use super::{evm_state_to_hashed_post_state, StateRootComputeOutcome, StateRootMessage};
@@ -771,7 +771,7 @@ where
     /// recompute.
     ///
     /// Each pass owns its address' payload for its whole duration, so the passes are independent
-    /// of each other and of this thread. Most of them are handed to the rayon pool; the ones that
+    /// of each other and of this thread. Most of them are handed to the shard pool; the ones that
     /// would cost more in handoff than in work stay here, see [`StorageTrieWork::is_target_only`]
     /// and [`INLINE_STORAGE_WORK_UNITS`].
     #[instrument(
@@ -823,7 +823,7 @@ where
             jobs.push(StorageTrieJob { address, work });
         }
 
-        self.spawn_storage_jobs(jobs);
+        self.submit_storage_jobs(jobs);
 
         Ok(())
     }
@@ -908,53 +908,65 @@ where
         Ok(pending_after < pending_before)
     }
 
-    /// Hands checked out storage tries to the rayon pool in chunks.
+    /// Hands checked out storage tries to the shard that owns their address.
     ///
-    /// Chunking amortizes the spawn cost over a batch, while each trie is still sent back on its
-    /// own so promotion does not wait for the rest of the chunk.
-    fn spawn_storage_jobs(&self, mut jobs: Vec<StorageTrieJob<S>>) {
+    /// A round costs one queue push per shard that has work, instead of one spawn per chunk of
+    /// tries, and the shard hands its results back in batches instead of waking this thread once
+    /// per trie. Because the shard of an address never changes, the pass for a storage trie runs
+    /// on the thread that ran its previous pass.
+    fn submit_storage_jobs(&self, jobs: Vec<StorageTrieJob<S>>) {
         if jobs.is_empty() {
             return;
         }
 
-        let parent_span = debug_span!("spawn_storage_jobs", n = jobs.len());
-        let chunk_len = storage_job_chunk_len(jobs.len());
+        let pool = storage_shard_pool();
+        let parent_span = debug_span!("submit_storage_jobs", n = jobs.len());
+        let mut by_shard = (0..pool.len()).map(|_| Vec::new()).collect::<Vec<_>>();
+        for job in jobs {
+            by_shard[pool.shard_of(&job.address)].push(job);
+        }
+
         let new_epoch = self.new_epoch;
         let retain_updates = self.trie.retains_updates();
-        while !jobs.is_empty() {
-            let chunk = jobs.split_off(jobs.len().saturating_sub(chunk_len));
+        for (shard, group) in by_shard.into_iter().enumerate() {
+            if group.is_empty() {
+                continue;
+            }
+
             let storage_done_tx = self.storage_done_tx.clone();
             let parent_span = parent_span.clone();
-            rayon::spawn(move || {
+            pool.submit(shard, move || {
                 let _enter = debug_span!(
                     target: "engine::tree::payload_processor::sparse_trie",
                     parent: &parent_span,
                     "storage_jobs",
-                    n = chunk.len(),
+                    n = group.len(),
                 )
                 .entered();
-                for job in chunk {
-                    let address = job.address;
-                    let message = match panic::catch_unwind(AssertUnwindSafe(|| {
-                        job.run(new_epoch, retain_updates)
-                    })) {
-                        Ok(done) => StorageJobMessage::Done(done),
-                        Err(payload) => StorageJobMessage::Panicked { address, payload },
-                    };
-                    if storage_done_tx.send(message).is_err() {
-                        // Nobody is waiting for the result anymore, drop the rest here.
-                        return;
-                    }
-                }
+                run_storage_jobs(group, &storage_done_tx, new_epoch, retain_updates);
             });
         }
     }
 
-    /// Handles a message from a storage job: takes a finished payload back, or resumes a panic
-    /// that happened on the job thread here, where it fails this task like an inline panic would.
+    /// Handles a message from a shard: takes a batch of finished payloads back, or resumes a
+    /// panic that happened on the shard thread here, where it fails this task like an inline
+    /// panic would.
+    ///
+    /// A pass that failed does not stop the rest of the batch from being taken back, so the
+    /// error the task reports is the first one and no payload is left with the shard.
     fn on_storage_job_message(&mut self, message: StorageJobMessage<S>) -> SparseTrieResult<()> {
         match message {
-            StorageJobMessage::Done(done) => self.on_storage_trie_returned(done),
+            StorageJobMessage::Done(batch) => {
+                self.metrics.sparse_trie_storage_return_batch_size.record(batch.len() as f64);
+                let mut result = Ok(());
+                for done in batch {
+                    let returned = self.on_storage_trie_returned(done);
+                    if result.is_ok() {
+                        result = returned;
+                    }
+                }
+                result
+            }
             StorageJobMessage::Panicked { address, payload } => {
                 if self.storage.remove(&address).is_some() {
                     self.storage_in_flight -= 1;
@@ -1556,13 +1568,13 @@ impl<S: SparseTrie + Default> StorageTrieJob<S> {
     }
 }
 
-/// What a spawned storage job sends back to the sparse trie task.
+/// What a shard sends back to the sparse trie task.
 enum StorageJobMessage<S> {
-    /// The job finished and hands its payload back.
-    Done(StorageTrieJobDone<S>),
-    /// The job panicked and its trie is lost. The global rayon pool has no panic handler, so a
-    /// panic escaping a spawned job would abort the process; it is caught and resumed on the task
-    /// thread instead, where it fails the state root calculation like an inline panic.
+    /// The passes of these payloads finished and the shard hands them back.
+    Done(Vec<StorageTrieJobDone<S>>),
+    /// A pass panicked and its trie is lost. A panic escaping a shard thread would take the
+    /// thread down and wedge every later block that maps to it, so it is caught and resumed on
+    /// the task thread instead, where it fails the state root calculation like an inline panic.
     Panicked {
         /// Hashed address of the payload the job owned.
         address: B256,
@@ -1599,6 +1611,52 @@ impl Default for StorageWorkOutput {
     }
 }
 
+/// Runs the passes of one shard's group and hands the payloads back in growing batches.
+///
+/// The first payload goes back on its own, so the proof targets its pass discovered are
+/// dispatched without waiting for the rest of the group, and the batch then doubles up to
+/// [`MAX_STORAGE_RETURN_BATCH`]: a long queue costs the task a handful of wakeups instead of one
+/// per trie, and the tries behind a batch boundary are still promoted while the shard works on
+/// the ones after it. Starting at one also bounds what a group queued for a task that has since
+/// been cancelled costs: it notices on the first send and drops the rest.
+fn run_storage_jobs<S: SparseTrie + Default>(
+    group: Vec<StorageTrieJob<S>>,
+    storage_done_tx: &CrossbeamSender<StorageJobMessage<S>>,
+    new_epoch: TrieNodeEpoch,
+    retain_updates: bool,
+) {
+    let mut batch_len = 1;
+    let mut done = Vec::with_capacity(batch_len);
+    for job in group {
+        let address = job.address;
+        match panic::catch_unwind(AssertUnwindSafe(|| job.run(new_epoch, retain_updates))) {
+            Ok(finished) => done.push(finished),
+            Err(payload) => {
+                // The task fails on the panic, but the payloads whose passes did finish are
+                // still handed back so its bookkeeping stays consistent while it unwinds.
+                if !done.is_empty() {
+                    let _ = storage_done_tx.send(StorageJobMessage::Done(done));
+                }
+                let _ = storage_done_tx.send(StorageJobMessage::Panicked { address, payload });
+                return;
+            }
+        }
+
+        if done.len() >= batch_len {
+            batch_len = (batch_len * 2).min(MAX_STORAGE_RETURN_BATCH);
+            let batch = core::mem::replace(&mut done, Vec::with_capacity(batch_len));
+            if storage_done_tx.send(StorageJobMessage::Done(batch)).is_err() {
+                // Nobody is waiting for the result anymore, drop the rest here.
+                return;
+            }
+        }
+    }
+
+    if !done.is_empty() {
+        let _ = storage_done_tx.send(StorageJobMessage::Done(done));
+    }
+}
+
 /// Merges leaf updates into a queue, letting a newly known value win over a queued one.
 fn merge_leaf_updates(queued: &mut B256Map<LeafUpdate>, updates: B256Map<LeafUpdate>) {
     if queued.is_empty() {
@@ -1621,18 +1679,97 @@ fn merge_leaf_updates(queued: &mut B256Map<LeafUpdate>, updates: B256Map<LeafUpd
     }
 }
 
-/// Number of storage tries handed to a single spawned job.
+/// A small pool of long lived threads that run storage trie passes, one queue per shard.
 ///
-/// Chunking keeps a block with thousands of tiny tries from paying a rayon spawn per trie, while
-/// staying small enough that one slow trie only delays the few behind it in its own chunk. Tries
-/// are still handed back one at a time, so a chunk does not delay promotion of the ones it
-/// already finished.
-fn storage_job_chunk_len(tries: usize) -> usize {
-    /// Upper bound on how many tries a single slow one can hold up.
-    const MAX_CHUNK_LEN: usize = 32;
-
-    tries.div_ceil(rayon::current_num_threads().max(1) * 4).clamp(1, MAX_CHUNK_LEN)
+/// The sparse trie task used to hand every pass to the global rayon pool, which meant a spawn per
+/// chunk of tries, a wakeup per finished trie and CPU shared with everything else execution runs
+/// there. A shard instead owns a queue and a thread: a round is one push per shard, results come
+/// back in batches, and because a hashed address always maps to the same shard, the pass for a
+/// storage trie runs on the thread that ran its previous pass and finds its arena in that core's
+/// caches.
+///
+/// The pool is process wide. A sparse trie task exists for one block, its shards do not, so a
+/// block pays neither thread creation nor a cold cache for a trie the previous block touched.
+///
+/// A shard thread is not a rayon worker, so a trie big enough to cross the arena's parallelism
+/// thresholds still fans its subtries out to the global pool and blocks the shard until they are
+/// done. That is the intended split: the many small tries never touch rayon at all, and the few
+/// that are worth splitting keep the parallelism they had.
+struct StorageShardPool {
+    /// Work queue of each shard, indexed by shard.
+    shards: Vec<CrossbeamSender<ShardJob>>,
 }
+
+impl StorageShardPool {
+    /// Starts `shards` shard threads.
+    fn new(shards: usize) -> Self {
+        let shards = (0..shards)
+            .map(|shard| {
+                let (job_tx, job_rx) = crossbeam_channel::unbounded::<ShardJob>();
+                reth_tasks::spawn_os_thread(&format!("sparse-shard-{shard:02}"), move || {
+                    while let Ok(job) = job_rx.recv() {
+                        // A panicking pass is caught by the job itself and resumed on the sparse
+                        // trie task. This is only the net that keeps a panic anywhere else in a
+                        // job from taking the shard down and wedging every later block whose
+                        // addresses map to it.
+                        let _ = panic::catch_unwind(AssertUnwindSafe(job));
+                    }
+                });
+                job_tx
+            })
+            .collect();
+
+        Self { shards }
+    }
+
+    /// Returns the number of shards.
+    fn len(&self) -> usize {
+        self.shards.len()
+    }
+
+    /// Returns the shard that owns `address`.
+    fn shard_of(&self, address: &B256) -> usize {
+        usize::from(address[0]) % self.shards.len()
+    }
+
+    /// Queues a job on `shard`, to run after everything already queued there.
+    fn submit(&self, shard: usize, job: impl FnOnce() + Send + 'static) {
+        // The shard threads only exit when the pool is dropped, which never happens.
+        let _ = self.shards[shard].send(Box::new(job));
+    }
+}
+
+/// A unit of work handed to a shard thread.
+///
+/// Erased because the pool outlives every sparse trie task and cannot be generic over the trie
+/// type a task was built with.
+type ShardJob = Box<dyn FnOnce() + Send>;
+
+/// Returns the process wide storage shard pool, starting its threads on first use.
+fn storage_shard_pool() -> &'static StorageShardPool {
+    static POOL: OnceLock<StorageShardPool> = OnceLock::new();
+
+    POOL.get_or_init(|| StorageShardPool::new(storage_shard_count()))
+}
+
+/// Number of shard threads to run storage trie passes on.
+///
+/// A quarter of the machine, at least two. The passes compete with the proof workers, the engine
+/// thread and the sparse trie task itself, all of which are resident while a block is validated,
+/// and the tail of a block is a long sequence of small rounds in which the handoff costs more
+/// than the pass. Widening the pool would add runnable threads without shortening those rounds.
+fn storage_shard_count() -> usize {
+    /// Upper bound, so a large machine does not spend threads on shards that stay idle.
+    const MAX_SHARDS: usize = 8;
+
+    std::thread::available_parallelism()
+        .map_or(2, |threads| threads.get())
+        .div_ceil(4)
+        .clamp(2, MAX_SHARDS)
+}
+
+/// Largest number of finished payloads a shard hands back in one message.
+const MAX_STORAGE_RETURN_BATCH: usize = 32;
 
 /// Metrics recorded by sparse trie and hashing tasks.
 #[derive(Metrics, Clone)]
@@ -1648,6 +1785,9 @@ pub(super) struct SparseTrieTaskMetrics {
     pub(super) sparse_trie_process_updates_duration_histogram: Histogram,
     /// Histogram of durations storage tries spend checked out for a job on another thread.
     pub(super) sparse_trie_storage_job_duration_histogram: Histogram,
+    /// Histogram of how many storage tries a shard hands back in one message, which is how many
+    /// tries the task takes back per wakeup.
+    pub(super) sparse_trie_storage_return_batch_size: Histogram,
     /// Histogram of sparse trie final update durations.
     pub(super) sparse_trie_final_update_duration_histogram: Histogram,
     /// Histogram of sparse trie total durations.
@@ -1857,6 +1997,16 @@ mod tests {
             panic!("payload is out with a job")
         };
         work.trie.root(TrieNodeEpoch::new(1)).expect("storage trie must be revealed")
+    }
+
+    /// Builds a job for `address` whose pass applies one leaf update to a revealed empty trie.
+    fn storage_job(address: B256) -> StorageTrieJob<ArenaParallelSparseTrie> {
+        let mut work = Box::new(StorageTrieWork::new(RevealableSparseTrie::revealed_empty()));
+        work.queue_updates(B256Map::from_iter([(
+            B256::repeat_byte(0x77),
+            LeafUpdate::Changed(alloy_rlp::encode_fixed_size(&U256::from(1)).to_vec()),
+        )]));
+        StorageTrieJob { address, work }
     }
 
     #[test]
@@ -2774,5 +2924,91 @@ mod tests {
 
         drop(updates_tx);
         drain_sparse_trie_tasks(&runtime);
+    }
+
+    #[test]
+    fn addresses_of_one_shard_are_processed_in_order_on_its_thread() {
+        let pool = storage_shard_pool();
+        // Two addresses that share a leading byte always share a shard.
+        let first = B256::repeat_byte(0x5a);
+        let mut second = B256::repeat_byte(0x5a);
+        second[31] = 0x01;
+        let shard = pool.shard_of(&first);
+        assert_eq!(shard, pool.shard_of(&second));
+
+        let (run_tx, run_rx) = crossbeam_channel::unbounded();
+        for address in [first, second] {
+            let run_tx = run_tx.clone();
+            pool.submit(shard, move || {
+                let _ = run_tx.send((address, std::thread::current().id()));
+            });
+        }
+        drop(run_tx);
+
+        let (first_address, first_thread) = run_rx.recv().expect("first job must run");
+        let (second_address, second_thread) = run_rx.recv().expect("second job must run");
+        assert_eq!([first_address, second_address], [first, second]);
+        assert_eq!(first_thread, second_thread, "a shard is one thread");
+    }
+
+    #[test]
+    fn a_shard_hands_its_group_back_in_growing_batches() {
+        const JOBS: usize = MAX_STORAGE_RETURN_BATCH * 2;
+
+        let addresses = (0..JOBS).map(|index| B256::from(U256::from(index))).collect::<Vec<_>>();
+        let (done_tx, done_rx) = crossbeam_channel::unbounded();
+        run_storage_jobs(
+            addresses.iter().copied().map(storage_job).collect(),
+            &done_tx,
+            TrieNodeEpoch::new(1),
+            false,
+        );
+        drop(done_tx);
+
+        let mut batch_lens = Vec::new();
+        let mut returned = Vec::new();
+        for message in done_rx {
+            let StorageJobMessage::Done(batch) = message else { panic!("no pass panicked") };
+            batch_lens.push(batch.len());
+            returned.extend(batch.into_iter().map(|done| done.address));
+        }
+
+        assert_eq!(returned, addresses, "every payload comes back, in the order it was queued");
+        assert_eq!(batch_lens[..4], [1, 2, 4, 8], "the first payload does not wait for the rest");
+        assert!(
+            batch_lens.iter().all(|len| *len <= MAX_STORAGE_RETURN_BATCH),
+            "batches stay bounded: {batch_lens:?}"
+        );
+    }
+
+    #[test]
+    fn a_group_queued_for_a_cancelled_task_is_dropped() {
+        let (done_tx, done_rx) = crossbeam_channel::unbounded();
+        drop(done_rx);
+
+        // A cancelled task drops its receiver, so the shard has nowhere to hand payloads back
+        // to. It must return instead of running the whole group for nobody.
+        run_storage_jobs(
+            (0..8).map(|index| storage_job(B256::repeat_byte(index))).collect(),
+            &done_tx,
+            TrieNodeEpoch::new(1),
+            false,
+        );
+    }
+
+    #[test]
+    fn a_shard_thread_survives_a_panicking_job() {
+        let pool = storage_shard_pool();
+        let shard = pool.shard_of(&B256::repeat_byte(0xc3));
+
+        pool.submit(shard, || panic!("pass panicked"));
+
+        let (alive_tx, alive_rx) = crossbeam_channel::bounded(1);
+        pool.submit(shard, move || {
+            let _ = alive_tx.send(());
+        });
+        alive_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("the shard must keep serving its queue");
     }
 }

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -28,8 +28,8 @@ use reth_trie_parallel::{
 };
 use reth_trie_sparse::{
     errors::{SparseStateTrieErrorKind, SparseTrieErrorKind, SparseTrieResult},
-    ArenaParallelSparseTrie, BlockedLeafUpdates, DeferredDrops, LeafUpdate, RevealableSparseTrie,
-    SparseStateTrie, SparseTrie, TrieNodeEpoch,
+    ArenaParallelSparseTrie, BlockedLeafUpdates, DeferredDrops, LeafUpdate, LeafUpdateEvent,
+    RevealableSparseTrie, SparseStateTrie, SparseTrie, TrieNodeEpoch,
 };
 use tracing::{debug, debug_span, error, instrument, trace_span};
 
@@ -96,6 +96,15 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     ///   - Some(_): account was changed/destroyed and is awaiting storage root calculation/reveal
     ///     to complete.
     pending_account_updates: B256Map<Option<Option<Account>>>,
+    /// Account leaf values the accounts trie reported while applying a [`LeafUpdate::Touched`]
+    /// entry, so promotion does not have to walk the trie again for an account whose fields did
+    /// not change.
+    ///
+    /// Only accounts awaiting promotion are recorded, and a report never overwrites an existing
+    /// entry: it can lag behind an update that promotion already queued but that the trie has
+    /// not applied yet. Promotion instead writes the value it just encoded, which is always the
+    /// newest one.
+    existing_accounts: B256Map<Option<TrieAccount>>,
     /// Cache of account proof targets that were already fetched/requested from the proof workers.
     /// Account to the broadest requested parent context (an unknown parent sorts before every
     /// known parent).
@@ -115,6 +124,9 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     storage_cache_hits: u64,
     /// Accumulated storage leaf update cache misses.
     storage_cache_misses: u64,
+    /// Number of times promotion had to read an account value back from the accounts trie
+    /// because [`Self::existing_accounts`] held no report for it.
+    account_value_fallbacks: u64,
     /// Pending proof targets queued for dispatch to proof workers.
     pending_targets: PendingTargets,
     /// Proof batches dispatched to workers and not yet received.
@@ -184,6 +196,7 @@ where
             new_account_updates: Default::default(),
             new_storage_updates: Default::default(),
             pending_account_updates: Default::default(),
+            existing_accounts: Default::default(),
             fetched_account_targets: Default::default(),
             fetched_storage_targets: Default::default(),
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
@@ -192,6 +205,7 @@ where
             account_cache_misses: 0,
             storage_cache_hits: 0,
             storage_cache_misses: 0,
+            account_value_fallbacks: 0,
             pending_targets: Default::default(),
             in_flight_proof_batches: 0,
             pending_updates: Default::default(),
@@ -381,10 +395,14 @@ where
         self.metrics.sparse_trie_account_cache_misses.record(self.account_cache_misses as f64);
         self.metrics.sparse_trie_storage_cache_hits.record(self.storage_cache_hits as f64);
         self.metrics.sparse_trie_storage_cache_misses.record(self.storage_cache_misses as f64);
+        self.metrics
+            .sparse_trie_account_value_fallbacks
+            .record(self.account_value_fallbacks as f64);
         self.account_cache_hits = 0;
         self.account_cache_misses = 0;
         self.storage_cache_hits = 0;
         self.storage_cache_misses = 0;
+        self.account_value_fallbacks = 0;
 
         Ok(StateRootComputeOutcome {
             state_root,
@@ -753,22 +771,39 @@ where
 
         let pending_before = account_updates.len() + self.trie.trie_mut().blocked_updates().len();
 
-        self.trie.trie_mut().update_leaves(account_updates, |target, parent| {
-            match self.fetched_account_targets.entry(target) {
-                Entry::Occupied(mut entry) => {
-                    if parent < *entry.get() {
-                        entry.insert(parent);
-                        self.pending_targets
-                            .push_account_target(ProofV2Target::new(target).with_parent(parent));
+        self.trie.trie_mut().update_leaves_with_events(
+            account_updates,
+            true,
+            |event| match event {
+                LeafUpdateEvent::ProofRequired { key: target, parent } => {
+                    match self.fetched_account_targets.entry(target) {
+                        Entry::Occupied(mut entry) => {
+                            if parent < *entry.get() {
+                                entry.insert(parent);
+                                self.pending_targets.push_account_target(
+                                    ProofV2Target::new(target).with_parent(parent),
+                                );
+                            }
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(parent);
+                            self.pending_targets.push_account_target(
+                                ProofV2Target::new(target).with_parent(parent),
+                            );
+                        }
                     }
                 }
-                Entry::Vacant(entry) => {
-                    entry.insert(parent);
-                    self.pending_targets
-                        .push_account_target(ProofV2Target::new(target).with_parent(parent));
+                LeafUpdateEvent::Touched { key, value } => {
+                    if self.pending_account_updates.contains_key(&key) &&
+                        let Entry::Vacant(entry) = self.existing_accounts.entry(key)
+                    {
+                        entry.insert(
+                            value.filter(|value| !value.is_empty()).map(decode_trie_account),
+                        );
+                    }
                 }
-            }
-        })?;
+            },
+        )?;
 
         let pending_after = account_updates.len() + self.trie.trie_mut().blocked_updates().len();
         self.account_cache_hits += pending_before.saturating_sub(pending_after) as u64;
@@ -860,6 +895,8 @@ where
             let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
             // Now handle pending account updates that can be upgraded to a proper update.
             let account_rlp_buf = &mut self.account_rlp_buf;
+            let existing_accounts = &mut self.existing_accounts;
+            let account_value_fallbacks = &mut self.account_value_fallbacks;
             let mut num_promoted = 0;
             self.pending_account_updates.retain(|addr, account| {
                 if let Some(updates) = self.storage_updates.get(addr) {
@@ -868,8 +905,7 @@ where
                         return true;
                     } else if let Some(account) = account.take() {
                         let storage_root = self.trie.storage_root(addr, self.new_epoch).expect("updates are drained, storage trie should be revealed by now");
-                        let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
-                        self.account_updates.insert(*addr, LeafUpdate::Changed(encoded));
+                        promote_account_leaf(&mut self.account_updates, existing_accounts, account_rlp_buf, *addr, account, storage_root);
                         num_promoted += 1;
                         return false;
                     }
@@ -885,15 +921,21 @@ where
                         .and_then(|trie| trie.blocked_updates().get(addr)),
                 };
                 let trie_account = match pending_update {
-                    Some(LeafUpdate::Changed(encoded)) => {
-                        Some(encoded).filter(|encoded| !encoded.is_empty())
-                    }
+                    Some(LeafUpdate::Changed(encoded)) => Some(encoded)
+                        .filter(|encoded| !encoded.is_empty())
+                        .map(|encoded| decode_trie_account(encoded)),
                     // Needs to be revealed first
                     Some(LeafUpdate::Touched) => return true,
-                    None => self.trie.get_account_value(addr),
+                    // The trie reports the value of every touched leaf it applies, so an
+                    // account whose update was already drained is normally cached here.
+                    None => match existing_accounts.get(addr) {
+                        Some(reported) => *reported,
+                        None => {
+                            *account_value_fallbacks += 1;
+                            self.trie.get_account_value(addr).map(|value| decode_trie_account(value))
+                        }
+                    },
                 };
-
-                let trie_account = trie_account.map(|value| TrieAccount::decode(&mut &value[..]).expect("invalid account RLP"));
 
                 let (account, storage_root) = if let Some(account) = account.take() {
                     // If account is Some(_) here it means it didn't have any storage updates
@@ -907,8 +949,7 @@ where
                     (trie_account.map(Into::into), self.trie.storage_root(addr, self.new_epoch).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
                 };
 
-                let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
-                self.account_updates.insert(*addr, LeafUpdate::Changed(encoded));
+                promote_account_leaf(&mut self.account_updates, existing_accounts, account_rlp_buf, *addr, account, storage_root);
                 num_promoted += 1;
 
                 false
@@ -1094,6 +1135,9 @@ pub(super) struct SparseTrieTaskMetrics {
     pub(super) sparse_trie_storage_cache_hits: Histogram,
     /// Number of storage leaf updates that required a new proof (cache misses).
     pub(super) sparse_trie_storage_cache_misses: Histogram,
+    /// Number of account values promotion had to read back from the accounts trie because the
+    /// trie never reported them while applying a touched update.
+    pub(super) sparse_trie_account_value_fallbacks: Histogram,
 
     /// Number of storage tries retained in the preserved sparse trie cache.
     pub(super) sparse_trie_retained_storage_tries: Gauge,
@@ -1134,6 +1178,29 @@ fn dispatch_with_chunking<T, I>(
     }
 
     dispatch(items);
+}
+
+/// Queues the promoted account leaf value for the accounts trie and records it as the trie's
+/// value for `addr`, so a later promotion of the same account does not have to read it back.
+fn promote_account_leaf(
+    account_updates: &mut B256Map<LeafUpdate>,
+    existing_accounts: &mut B256Map<Option<TrieAccount>>,
+    account_rlp_buf: &mut Vec<u8>,
+    addr: B256,
+    account: Option<Account>,
+    storage_root: B256,
+) {
+    let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
+    existing_accounts.insert(
+        addr,
+        (!encoded.is_empty()).then(|| account.unwrap_or_default().into_trie_account(storage_root)),
+    );
+    account_updates.insert(addr, LeafUpdate::Changed(encoded));
+}
+
+/// Decodes an account trie leaf value.
+fn decode_trie_account(encoded: &[u8]) -> TrieAccount {
+    TrieAccount::decode(&mut &encoded[..]).expect("invalid account RLP")
 }
 
 /// RLP-encodes the account as a [`TrieAccount`] leaf value, or returns empty for deletions.
@@ -1468,6 +1535,96 @@ mod tests {
         assert!(task.storage_updates[&first].is_empty());
         assert_eq!(task.storage_updates[&second].len(), 1);
         assert_eq!(task.storage_cache_misses, misses);
+
+        drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
+    }
+
+    #[test]
+    fn storage_only_change_promotes_from_the_reported_account_value() {
+        let runtime = reth_tasks::Runtime::test();
+        let provider_factory = create_test_provider_factory();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            provider_factory,
+            OverlayManager::<reth_chain_state::EthPrimitives>::default()
+                .overlay_builder(anchor_hash),
+        );
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(state_provider_factory),
+            false,
+            proof_result_tx.clone(),
+        );
+
+        let address = B256::repeat_byte(0x11);
+        let account = Account {
+            nonce: 7,
+            balance: U256::from(42),
+            bytecode_hash: Some(B256::repeat_byte(9)),
+        };
+
+        // Seed the accounts trie with the account's parent-state leaf. Both tries start revealed
+        // and empty so the promotion path runs without any proof round trips.
+        let mut accounts_trie = RevealableSparseTrie::<ArenaParallelSparseTrie>::revealed_empty();
+        let mut seed = B256Map::from_iter([(
+            address,
+            LeafUpdate::Changed(encode_account_leaf_value(
+                Some(account),
+                EMPTY_ROOT_HASH,
+                &mut Vec::new(),
+            )),
+        )]);
+        accounts_trie
+            .update_leaves(&mut seed, |_, _| panic!("a revealed empty trie needs no proofs"))
+            .unwrap();
+
+        let trie = SparseStateTrie::default()
+            .with_accounts_trie(accounts_trie)
+            .with_default_storage_trie(
+                RevealableSparseTrie::<ArenaParallelSparseTrie>::revealed_empty(),
+            )
+            .with_updates(true);
+
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (_cancel_guard, cancel_rx) = crossbeam_channel::bounded::<()>(0);
+        let mut task = SparseTrieCacheTask::new_with_trie(
+            &runtime,
+            updates_rx,
+            cancel_rx,
+            std::sync::mpsc::channel().0,
+            proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
+            SparseTrieTaskMetrics::default(),
+            trie,
+            B256::from([0x55; 32]),
+            TrieNodeEpoch::UNMODIFIED,
+            1,
+        );
+
+        let mut hashed_state = HashedPostState::default();
+        let mut storage = reth_trie::HashedStorage::default();
+        storage.storage.insert(B256::repeat_byte(0x22), U256::from(5));
+        hashed_state.storages.insert(address, storage);
+        task.on_hashed_state_update(hashed_state);
+        task.pending_updates = 1;
+        task.process_new_updates().unwrap();
+        task.promote_pending_account_updates().unwrap();
+
+        assert!(task.pending_account_updates.is_empty(), "the account should have been promoted");
+        assert_eq!(
+            task.account_value_fallbacks, 0,
+            "the touched report must cover the promoted account"
+        );
+
+        let promoted = task.trie.get_account_value(&address).expect("account leaf was written");
+        let promoted = TrieAccount::decode(&mut &promoted[..]).unwrap();
+        assert_eq!(promoted.nonce, account.nonce, "unchanged fields must survive promotion");
+        assert_eq!(promoted.balance, account.balance);
+        assert_ne!(promoted.storage_root, EMPTY_ROOT_HASH, "the storage change must be applied");
 
         drop(updates_tx);
         drop(task);

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -26,7 +26,9 @@ use reth_trie_parallel::{
     },
 };
 use reth_trie_sparse::{
-    errors::{SparseStateTrieErrorKind, SparseTrieErrorKind, SparseTrieResult},
+    errors::{
+        SparseStateTrieErrorKind, SparseStateTrieResult, SparseTrieErrorKind, SparseTrieResult,
+    },
     ArenaParallelSparseTrie, DeferredDrops, LeafUpdate, RevealableSparseTrie, SparseStateTrie,
     SparseTrie, TrieNodeEpoch,
 };
@@ -120,6 +122,9 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     storage_done_tx: CrossbeamSender<StorageTrieJobDone<S>>,
     /// Receives storage tries coming back from jobs spawned by this task.
     storage_done_rx: CrossbeamReceiver<StorageTrieJobDone<S>>,
+    /// Whether blocked storage leaf updates are worth retrying, see
+    /// [`Self::process_leaf_updates`].
+    storage_retry_armed: bool,
     /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
     pending_updates: usize,
@@ -197,6 +202,7 @@ where
             in_flight_storage: Default::default(),
             storage_done_tx,
             storage_done_rx,
+            storage_retry_armed: true,
             pending_updates: Default::default(),
             initial_updates_applied: false,
             final_hashed_state: Default::default(),
@@ -607,31 +613,65 @@ where
         self.final_hashed_state.extend(hashed_state_update);
     }
 
-    fn on_proof_result(
-        &mut self,
-        mut result: DecodedMultiProofV2,
-    ) -> Result<(), StateRootTaskError> {
-        self.buffer_checked_out_storage_proofs(&mut result);
-        self.trie
-            .reveal_decoded_multiproof_v2(result)
+    fn on_proof_result(&mut self, result: DecodedMultiProofV2) -> Result<(), StateRootTaskError> {
+        self.reveal_proof_result(result)
             .map_err(|e| StateRootTaskError::Other(format!("could not reveal multiproof: {e:?}")))
+    }
+
+    /// Reveals a proof batch.
+    ///
+    /// The account trie is revealed here because it can never be checked out. Storage tries are
+    /// checked out and revealed by jobs on the rayon pool, unless the batch is small enough that
+    /// the handoff would cost more than the reveal itself.
+    fn reveal_proof_result(&mut self, result: DecodedMultiProofV2) -> SparseStateTrieResult<()> {
+        let DecodedMultiProofV2 { account_proofs, mut storage_proofs } = result;
+
+        self.buffer_checked_out_storage_proofs(&mut storage_proofs);
+
+        let storage_nodes = storage_proofs.values().map(Vec::len).sum::<usize>();
+        if storage_nodes <= INLINE_STORAGE_REVEAL_NODES {
+            self.storage_retry_armed |= storage_nodes > 0;
+            for (address, nodes) in storage_proofs {
+                self.trie.reveal_storage_proof_nodes(address, nodes)?;
+            }
+        } else {
+            self.trie.record_revealed_storage_nodes(storage_nodes);
+
+            let started = Instant::now();
+            let mut jobs = Vec::with_capacity(storage_proofs.len());
+            for (address, nodes) in storage_proofs {
+                let trie = self.trie.take_or_create_storage_trie(&address);
+                self.in_flight_storage.insert(address, InFlightStorage::new(started));
+                jobs.push(StorageTrieJob { address, trie, kind: StorageJobKind::Reveal(nodes) });
+            }
+            // Get the workers going before spending this thread on the account trie.
+            self.spawn_storage_jobs(jobs);
+        }
+
+        self.trie.reveal_account_proof_nodes(account_proofs)
     }
 
     /// Moves storage proofs addressed to a checked out trie into its in-flight buffer.
     ///
     /// Revealing them now would create a fresh blind trie for that address which the returning
     /// job would then overwrite, silently dropping the proof.
-    fn buffer_checked_out_storage_proofs(&mut self, result: &mut DecodedMultiProofV2) {
+    fn buffer_checked_out_storage_proofs(
+        &mut self,
+        storage_proofs: &mut B256Map<Vec<ProofTrieNodeV2>>,
+    ) {
         if self.in_flight_storage.is_empty() {
             return;
         }
 
         let in_flight_storage = &mut self.in_flight_storage;
-        result.storage_proofs.retain(|address, nodes| {
+        let mut buffered_nodes = 0;
+        storage_proofs.retain(|address, nodes| {
             let Some(in_flight) = in_flight_storage.get_mut(address) else { return true };
+            buffered_nodes += nodes.len();
             in_flight.buffered_proofs.append(nodes);
             false
         });
+        self.trie.record_revealed_storage_nodes(buffered_nodes);
     }
 
     fn on_proof_result_message(
@@ -706,46 +746,55 @@ where
         skip_all
     )]
     fn process_leaf_updates(&mut self, new: bool) -> SparseTrieResult<()> {
-        let storage_updates =
-            if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
+        // A blocked storage leaf only becomes applicable once nodes are revealed into its trie,
+        // so while storage jobs are running a retry pass has nothing to apply and would only
+        // rescan and resort every queued update. Returning tries arm the retry again, and it
+        // always runs once no trie is checked out.
+        let retry_blocked = self.storage_retry_armed || self.in_flight_storage.is_empty();
+        if !new {
+            self.storage_retry_armed = false;
+        }
 
-        // Process all storage updates, skipping tries with no pending updates and tries that are
-        // checked out: their updates stay queued until the trie comes back.
-        let in_flight_storage = &self.in_flight_storage;
-        let span = trace_span!("process_storage_leaf_updates").entered();
-        for (address, updates) in storage_updates {
-            if updates.is_empty() || in_flight_storage.contains_key(address) {
-                continue;
-            }
-            let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
+        if new || retry_blocked {
+            let storage_updates =
+                if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
 
-            let trie = self.trie.get_or_create_storage_trie_mut(*address);
-            let fetched = self.fetched_storage_targets.entry(*address).or_default();
-            let mut targets = Vec::new();
+            // Process all storage updates, skipping tries with no pending updates and tries that
+            // are checked out: their updates stay queued until the trie comes back.
+            let in_flight_storage = &self.in_flight_storage;
+            let span = trace_span!("process_storage_leaf_updates").entered();
+            for (address, updates) in storage_updates {
+                if updates.is_empty() || in_flight_storage.contains_key(address) {
+                    continue;
+                }
+                let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
 
-            let updates_len_before = updates.len();
-            trie.update_leaves(updates, |path, parent| match fetched.entry(path) {
-                Entry::Occupied(mut entry) => {
-                    if parent < *entry.get() {
+                let trie = self.trie.get_or_create_storage_trie_mut(*address);
+                let fetched = self.fetched_storage_targets.entry(*address).or_default();
+                let mut targets = Vec::new();
+
+                let updates_len_before = updates.len();
+                trie.update_leaves(updates, |path, parent| match fetched.entry(path) {
+                    Entry::Occupied(mut entry) => {
+                        if parent < *entry.get() {
+                            entry.insert(parent);
+                            targets.push(ProofV2Target::new(path).with_parent(parent));
+                        }
+                    }
+                    Entry::Vacant(entry) => {
                         entry.insert(parent);
                         targets.push(ProofV2Target::new(path).with_parent(parent));
                     }
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(parent);
-                    targets.push(ProofV2Target::new(path).with_parent(parent));
-                }
-            })?;
-            let updates_len_after = updates.len();
-            self.storage_cache_hits += (updates_len_before - updates_len_after) as u64;
-            self.storage_cache_misses += updates_len_after as u64;
+                })?;
+                let updates_len_after = updates.len();
+                self.storage_cache_hits += (updates_len_before - updates_len_after) as u64;
+                self.storage_cache_misses += updates_len_after as u64;
 
-            if !targets.is_empty() {
-                self.pending_targets.extend_storage_targets(address, targets);
+                if !targets.is_empty() {
+                    self.pending_targets.extend_storage_targets(address, targets);
+                }
             }
         }
-
-        drop(span);
 
         // Process account trie updates and fill the account targets.
         self.process_account_leaf_updates(new)?;
@@ -803,7 +852,7 @@ where
     /// consuming proof results and state updates while the batch runs.
     fn spawn_drained_storage_roots(&mut self) {
         let started = Instant::now();
-        let mut checked_out: Vec<(B256, RevealableSparseTrie<S>)> = Vec::new();
+        let mut jobs: Vec<StorageTrieJob<S>> = Vec::new();
         for (address, updates) in &self.storage_updates {
             if !updates.is_empty() {
                 continue;
@@ -817,31 +866,39 @@ where
 
             let trie = self.trie.take_storage_trie(address).expect("checked above");
             self.in_flight_storage.insert(*address, InFlightStorage::new(started));
-            checked_out.push((*address, trie));
+            jobs.push(StorageTrieJob { address: *address, trie, kind: StorageJobKind::Root });
         }
 
-        if checked_out.is_empty() {
+        self.spawn_storage_jobs(jobs);
+    }
+
+    /// Hands checked out storage tries to the rayon pool in chunks.
+    ///
+    /// Chunking amortizes the spawn cost over a batch, while each trie is still sent back on its
+    /// own so promotion does not wait for the rest of the chunk.
+    fn spawn_storage_jobs(&self, mut jobs: Vec<StorageTrieJob<S>>) {
+        if jobs.is_empty() {
             return;
         }
 
-        let parent_span = debug_span!("spawn_drained_storage_roots", n = checked_out.len());
-        let chunk_len = storage_job_chunk_len(checked_out.len());
+        let parent_span = debug_span!("spawn_storage_jobs", n = jobs.len());
+        let chunk_len = storage_job_chunk_len(jobs.len());
         let new_epoch = self.new_epoch;
-        while !checked_out.is_empty() {
-            let chunk = checked_out.split_off(checked_out.len().saturating_sub(chunk_len));
+        let retain_updates = self.trie.retains_updates();
+        while !jobs.is_empty() {
+            let chunk = jobs.split_off(jobs.len().saturating_sub(chunk_len));
             let storage_done_tx = self.storage_done_tx.clone();
             let parent_span = parent_span.clone();
             rayon::spawn(move || {
                 let _enter = debug_span!(
                     target: "engine::tree::payload_processor::sparse_trie",
                     parent: &parent_span,
-                    "storage_roots",
+                    "storage_jobs",
                     n = chunk.len(),
                 )
                 .entered();
-                for (address, mut trie) in chunk {
-                    trie.root(new_epoch);
-                    if storage_done_tx.send(StorageTrieJobDone { address, trie }).is_err() {
+                for job in chunk {
+                    if storage_done_tx.send(job.run(new_epoch, retain_updates)).is_err() {
                         // Nobody is waiting for the result anymore, drop the rest here.
                         return;
                     }
@@ -853,20 +910,34 @@ where
     /// Puts a storage trie back into the state trie once its job finished, revealing any proof
     /// nodes that arrived while it was gone.
     fn on_storage_trie_returned(&mut self, done: StorageTrieJobDone<S>) -> SparseTrieResult<()> {
-        let StorageTrieJobDone { address, mut trie } = done;
+        let StorageTrieJobDone { address, mut trie, revealed } = done;
         let in_flight = self
             .in_flight_storage
             .remove(&address)
             .expect("a returned storage trie was checked out");
         self.metrics.sparse_trie_storage_job_duration_histogram.record(in_flight.started.elapsed());
 
+        let mut revealed_nodes = false;
         let mut result = Ok(());
-        if !in_flight.buffered_proofs.is_empty() {
-            let mut proof_nodes = in_flight.buffered_proofs;
-            result = trie.reveal_v2_proof_nodes(&mut proof_nodes, self.trie.retains_updates());
+        if let Some((proof_nodes, revealed)) = revealed {
+            revealed_nodes = true;
+            result = revealed;
             self.trie.defer_drop_proof_nodes(proof_nodes);
         }
+        if !in_flight.buffered_proofs.is_empty() {
+            revealed_nodes = true;
+            let mut proof_nodes = in_flight.buffered_proofs;
+            let buffered =
+                trie.reveal_v2_proof_nodes(&mut proof_nodes, self.trie.retains_updates());
+            self.trie.defer_drop_proof_nodes(proof_nodes);
+            result = result.and(buffered);
+        }
         self.trie.insert_storage_trie(address, trie);
+
+        // Retry blocked leaves now that the trie is back, both for what was revealed into it and
+        // for the updates that were skipped while it was gone.
+        self.storage_retry_armed |= revealed_nodes ||
+            self.storage_updates.get(&address).is_some_and(|updates| !updates.is_empty());
 
         result
     }
@@ -1102,12 +1173,50 @@ impl InFlightStorage {
     }
 }
 
+/// A storage trie checked out of the sparse state trie, along with the work to run on it.
+struct StorageTrieJob<S> {
+    /// Hashed address the trie belongs to.
+    address: B256,
+    /// The checked out trie.
+    trie: RevealableSparseTrie<S>,
+    /// What to do with it.
+    kind: StorageJobKind,
+}
+
+impl<S: SparseTrie + Default> StorageTrieJob<S> {
+    fn run(self, new_epoch: TrieNodeEpoch, retain_updates: bool) -> StorageTrieJobDone<S> {
+        let Self { address, mut trie, kind } = self;
+        let revealed = match kind {
+            StorageJobKind::Root => {
+                trie.root(new_epoch);
+                None
+            }
+            StorageJobKind::Reveal(mut proof_nodes) => {
+                let revealed = trie.reveal_v2_proof_nodes(&mut proof_nodes, retain_updates);
+                Some((proof_nodes, revealed))
+            }
+        };
+
+        StorageTrieJobDone { address, trie, revealed }
+    }
+}
+
+/// Work that a spawned job performs on a checked out storage trie.
+enum StorageJobKind {
+    /// Recompute the trie root.
+    Root,
+    /// Reveal these proof nodes into the trie.
+    Reveal(Vec<ProofTrieNodeV2>),
+}
+
 /// A storage trie coming back to the sparse trie task after its job finished.
 struct StorageTrieJobDone<S> {
     /// Hashed address the trie belongs to.
     address: B256,
     /// The trie itself, to be put back into the sparse state trie.
     trie: RevealableSparseTrie<S>,
+    /// For a reveal job, the proof node buffer to drop later and the outcome of the reveal.
+    revealed: Option<(Vec<ProofTrieNodeV2>, SparseTrieResult<()>)>,
 }
 
 /// Number of storage tries handed to a single spawned job.
@@ -1173,6 +1282,10 @@ const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 
 /// Start proof fetching while the first state-update batch is still arriving.
 const INITIAL_UPDATE_BATCH_SIZE: usize = 64;
+
+/// Storage proof batches with at most this many nodes are revealed on the sparse trie task
+/// itself, because handing the tries to another thread costs more than the reveal.
+const INLINE_STORAGE_REVEAL_NODES: usize = 16;
 
 /// Dispatches work items as a single unit or in chunks based on target size and worker
 /// availability.
@@ -1475,7 +1588,12 @@ mod tests {
         assert!(!task.trie.storage_tries_mut().contains_key(&address));
         assert!(task.storage_updates[&address].contains_key(&late_slot));
 
-        task.on_storage_trie_returned(StorageTrieJobDone { address, trie: storage_trie }).unwrap();
+        task.on_storage_trie_returned(StorageTrieJobDone {
+            address,
+            trie: storage_trie,
+            revealed: None,
+        })
+        .unwrap();
 
         assert!(task.in_flight_storage.is_empty());
         assert_eq!(
@@ -1498,6 +1616,87 @@ mod tests {
             task.drain_returned_storage_tries().unwrap();
         }
         assert!(task.trie.storage_tries_mut()[&address].is_root_cached());
+
+        drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
+    }
+
+    #[test]
+    fn large_storage_proof_batches_are_revealed_off_thread() {
+        let runtime = reth_tasks::Runtime::test();
+        let provider_factory = create_test_provider_factory();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            provider_factory,
+            OverlayManager::<reth_chain_state::EthPrimitives>::default()
+                .overlay_builder(anchor_hash),
+        );
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(state_provider_factory),
+            false,
+            proof_result_tx.clone(),
+        );
+
+        let trie = SparseStateTrie::default()
+            .with_accounts_trie(RevealableSparseTrie::<ArenaParallelSparseTrie>::revealed_empty())
+            .with_default_storage_trie(RevealableSparseTrie::blind_from(
+                ArenaParallelSparseTrie::default(),
+            ))
+            .with_updates(true);
+
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (_cancel_guard, cancel_rx) = crossbeam_channel::bounded::<()>(0);
+        let mut task = SparseTrieCacheTask::new_with_trie(
+            &runtime,
+            updates_rx,
+            cancel_rx,
+            std::sync::mpsc::channel().0,
+            proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
+            SparseTrieTaskMetrics::default(),
+            trie,
+            EMPTY_ROOT_HASH,
+            TrieNodeEpoch::new(1),
+            1,
+        );
+
+        // One leaf per address, enough of them to exceed the inline reveal budget.
+        let leaves = (0..=INLINE_STORAGE_REVEAL_NODES as u8)
+            .map(|index| {
+                let address = B256::repeat_byte(0x10 + index);
+                let slot = B256::repeat_byte(0x80 + index);
+                let value = alloy_rlp::encode_fixed_size(&U256::from(index + 1)).to_vec();
+                (address, slot, value)
+            })
+            .collect::<Vec<_>>();
+        let storage_proofs = leaves
+            .iter()
+            .map(|(address, slot, value)| {
+                let leaf = ProofTrieNodeV2 {
+                    path: Nibbles::default(),
+                    node: TrieNodeV2::Leaf(LeafNode::new(Nibbles::unpack(slot), value.clone())),
+                    masks: None,
+                };
+                (*address, vec![leaf])
+            })
+            .collect();
+
+        task.on_proof_result(DecodedMultiProofV2 { account_proofs: Vec::new(), storage_proofs })
+            .unwrap();
+
+        assert_eq!(task.in_flight_storage.len(), leaves.len());
+        assert!(task.has_pending_sparse_trie_updates(), "completion must wait for the reveals");
+
+        while !task.in_flight_storage.is_empty() {
+            task.drain_returned_storage_tries().unwrap();
+        }
+        for (address, slot, value) in &leaves {
+            assert_eq!(task.trie.get_storage_slot_value(address, slot), Some(value));
+        }
 
         drop(updates_tx);
         drop(task);

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -71,8 +71,6 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
 
     /// Account trie updates.
     account_updates: B256Map<LeafUpdate>,
-    /// Storage trie updates. hashed address -> slot -> update.
-    storage_updates: B256Map<B256Map<LeafUpdate>>,
 
     /// Account updates that are buffered but were not yet applied to the trie.
     new_account_updates: B256Map<LeafUpdate>,
@@ -96,9 +94,6 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// Account to the broadest requested parent context (an unknown parent sorts before every
     /// known parent).
     fetched_account_targets: B256Map<ProofV2TargetParent>,
-    /// Cache of storage proof targets that have already been fetched/requested from the proof
-    /// workers. Account to slot to the broadest requested parent context.
-    fetched_storage_targets: B256Map<B256Map<ProofV2TargetParent>>,
     /// Reusable buffer for RLP encoding of accounts.
     account_rlp_buf: Vec<u8>,
     /// Whether the last state update has been received.
@@ -115,20 +110,20 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     pending_targets: PendingTargets,
     /// Proof batches dispatched to workers and not yet received.
     in_flight_proof_batches: usize,
-    /// Storage tries that are currently checked out of [`SparseStateTrie`] and owned by a job
-    /// running off this thread.
+    /// Everything the task knows about a storage trie touched by this block: the trie itself, its
+    /// queued leaf updates, the proof nodes waiting to be revealed into it and its proof target
+    /// cache. See [`StorageSlot`].
     ///
     /// Invariant: an address is either listed here or has its trie in the state trie's storage
-    /// trie map, never both. Everything that would otherwise create or read the trie for such an
-    /// address has to treat it as unavailable until the job hands it back.
-    in_flight_storage: B256Map<InFlightStorage>,
+    /// trie map, never both. Everything that reads a storage trie goes through its slot until
+    /// [`Self::return_storage_tries`] hands them all back.
+    storage: B256Map<StorageSlot<S>>,
+    /// Number of slots currently owned by a job running off this thread.
+    storage_in_flight: usize,
     /// Sender handed to storage jobs. Kept alive by the task so the receiver never disconnects.
     storage_done_tx: CrossbeamSender<StorageJobMessage<S>>,
     /// Receives storage tries coming back from jobs spawned by this task.
     storage_done_rx: CrossbeamReceiver<StorageJobMessage<S>>,
-    /// Whether blocked storage leaf updates are worth retrying, see
-    /// [`Self::process_leaf_updates`].
-    storage_retry_armed: bool,
     /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
     pending_updates: usize,
@@ -189,12 +184,10 @@ where
             chunk_size,
             max_targets_for_chunking: DEFAULT_MAX_TARGETS_FOR_CHUNKING,
             account_updates: Default::default(),
-            storage_updates: Default::default(),
             new_account_updates: Default::default(),
             new_storage_updates: Default::default(),
             pending_account_updates: Default::default(),
             fetched_account_targets: Default::default(),
-            fetched_storage_targets: Default::default(),
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             finished_state_updates: Default::default(),
             account_cache_hits: 0,
@@ -203,10 +196,10 @@ where
             storage_cache_misses: 0,
             pending_targets: Default::default(),
             in_flight_proof_batches: 0,
-            in_flight_storage: Default::default(),
+            storage: Default::default(),
+            storage_in_flight: 0,
             storage_done_tx,
             storage_done_rx,
-            storage_retry_armed: true,
             pending_updates: Default::default(),
             initial_updates_applied: false,
             final_hashed_state: Default::default(),
@@ -258,7 +251,7 @@ where
     /// Should be called after the state root result has been sent.
     pub(super) fn into_trie_for_reuse(self) -> (SparseStateTrie<A, S>, DeferredDrops) {
         debug_assert!(
-            self.in_flight_storage.is_empty(),
+            self.storage.is_empty(),
             "storage tries must be back before the trie is preserved"
         );
         let Self { mut trie, .. } = self;
@@ -271,9 +264,14 @@ where
     /// Use this when the payload was invalid or cancelled - we don't want to preserve
     /// potentially invalid trie state, but we keep the allocations for reuse.
     pub(super) fn into_cleared_trie(self) -> (SparseStateTrie<A, S>, DeferredDrops) {
-        let Self { mut trie, storage_done_rx, .. } = self;
+        let Self { mut trie, storage_done_rx, storage, .. } = self;
         // Disconnect first so tries still out with a job are dropped by that job instead of here.
         drop(storage_done_rx);
+        for (address, slot) in storage {
+            if let StorageSlot::Idle(work) = slot {
+                trie.insert_storage_trie(address, work.trie);
+            }
+        }
         trie.clear();
         let deferred = trie.take_deferred_drops();
         (trie, deferred)
@@ -391,8 +389,8 @@ where
             idle_start = Instant::now();
         }
 
-        debug_assert!(
-            self.in_flight_storage.is_empty(),
+        debug_assert_eq!(
+            self.storage_in_flight, 0,
             "completion must wait for every checked out storage trie"
         );
         self.metrics.sparse_trie_idle_time_seconds.record(total_idle_time.as_secs_f64());
@@ -400,6 +398,7 @@ where
         debug!(target: "engine::root", "All proofs processed, ending calculation");
 
         let start = Instant::now();
+        self.return_storage_tries();
         let (state_root, trie_updates) = match self.trie.root_with_updates(self.new_epoch) {
             Ok(result) => result,
             Err(err)
@@ -482,6 +481,7 @@ where
             self.dispatch_pending_targets()?;
             let t = Instant::now();
             self.process_new_updates()?;
+            self.run_ready_storage_work()?;
             self.promote_pending_account_updates()?;
             self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
 
@@ -501,6 +501,7 @@ where
             // If we don't have any pending updates, apply them to the trie,
             let t = Instant::now();
             self.process_new_updates()?;
+            self.run_ready_storage_work()?;
             self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
             self.dispatch_pending_targets()?;
         } else if !self.initial_updates_applied && self.pending_updates >= INITIAL_UPDATE_BATCH_SIZE
@@ -509,6 +510,7 @@ where
             // batches retain the usual coalescing policy to avoid repeatedly sorting small maps.
             let t = Instant::now();
             self.process_new_updates()?;
+            self.run_ready_storage_work()?;
             self.metrics.sparse_trie_process_updates_duration_histogram.record(t.elapsed());
             self.dispatch_pending_targets()?;
         } else if self.pending_targets.len() > self.chunk_size {
@@ -574,9 +576,8 @@ where
     fn on_hashed_state_update(&mut self, hashed_state_update: HashedPostState) {
         for (&address, storage) in &hashed_state_update.storages {
             if !storage.storage.is_empty() {
-                // Look up outer maps once per address instead of once per slot.
+                // Look up the outer map once per address instead of once per slot.
                 let new_updates = self.new_storage_updates.entry(address).or_default();
-                let mut existing_updates = self.storage_updates.get_mut(&address);
 
                 for (&slot, &value) in &storage.storage {
                     let encoded = if value.is_zero() {
@@ -585,11 +586,6 @@ where
                         alloy_rlp::encode_fixed_size(&value).to_vec()
                     };
                     new_updates.insert(slot, LeafUpdate::Changed(encoded));
-
-                    // Remove an existing storage update if it exists.
-                    if let Some(ref mut existing) = existing_updates {
-                        existing.remove(&slot);
-                    }
                 }
             }
 
@@ -624,58 +620,44 @@ where
 
     /// Reveals a proof batch.
     ///
-    /// The account trie is revealed here because it can never be checked out. Storage tries are
-    /// checked out and revealed by jobs on the rayon pool, unless the batch is small enough that
-    /// the handoff would cost more than the reveal itself.
+    /// The account trie is revealed here because it can never be checked out. Storage proof nodes
+    /// are queued on their address' slot and revealed by the job that runs for it next.
     fn reveal_proof_result(&mut self, result: DecodedMultiProofV2) -> SparseStateTrieResult<()> {
-        let DecodedMultiProofV2 { account_proofs, mut storage_proofs } = result;
+        let DecodedMultiProofV2 { account_proofs, storage_proofs } = result;
 
-        self.buffer_checked_out_storage_proofs(&mut storage_proofs);
-
-        let storage_nodes = storage_proofs.values().map(Vec::len).sum::<usize>();
-        if storage_nodes <= INLINE_STORAGE_REVEAL_NODES {
-            self.storage_retry_armed |= storage_nodes > 0;
-            for (address, nodes) in storage_proofs {
-                self.trie.reveal_storage_proof_nodes(address, nodes)?;
-            }
-        } else {
-            self.trie.record_revealed_storage_nodes(storage_nodes);
-
-            let started = Instant::now();
-            let mut jobs = Vec::with_capacity(storage_proofs.len());
-            for (address, nodes) in storage_proofs {
-                let trie = self.trie.take_or_create_storage_trie(&address);
-                self.in_flight_storage.insert(address, InFlightStorage::new(started));
-                jobs.push(StorageTrieJob { address, trie, kind: StorageJobKind::Reveal(nodes) });
-            }
-            // Get the workers going before spending this thread on the account trie.
-            self.spawn_storage_jobs(jobs);
-        }
+        self.queue_storage_proofs(storage_proofs);
+        // Get the workers going before spending this thread on the account trie.
+        self.run_ready_storage_work()?;
 
         self.trie.reveal_account_proof_nodes(account_proofs)
     }
 
-    /// Moves storage proofs addressed to a checked out trie into its in-flight buffer.
-    ///
-    /// Revealing them now would create a fresh blind trie for that address which the returning
-    /// job would then overwrite, silently dropping the proof.
-    fn buffer_checked_out_storage_proofs(
-        &mut self,
-        storage_proofs: &mut B256Map<Vec<ProofTrieNodeV2>>,
-    ) {
-        if self.in_flight_storage.is_empty() {
-            return;
-        }
+    /// Queues storage proof nodes on the slot of the address they belong to.
+    fn queue_storage_proofs(&mut self, storage_proofs: B256Map<Vec<ProofTrieNodeV2>>) {
+        let mut revealed_nodes = 0;
+        for (address, mut nodes) in storage_proofs {
+            if nodes.is_empty() {
+                continue;
+            }
+            revealed_nodes += nodes.len();
 
-        let in_flight_storage = &mut self.in_flight_storage;
-        let mut buffered_nodes = 0;
-        storage_proofs.retain(|address, nodes| {
-            let Some(in_flight) = in_flight_storage.get_mut(address) else { return true };
-            buffered_nodes += nodes.len();
-            in_flight.buffered_proofs.append(nodes);
-            false
-        });
-        self.trie.record_revealed_storage_nodes(buffered_nodes);
+            match self.storage_slot_mut(address) {
+                StorageSlot::Idle(work) => work.queue_proofs(&mut nodes),
+                StorageSlot::InFlight(in_flight) => in_flight.proofs.append(&mut nodes),
+            }
+        }
+        self.trie.record_revealed_storage_nodes(revealed_nodes);
+    }
+
+    /// Returns the slot for `address`, checking its storage trie out of the state trie the first
+    /// time the address is touched by this block.
+    fn storage_slot_mut(&mut self, address: B256) -> &mut StorageSlot<S> {
+        let Self { storage, trie, .. } = self;
+        storage.entry(address).or_insert_with(|| {
+            StorageSlot::Idle(Box::new(StorageTrieWork::new(
+                trie.take_or_create_storage_trie(&address),
+            )))
+        })
     }
 
     fn on_proof_result_message(
@@ -700,31 +682,26 @@ where
         self.pending_updates = 0;
         self.initial_updates_applied = true;
 
-        // Firstly apply all new storage and account updates to the tries.
-        self.process_leaf_updates(true)?;
+        // Queue the new storage updates on their slots; the jobs apply them to the tries.
+        let Self { storage, trie, new_storage_updates, .. } = self;
+        for (address, new) in new_storage_updates.drain() {
+            if new.is_empty() {
+                continue;
+            }
 
-        for (address, mut new) in self.new_storage_updates.drain() {
-            match self.storage_updates.entry(address) {
-                Entry::Vacant(entry) => {
-                    entry.insert(new); // insert the whole map at once, no per-slot loop
-                }
-                Entry::Occupied(mut entry) => {
-                    let updates = entry.get_mut();
-                    for (slot, new) in new.drain() {
-                        match updates.entry(slot) {
-                            Entry::Occupied(mut slot_entry) => {
-                                if new.is_changed() {
-                                    slot_entry.insert(new);
-                                }
-                            }
-                            Entry::Vacant(slot_entry) => {
-                                slot_entry.insert(new);
-                            }
-                        }
-                    }
-                }
+            let slot = storage.entry(address).or_insert_with(|| {
+                StorageSlot::Idle(Box::new(StorageTrieWork::new(
+                    trie.take_or_create_storage_trie(&address),
+                )))
+            });
+            match slot {
+                StorageSlot::Idle(work) => work.queue_updates(new),
+                StorageSlot::InFlight(in_flight) => merge_leaf_updates(&mut in_flight.updates, new),
             }
         }
+
+        // Apply the new account updates to the accounts trie, which is never checked out.
+        self.process_account_leaf_updates(true)?;
 
         for (address, new) in self.new_account_updates.drain() {
             match self.account_updates.entry(address) {
@@ -742,68 +719,84 @@ where
         Ok(())
     }
 
-    /// Applies all account and storage leaf updates to corresponding tries and collects any new
-    /// multiproof targets.
+    /// Runs a pass over every idle storage slot that has something to do: proof nodes to reveal,
+    /// leaf updates that were not tried against the current state of the trie yet, or a root to
+    /// recompute.
+    ///
+    /// Each pass owns its address' payload for its whole duration, so the passes are independent
+    /// of each other and of this thread. Most of them are handed to the rayon pool; the ones that
+    /// would cost more in handoff than in work stay here, see [`StorageTrieWork::is_target_only`]
+    /// and [`INLINE_STORAGE_WORK_UNITS`].
     #[instrument(
         level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
-    fn process_leaf_updates(&mut self, new: bool) -> SparseTrieResult<()> {
-        // A blocked storage leaf only becomes applicable once nodes are revealed into its trie,
-        // so while storage jobs are running a retry pass has nothing to apply and would only
-        // rescan and resort every queued update. Returning tries arm the retry again, and it
-        // always runs once no trie is checked out.
-        let retry_blocked = self.storage_retry_armed || self.in_flight_storage.is_empty();
-        if !new {
-            self.storage_retry_armed = false;
-        }
-
-        if new || retry_blocked {
-            let storage_updates =
-                if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
-
-            // Process all storage updates, skipping tries with no pending updates and tries that
-            // are checked out: their updates stay queued until the trie comes back.
-            let in_flight_storage = &self.in_flight_storage;
-            let span = trace_span!("process_storage_leaf_updates").entered();
-            for (address, updates) in storage_updates {
-                if updates.is_empty() || in_flight_storage.contains_key(address) {
-                    continue;
-                }
-                let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
-
-                let trie = self.trie.get_or_create_storage_trie_mut(*address);
-                let fetched = self.fetched_storage_targets.entry(*address).or_default();
-                let mut targets = Vec::new();
-
-                let updates_len_before = updates.len();
-                trie.update_leaves(updates, |path, parent| match fetched.entry(path) {
-                    Entry::Occupied(mut entry) => {
-                        if parent < *entry.get() {
-                            entry.insert(parent);
-                            targets.push(ProofV2Target::new(path).with_parent(parent));
-                        }
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(parent);
-                        targets.push(ProofV2Target::new(path).with_parent(parent));
-                    }
-                })?;
-                let updates_len_after = updates.len();
-                self.storage_cache_hits += (updates_len_before - updates_len_after) as u64;
-                self.storage_cache_misses += updates_len_after as u64;
-
-                if !targets.is_empty() {
-                    self.pending_targets.extend_storage_targets(address, targets);
-                }
+    fn run_ready_storage_work(&mut self) -> SparseTrieResult<()> {
+        let mut ready = Vec::new();
+        let mut job_units = 0;
+        for (address, slot) in &self.storage {
+            let StorageSlot::Idle(work) = slot else { continue };
+            if !work.has_work() {
+                continue;
             }
+            if !work.is_target_only() {
+                job_units += work.work_units();
+            }
+            ready.push(*address);
+        }
+        if ready.is_empty() {
+            return Ok(())
         }
 
-        // Process account trie updates and fill the account targets.
-        self.process_account_leaf_updates(new)?;
+        let inline_round = job_units <= INLINE_STORAGE_WORK_UNITS;
+        let new_epoch = self.new_epoch;
+        let retain_updates = self.trie.retains_updates();
+        let started = Instant::now();
+        let mut jobs = Vec::new();
+        for address in ready {
+            let slot = self.storage.get_mut(&address).expect("slot was just seen");
+            let StorageSlot::Idle(work) = slot else {
+                unreachable!("an idle slot is only checked out from here")
+            };
+
+            if inline_round || work.is_target_only() {
+                let output = work.run(new_epoch, retain_updates);
+                self.apply_storage_output(address, output)?;
+                continue;
+            }
+
+            let StorageSlot::Idle(work) = core::mem::replace(
+                slot,
+                StorageSlot::InFlight(Box::new(InFlightStorage::new(started))),
+            ) else {
+                unreachable!("just matched")
+            };
+            self.storage_in_flight += 1;
+            jobs.push(StorageTrieJob { address, work });
+        }
+
+        self.spawn_storage_jobs(jobs);
 
         Ok(())
+    }
+
+    /// Records what a storage pass produced: the proof targets it discovered and its cache
+    /// counters. Returns the error the pass stopped at, if any.
+    fn apply_storage_output(
+        &mut self,
+        address: B256,
+        output: StorageWorkOutput,
+    ) -> SparseTrieResult<()> {
+        let StorageWorkOutput { targets, cache_hits, cache_misses, result } = output;
+
+        self.storage_cache_hits += cache_hits;
+        self.storage_cache_misses += cache_misses;
+        if !targets.is_empty() {
+            self.pending_targets.extend_storage_targets(&address, targets);
+        }
+
+        result
     }
 
     /// Invokes `update_leaves` for the accounts trie and collects any new targets.
@@ -842,38 +835,6 @@ where
         self.account_cache_misses += updates_len_after as u64;
 
         Ok(updates_len_after < updates_len_before)
-    }
-
-    /// Computes storage roots for accounts whose storage updates are fully drained.
-    ///
-    /// For each storage trie T that:
-    /// 1. was modified in the current block,
-    /// 2. all the storage updates are fully drained,
-    /// 3. but the storage root hasn't been updated yet,
-    ///
-    /// we check the trie out of the state trie and hash it on the rayon pool. The trie comes back
-    /// through [`Self::storage_done_rx`] with its root cached, so this thread stays free to keep
-    /// consuming proof results and state updates while the batch runs.
-    fn spawn_drained_storage_roots(&mut self) {
-        let started = Instant::now();
-        let mut jobs: Vec<StorageTrieJob<S>> = Vec::new();
-        for (address, updates) in &self.storage_updates {
-            if !updates.is_empty() {
-                continue;
-            }
-            // A trie missing from the map is already checked out for another job. A blind one has
-            // no root to compute and is left in place so promotion reports it as it did before.
-            let Some(trie) = self.trie.storage_tries_mut().get(address) else { continue };
-            if trie.is_root_cached() || !trie.is_revealed() {
-                continue;
-            }
-
-            let trie = self.trie.take_storage_trie(address).expect("checked above");
-            self.in_flight_storage.insert(*address, InFlightStorage::new(started));
-            jobs.push(StorageTrieJob { address: *address, trie, kind: StorageJobKind::Root });
-        }
-
-        self.spawn_storage_jobs(jobs);
     }
 
     /// Hands checked out storage tries to the rayon pool in chunks.
@@ -918,54 +879,41 @@ where
         }
     }
 
-    /// Handles a message from a storage job: puts a finished trie back, or resumes a panic that
-    /// happened on the job thread here, where it fails this task like an inline panic would.
+    /// Handles a message from a storage job: takes a finished payload back, or resumes a panic
+    /// that happened on the job thread here, where it fails this task like an inline panic would.
     fn on_storage_job_message(&mut self, message: StorageJobMessage<S>) -> SparseTrieResult<()> {
         match message {
             StorageJobMessage::Done(done) => self.on_storage_trie_returned(done),
             StorageJobMessage::Panicked { address, payload } => {
-                self.in_flight_storage.remove(&address);
+                if self.storage.remove(&address).is_some() {
+                    self.storage_in_flight -= 1;
+                }
                 panic::resume_unwind(payload)
             }
         }
     }
 
-    /// Puts a storage trie back into the state trie once its job finished, revealing any proof
-    /// nodes that arrived while it was gone.
+    /// Puts a payload back into its slot once its job finished, folding in everything that
+    /// arrived for the address while it was gone.
     fn on_storage_trie_returned(&mut self, done: StorageTrieJobDone<S>) -> SparseTrieResult<()> {
-        let StorageTrieJobDone { address, mut trie, revealed } = done;
-        let in_flight = self
-            .in_flight_storage
-            .remove(&address)
-            .expect("a returned storage trie was checked out");
-        self.metrics.sparse_trie_storage_job_duration_histogram.record(in_flight.started.elapsed());
+        let StorageTrieJobDone { address, work, output } = done;
 
-        let mut revealed_nodes = false;
-        let mut result = Ok(());
-        if let Some((proof_nodes, revealed)) = revealed {
-            revealed_nodes = true;
-            result = revealed;
-            self.trie.defer_drop_proof_nodes(proof_nodes);
-        }
-        if !in_flight.buffered_proofs.is_empty() {
-            revealed_nodes = true;
-            let mut proof_nodes = in_flight.buffered_proofs;
-            let buffered =
-                trie.reveal_v2_proof_nodes(&mut proof_nodes, self.trie.retains_updates());
-            self.trie.defer_drop_proof_nodes(proof_nodes);
-            result = result.and(buffered);
-        }
-        self.trie.insert_storage_trie(address, trie);
+        let Entry::Occupied(mut entry) = self.storage.entry(address) else {
+            unreachable!("a returned payload was checked out of its slot")
+        };
+        let StorageSlot::InFlight(in_flight) = entry.insert(StorageSlot::Idle(work)) else {
+            unreachable!("a checked out address stays in flight until its job returns")
+        };
+        let started = in_flight.started;
+        let StorageSlot::Idle(work) = entry.into_mut() else { unreachable!("just inserted") };
+        work.take_buffered(*in_flight);
+        self.storage_in_flight -= 1;
+        self.metrics.sparse_trie_storage_job_duration_histogram.record(started.elapsed());
 
-        // Retry blocked leaves now that the trie is back, both for what was revealed into it and
-        // for the updates that were skipped while it was gone.
-        self.storage_retry_armed |= revealed_nodes ||
-            self.storage_updates.get(&address).is_some_and(|updates| !updates.is_empty());
-
-        result
+        self.apply_storage_output(address, output)
     }
 
-    /// Reinstates every storage trie whose job has already finished, without blocking.
+    /// Takes back every payload whose job has already finished, without blocking.
     fn drain_returned_storage_tries(&mut self) -> SparseTrieResult<()> {
         while let Ok(message) = self.storage_done_rx.try_recv() {
             self.on_storage_job_message(message)?;
@@ -974,44 +922,58 @@ where
         Ok(())
     }
 
-    /// Hands off every storage trie whose updates were processed for hashing, and promotes the
-    /// pending account updates whose storage root is already available into proper leaf updates
-    /// for the accounts trie.
+    /// Puts every storage trie back into the sparse state trie.
+    ///
+    /// The final root and everything after it - trie updates, preservation, pruning - reads the
+    /// storage tries through [`SparseStateTrie`], so no address may be left in a slot.
+    fn return_storage_tries(&mut self) {
+        let Self { storage, trie, .. } = self;
+        for (address, slot) in storage.drain() {
+            // A payload still out with a job is only reachable on the cancellation path, where
+            // the job drops it.
+            if let StorageSlot::Idle(work) = slot {
+                trie.insert_storage_trie(address, work.trie);
+            }
+        }
+    }
+
+    /// Promotes the pending account updates whose storage root is already available into proper
+    /// leaf updates for the accounts trie.
     ///
     /// Accounts whose trie is still checked out stay pending and are promoted by a later call,
-    /// once the trie has come back.
+    /// once the payload has come back.
     #[instrument(
         level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
         skip_all
     )]
     fn promote_pending_account_updates(&mut self) -> SparseTrieResult<()> {
-        self.process_leaf_updates(false)?;
+        self.process_account_leaf_updates(false)?;
 
         if self.pending_account_updates.is_empty() {
             return Ok(());
         }
 
-        self.spawn_drained_storage_roots();
-
+        let new_epoch = self.new_epoch;
         loop {
             let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
             // Now handle pending account updates that can be upgraded to a proper update.
             let account_rlp_buf = &mut self.account_rlp_buf;
-            let in_flight_storage = &self.in_flight_storage;
             let mut num_promoted = 0;
             self.pending_account_updates.retain(|addr, account| {
-                if in_flight_storage.contains_key(addr) {
-                    // The storage trie is checked out, so its root is not readable yet.
-                    return true;
-                }
+                let updated_storage = match self.storage.get_mut(addr) {
+                    // The payload is out with a job, so the root is not readable yet.
+                    Some(StorageSlot::InFlight(_)) => return true,
+                    Some(StorageSlot::Idle(work)) if work.updated => Some(work),
+                    _ => None,
+                };
 
-                if let Some(updates) = self.storage_updates.get(addr) {
-                    if !updates.is_empty() {
+                if let Some(work) = updated_storage {
+                    if !work.pending.is_empty() {
                         // If account has pending storage updates, it is still pending.
                         return true;
                     } else if let Some(account) = account.take() {
-                        let storage_root = self.trie.storage_root(addr, self.new_epoch).expect("updates are drained, storage trie should be revealed by now");
+                        let storage_root = work.trie.root(new_epoch).expect("updates are drained, storage trie should be revealed by now");
                         let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
                         self.account_updates.insert(*addr, LeafUpdate::Changed(encoded));
                         num_promoted += 1;
@@ -1040,7 +1002,14 @@ where
 
                     (account, storage_root)
                 } else {
-                    (trie_account.map(Into::into), self.trie.storage_root(addr, self.new_epoch).expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
+                    // An address with no slot was not touched by this block, so its trie, if any,
+                    // is still in the state trie with the root it was preserved with.
+                    let storage_root = match self.storage.get_mut(addr) {
+                        Some(StorageSlot::Idle(work)) => work.trie.root(new_epoch),
+                        Some(StorageSlot::InFlight(_)) => unreachable!("returned above"),
+                        None => self.trie.storage_root(addr, new_epoch),
+                    };
+                    (trie_account.map(Into::into), storage_root.expect("account had storage updates that were applied to its trie, storage root must be revealed by now"))
                 };
 
                 let encoded = encode_account_leaf_value(account, storage_root, account_rlp_buf);
@@ -1112,15 +1081,23 @@ where
     }
 
     fn has_pending_sparse_trie_updates(&self) -> bool {
-        !self.in_flight_storage.is_empty() ||
-            !self.account_updates.is_empty() ||
-            self.storage_updates.values().any(|updates| !updates.is_empty()) ||
-            !self.pending_account_updates.is_empty()
+        !self.account_updates.is_empty() ||
+            !self.pending_account_updates.is_empty() ||
+            self.storage.values().any(|slot| slot.is_pending())
+    }
+
+    /// Returns whether any idle slot has a pass to run, which is progress that has not been made
+    /// yet rather than a stall.
+    fn has_ready_storage_work(&self) -> bool {
+        self.storage.values().any(|slot| match slot {
+            StorageSlot::Idle(work) => work.has_work(),
+            StorageSlot::InFlight(_) => false,
+        })
     }
 
     /// Errors when pending trie updates remain but nothing can deliver them: no update
     /// messages are queued, no proof targets are queued or in flight, no proof results
-    /// are waiting, and no storage trie is checked out.
+    /// are waiting, and no storage pass is running or waiting to run.
     ///
     /// `updates_queued` is passed in instead of reading `self.updates` directly, because in
     /// the draining phase the updates channel is not read anymore and may hold ignored late
@@ -1132,7 +1109,8 @@ where
             self.pending_targets.is_empty() &&
             self.in_flight_proof_batches == 0 &&
             self.proof_result_rx.is_empty() &&
-            self.in_flight_storage.is_empty() &&
+            self.storage_in_flight == 0 &&
+            !self.has_ready_storage_work() &&
             self.has_pending_sparse_trie_updates()
         {
             const MAX_STALLED_PROOF_TARGETS_TO_LOG: usize = 5;
@@ -1148,17 +1126,16 @@ where
             account_targets.truncate(MAX_STALLED_PROOF_TARGETS_TO_LOG);
 
             let mut storage_targets = self
-                .storage_updates
+                .storage
                 .iter()
-                .flat_map(|(address, updates)| {
-                    let fetched_targets = self.fetched_storage_targets.get(address);
-                    updates.keys().map(move |target| {
-                        (
-                            *address,
-                            *target,
-                            fetched_targets.and_then(|targets| targets.get(target)).copied(),
-                        )
-                    })
+                .filter_map(|(address, slot)| match slot {
+                    StorageSlot::Idle(work) => Some((address, work)),
+                    StorageSlot::InFlight(_) => None,
+                })
+                .flat_map(|(address, work)| {
+                    work.pending
+                        .keys()
+                        .map(move |target| (*address, *target, work.fetched.get(target).copied()))
                 })
                 .collect::<Vec<_>>();
             storage_targets.sort_unstable();
@@ -1181,80 +1158,264 @@ where
     }
 }
 
-/// Bookkeeping for a storage trie that is checked out of the sparse state trie while a job on
-/// another thread owns it.
+/// State of one address' storage trie in the sparse trie task.
+enum StorageSlot<S> {
+    /// Nothing is running for this address, so its payload can be read and handed to a job.
+    Idle(Box<StorageTrieWork<S>>),
+    /// A job owns the payload. Everything arriving for the address meanwhile is buffered here
+    /// and folded back in when the job returns.
+    InFlight(Box<InFlightStorage>),
+}
+
+impl<S: SparseTrie + Default> StorageSlot<S> {
+    /// Returns whether the address still owes the state root some work.
+    fn is_pending(&self) -> bool {
+        match self {
+            Self::InFlight(_) => true,
+            Self::Idle(work) => !work.pending.is_empty() || work.has_work(),
+        }
+    }
+}
+
+/// Everything the sparse trie task knows about one storage trie, moved into a job as a whole and
+/// handed back by it.
+struct StorageTrieWork<S> {
+    /// The storage trie, checked out of the [`SparseStateTrie`] for the whole run.
+    trie: RevealableSparseTrie<S>,
+    /// Leaf updates that are not applied to `trie` yet, either because they are new or because
+    /// they are blocked on a blinded node.
+    pending: B256Map<LeafUpdate>,
+    /// Proof nodes to reveal into `trie` before the next leaf pass.
+    proofs: Vec<ProofTrieNodeV2>,
+    /// Slots whose proof was already requested, mapped to the broadest requested parent context
+    /// (an unknown parent sorts before every known parent).
+    fetched: B256Map<ProofV2TargetParent>,
+    /// Whether a pass could act on something: proof nodes to reveal, or leaf updates that were
+    /// not tried against the current state of the trie yet.
+    ///
+    /// Blocked updates alone are not enough. Retrying them without a reveal in between cannot
+    /// apply anything and would only resort the whole set again, and only this trie's own proof
+    /// nodes can unblock them.
+    dirty: bool,
+    /// Whether this address ever had storage leaf updates queued, which is what makes promotion
+    /// of its account wait for a recomputed storage root.
+    updated: bool,
+}
+
+impl<S: SparseTrie + Default> StorageTrieWork<S> {
+    fn new(trie: RevealableSparseTrie<S>) -> Self {
+        Self {
+            trie,
+            pending: Default::default(),
+            proofs: Vec::new(),
+            fetched: Default::default(),
+            dirty: false,
+            updated: false,
+        }
+    }
+
+    /// Reveals the queued proof nodes, applies the leaf updates that are not blocked by a blinded
+    /// node, and recomputes the root once nothing is left to apply.
+    fn run(&mut self, new_epoch: TrieNodeEpoch, retain_updates: bool) -> StorageWorkOutput {
+        let Self { trie, pending, proofs, fetched, dirty, .. } = self;
+        *dirty = false;
+        let mut output = StorageWorkOutput::default();
+
+        if !proofs.is_empty() {
+            output.result = trie.reveal_v2_proof_nodes(proofs, retain_updates);
+            proofs.clear();
+            if output.result.is_err() {
+                return output
+            }
+        }
+
+        if !pending.is_empty() {
+            let updates_len_before = pending.len();
+            let targets = &mut output.targets;
+            output.result = trie.update_leaves(pending, |path, parent| match fetched.entry(path) {
+                Entry::Occupied(mut entry) => {
+                    if parent < *entry.get() {
+                        entry.insert(parent);
+                        targets.push(ProofV2Target::new(path).with_parent(parent));
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(parent);
+                    targets.push(ProofV2Target::new(path).with_parent(parent));
+                }
+            });
+            output.cache_hits = (updates_len_before - pending.len()) as u64;
+            output.cache_misses = pending.len() as u64;
+            if output.result.is_err() {
+                return output
+            }
+        }
+
+        if self.needs_root() {
+            self.trie.root(new_epoch);
+        }
+
+        output
+    }
+
+    /// Queues leaf updates, letting a newly known value win over one that is still queued.
+    fn queue_updates(&mut self, updates: B256Map<LeafUpdate>) {
+        if updates.is_empty() {
+            return
+        }
+
+        self.updated = true;
+        self.dirty = true;
+        merge_leaf_updates(&mut self.pending, updates);
+    }
+
+    /// Queues proof nodes, draining them out of the batch they arrived in.
+    fn queue_proofs(&mut self, nodes: &mut Vec<ProofTrieNodeV2>) {
+        if nodes.is_empty() {
+            return
+        }
+
+        self.dirty = true;
+        self.proofs.append(nodes);
+    }
+
+    /// Folds what arrived while a job owned this payload back into it.
+    fn take_buffered(&mut self, buffered: InFlightStorage) {
+        let InFlightStorage { mut proofs, updates, .. } = buffered;
+        self.queue_proofs(&mut proofs);
+        self.queue_updates(updates);
+    }
+
+    /// Returns whether a pass would do anything.
+    fn has_work(&self) -> bool {
+        self.dirty || self.needs_root()
+    }
+
+    /// Returns whether the trie was modified since its root was last computed.
+    ///
+    /// Only a trie this block changed is hashed here: for the others the root the account leaf
+    /// already carries is still correct.
+    fn needs_root(&self) -> bool {
+        self.updated &&
+            self.pending.is_empty() &&
+            self.trie.is_revealed() &&
+            !self.trie.is_root_cached()
+    }
+
+    /// Returns whether a pass would only turn pending updates into proof targets.
+    ///
+    /// A blind trie has nothing to reveal into and nothing to apply, so running the pass on the
+    /// task itself keeps the proof request from waiting for a job round trip.
+    const fn is_target_only(&self) -> bool {
+        self.proofs.is_empty() && self.trie.is_blind()
+    }
+
+    /// Rough cost of the next pass, for deciding whether it is worth a handoff.
+    fn work_units(&self) -> usize {
+        // Hashing walks everything the applied updates dirtied, which is the work the handoff
+        // exists for.
+        if self.needs_root() {
+            return INLINE_STORAGE_WORK_UNITS + 1
+        }
+
+        self.proofs.len() + self.pending.len()
+    }
+}
+
+/// Buffers for one address while a job owns its payload.
 struct InFlightStorage {
-    /// When the trie was handed off, for the round trip histogram.
+    /// When the payload was handed off, for the round trip histogram.
     started: Instant,
-    /// Proof nodes that arrived for this address while the trie was gone.
-    buffered_proofs: Vec<ProofTrieNodeV2>,
+    /// Proof nodes that arrived for this address while the payload was gone.
+    proofs: Vec<ProofTrieNodeV2>,
+    /// Leaf updates that were queued for this address while the payload was gone.
+    updates: B256Map<LeafUpdate>,
 }
 
 impl InFlightStorage {
-    const fn new(started: Instant) -> Self {
-        Self { started, buffered_proofs: Vec::new() }
+    fn new(started: Instant) -> Self {
+        Self { started, proofs: Vec::new(), updates: Default::default() }
     }
 }
 
-/// A storage trie checked out of the sparse state trie, along with the work to run on it.
+/// A storage payload checked out of its slot and handed to a job.
 struct StorageTrieJob<S> {
-    /// Hashed address the trie belongs to.
+    /// Hashed address the payload belongs to.
     address: B256,
-    /// The checked out trie.
-    trie: RevealableSparseTrie<S>,
-    /// What to do with it.
-    kind: StorageJobKind,
+    /// The checked out payload.
+    work: Box<StorageTrieWork<S>>,
 }
 
 impl<S: SparseTrie + Default> StorageTrieJob<S> {
-    fn run(self, new_epoch: TrieNodeEpoch, retain_updates: bool) -> StorageTrieJobDone<S> {
-        let Self { address, mut trie, kind } = self;
-        let revealed = match kind {
-            StorageJobKind::Root => {
-                trie.root(new_epoch);
-                None
-            }
-            StorageJobKind::Reveal(mut proof_nodes) => {
-                let revealed = trie.reveal_v2_proof_nodes(&mut proof_nodes, retain_updates);
-                Some((proof_nodes, revealed))
-            }
-        };
-
-        StorageTrieJobDone { address, trie, revealed }
+    fn run(mut self, new_epoch: TrieNodeEpoch, retain_updates: bool) -> StorageTrieJobDone<S> {
+        let output = self.work.run(new_epoch, retain_updates);
+        StorageTrieJobDone { address: self.address, work: self.work, output }
     }
-}
-
-/// Work that a spawned job performs on a checked out storage trie.
-enum StorageJobKind {
-    /// Recompute the trie root.
-    Root,
-    /// Reveal these proof nodes into the trie.
-    Reveal(Vec<ProofTrieNodeV2>),
 }
 
 /// What a spawned storage job sends back to the sparse trie task.
 enum StorageJobMessage<S> {
-    /// The job finished and hands its trie back.
+    /// The job finished and hands its payload back.
     Done(StorageTrieJobDone<S>),
     /// The job panicked and its trie is lost. The global rayon pool has no panic handler, so a
     /// panic escaping a spawned job would abort the process; it is caught and resumed on the task
     /// thread instead, where it fails the state root calculation like an inline panic.
     Panicked {
-        /// Hashed address of the trie the job owned.
+        /// Hashed address of the payload the job owned.
         address: B256,
         /// The panic payload, resumed on the task thread.
         payload: Box<dyn Any + Send>,
     },
 }
 
-/// A storage trie coming back to the sparse trie task after its job finished.
+/// A storage payload coming back to the sparse trie task after its job finished.
 struct StorageTrieJobDone<S> {
-    /// Hashed address the trie belongs to.
+    /// Hashed address the payload belongs to.
     address: B256,
-    /// The trie itself, to be put back into the sparse state trie.
-    trie: RevealableSparseTrie<S>,
-    /// For a reveal job, the proof node buffer to drop later and the outcome of the reveal.
-    revealed: Option<(Vec<ProofTrieNodeV2>, SparseTrieResult<()>)>,
+    /// The payload itself, to be put back into its slot.
+    work: Box<StorageTrieWork<S>>,
+    /// What the pass produced.
+    output: StorageWorkOutput,
+}
+
+/// What one storage pass produced for the sparse trie task.
+struct StorageWorkOutput {
+    /// Proof targets discovered while applying the leaf updates.
+    targets: Vec<ProofV2Target>,
+    /// Leaf updates applied without needing a new proof.
+    cache_hits: u64,
+    /// Leaf updates that stayed blocked on a blinded node.
+    cache_misses: u64,
+    /// The error the pass stopped at, if any.
+    result: SparseTrieResult<()>,
+}
+
+impl Default for StorageWorkOutput {
+    fn default() -> Self {
+        Self { targets: Vec::new(), cache_hits: 0, cache_misses: 0, result: Ok(()) }
+    }
+}
+
+/// Merges leaf updates into a queue, letting a newly known value win over a queued one.
+fn merge_leaf_updates(queued: &mut B256Map<LeafUpdate>, updates: B256Map<LeafUpdate>) {
+    if queued.is_empty() {
+        // Take the whole map at once, no per-slot loop.
+        *queued = updates;
+        return
+    }
+
+    for (slot, update) in updates {
+        match queued.entry(slot) {
+            Entry::Occupied(mut entry) => {
+                if update.is_changed() {
+                    entry.insert(update);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(update);
+            }
+        }
+    }
 }
 
 /// Number of storage tries handed to a single spawned job.
@@ -1321,9 +1482,10 @@ const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;
 /// Start proof fetching while the first state-update batch is still arriving.
 const INITIAL_UPDATE_BATCH_SIZE: usize = 64;
 
-/// Storage proof batches with at most this many nodes are revealed on the sparse trie task
-/// itself, because handing the tries to another thread costs more than the reveal.
-const INLINE_STORAGE_REVEAL_NODES: usize = 16;
+/// A round of storage passes that would do at most this much work - proof nodes to reveal plus
+/// leaf updates to apply - runs on the sparse trie task itself, because handing the tries to
+/// another thread and waiting for them to come back costs more than the work.
+const INLINE_STORAGE_WORK_UNITS: usize = 16;
 
 /// Dispatches work items as a single unit or in chunks based on target size and worker
 /// availability.
@@ -1438,6 +1600,52 @@ mod tests {
         for task_name in ["trie-hashing", "storage-workers", "account-workers"] {
             runtime.spawn_blocking_named(task_name, || {}).get();
         }
+    }
+
+    /// Checks a payload out of its slot the way a spawned job does, without racing one.
+    fn check_out_storage(
+        task: &mut SparseTrieCacheTask,
+        address: B256,
+    ) -> Box<StorageTrieWork<ArenaParallelSparseTrie>> {
+        let slot = task.storage.get_mut(&address).expect("address must have a slot");
+        let StorageSlot::Idle(work) = core::mem::replace(
+            slot,
+            StorageSlot::InFlight(Box::new(InFlightStorage::new(Instant::now()))),
+        ) else {
+            panic!("slot must be idle")
+        };
+        task.storage_in_flight += 1;
+        work
+    }
+
+    /// Hands a payload checked out by [`check_out_storage`] back, as a finished job would.
+    fn return_storage(
+        task: &mut SparseTrieCacheTask,
+        address: B256,
+        work: Box<StorageTrieWork<ArenaParallelSparseTrie>>,
+    ) {
+        task.on_storage_trie_returned(StorageTrieJobDone {
+            address,
+            work,
+            output: StorageWorkOutput::default(),
+        })
+        .unwrap();
+    }
+
+    fn storage_slot_value(
+        task: &SparseTrieCacheTask,
+        address: &B256,
+        slot: &B256,
+    ) -> Option<Vec<u8>> {
+        let StorageSlot::Idle(work) = task.storage.get(address)? else { return None };
+        work.trie.as_revealed_ref()?.get_leaf_value(&Nibbles::unpack(slot)).cloned()
+    }
+
+    fn storage_root_of(task: &mut SparseTrieCacheTask, address: B256) -> B256 {
+        let StorageSlot::Idle(work) = task.storage.get_mut(&address).expect("slot") else {
+            panic!("payload is out with a job")
+        };
+        work.trie.root(TrieNodeEpoch::new(1)).expect("storage trie must be revealed")
     }
 
     #[test]
@@ -1580,6 +1788,7 @@ mod tests {
         let late_slot = B256::repeat_byte(0x33);
         let revealed_value = alloy_rlp::encode_fixed_size(&U256::from(7)).to_vec();
         let late_value = alloy_rlp::encode_fixed_size(&U256::from(9)).to_vec();
+        let later_value = alloy_rlp::encode_fixed_size(&U256::from(11)).to_vec();
 
         let mut state = HashedPostState::default();
         state.accounts.insert(address, Some(Account { nonce: 1, ..Default::default() }));
@@ -1588,19 +1797,18 @@ mod tests {
         task.pending_updates = 1;
         task.process_new_updates().unwrap();
 
-        // Check the (still blind) trie out by hand so the test does not race a spawned job.
-        let storage_trie = task.trie.take_or_create_storage_trie(&address);
-        task.in_flight_storage.insert(address, InFlightStorage::new(Instant::now()));
+        // Check the payload out by hand so the test does not race a spawned job.
+        let work = check_out_storage(&mut task, address);
         task.finished_state_updates = true;
 
         assert!(task.has_pending_sparse_trie_updates());
         assert!(
             task.ensure_not_stalled(false).is_ok(),
-            "a checked out trie can still deliver progress"
+            "a checked out payload can still deliver progress"
         );
 
-        // A proof for a checked out trie must be buffered, not revealed into a fresh blind trie
-        // that the returning job would then overwrite.
+        // A proof for a checked out address must be buffered, not revealed into a fresh blind
+        // trie that the returning job would then overwrite.
         let leaf = ProofTrieNodeV2 {
             path: Nibbles::default(),
             node: TrieNodeV2::Leaf(LeafNode::new(
@@ -1615,45 +1823,51 @@ mod tests {
         })
         .unwrap();
         assert!(!task.trie.storage_tries_mut().contains_key(&address));
-        assert_eq!(task.in_flight_storage[&address].buffered_proofs.len(), 1);
+        let StorageSlot::InFlight(in_flight) = &task.storage[&address] else {
+            panic!("payload is out with a job")
+        };
+        assert_eq!(in_flight.proofs.len(), 1);
 
-        // The same holds for leaf updates arriving while the trie is gone.
+        // The same holds for leaf updates arriving while the payload is gone.
         let mut state = HashedPostState::default();
         state.storages.entry(address).or_default().storage.insert(late_slot, U256::from(9));
         task.on_hashed_state_update(state);
         task.pending_updates = 1;
         task.process_new_updates().unwrap();
-        assert!(!task.trie.storage_tries_mut().contains_key(&address));
-        assert!(task.storage_updates[&address].contains_key(&late_slot));
+        let StorageSlot::InFlight(in_flight) = &task.storage[&address] else {
+            panic!("payload is out with a job")
+        };
+        assert!(in_flight.updates.contains_key(&late_slot));
 
-        task.on_storage_trie_returned(StorageTrieJobDone {
-            address,
-            trie: storage_trie,
-            revealed: None,
-        })
-        .unwrap();
+        return_storage(&mut task, address, work);
+        assert_eq!(task.storage_in_flight, 0);
 
-        assert!(task.in_flight_storage.is_empty());
-        assert_eq!(
-            task.trie.get_storage_slot_value(&address, &revealed_slot),
-            Some(&revealed_value),
-            "buffered proof nodes are revealed when the trie comes back"
-        );
+        // The next pass reveals what was buffered and applies both the update it was checked out
+        // with and the one that arrived meanwhile.
+        task.run_ready_storage_work().unwrap();
+        assert_eq!(storage_slot_value(&task, &address, &revealed_slot), Some(revealed_value));
+        assert_eq!(storage_slot_value(&task, &address, &late_slot), Some(late_value));
 
-        task.process_leaf_updates(false).unwrap();
-        assert!(task.storage_updates[&address].is_empty());
-        assert_eq!(task.trie.get_storage_slot_value(&address, &late_slot), Some(&late_value));
+        let StorageSlot::Idle(work) = &task.storage[&address] else { panic!("payload is back") };
+        assert!(work.pending.is_empty());
+        assert!(work.trie.is_root_cached(), "a drained payload hashes its trie");
+        let root_before = storage_root_of(&mut task, address);
 
-        // Now that its updates are drained the trie is handed off again, this time for real.
-        task.promote_pending_account_updates().unwrap();
-        assert!(
-            task.in_flight_storage.contains_key(&address),
-            "a drained storage trie is hashed off the task thread"
-        );
-        while !task.in_flight_storage.is_empty() {
-            task.drain_returned_storage_tries().unwrap();
-        }
-        assert!(task.trie.storage_tries_mut()[&address].is_root_cached());
+        // An update arriving during a job invalidates the root the previous pass computed.
+        let work = check_out_storage(&mut task, address);
+        let mut state = HashedPostState::default();
+        state.storages.entry(address).or_default().storage.insert(late_slot, U256::from(11));
+        task.on_hashed_state_update(state);
+        task.pending_updates = 1;
+        task.process_new_updates().unwrap();
+        return_storage(&mut task, address, work);
+
+        let StorageSlot::Idle(work) = &task.storage[&address] else { panic!("payload is back") };
+        assert!(work.has_work(), "a buffered update makes the payload ready again");
+
+        task.run_ready_storage_work().unwrap();
+        assert_eq!(storage_slot_value(&task, &address, &late_slot), Some(later_value));
+        assert_ne!(storage_root_of(&mut task, address), root_before);
 
         drop(updates_tx);
         drop(task);
@@ -1661,7 +1875,7 @@ mod tests {
     }
 
     #[test]
-    fn large_storage_proof_batches_are_revealed_off_thread() {
+    fn large_storage_batches_run_off_thread() {
         let runtime = reth_tasks::Runtime::test();
         let provider_factory = create_test_provider_factory();
         let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
@@ -1702,8 +1916,8 @@ mod tests {
             1,
         );
 
-        // One leaf per address, enough of them to exceed the inline reveal budget.
-        let leaves = (0..=INLINE_STORAGE_REVEAL_NODES as u8)
+        // One leaf per address, enough of them to exceed the inline budget.
+        let leaves = (0..=INLINE_STORAGE_WORK_UNITS as u8)
             .map(|index| {
                 let address = B256::repeat_byte(0x10 + index);
                 let slot = B256::repeat_byte(0x80 + index);
@@ -1726,14 +1940,14 @@ mod tests {
         task.on_proof_result(DecodedMultiProofV2 { account_proofs: Vec::new(), storage_proofs })
             .unwrap();
 
-        assert_eq!(task.in_flight_storage.len(), leaves.len());
+        assert_eq!(task.storage_in_flight, leaves.len());
         assert!(task.has_pending_sparse_trie_updates(), "completion must wait for the reveals");
 
-        while !task.in_flight_storage.is_empty() {
+        while task.storage_in_flight > 0 {
             task.drain_returned_storage_tries().unwrap();
         }
         for (address, slot, value) in &leaves {
-            assert_eq!(task.trie.get_storage_slot_value(address, slot), Some(value));
+            assert_eq!(storage_slot_value(&task, address, slot).as_ref(), Some(value));
         }
 
         drop(updates_tx);
@@ -1818,7 +2032,8 @@ mod tests {
             (*address, account.into_trie_account(storage_root))
         });
         assert_eq!(outcome.state_root, reth_trie_common::root::state_root_unsorted(expected));
-        assert!(task.in_flight_storage.is_empty());
+        assert_eq!(task.storage_in_flight, 0);
+        assert!(task.storage.is_empty(), "every storage trie is back in the state trie");
 
         drop(updates_tx);
         drop(task);
@@ -2014,13 +2229,16 @@ mod tests {
 
         task.finished_state_updates = true;
         task.account_updates.insert(account, LeafUpdate::Touched);
-        task.storage_updates.entry(account).or_default().insert(slot, LeafUpdate::Touched);
         task.pending_account_updates.insert(account, None);
         task.fetched_account_targets.insert(account_target, ProofV2TargetParent::NONE);
-        task.fetched_storage_targets
-            .entry(account)
-            .or_default()
-            .insert(storage_target, ProofV2TargetParent::new(11));
+
+        // A storage leaf that stayed blocked after its pass ran, so no pass is ready to run.
+        let StorageSlot::Idle(work) = task.storage_slot_mut(account) else {
+            panic!("a fresh slot is idle")
+        };
+        work.updated = true;
+        work.pending.insert(slot, LeafUpdate::Touched);
+        work.fetched.insert(storage_target, ProofV2TargetParent::new(11));
         task.in_flight_proof_batches = 1;
 
         assert!(task.ensure_not_stalled(false).is_ok());

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -111,7 +111,12 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     /// Cache of account proof targets that were already fetched/requested from the proof workers.
     /// Account to the broadest requested parent context (an unknown parent sorts before every
     /// known parent).
-    fetched_account_targets: B256Map<ProofV2TargetParent>,
+    fetched_account_targets: B256Map<FetchedTarget>,
+    /// How many proof round trips the account keys of this block needed.
+    account_proof_rounds: ProofRounds,
+    /// How many proof round trips the storage keys of this block needed, summed over all
+    /// addresses when their tries are handed back.
+    storage_proof_rounds: ProofRounds,
     /// Reusable buffer for RLP encoding of accounts.
     account_rlp_buf: Vec<u8>,
     /// Whether the last state update has been received.
@@ -211,6 +216,8 @@ where
             existing_accounts: Default::default(),
             promotable_accounts: Default::default(),
             fetched_account_targets: Default::default(),
+            account_proof_rounds: Default::default(),
+            storage_proof_rounds: Default::default(),
             account_rlp_buf: Vec::with_capacity(TRIE_ACCOUNT_RLP_MAX_SIZE),
             finished_state_updates: Default::default(),
             account_cache_hits: 0,
@@ -459,6 +466,8 @@ where
         self.storage_cache_hits = 0;
         self.storage_cache_misses = 0;
         self.account_value_fallbacks = 0;
+
+        self.record_proof_rounds();
 
         Ok(StateRootComputeOutcome {
             state_root,
@@ -869,17 +878,24 @@ where
             true,
             |event| match event {
                 LeafUpdateEvent::ProofRequired { key: target, parent } => {
+                    let rounds = &mut self.account_proof_rounds;
                     match self.fetched_account_targets.entry(target) {
                         Entry::Occupied(mut entry) => {
-                            if parent < *entry.get() {
-                                entry.insert(parent);
+                            let fetched = entry.get_mut();
+                            if parent < fetched.parent {
+                                rounds.repeat_target(fetched.rounds);
+                                fetched.parent = parent;
+                                fetched.rounds = fetched.rounds.saturating_add(1);
                                 self.pending_targets.push_account_target(
                                     ProofV2Target::new(target).with_parent(parent),
                                 );
+                            } else {
+                                rounds.dropped_target(parent, fetched.parent);
                             }
                         }
                         Entry::Vacant(entry) => {
-                            entry.insert(parent);
+                            entry.insert(FetchedTarget::new(parent));
+                            rounds.first_target(parent);
                             self.pending_targets.push_account_target(
                                 ProofV2Target::new(target).with_parent(parent),
                             );
@@ -1010,11 +1026,12 @@ where
     /// The final root and everything after it - trie updates, preservation, pruning - reads the
     /// storage tries through [`SparseStateTrie`], so no address may be left in a slot.
     fn return_storage_tries(&mut self) {
-        let Self { storage, trie, .. } = self;
+        let Self { storage, trie, storage_proof_rounds, .. } = self;
         for (address, slot) in storage.drain() {
             // A payload still out with a job is only reachable on the cancellation path, where
             // the job drops it.
             if let StorageSlot::Idle(work) = slot {
+                storage_proof_rounds.merge(&work.rounds);
                 trie.insert_storage_trie(address, work.trie);
             }
         }
@@ -1306,26 +1323,28 @@ where
                 .keys()
                 .copied()
                 .chain(self.account_blocked_updates().into_iter().flat_map(|b| b.keys()))
-                .map(|target| (target, self.fetched_account_targets.get(&target).copied()))
+                .map(|target| (target, self.fetched_account_targets.get(&target).map(|f| f.parent)))
                 .collect::<Vec<_>>();
             account_targets.sort_unstable();
             let account_targets_truncated =
                 account_targets.len().saturating_sub(MAX_STALLED_PROOF_TARGETS_TO_LOG);
             account_targets.truncate(MAX_STALLED_PROOF_TARGETS_TO_LOG);
 
-            let mut storage_targets =
-                self.storage
-                    .iter()
-                    .filter_map(|(address, slot)| match slot {
-                        StorageSlot::Idle(work) => Some((address, work)),
-                        StorageSlot::InFlight(_) => None,
-                    })
-                    .flat_map(|(address, work)| {
-                        work.pending.keys().copied().chain(work.trie.blocked_updates().keys()).map(
-                            move |target| (*address, target, work.fetched.get(&target).copied()),
-                        )
-                    })
-                    .collect::<Vec<_>>();
+            let mut storage_targets = self
+                .storage
+                .iter()
+                .filter_map(|(address, slot)| match slot {
+                    StorageSlot::Idle(work) => Some((address, work)),
+                    StorageSlot::InFlight(_) => None,
+                })
+                .flat_map(|(address, work)| {
+                    work.pending.keys().copied().chain(work.trie.blocked_updates().keys()).map(
+                        move |target| {
+                            (*address, target, work.fetched.get(&target).map(|f| f.parent))
+                        },
+                    )
+                })
+                .collect::<Vec<_>>();
             storage_targets.sort_unstable();
             let storage_targets_truncated =
                 storage_targets.len().saturating_sub(MAX_STALLED_PROOF_TARGETS_TO_LOG);
@@ -1343,6 +1362,33 @@ where
         }
 
         Ok(())
+    }
+
+    /// Reports how many proof round trips this block's leaf keys needed.
+    fn record_proof_rounds(&mut self) {
+        let account = &self.account_proof_rounds;
+        let storage = &self.storage_proof_rounds;
+
+        self.metrics.sparse_trie_account_proof_keys.record(account.keys() as f64);
+        self.metrics.sparse_trie_account_multi_round_keys.record(account.multi_round_keys() as f64);
+        self.metrics
+            .sparse_trie_account_deeper_proof_asks
+            .record(account.dropped_deeper_parent as f64);
+        self.metrics.sparse_trie_storage_proof_keys.record(storage.keys() as f64);
+        self.metrics.sparse_trie_storage_multi_round_keys.record(storage.multi_round_keys() as f64);
+        self.metrics
+            .sparse_trie_storage_deeper_proof_asks
+            .record(storage.dropped_deeper_parent as f64);
+
+        debug!(
+            target: "engine::root",
+            ?account,
+            ?storage,
+            "Proof rounds per leaf",
+        );
+
+        self.account_proof_rounds = Default::default();
+        self.storage_proof_rounds = Default::default();
     }
 }
 
@@ -1386,7 +1432,9 @@ struct StorageTrieWork<S> {
     proofs: Vec<ProofTrieNodeV2>,
     /// Slots whose proof was already requested, mapped to the broadest requested parent context
     /// (an unknown parent sorts before every known parent).
-    fetched: B256Map<ProofV2TargetParent>,
+    fetched: B256Map<FetchedTarget>,
+    /// How many proof round trips the slots of this trie needed.
+    rounds: ProofRounds,
     /// Whether a pass could act on something: proof nodes to reveal, or leaf updates that were
     /// not tried against the current state of the trie yet.
     ///
@@ -1406,6 +1454,7 @@ impl<S: SparseTrie + Default> StorageTrieWork<S> {
             pending: Default::default(),
             proofs: Vec::new(),
             fetched: Default::default(),
+            rounds: Default::default(),
             dirty: false,
             updated: false,
         }
@@ -1414,7 +1463,7 @@ impl<S: SparseTrie + Default> StorageTrieWork<S> {
     /// Reveals the queued proof nodes, applies the leaf updates that are not blocked by a blinded
     /// node, and recomputes the root once nothing is left to apply.
     fn run(&mut self, new_epoch: TrieNodeEpoch, retain_updates: bool) -> StorageWorkOutput {
-        let Self { trie, pending, proofs, fetched, dirty, .. } = self;
+        let Self { trie, pending, proofs, fetched, rounds, dirty, .. } = self;
         *dirty = false;
         let mut output = StorageWorkOutput::default();
 
@@ -1433,13 +1482,19 @@ impl<S: SparseTrie + Default> StorageTrieWork<S> {
             let targets = &mut output.targets;
             output.result = trie.update_leaves(pending, |path, parent| match fetched.entry(path) {
                 Entry::Occupied(mut entry) => {
-                    if parent < *entry.get() {
-                        entry.insert(parent);
+                    let fetched = entry.get_mut();
+                    if parent < fetched.parent {
+                        rounds.repeat_target(fetched.rounds);
+                        fetched.parent = parent;
+                        fetched.rounds = fetched.rounds.saturating_add(1);
                         targets.push(ProofV2Target::new(path).with_parent(parent));
+                    } else {
+                        rounds.dropped_target(parent, fetched.parent);
                     }
                 }
                 Entry::Vacant(entry) => {
-                    entry.insert(parent);
+                    entry.insert(FetchedTarget::new(parent));
+                    rounds.first_target(parent);
                     targets.push(ProofV2Target::new(path).with_parent(parent));
                 }
             });
@@ -1817,6 +1872,21 @@ pub(super) struct SparseTrieTaskMetrics {
     /// trie never reported them while applying a touched update.
     pub(super) sparse_trie_account_value_fallbacks: Histogram,
 
+    /// Number of account keys a proof target was dispatched for.
+    pub(super) sparse_trie_account_proof_keys: Histogram,
+    /// Number of account keys that needed more than one proof target.
+    pub(super) sparse_trie_account_multi_round_keys: Histogram,
+    /// Number of times the accounts trie asked for a proof below an already requested parent,
+    /// which no target is dispatched for.
+    pub(super) sparse_trie_account_deeper_proof_asks: Histogram,
+    /// Number of storage keys a proof target was dispatched for.
+    pub(super) sparse_trie_storage_proof_keys: Histogram,
+    /// Number of storage keys that needed more than one proof target.
+    pub(super) sparse_trie_storage_multi_round_keys: Histogram,
+    /// Number of times a storage trie asked for a proof below an already requested parent,
+    /// which no target is dispatched for.
+    pub(super) sparse_trie_storage_deeper_proof_asks: Histogram,
+
     /// Number of storage tries retained in the preserved sparse trie cache.
     pub(super) sparse_trie_retained_storage_tries: Gauge,
 }
@@ -1923,6 +1993,117 @@ impl PendingTargets {
     fn extend_storage_targets(&mut self, address: &B256, targets: Vec<ProofV2Target>) {
         self.len += targets.len();
         self.targets.storage_targets.entry(*address).or_default().extend(targets);
+    }
+}
+
+/// What one trie already asked the proof workers for one leaf key.
+#[derive(Debug, Clone, Copy)]
+struct FetchedTarget {
+    /// Broadest parent context requested so far. An unknown parent sorts before every known
+    /// parent, so this only ever moves towards the trie root.
+    parent: ProofV2TargetParent,
+    /// Proof targets dispatched for this key, saturating.
+    rounds: u8,
+}
+
+impl FetchedTarget {
+    /// Records the first dispatched target for a key.
+    const fn new(parent: ProofV2TargetParent) -> Self {
+        Self { parent, rounds: 1 }
+    }
+}
+
+/// Number of round buckets in [`ProofRounds`]; the last one absorbs everything above it.
+const PROOF_ROUND_BUCKETS: usize = 4;
+
+/// Number of parent depth buckets in [`ProofRounds`]; the last one absorbs everything deeper.
+const PARENT_DEPTH_BUCKETS: usize = 12;
+
+/// How many proof round trips the leaf keys of one or more tries needed in this block.
+///
+/// A leaf update that hits a blinded node makes the trie ask for a proof for its key. The ask is
+/// only turned into a target when no proof for that key was requested from an equally broad or
+/// broader parent yet, so a key needing more than one target means one proof did not reveal
+/// enough of its path. An ask that was dropped instead is counted separately: with a strictly
+/// deeper parent it is the trie finding the next blinded node further down the same path, which
+/// no target would be dispatched for.
+#[derive(Debug, Default, Clone, Copy)]
+struct ProofRounds {
+    /// Keys by dispatched target count; index `i` holds the keys with `i + 1` targets.
+    keys_by_round: [u32; PROOF_ROUND_BUCKETS],
+    /// Asks dropped because the key was already requested from the same parent.
+    dropped_same_parent: u32,
+    /// Asks dropped because the key was already requested from a shallower parent.
+    dropped_deeper_parent: u32,
+    /// First targets of a key that had to include the trie root.
+    root_targets: u32,
+    /// First targets of a key by the depth of their parent hint.
+    first_targets_by_parent_depth: [u32; PARENT_DEPTH_BUCKETS],
+    /// Sum of the parent hint depths counted in [`Self::first_targets_by_parent_depth`].
+    parent_depth_sum: u64,
+}
+
+impl ProofRounds {
+    /// Records the first target dispatched for a key.
+    fn first_target(&mut self, parent: ProofV2TargetParent) {
+        self.keys_by_round[0] += 1;
+        match parent.path_len() {
+            Some(depth) => {
+                self.first_targets_by_parent_depth[depth.min(PARENT_DEPTH_BUCKETS - 1)] += 1;
+                self.parent_depth_sum += depth as u64;
+            }
+            None => self.root_targets += 1,
+        }
+    }
+
+    /// Records another target dispatched for a key that already had `rounds` of them.
+    fn repeat_target(&mut self, rounds: u8) {
+        let from = Self::bucket(rounds);
+        let to = Self::bucket(rounds.saturating_add(1));
+        if from != to {
+            self.keys_by_round[from] -= 1;
+            self.keys_by_round[to] += 1;
+        }
+    }
+
+    /// Records an ask that was dropped in favour of the target already dispatched from `fetched`.
+    fn dropped_target(&mut self, parent: ProofV2TargetParent, fetched: ProofV2TargetParent) {
+        if parent > fetched {
+            self.dropped_deeper_parent += 1;
+        } else {
+            self.dropped_same_parent += 1;
+        }
+    }
+
+    /// Adds another trie's counts to these.
+    fn merge(&mut self, other: &Self) {
+        for (total, count) in self.keys_by_round.iter_mut().zip(other.keys_by_round) {
+            *total += count;
+        }
+        for (total, count) in
+            self.first_targets_by_parent_depth.iter_mut().zip(other.first_targets_by_parent_depth)
+        {
+            *total += count;
+        }
+        self.dropped_same_parent += other.dropped_same_parent;
+        self.dropped_deeper_parent += other.dropped_deeper_parent;
+        self.root_targets += other.root_targets;
+        self.parent_depth_sum += other.parent_depth_sum;
+    }
+
+    /// Returns the number of keys a proof was requested for.
+    fn keys(&self) -> u32 {
+        self.keys_by_round.iter().sum()
+    }
+
+    /// Returns the number of keys that needed more than one dispatched target.
+    fn multi_round_keys(&self) -> u32 {
+        self.keys_by_round[1..].iter().sum()
+    }
+
+    /// Returns the bucket a key with the given number of dispatched targets belongs in.
+    fn bucket(rounds: u8) -> usize {
+        (rounds.max(1) as usize - 1).min(PROOF_ROUND_BUCKETS - 1)
     }
 }
 
@@ -2765,7 +2946,8 @@ mod tests {
         task.finished_state_updates = true;
         task.account_updates.insert(account, LeafUpdate::Touched);
         task.pending_account_updates.insert(account, None);
-        task.fetched_account_targets.insert(account_target, ProofV2TargetParent::NONE);
+        task.fetched_account_targets
+            .insert(account_target, FetchedTarget::new(ProofV2TargetParent::NONE));
 
         // A storage leaf that stayed blocked after its pass ran, so no pass is ready to run.
         let StorageSlot::Idle(work) = task.storage_slot_mut(account) else {
@@ -2773,7 +2955,7 @@ mod tests {
         };
         work.updated = true;
         work.pending.insert(slot, LeafUpdate::Touched);
-        work.fetched.insert(storage_target, ProofV2TargetParent::new(11));
+        work.fetched.insert(storage_target, FetchedTarget::new(ProofV2TargetParent::new(11)));
         task.in_flight_proof_batches = 1;
 
         assert!(task.ensure_not_stalled(false).is_ok());
@@ -3010,5 +3192,37 @@ mod tests {
         alive_rx
             .recv_timeout(std::time::Duration::from_secs(5))
             .expect("the shard must keep serving its queue");
+    }
+
+    #[test]
+    fn a_key_stays_counted_once_while_it_moves_through_the_round_buckets() {
+        let mut rounds = ProofRounds::default();
+        rounds.first_target(ProofV2TargetParent::new(3));
+        rounds.first_target(ProofV2TargetParent::NONE);
+        assert_eq!(rounds.keys(), 2);
+        assert_eq!(rounds.multi_round_keys(), 0);
+        assert_eq!(rounds.root_targets, 1);
+        assert_eq!(rounds.first_targets_by_parent_depth[3], 1);
+        assert_eq!(rounds.parent_depth_sum, 3);
+
+        // One key needs more targets than there are buckets; the last bucket absorbs them.
+        for round in 1..=(PROOF_ROUND_BUCKETS as u8 + 1) {
+            rounds.repeat_target(round);
+            assert_eq!(rounds.keys(), 2, "round {round} lost or duplicated a key");
+        }
+        assert_eq!(rounds.multi_round_keys(), 1);
+        assert_eq!(rounds.keys_by_round[PROOF_ROUND_BUCKETS - 1], 1);
+
+        rounds.dropped_target(ProofV2TargetParent::new(5), ProofV2TargetParent::new(3));
+        rounds.dropped_target(ProofV2TargetParent::new(3), ProofV2TargetParent::new(3));
+        assert_eq!(rounds.dropped_deeper_parent, 1);
+        assert_eq!(rounds.dropped_same_parent, 1);
+
+        let mut total = ProofRounds::default();
+        total.merge(&rounds);
+        total.merge(&rounds);
+        assert_eq!(total.keys(), 4);
+        assert_eq!(total.multi_round_keys(), 2);
+        assert_eq!(total.parent_depth_sum, 6);
     }
 }

--- a/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/state_root_strategy/sparse_trie.rs
@@ -10,7 +10,6 @@ use alloy_primitives::{
 use alloy_rlp::{Decodable, Encodable};
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
 use metrics::{Gauge, Histogram};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reth_metrics::Metrics;
 use reth_primitives_traits::{Account, FastInstant as Instant};
 use reth_tasks::Runtime;
@@ -18,7 +17,7 @@ use reth_trie::{
     updates::TrieUpdates, DecodedMultiProofV2, HashedPostState, TrieAccount, EMPTY_ROOT_HASH,
     TRIE_ACCOUNT_RLP_MAX_SIZE,
 };
-use reth_trie_common::{MultiProofTargetsV2, ProofV2Target, ProofV2TargetParent};
+use reth_trie_common::{MultiProofTargetsV2, ProofTrieNodeV2, ProofV2Target, ProofV2TargetParent};
 use reth_trie_parallel::{
     error::StateRootTaskError,
     proof_task::{
@@ -110,6 +109,17 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
     pending_targets: PendingTargets,
     /// Proof batches dispatched to workers and not yet received.
     in_flight_proof_batches: usize,
+    /// Storage tries that are currently checked out of [`SparseStateTrie`] and owned by a job
+    /// running off this thread.
+    ///
+    /// Invariant: an address is either listed here or has its trie in the state trie's storage
+    /// trie map, never both. Everything that would otherwise create or read the trie for such an
+    /// address has to treat it as unavailable until the job hands it back.
+    in_flight_storage: B256Map<InFlightStorage>,
+    /// Sender handed to storage jobs. Kept alive by the task so the receiver never disconnects.
+    storage_done_tx: CrossbeamSender<StorageTrieJobDone<S>>,
+    /// Receives storage tries coming back from jobs spawned by this task.
+    storage_done_rx: CrossbeamReceiver<StorageTrieJobDone<S>>,
     /// Number of pending execution/prewarming updates received but not yet passed to
     /// `update_leaves`.
     pending_updates: usize,
@@ -129,7 +139,7 @@ pub(super) struct SparseTrieCacheTask<A = ArenaParallelSparseTrie, S = ArenaPara
 impl<A, S> SparseTrieCacheTask<A, S>
 where
     A: SparseTrie + Default,
-    S: SparseTrie + Default + Clone,
+    S: SparseTrie + Default + Clone + 'static,
 {
     /// Creates a new sparse trie, pre-populating with an existing [`SparseStateTrie`].
     #[expect(clippy::too_many_arguments)]
@@ -148,6 +158,7 @@ where
         chunk_size: usize,
     ) -> Self {
         let (hashed_state_tx, hashed_state_rx) = crossbeam_channel::unbounded();
+        let (storage_done_tx, storage_done_rx) = crossbeam_channel::unbounded();
 
         let parent_span = tracing::Span::current();
         let hashing_metrics = metrics.clone();
@@ -183,6 +194,9 @@ where
             storage_cache_misses: 0,
             pending_targets: Default::default(),
             in_flight_proof_batches: 0,
+            in_flight_storage: Default::default(),
+            storage_done_tx,
+            storage_done_rx,
             pending_updates: Default::default(),
             initial_updates_applied: false,
             final_hashed_state: Default::default(),
@@ -233,6 +247,10 @@ where
     ///
     /// Should be called after the state root result has been sent.
     pub(super) fn into_trie_for_reuse(self) -> (SparseStateTrie<A, S>, DeferredDrops) {
+        debug_assert!(
+            self.in_flight_storage.is_empty(),
+            "storage tries must be back before the trie is preserved"
+        );
         let Self { mut trie, .. } = self;
         let deferred = trie.take_deferred_drops();
         (trie, deferred)
@@ -243,7 +261,9 @@ where
     /// Use this when the payload was invalid or cancelled - we don't want to preserve
     /// potentially invalid trie state, but we keep the allocations for reuse.
     pub(super) fn into_cleared_trie(self) -> (SparseStateTrie<A, S>, DeferredDrops) {
-        let Self { mut trie, .. } = self;
+        let Self { mut trie, storage_done_rx, .. } = self;
+        // Disconnect first so tries still out with a job are dropped by that job instead of here.
+        drop(storage_done_rx);
         trie.clear();
         let deferred = trie.take_deferred_drops();
         (trie, deferred)
@@ -303,6 +323,18 @@ where
                     };
                     self.on_proof_results(result, &mut t)?;
                 },
+                recv(self.storage_done_rx) -> message => {
+                    let wake = Instant::now();
+                    total_idle_time += wake.duration_since(idle_start);
+                    self.metrics
+                        .sparse_trie_channel_wait_duration_histogram
+                        .record(wake.duration_since(t));
+
+                    let Ok(returned) = message else {
+                        unreachable!("we own the sender half")
+                    };
+                    self.on_storage_trie_returned(returned)?;
+                },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
 
@@ -330,6 +362,18 @@ where
                     };
                     self.on_proof_results(result, &mut t)?;
                 },
+                recv(self.storage_done_rx) -> message => {
+                    let wake = Instant::now();
+                    total_idle_time += wake.duration_since(idle_start);
+                    self.metrics
+                        .sparse_trie_channel_wait_duration_histogram
+                        .record(wake.duration_since(t));
+
+                    let Ok(returned) = message else {
+                        unreachable!("we own the sender half")
+                    };
+                    self.on_storage_trie_returned(returned)?;
+                },
                 recv(self.cancel_rx) -> _ => return Err(StateRootTaskError::Canceled),
             }
 
@@ -337,6 +381,10 @@ where
             idle_start = Instant::now();
         }
 
+        debug_assert!(
+            self.in_flight_storage.is_empty(),
+            "completion must wait for every checked out storage trie"
+        );
         self.metrics.sparse_trie_idle_time_seconds.record(total_idle_time.as_secs_f64());
 
         debug!(target: "engine::root", "All proofs processed, ending calculation");
@@ -412,6 +460,10 @@ where
     /// Messages queued after the finish marker are best-effort hints and are not actionable.
     /// Returns `true` once the finish marker was received and all pending trie work is done.
     fn make_progress(&mut self) -> Result<bool, StateRootTaskError> {
+        // Absorb a whole burst of returns before the scans below, so one batch of storage jobs
+        // costs one promotion pass rather than one per trie.
+        self.drain_returned_storage_tries()?;
+
         let updates_queued = !self.finished_state_updates && !self.updates.is_empty();
 
         if !updates_queued && self.proof_result_rx.is_empty() {
@@ -555,10 +607,31 @@ where
         self.final_hashed_state.extend(hashed_state_update);
     }
 
-    fn on_proof_result(&mut self, result: DecodedMultiProofV2) -> Result<(), StateRootTaskError> {
+    fn on_proof_result(
+        &mut self,
+        mut result: DecodedMultiProofV2,
+    ) -> Result<(), StateRootTaskError> {
+        self.buffer_checked_out_storage_proofs(&mut result);
         self.trie
             .reveal_decoded_multiproof_v2(result)
             .map_err(|e| StateRootTaskError::Other(format!("could not reveal multiproof: {e:?}")))
+    }
+
+    /// Moves storage proofs addressed to a checked out trie into its in-flight buffer.
+    ///
+    /// Revealing them now would create a fresh blind trie for that address which the returning
+    /// job would then overwrite, silently dropping the proof.
+    fn buffer_checked_out_storage_proofs(&mut self, result: &mut DecodedMultiProofV2) {
+        if self.in_flight_storage.is_empty() {
+            return;
+        }
+
+        let in_flight_storage = &mut self.in_flight_storage;
+        result.storage_proofs.retain(|address, nodes| {
+            let Some(in_flight) = in_flight_storage.get_mut(address) else { return true };
+            in_flight.buffered_proofs.append(nodes);
+            false
+        });
     }
 
     fn on_proof_result_message(
@@ -636,10 +709,12 @@ where
         let storage_updates =
             if new { &mut self.new_storage_updates } else { &mut self.storage_updates };
 
-        // Process all storage updates, skipping tries with no pending updates.
+        // Process all storage updates, skipping tries with no pending updates and tries that are
+        // checked out: their updates stay queued until the trie comes back.
+        let in_flight_storage = &self.in_flight_storage;
         let span = trace_span!("process_storage_leaf_updates").entered();
         for (address, updates) in storage_updates {
-            if updates.is_empty() {
+            if updates.is_empty() || in_flight_storage.contains_key(address) {
                 continue;
             }
             let _enter = trace_span!(target: "engine::tree::payload_processor::sparse_trie", parent: &span, "storage_trie_leaf_updates", a=%address).entered();
@@ -723,63 +798,94 @@ where
     /// 2. all the storage updates are fully drained,
     /// 3. but the storage root hasn't been updated yet,
     ///
-    /// we trigger state root computation on a rayon pool.
-    fn compute_drained_storage_roots(&mut self) {
-        struct SendStorageTriePtr<S>(*mut RevealableSparseTrie<S>);
-        // SAFETY: this wrapper only forwards the pointer across rayon; deref invariants are
-        // documented at the use site below.
-        unsafe impl<S: Send> Send for SendStorageTriePtr<S> {}
-
-        let mut tries_to_compute_roots: Vec<(B256, SendStorageTriePtr<S>)> = Vec::new();
+    /// we check the trie out of the state trie and hash it on the rayon pool. The trie comes back
+    /// through [`Self::storage_done_rx`] with its root cached, so this thread stays free to keep
+    /// consuming proof results and state updates while the batch runs.
+    fn spawn_drained_storage_roots(&mut self) {
+        let started = Instant::now();
+        let mut checked_out: Vec<(B256, RevealableSparseTrie<S>)> = Vec::new();
         for (address, updates) in &self.storage_updates {
-            if updates.is_empty() &&
-                let Some(trie) = self.trie.storage_tries_mut().get_mut(address) &&
-                !trie.is_root_cached()
-            {
-                tries_to_compute_roots.push((*address, SendStorageTriePtr(trie)));
+            if !updates.is_empty() {
+                continue;
             }
+            // A trie missing from the map is already checked out for another job. A blind one has
+            // no root to compute and is left in place so promotion reports it as it did before.
+            let Some(trie) = self.trie.storage_tries_mut().get(address) else { continue };
+            if trie.is_root_cached() || !trie.is_revealed() {
+                continue;
+            }
+
+            let trie = self.trie.take_storage_trie(address).expect("checked above");
+            self.in_flight_storage.insert(*address, InFlightStorage::new(started));
+            checked_out.push((*address, trie));
         }
 
-        if tries_to_compute_roots.is_empty() {
+        if checked_out.is_empty() {
             return;
         }
 
-        let parent_span =
-            debug_span!("compute_drained_storage_roots", n = tries_to_compute_roots.len());
+        let parent_span = debug_span!("spawn_drained_storage_roots", n = checked_out.len());
+        let chunk_len = storage_job_chunk_len(checked_out.len());
         let new_epoch = self.new_epoch;
-        tries_to_compute_roots.into_par_iter().for_each(|(address, SendStorageTriePtr(trie))| {
-            let span = if tracing::enabled!(tracing::Level::TRACE) {
-                debug_span!(
+        while !checked_out.is_empty() {
+            let chunk = checked_out.split_off(checked_out.len().saturating_sub(chunk_len));
+            let storage_done_tx = self.storage_done_tx.clone();
+            let parent_span = parent_span.clone();
+            rayon::spawn(move || {
+                let _enter = debug_span!(
                     target: "engine::tree::payload_processor::sparse_trie",
                     parent: &parent_span,
-                    "storage_root",
-                    ?address
+                    "storage_roots",
+                    n = chunk.len(),
                 )
-            } else {
-                debug_span!(
-                    target: "engine::tree::payload_processor::sparse_trie",
-                    parent: &parent_span,
-                    "storage_root",
-                )
-            };
-            let _enter = span.entered();
-            // SAFETY:
-            // - pointers are created from `storage_tries_mut().get_mut(address)` above;
-            // - `storage_updates` is a map, so addresses are unique;
-            // - we do not insert/remove entries between pointer collection and use, so pointers
-            //   stay valid and map reallocation cannot occur;
-            // - each pointer is consumed by at most one rayon task, so no aliasing mutable access.
-            unsafe {
-                (*trie)
-                    .root(new_epoch)
-                    .expect("updates are drained, trie should be revealed by now")
-            };
-        });
+                .entered();
+                for (address, mut trie) in chunk {
+                    trie.root(new_epoch);
+                    if storage_done_tx.send(StorageTrieJobDone { address, trie }).is_err() {
+                        // Nobody is waiting for the result anymore, drop the rest here.
+                        return;
+                    }
+                }
+            });
+        }
     }
 
-    /// Iterates through all storage tries for which all updates were processed, computes their
-    /// storage roots, and promotes corresponding pending account updates into proper leaf updates
-    /// for accounts trie.
+    /// Puts a storage trie back into the state trie once its job finished, revealing any proof
+    /// nodes that arrived while it was gone.
+    fn on_storage_trie_returned(&mut self, done: StorageTrieJobDone<S>) -> SparseTrieResult<()> {
+        let StorageTrieJobDone { address, mut trie } = done;
+        let in_flight = self
+            .in_flight_storage
+            .remove(&address)
+            .expect("a returned storage trie was checked out");
+        self.metrics.sparse_trie_storage_job_duration_histogram.record(in_flight.started.elapsed());
+
+        let mut result = Ok(());
+        if !in_flight.buffered_proofs.is_empty() {
+            let mut proof_nodes = in_flight.buffered_proofs;
+            result = trie.reveal_v2_proof_nodes(&mut proof_nodes, self.trie.retains_updates());
+            self.trie.defer_drop_proof_nodes(proof_nodes);
+        }
+        self.trie.insert_storage_trie(address, trie);
+
+        result
+    }
+
+    /// Reinstates every storage trie whose job has already finished, without blocking.
+    fn drain_returned_storage_tries(&mut self) -> SparseTrieResult<()> {
+        while let Ok(done) = self.storage_done_rx.try_recv() {
+            self.on_storage_trie_returned(done)?;
+        }
+
+        Ok(())
+    }
+
+    /// Hands off every storage trie whose updates were processed for hashing, and promotes the
+    /// pending account updates whose storage root is already available into proper leaf updates
+    /// for the accounts trie.
+    ///
+    /// Accounts whose trie is still checked out stay pending and are promoted by a later call,
+    /// once the trie has come back.
     #[instrument(
         level = "trace",
         target = "engine::tree::payload_processor::sparse_trie",
@@ -792,14 +898,20 @@ where
             return Ok(());
         }
 
-        self.compute_drained_storage_roots();
+        self.spawn_drained_storage_roots();
 
         loop {
             let span = trace_span!("promote_updates", promoted = tracing::field::Empty).entered();
             // Now handle pending account updates that can be upgraded to a proper update.
             let account_rlp_buf = &mut self.account_rlp_buf;
+            let in_flight_storage = &self.in_flight_storage;
             let mut num_promoted = 0;
             self.pending_account_updates.retain(|addr, account| {
+                if in_flight_storage.contains_key(addr) {
+                    // The storage trie is checked out, so its root is not readable yet.
+                    return true;
+                }
+
                 if let Some(updates) = self.storage_updates.get(addr) {
                     if !updates.is_empty() {
                         // If account has pending storage updates, it is still pending.
@@ -906,14 +1018,15 @@ where
     }
 
     fn has_pending_sparse_trie_updates(&self) -> bool {
-        !self.account_updates.is_empty() ||
+        !self.in_flight_storage.is_empty() ||
+            !self.account_updates.is_empty() ||
             self.storage_updates.values().any(|updates| !updates.is_empty()) ||
             !self.pending_account_updates.is_empty()
     }
 
     /// Errors when pending trie updates remain but nothing can deliver them: no update
-    /// messages are queued, no proof targets are queued or in flight, and no proof results
-    /// are waiting.
+    /// messages are queued, no proof targets are queued or in flight, no proof results
+    /// are waiting, and no storage trie is checked out.
     ///
     /// `updates_queued` is passed in instead of reading `self.updates` directly, because in
     /// the draining phase the updates channel is not read anymore and may hold ignored late
@@ -925,6 +1038,7 @@ where
             self.pending_targets.is_empty() &&
             self.in_flight_proof_batches == 0 &&
             self.proof_result_rx.is_empty() &&
+            self.in_flight_storage.is_empty() &&
             self.has_pending_sparse_trie_updates()
         {
             const MAX_STALLED_PROOF_TARGETS_TO_LOG: usize = 5;
@@ -973,6 +1087,42 @@ where
     }
 }
 
+/// Bookkeeping for a storage trie that is checked out of the sparse state trie while a job on
+/// another thread owns it.
+struct InFlightStorage {
+    /// When the trie was handed off, for the round trip histogram.
+    started: Instant,
+    /// Proof nodes that arrived for this address while the trie was gone.
+    buffered_proofs: Vec<ProofTrieNodeV2>,
+}
+
+impl InFlightStorage {
+    const fn new(started: Instant) -> Self {
+        Self { started, buffered_proofs: Vec::new() }
+    }
+}
+
+/// A storage trie coming back to the sparse trie task after its job finished.
+struct StorageTrieJobDone<S> {
+    /// Hashed address the trie belongs to.
+    address: B256,
+    /// The trie itself, to be put back into the sparse state trie.
+    trie: RevealableSparseTrie<S>,
+}
+
+/// Number of storage tries handed to a single spawned job.
+///
+/// Chunking keeps a block with thousands of tiny tries from paying a rayon spawn per trie, while
+/// staying small enough that one slow trie only delays the few behind it in its own chunk. Tries
+/// are still handed back one at a time, so a chunk does not delay promotion of the ones it
+/// already finished.
+fn storage_job_chunk_len(tries: usize) -> usize {
+    /// Upper bound on how many tries a single slow one can hold up.
+    const MAX_CHUNK_LEN: usize = 32;
+
+    tries.div_ceil(rayon::current_num_threads().max(1) * 4).clamp(1, MAX_CHUNK_LEN)
+}
+
 /// Metrics recorded by sparse trie and hashing tasks.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tree.root")]
@@ -985,6 +1135,8 @@ pub(super) struct SparseTrieTaskMetrics {
     pub(super) sparse_trie_channel_wait_duration_histogram: Histogram,
     /// Histogram of durations spent processing trie updates and promoting pending accounts.
     pub(super) sparse_trie_process_updates_duration_histogram: Histogram,
+    /// Histogram of durations storage tries spend checked out for a job on another thread.
+    pub(super) sparse_trie_storage_job_duration_histogram: Histogram,
     /// Histogram of sparse trie final update durations.
     pub(super) sparse_trie_final_update_duration_histogram: Histogram,
     /// Histogram of sparse trie total durations.
@@ -1127,6 +1279,7 @@ mod tests {
     use reth_db_common::init::init_genesis;
     use reth_provider::test_utils::create_test_provider_factory;
     use reth_storage_overlay::{OverlayManager, OverlayStateProviderFactory};
+    use reth_trie_common::{LeafNode, Nibbles, TrieNodeV2};
     use reth_trie_parallel::proof_task::ProofTaskCtx;
     use reth_trie_sparse::ArenaParallelSparseTrie;
 
@@ -1227,6 +1380,212 @@ mod tests {
         assert_eq!(decoded.balance, U256::from(42));
         assert_eq!(decoded.storage_root, storage_root);
         assert_eq!(account_rlp_buf, encoded);
+    }
+
+    #[test]
+    fn checked_out_storage_trie_holds_back_its_updates_until_it_returns() {
+        let runtime = reth_tasks::Runtime::test();
+        let provider_factory = create_test_provider_factory();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            provider_factory,
+            OverlayManager::<reth_chain_state::EthPrimitives>::default()
+                .overlay_builder(anchor_hash),
+        );
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(state_provider_factory),
+            false,
+            proof_result_tx.clone(),
+        );
+
+        let trie = SparseStateTrie::default()
+            .with_accounts_trie(RevealableSparseTrie::<ArenaParallelSparseTrie>::revealed_empty())
+            .with_default_storage_trie(RevealableSparseTrie::blind_from(
+                ArenaParallelSparseTrie::default(),
+            ))
+            .with_updates(true);
+
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (_cancel_guard, cancel_rx) = crossbeam_channel::bounded::<()>(0);
+        let mut task = SparseTrieCacheTask::new_with_trie(
+            &runtime,
+            updates_rx,
+            cancel_rx,
+            std::sync::mpsc::channel().0,
+            proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
+            SparseTrieTaskMetrics::default(),
+            trie,
+            EMPTY_ROOT_HASH,
+            TrieNodeEpoch::new(1),
+            1,
+        );
+
+        let address = B256::repeat_byte(0x11);
+        let revealed_slot = B256::repeat_byte(0x22);
+        let late_slot = B256::repeat_byte(0x33);
+        let revealed_value = alloy_rlp::encode_fixed_size(&U256::from(7)).to_vec();
+        let late_value = alloy_rlp::encode_fixed_size(&U256::from(9)).to_vec();
+
+        let mut state = HashedPostState::default();
+        state.accounts.insert(address, Some(Account { nonce: 1, ..Default::default() }));
+        state.storages.entry(address).or_default().storage.insert(revealed_slot, U256::from(7));
+        task.on_hashed_state_update(state);
+        task.pending_updates = 1;
+        task.process_new_updates().unwrap();
+
+        // Check the (still blind) trie out by hand so the test does not race a spawned job.
+        let storage_trie = task.trie.take_or_create_storage_trie(&address);
+        task.in_flight_storage.insert(address, InFlightStorage::new(Instant::now()));
+        task.finished_state_updates = true;
+
+        assert!(task.has_pending_sparse_trie_updates());
+        assert!(
+            task.ensure_not_stalled(false).is_ok(),
+            "a checked out trie can still deliver progress"
+        );
+
+        // A proof for a checked out trie must be buffered, not revealed into a fresh blind trie
+        // that the returning job would then overwrite.
+        let leaf = ProofTrieNodeV2 {
+            path: Nibbles::default(),
+            node: TrieNodeV2::Leaf(LeafNode::new(
+                Nibbles::unpack(revealed_slot),
+                revealed_value.clone(),
+            )),
+            masks: None,
+        };
+        task.on_proof_result(DecodedMultiProofV2 {
+            storage_proofs: B256Map::from_iter([(address, vec![leaf])]),
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(!task.trie.storage_tries_mut().contains_key(&address));
+        assert_eq!(task.in_flight_storage[&address].buffered_proofs.len(), 1);
+
+        // The same holds for leaf updates arriving while the trie is gone.
+        let mut state = HashedPostState::default();
+        state.storages.entry(address).or_default().storage.insert(late_slot, U256::from(9));
+        task.on_hashed_state_update(state);
+        task.pending_updates = 1;
+        task.process_new_updates().unwrap();
+        assert!(!task.trie.storage_tries_mut().contains_key(&address));
+        assert!(task.storage_updates[&address].contains_key(&late_slot));
+
+        task.on_storage_trie_returned(StorageTrieJobDone { address, trie: storage_trie }).unwrap();
+
+        assert!(task.in_flight_storage.is_empty());
+        assert_eq!(
+            task.trie.get_storage_slot_value(&address, &revealed_slot),
+            Some(&revealed_value),
+            "buffered proof nodes are revealed when the trie comes back"
+        );
+
+        task.process_leaf_updates(false).unwrap();
+        assert!(task.storage_updates[&address].is_empty());
+        assert_eq!(task.trie.get_storage_slot_value(&address, &late_slot), Some(&late_value));
+
+        // Now that its updates are drained the trie is handed off again, this time for real.
+        task.promote_pending_account_updates().unwrap();
+        assert!(
+            task.in_flight_storage.contains_key(&address),
+            "a drained storage trie is hashed off the task thread"
+        );
+        while !task.in_flight_storage.is_empty() {
+            task.drain_returned_storage_tries().unwrap();
+        }
+        assert!(task.trie.storage_tries_mut()[&address].is_root_cached());
+
+        drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
+    }
+
+    #[test]
+    fn run_waits_for_storage_tries_hashed_off_thread() {
+        let runtime = reth_tasks::Runtime::test();
+        let provider_factory = create_test_provider_factory();
+        let anchor_hash = init_genesis(&provider_factory).expect("failed to initialize genesis");
+        let state_provider_factory = OverlayStateProviderFactory::new(
+            provider_factory,
+            OverlayManager::<reth_chain_state::EthPrimitives>::default()
+                .overlay_builder(anchor_hash),
+        );
+        let (proof_result_tx, proof_result_rx) = crossbeam_channel::unbounded();
+        let proof_worker_handle = ProofWorkerHandle::new(
+            &runtime,
+            ProofTaskCtx::new(state_provider_factory),
+            false,
+            proof_result_tx.clone(),
+        );
+
+        let default_trie = RevealableSparseTrie::<ArenaParallelSparseTrie>::revealed_empty();
+        let trie = SparseStateTrie::default()
+            .with_accounts_trie(default_trie.clone())
+            .with_default_storage_trie(default_trie)
+            .with_updates(true);
+
+        let (updates_tx, updates_rx) = crossbeam_channel::unbounded();
+        let (_cancel_guard, cancel_rx) = crossbeam_channel::bounded::<()>(0);
+        let mut task = SparseTrieCacheTask::new_with_trie(
+            &runtime,
+            updates_rx,
+            cancel_rx,
+            std::sync::mpsc::channel().0,
+            proof_worker_handle,
+            proof_result_tx,
+            proof_result_rx,
+            SparseTrieTaskMetrics::default(),
+            trie,
+            EMPTY_ROOT_HASH,
+            TrieNodeEpoch::new(1),
+            1,
+        );
+
+        let accounts = (0..8u8)
+            .map(|index| {
+                let address = B256::repeat_byte(0x10 + index);
+                let account = Account {
+                    nonce: u64::from(index) + 1,
+                    balance: U256::from(index),
+                    bytecode_hash: None,
+                };
+                let storage = (0..4u8)
+                    .map(|slot| {
+                        (
+                            B256::repeat_byte(0x40 + index * 4 + slot),
+                            U256::from(slot) + U256::from(1),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                (address, account, storage)
+            })
+            .collect::<Vec<_>>();
+
+        let mut state = HashedPostState::default();
+        for (address, account, storage) in &accounts {
+            state.accounts.insert(*address, Some(*account));
+            state.storages.entry(*address).or_default().storage.extend(storage.iter().copied());
+        }
+        updates_tx.send(StateRootMessage::HashedStateUpdate(state)).unwrap();
+        updates_tx.send(StateRootMessage::FinishedStateUpdates).unwrap();
+
+        let outcome = task.run().expect("state root computation should succeed");
+
+        let expected = accounts.iter().map(|(address, account, storage)| {
+            let storage_root =
+                reth_trie_common::root::storage_root_unsorted(storage.iter().copied());
+            (*address, account.into_trie_account(storage_root))
+        });
+        assert_eq!(outcome.state_root, reth_trie_common::root::state_root_unsorted(expected));
+        assert!(task.in_flight_storage.is_empty());
+
+        drop(updates_tx);
+        drop(task);
+        drain_sparse_trie_tasks(&runtime);
     }
 
     #[test]

--- a/crates/trie/sparse/Cargo.toml
+++ b/crates/trie/sparse/Cargo.toml
@@ -26,7 +26,6 @@ alloy-primitives.workspace = true
 either = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
-slotmap = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 
 # metrics
@@ -55,7 +54,6 @@ std = [
     "dep:rayon",
     "dep:reth-primitives-traits",
     "dep:smallvec",
-    "dep:slotmap",
     "dep:tracing",
     "alloy-primitives/std",
     "alloy-rlp/std",

--- a/crates/trie/sparse/src/arena/branch_child_idx.rs
+++ b/crates/trie/sparse/src/arena/branch_child_idx.rs
@@ -3,7 +3,7 @@ use core::{
     iter::Enumerate,
     ops::{Index, IndexMut},
 };
-use smallvec::SmallVec;
+use smallvec::{Array, SmallVec};
 
 /// A dense index into a branch node's children array.
 ///
@@ -49,15 +49,15 @@ impl BranchChildIdx {
     }
 }
 
-impl<T> Index<BranchChildIdx> for SmallVec<[T; 4]> {
-    type Output = T;
+impl<A: Array> Index<BranchChildIdx> for SmallVec<A> {
+    type Output = A::Item;
 
     fn index(&self, idx: BranchChildIdx) -> &Self::Output {
         &self.as_slice()[idx.get()]
     }
 }
 
-impl<T> IndexMut<BranchChildIdx> for SmallVec<[T; 4]> {
+impl<A: Array> IndexMut<BranchChildIdx> for SmallVec<A> {
     fn index_mut(&mut self, idx: BranchChildIdx) -> &mut Self::Output {
         &mut self.as_mut_slice()[idx.get()]
     }

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -1,6 +1,6 @@
 use super::{
     branch_child_idx::{BranchChildIdx, BranchChildIter},
-    ArenaSparseNode, ArenaSparseNodeBranchChild, ArenaSparseNodeState, Index, NodeArena,
+    ArenaSparseNode, ArenaSparseNodeState, BranchChild, Index, NodeArena,
 };
 use alloc::vec::Vec;
 use reth_trie_common::Nibbles;
@@ -210,16 +210,13 @@ impl ArenaCursor {
         let child_idx = BranchChildIdx::new(parent_branch.state_mask, child_nibble)
             .expect("child nibble not found in parent state_mask");
 
-        debug_assert!(
-            matches!(
-                parent_branch.children[child_idx],
-                ArenaSparseNodeBranchChild::Revealed(idx)
-                if idx == old_idx
-            ),
+        debug_assert_eq!(
+            parent_branch.children[child_idx].revealed_index(),
+            Some(old_idx),
             "parent child at nibble {child_nibble} does not match old_idx",
         );
 
-        parent_branch.children[child_idx] = ArenaSparseNodeBranchChild::Revealed(new_idx);
+        parent_branch.children[child_idx] = BranchChild::revealed(new_idx);
     }
 
     /// Advances the DFS traversal to the next actionable node.
@@ -267,9 +264,10 @@ impl ArenaCursor {
                     continue;
                 }
 
-                let child_idx = match &arena[head_idx].branch_ref().children[branch_child_idx] {
-                    ArenaSparseNodeBranchChild::Revealed(child_idx) => *child_idx,
-                    ArenaSparseNodeBranchChild::Blinded(_) => continue,
+                let Some(child_idx) =
+                    arena[head_idx].branch_ref().children[branch_child_idx].revealed_index()
+                else {
+                    continue;
                 };
 
                 if should_descend(child_depth, &arena[child_idx]) {
@@ -344,16 +342,11 @@ impl ArenaCursor {
                 return SeekResult::NoChild { child_nibble };
             };
 
-            match &head_branch.children[branch_child_idx] {
-                ArenaSparseNodeBranchChild::Blinded(_) => {
-                    return SeekResult::Blinded;
-                }
-                ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                    let child_idx = *child_idx;
-                    let path = self.child_path(arena, child_nibble);
-                    self.push(arena, child_idx, path);
-                }
-            }
+            let Some(child_idx) = head_branch.children[branch_child_idx].revealed_index() else {
+                return SeekResult::Blinded;
+            };
+            let path = self.child_path(arena, child_nibble);
+            self.push(arena, child_idx, path);
         }
     }
 }

--- a/crates/trie/sparse/src/arena/cursor.rs
+++ b/crates/trie/sparse/src/arena/cursor.rs
@@ -9,15 +9,18 @@ use tracing::{instrument, trace};
 const TRACE_TARGET: &str = "trie::arena::cursor";
 
 /// An entry on the cursor's traversal stack, tracking an ancestor node during trie walks.
+///
+/// The node's absolute path is not stored: it is the first `path_len` nibbles of the cursor's
+/// [`ArenaCursor::path`], which every entry on the stack is a prefix of.
 #[derive(Debug, Clone)]
 pub(super) struct ArenaCursorStackEntry {
     /// The arena index of this node.
     pub(super) index: Index,
-    /// The absolute path of this node in the trie (not including its `short_key`).
-    pub(super) path: Nibbles,
+    /// The nibble length of the absolute path of this node (not including its `short_key`).
+    pub(super) path_len: u8,
     /// The dense index at which to resume child iteration in [`ArenaCursor::next`].
     /// Only meaningful when this entry's node is a branch.
-    pub(super) next_dense_idx: usize,
+    pub(super) next_dense_idx: u8,
 }
 
 /// Result of [`ArenaCursor::seek`] describing the state at the deepest ancestor node.
@@ -61,6 +64,14 @@ pub(super) enum NextResult {
 #[derive(Debug, Default, Clone)]
 pub(super) struct ArenaCursor {
     stack: Vec<ArenaCursorStackEntry>,
+    /// A path that every stack entry's path is a prefix of: the entry with `path_len` nibbles
+    /// has the absolute path `path[..path_len]`.
+    ///
+    /// It holds the last seeked target, or the path of the deepest node a [`Self::next`] walk
+    /// descended to, and may therefore be longer than the head's own path. Popping never
+    /// shortens it, which is what keeps the ancestor test in [`Self::seek`] to a single
+    /// [`Nibbles::common_prefix_length`].
+    path: Nibbles,
     /// Whether the head entry should be popped at the start of the next [`Self::next`] call.
     /// Set when `next` returns [`NextResult::NonBranch`] or [`NextResult::Branch`].
     needs_pop: bool,
@@ -87,6 +98,23 @@ impl ArenaCursor {
         self.stack.len() - 1
     }
 
+    /// Returns the absolute path of the node at the top of the stack.
+    pub(super) fn head_path(&self) -> Nibbles {
+        self.entry_path(self.head_entry())
+    }
+
+    /// Returns the nibble length of the absolute path of the node at the top of the stack.
+    /// Equivalent to `head_path().len()` but avoids constructing the path.
+    pub(super) fn head_path_len(&self) -> usize {
+        self.head_entry().path_len as usize
+    }
+
+    /// Returns the last nibble of the head node's absolute path, or `None` if that path is
+    /// empty.
+    pub(super) fn head_last_nibble(&self) -> Option<u8> {
+        self.head_path_len().checked_sub(1).map(|i| self.path.get_unchecked(i))
+    }
+
     /// Replaces the root entry on the stack with a new one.
     ///
     /// The stack must contain exactly the root (depth 0) or be empty (freshly constructed).
@@ -100,14 +128,30 @@ impl ArenaCursor {
         );
         self.stack.clear();
         self.needs_pop = false;
-        self.push(arena, idx, path);
+        self.path = path;
+        self.push(arena, idx, path.len());
     }
 
-    /// Pushes an entry onto the stack for the node at the given index and path.
-    fn push(&mut self, arena: &NodeArena, idx: Index, path: Nibbles) {
+    /// Pushes an entry onto the stack for the node at the given index, whose absolute path is
+    /// the first `path_len` nibbles of [`Self::path`].
+    fn push(&mut self, arena: &NodeArena, idx: Index, path_len: usize) {
         debug_assert!(arena.contains_key(idx), "push called with invalid arena index");
-        self.stack.push(ArenaCursorStackEntry { index: idx, path, next_dense_idx: 0 });
-        trace!(target: TRACE_TARGET, entry = ?self.stack.last().expect("just pushed"), "Pushed stack entry");
+        debug_assert!(
+            path_len <= self.path.len(),
+            "pushed path length {path_len} exceeds cursor path {:?}",
+            self.path,
+        );
+        self.stack.push(ArenaCursorStackEntry {
+            index: idx,
+            path_len: path_len as u8,
+            next_dense_idx: 0,
+        });
+        trace!(
+            target: TRACE_TARGET,
+            ?idx,
+            path = ?self.path.slice_unchecked(0, path_len),
+            "Pushed stack entry",
+        );
     }
 
     /// Pops the top entry from the stack and propagates dirty state to the parent.
@@ -122,10 +166,11 @@ impl ArenaCursor {
 
         #[cfg(debug_assertions)]
         if let Some(ArenaSparseNode::Subtrie(s)) = arena.get(entry.index) {
+            let entry_path = self.path.slice_unchecked(0, entry.path_len as usize);
             debug_assert_eq!(
-                s.path, entry.path,
+                s.path, entry_path,
                 "subtrie cached path {:?} does not match stack entry path {:?}",
-                s.path, entry.path,
+                s.path, entry_path,
             );
         }
 
@@ -159,29 +204,22 @@ impl ArenaCursor {
     }
 
     /// Returns the logical path of the branch at the top of the stack.
-    /// The logical path is `entry.path + branch.short_key`.
+    /// The logical path is `head_path() + branch.short_key`.
     pub(super) fn head_logical_branch_path(&self, arena: &NodeArena) -> Nibbles {
-        logical_branch_path(arena, self.stack.last().expect("cursor is non-empty"))
+        self.logical_branch_path(arena, self.head_entry())
     }
 
     /// Returns the length of the logical path of the branch at the top of the stack.
     /// Equivalent to `head_logical_branch_path(arena).len()` but avoids constructing the path.
     pub(super) fn head_logical_branch_path_len(&self, arena: &NodeArena) -> usize {
-        logical_branch_path_len(arena, self.stack.last().expect("cursor is non-empty"))
-    }
-
-    /// Returns the absolute path of a child at `child_nibble` under the branch at the top of
-    /// the stack. The result is `stack_head.path + branch.short_key + child_nibble`.
-    pub(super) fn child_path(&self, arena: &NodeArena, child_nibble: u8) -> Nibbles {
-        let mut path = logical_branch_path(arena, self.stack.last().expect("cursor is non-empty"));
-        path.push_unchecked(child_nibble);
-        path
+        let head = self.head_entry();
+        head.path_len as usize + arena[head.index].branch_ref().short_key.len()
     }
 
     /// Returns the logical path of the parent branch entry (second from top of the stack).
     /// Panics if the stack has fewer than 2 entries.
     pub(super) fn parent_logical_branch_path(&self, arena: &NodeArena) -> Nibbles {
-        logical_branch_path(arena, self.parent().expect("cursor must have a parent"))
+        self.logical_branch_path(arena, self.parent().expect("cursor must have a parent"))
     }
 
     /// Replaces the arena index stored in the head entry with `new_idx`, and updates the
@@ -193,9 +231,9 @@ impl ArenaCursor {
         root: &mut Index,
         new_idx: Index,
     ) {
+        let child_nibble = self.head_last_nibble();
         let head = self.stack.last_mut().expect("cursor must have head");
         let old_idx = head.index;
-        let child_nibble = head.path.last();
         head.index = new_idx;
 
         let Some(parent) = self.parent() else {
@@ -251,6 +289,7 @@ impl ArenaCursor {
                 return NextResult::Done;
             };
             let head_idx = head.index;
+            let head_path_len = head.path_len as usize;
 
             let ArenaSparseNode::Branch(branch) = &arena[head_idx] else {
                 self.needs_pop = true;
@@ -258,7 +297,7 @@ impl ArenaCursor {
             };
 
             let state_mask = branch.state_mask;
-            let start = head.next_dense_idx;
+            let start = head.next_dense_idx as usize;
             let child_depth = self.stack.len();
 
             let mut descended = false;
@@ -275,9 +314,11 @@ impl ArenaCursor {
                 if should_descend(child_depth, &arena[child_idx]) {
                     // Record where to resume iteration when we return to this entry.
                     self.stack.last_mut().expect("head exists").next_dense_idx =
-                        branch_child_idx.get() + 1;
-                    let path = self.child_path(arena, nibble);
-                    self.push(arena, child_idx, path);
+                        branch_child_idx.get() as u8 + 1;
+                    self.path.truncate(head_path_len);
+                    self.path.extend(&arena[head_idx].branch_ref().short_key);
+                    self.path.push_unchecked(nibble);
+                    self.push(arena, child_idx, self.path.len());
                     descended = true;
                     break;
                 }
@@ -297,25 +338,33 @@ impl ArenaCursor {
     /// Returns a [`SeekResult`] describing the state at the stack head.
     #[instrument(level = "trace", target = TRACE_TARGET, skip(self, arena), ret)]
     pub(super) fn seek(&mut self, arena: &mut NodeArena, full_path: &Nibbles) -> SeekResult {
-        // Pop stack until head is ancestor of full_path.
-        while self.stack.len() > 1 &&
-            !full_path.starts_with(&self.stack.last().expect("cursor has root").path)
-        {
+        // Every entry's path is a prefix of `self.path`, so an entry is an ancestor of
+        // `full_path` exactly when its length fits within the common prefix of the previous
+        // target and this one.
+        let common = self.path.common_prefix_length(full_path);
+        while self.stack.len() > 1 && self.head_entry().path_len as usize > common {
             self.pop(arena);
         }
 
+        if self.head_entry().path_len as usize > common {
+            // The target is not below the walk's root. Callers only seek within the root's
+            // prefix, so this cannot happen for a revealed root; leaving `self.path` alone
+            // keeps the entry paths derivable.
+            return SeekResult::Diverged;
+        }
+        self.path = *full_path;
+
         loop {
-            let head = self.stack.last().expect("cursor has root");
+            let head = self.head_entry();
             let head_idx = head.index;
+            let head_path_len = head.path_len as usize;
 
             let head_branch = match &arena[head_idx] {
                 ArenaSparseNode::EmptyRoot { .. } => {
                     return SeekResult::EmptyRoot;
                 }
                 ArenaSparseNode::Leaf { key, .. } => {
-                    let mut leaf_full_path = head.path;
-                    leaf_full_path.extend(key);
-                    return if &leaf_full_path == full_path {
+                    return if full_path.slice_unchecked(head_path_len, full_path.len()) == *key {
                         SeekResult::RevealedLeaf
                     } else {
                         SeekResult::Diverged
@@ -328,17 +377,20 @@ impl ArenaCursor {
                 _ => unreachable!("unexpected node type on stack: {:?}", arena[head_idx]),
             };
 
-            let head_branch_logical_path = logical_branch_path(arena, head);
+            let short_key = &head_branch.short_key;
+            let logical_len = head_path_len + short_key.len();
 
             // If full_path doesn't extend past the branch's logical path, the target is at or
-            // within the branch's short_key — treat as diverged.
-            if full_path.len() <= head_branch_logical_path.len() ||
-                !full_path.starts_with(&head_branch_logical_path)
+            // within the branch's short_key — treat as diverged. Most branches carry no
+            // short_key, in which case there is nothing left to compare.
+            if full_path.len() <= logical_len ||
+                (!short_key.is_empty() &&
+                    full_path.slice_unchecked(head_path_len, logical_len) != *short_key)
             {
                 return SeekResult::Diverged;
             }
 
-            let child_nibble = full_path.get_unchecked(head_branch_logical_path.len());
+            let child_nibble = full_path.get_unchecked(logical_len);
             let Some(branch_child_idx) = BranchChildIdx::new(head_branch.state_mask, child_nibble)
             else {
                 return SeekResult::NoChild { child_nibble };
@@ -350,24 +402,26 @@ impl ArenaCursor {
                 }
                 ArenaSparseNodeBranchChild::Revealed(child_idx) => {
                     let child_idx = *child_idx;
-                    let path = self.child_path(arena, child_nibble);
-                    self.push(arena, child_idx, path);
+                    self.push(arena, child_idx, logical_len + 1);
                 }
             }
         }
     }
-}
 
-/// Returns the logical path of a branch stack entry. The logical path is
-/// `entry.path + branch.short_key`.
-fn logical_branch_path(arena: &NodeArena, entry: &ArenaCursorStackEntry) -> Nibbles {
-    let mut path = entry.path;
-    path.extend(&arena[entry.index].branch_ref().short_key);
-    path
-}
+    /// Returns the entry at the top of the stack, which must be non-empty.
+    fn head_entry(&self) -> &ArenaCursorStackEntry {
+        self.stack.last().expect("cursor is non-empty")
+    }
 
-/// Returns the length of the logical path of a branch stack entry.
-/// Equivalent to `logical_branch_path(arena, entry).len()` but avoids constructing the path.
-fn logical_branch_path_len(arena: &NodeArena, entry: &ArenaCursorStackEntry) -> usize {
-    entry.path.len() + arena[entry.index].branch_ref().short_key.len()
+    /// Returns the absolute path of a stack entry.
+    fn entry_path(&self, entry: &ArenaCursorStackEntry) -> Nibbles {
+        self.path.slice_unchecked(0, entry.path_len as usize)
+    }
+
+    /// Returns the logical path of a branch stack entry: `entry path + branch.short_key`.
+    fn logical_branch_path(&self, arena: &NodeArena, entry: &ArenaCursorStackEntry) -> Nibbles {
+        let mut path = self.entry_path(entry);
+        path.extend(&arena[entry.index].branch_ref().short_key);
+        path
+    }
 }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -9,7 +9,8 @@ use nodes::{
 };
 
 use crate::{
-    LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdates, TrieNodeEpoch,
+    blocked::BlockedOn, BlockedLeafUpdates, LeafLookup, LeafLookupError, LeafUpdate, SparseTrie,
+    SparseTrieUpdates, TrieNodeEpoch,
 };
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
 use alloy_primitives::{keccak256, map::B256Map, B256};
@@ -352,7 +353,11 @@ impl ArenaSparseSubtrie {
                 let logical_len = self.buffers.cursor.head_logical_branch_path_len(&self.arena);
                 self.required_proofs.push((
                     idx,
-                    ArenaRequiredProof { key, parent: ProofV2TargetParent::new(logical_len) },
+                    ArenaRequiredProof {
+                        key,
+                        parent: ProofV2TargetParent::new(logical_len),
+                        blocked_on: BlockedOn::Reveal((logical_len + 1) as u8),
+                    },
                 ));
                 continue;
             }
@@ -387,9 +392,13 @@ impl ArenaSparseSubtrie {
                         (self.num_dirty_leaves as i64 + deltas.num_dirty_leaves_delta) as u64;
 
                     if let RemoveLeafResult::NeedsProof { key, proof_key, parent } = result {
+                        // The collapse waits for a blinded sibling, which is not on the removed
+                        // leaf's own path, so the update is retried with every batch.
+                        let blocked_on = BlockedOn::Retryable;
                         self.required_proofs
-                            .push((idx, ArenaRequiredProof { key: proof_key, parent }));
-                        self.required_proofs.push((idx, ArenaRequiredProof { key, parent }));
+                            .push((idx, ArenaRequiredProof { key: proof_key, parent, blocked_on }));
+                        self.required_proofs
+                            .push((idx, ArenaRequiredProof { key, parent, blocked_on }));
                     }
                 }
                 LeafUpdate::Touched => {}
@@ -501,6 +510,8 @@ struct ArenaRequiredProof {
     key: B256,
     /// The revealed logical parent branch.
     parent: ProofV2TargetParent,
+    /// What the update that triggered this request is waiting for.
+    blocked_on: BlockedOn,
 }
 
 /// An arena-based parallel sparse trie.
@@ -602,6 +613,8 @@ pub struct ArenaParallelSparseTrie {
     root: Index,
     /// Reusable buffers for traversal, RLP encoding, and update actions.
     buffers: ArenaTrieBuffers,
+    /// Leaf updates that hit a blinded node, waiting for it to be revealed.
+    blocked: BlockedLeafUpdates,
     /// Thresholds controlling when parallelism is enabled for different operations.
     parallelism_thresholds: ArenaParallelismThresholds,
 }
@@ -1703,6 +1716,7 @@ impl ArenaParallelSparseTrie {
             parent: ProofV2TargetParent::new(
                 sibling_path.len().checked_sub(1).expect("sibling path has a child nibble"),
             ),
+            blocked_on: BlockedOn::Retryable,
         })
     }
 
@@ -2074,6 +2088,7 @@ impl Default for ArenaParallelSparseTrie {
             upper_arena,
             root,
             buffers: ArenaTrieBuffers::default(),
+            blocked: BlockedLeafUpdates::new(),
             parallelism_thresholds: ArenaParallelismThresholds::default(),
         }
     }
@@ -2168,6 +2183,14 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
         // Sort nodes lexicographically by path.
         nodes.sort_unstable_by_key(|n| n.path);
+
+        // Leaf updates that stopped at one of these paths can be applied again. Nodes that end
+        // up being skipped below only cause a superfluous retry.
+        if !self.blocked.is_empty() {
+            for node in nodes.iter() {
+                self.blocked.mark_revealed(&node.path);
+            }
+        }
 
         let threshold = self.parallelism_thresholds.min_revealed_nodes;
 
@@ -2451,6 +2474,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
             .upper_arena
             .insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed });
         self.buffers.clear();
+        self.blocked.clear();
     }
 
     #[instrument(
@@ -2461,6 +2485,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
     )]
     fn prune(&mut self, prune_before: TrieNodeEpoch) -> usize {
         assert!(self.root_epoch().is_some(), "prune cannot run on a dirty trie");
+        // Pruning re-blinds nodes, which would strand updates waiting for a reveal.
+        debug_assert!(self.blocked.is_empty(), "prune cannot run with blocked leaf updates");
 
         // Only descend if the root is a branch; otherwise there are no subtries.
         if !matches!(&self.upper_arena[self.root], ArenaSparseNode::Branch(_)) {
@@ -2610,14 +2636,20 @@ impl SparseTrie for ArenaParallelSparseTrie {
         updates: &mut B256Map<LeafUpdate>,
         mut proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
     ) -> SparseTrieResult<()> {
-        if updates.is_empty() {
+        if updates.is_empty() && !self.blocked.has_retryable() {
             return Ok(());
         }
 
-        // Drain and sort updates lexicographically by nibbles path.
-        let mut sorted: Vec<_> =
-            updates.drain().map(|(key, update)| (key, Nibbles::unpack(key), update)).collect();
-        sorted.sort_unstable_by_key(|entry| entry.1);
+        // Drain the new updates and the blocked updates that can be applied again into one batch,
+        // sorted lexicographically by nibbles path (which is the order of their packed keys).
+        let mut sorted = Vec::new();
+        self.blocked.take_batch(updates, &mut sorted);
+        if sorted.is_empty() {
+            return Ok(());
+        }
+
+        // Batch indices of the updates that hit a blinded node, filled during the walk below.
+        let mut newly_blocked = Vec::new();
 
         let threshold = self.parallelism_thresholds.min_updates;
         let parallelize_distributed_updates = sorted.len() >= threshold.saturating_mul(4);
@@ -2641,7 +2673,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     let parent = ProofV2TargetParent::new(logical_len);
                     trace!(target: TRACE_TARGET, ?key, ?parent, "Update hit blinded node, requesting proof");
                     proof_required_fn(key, parent);
-                    updates.insert(key, update.clone());
+                    newly_blocked
+                        .push((update_idx as u32, BlockedOn::Reveal((logical_len + 1) as u8)));
                 }
                 // Subtrie — forward all consecutive updates under this subtrie's prefix.
                 SeekResult::RevealedSubtrie => {
@@ -2668,9 +2701,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     ) {
                         trace!(target: TRACE_TARGET, proof_key = ?proof.key, proof_parent = ?proof.parent, "Subtrie collapse would need blinded sibling, requesting proof");
                         proof_required_fn(proof.key, proof.parent);
-                        for &(key, _, ref update) in subtrie_updates {
-                            updates.insert(key, update.clone());
-                        }
+                        newly_blocked.extend(
+                            (subtrie_start..update_idx).map(|idx| (idx as u32, proof.blocked_on)),
+                        );
                         // Pop the subtrie entry before continuing.
                         continue;
                     }
@@ -2718,8 +2751,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
                         for (target_idx, proof) in subtrie.required_proofs.drain(..) {
                             proof_required_fn(proof.key, proof.parent);
-                            let (key, _, ref update) = subtrie_updates[target_idx];
-                            updates.insert(key, update.clone());
+                            newly_blocked
+                                .push(((subtrie_start + target_idx) as u32, proof.blocked_on));
                         }
 
                         // Check if the subtrie's root became empty after updates.
@@ -2776,11 +2809,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             &mut self.buffers.updates,
                         );
                         match result {
-                            RemoveLeafResult::NeedsProof { key, proof_key, parent } => {
+                            RemoveLeafResult::NeedsProof { proof_key, parent, .. } => {
                                 proof_required_fn(proof_key, parent);
-                                let update =
-                                    mem::replace(&mut sorted[update_idx].2, LeafUpdate::Touched);
-                                updates.insert(key, update);
+                                // The collapse waits for a blinded sibling, which is not on the
+                                // removed leaf's own path.
+                                newly_blocked.push((update_idx as u32, BlockedOn::Retryable));
                             }
                             RemoveLeafResult::Removed => {
                                 // remove_leaf may have called collapse_branch, which
@@ -2811,6 +2844,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
         self.buffers.cursor = cursor;
 
         if taken.is_empty() {
+            self.blocked.block(&mut sorted, &mut newly_blocked);
+
             #[cfg(debug_assertions)]
             self.debug_assert_subtrie_structure();
 
@@ -2835,11 +2870,9 @@ impl SparseTrie for ArenaParallelSparseTrie {
         // process required proofs.
         let taken_paths: Vec<Nibbles> = taken.iter().map(|(_, s, _)| s.path).collect();
         for (child_idx, mut subtrie, range) in taken {
-            let subtrie_updates = &sorted[range];
             for (target_idx, proof) in subtrie.required_proofs.drain(..) {
                 proof_required_fn(proof.key, proof.parent);
-                let (key, _, ref update) = subtrie_updates[target_idx];
-                updates.insert(key, update.clone());
+                newly_blocked.push(((range.start + target_idx) as u32, proof.blocked_on));
             }
 
             // Restore the subtrie into the upper arena.
@@ -2888,10 +2921,16 @@ impl SparseTrie for ArenaParallelSparseTrie {
             self.buffers.cursor = cursor;
         }
 
+        self.blocked.block(&mut sorted, &mut newly_blocked);
+
         #[cfg(debug_assertions)]
         self.debug_assert_subtrie_structure();
 
         Ok(())
+    }
+
+    fn blocked_updates(&self) -> &BlockedLeafUpdates {
+        &self.blocked
     }
 }
 

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -9,8 +9,8 @@ use nodes::{
 };
 
 use crate::{
-    blocked::BlockedOn, BlockedLeafUpdates, LeafLookup, LeafLookupError, LeafUpdate, SparseTrie,
-    SparseTrieUpdates, TrieNodeEpoch,
+    blocked::BlockedOn, BlockedLeafUpdates, LeafLookup, LeafLookupError, LeafUpdate,
+    LeafUpdateEvent, SparseTrie, SparseTrieUpdates, TrieNodeEpoch,
 };
 use alloc::{borrow::Cow, boxed::Box, collections::VecDeque, vec::Vec};
 use alloy_primitives::{keccak256, map::B256Map, B256};
@@ -126,6 +126,11 @@ struct ArenaSparseSubtrie {
     /// Each entry is `(index, proof)` where `index` is the position of the target in the
     /// `sorted_updates` slice passed to [`Self::update_leaves`].
     required_proofs: Vec<(usize, ArenaRequiredProof)>,
+    /// Reusable buffer for the leaves that [`LeafUpdate::Touched`] entries resolved to.
+    /// Each entry is `(index, leaf)` where `index` is the position of the entry in the
+    /// `sorted_updates` slice and `leaf` is the arena index of the leaf found at its key, or
+    /// `None` for a revealed key that has no leaf. Drained by [`Self::emit_touched`].
+    touched: Vec<(usize, Option<Index>)>,
     /// Total number of revealed leaves in this subtrie.
     num_leaves: u64,
     /// Number of dirty (modified since last hash) leaves in this subtrie.
@@ -150,6 +155,7 @@ impl ArenaSparseSubtrie {
             path: Nibbles::default(),
             buffers,
             required_proofs: Vec::new(),
+            touched: Vec::new(),
             num_leaves: 0,
             num_dirty_leaves: 0,
         })
@@ -322,7 +328,9 @@ impl ArenaSparseSubtrie {
     /// `sorted_updates` must be sorted lexicographically by their nibbles path (index 1).
     ///
     /// Any required proofs are appended to `self.required_proofs` and should be drained by the
-    /// caller after this method returns.
+    /// caller after this method returns. With `report_touched` set, the leaves that
+    /// [`LeafUpdate::Touched`] entries resolved to are appended to `self.touched` and must be
+    /// drained by [`Self::emit_touched`] before the subtrie is mutated again.
     #[instrument(
         level = "trace",
         target = TRACE_TARGET,
@@ -332,7 +340,11 @@ impl ArenaSparseSubtrie {
             num_updates = sorted_updates.len(),
         ),
     )]
-    fn update_leaves(&mut self, sorted_updates: &[(B256, Nibbles, LeafUpdate)]) {
+    fn update_leaves(
+        &mut self,
+        sorted_updates: &[(B256, Nibbles, LeafUpdate)],
+        report_touched: bool,
+    ) {
         if sorted_updates.is_empty() {
             return;
         }
@@ -342,6 +354,7 @@ impl ArenaSparseSubtrie {
             !matches!(self.arena[self.root], ArenaSparseNode::EmptyRoot { .. }),
             "subtrie root must not be EmptyRoot at start of update_leaves"
         );
+        debug_assert!(self.touched.is_empty(), "touched leaves were not drained by the caller");
 
         self.buffers.cursor.reset(&self.arena, self.root, self.path);
 
@@ -401,7 +414,14 @@ impl ArenaSparseSubtrie {
                             .push((idx, ArenaRequiredProof { key, parent, blocked_on }));
                     }
                 }
-                LeafUpdate::Touched => {}
+                LeafUpdate::Touched => {
+                    if report_touched {
+                        let leaf = matches!(find_result, SeekResult::RevealedLeaf).then(|| {
+                            self.buffers.cursor.head().expect("cursor is non-empty").index
+                        });
+                        self.touched.push((idx, leaf));
+                    }
+                }
             }
         }
 
@@ -410,6 +430,48 @@ impl ArenaSparseSubtrie {
 
         #[cfg(debug_assertions)]
         self.debug_assert_counters();
+    }
+
+    /// Reports the leaves recorded by [`Self::update_leaves`] for its [`LeafUpdate::Touched`]
+    /// entries, where `offset` is the position of that call's slice inside `sorted_updates`.
+    ///
+    /// The recorded arena indices are still valid: within one batch every key appears at most
+    /// once, and a subtrie only ever frees the leaf of the key it is removing plus the branches
+    /// that collapse around it. Nodes are never migrated out of a subtrie while it is being
+    /// updated, so the caller only has to drain before wrapping or unwrapping it.
+    fn emit_touched(
+        &mut self,
+        offset: usize,
+        sorted_updates: &[(B256, Nibbles, LeafUpdate)],
+        event_fn: &mut impl FnMut(LeafUpdateEvent<'_>),
+    ) {
+        if self.touched.is_empty() {
+            return;
+        }
+
+        let mut touched = mem::take(&mut self.touched);
+        for &(idx, leaf) in &touched {
+            let (key, ref full_path, _) = sorted_updates[offset + idx];
+            let value = leaf.map(|leaf| match &self.arena[leaf] {
+                ArenaSparseNode::Leaf { value, .. } => value.as_slice(),
+                node => unreachable!("touched leaf is no longer a leaf: {node:?}"),
+            });
+            debug_assert_eq!(
+                value,
+                ArenaParallelSparseTrie::get_leaf_value_in_arena(
+                    &self.arena,
+                    self.root,
+                    full_path,
+                    self.path.len(),
+                )
+                .map(Vec::as_slice),
+                "touched leaf {key:?} does not match the subtrie's current value",
+            );
+            event_fn(LeafUpdateEvent::Touched { key, value });
+        }
+
+        touched.clear();
+        self.touched = touched;
     }
 
     /// Reveals nodes inside this subtrie. Uses [`ArenaCursor::seek`] to locate the ancestor
@@ -2631,10 +2693,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
         skip_all,
         fields(num_updates = updates.len()),
     )]
-    fn update_leaves(
+    fn update_leaves_with_events(
         &mut self,
         updates: &mut B256Map<LeafUpdate>,
-        mut proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
+        report_touched: bool,
+        mut event_fn: impl FnMut(LeafUpdateEvent<'_>),
     ) -> SparseTrieResult<()> {
         if updates.is_empty() && !self.blocked.has_retryable() {
             return Ok(());
@@ -2672,7 +2735,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     let logical_len = cursor.head_logical_branch_path_len(&self.upper_arena);
                     let parent = ProofV2TargetParent::new(logical_len);
                     trace!(target: TRACE_TARGET, ?key, ?parent, "Update hit blinded node, requesting proof");
-                    proof_required_fn(key, parent);
+                    event_fn(LeafUpdateEvent::ProofRequired { key, parent });
                     newly_blocked
                         .push((update_idx as u32, BlockedOn::Reveal((logical_len + 1) as u8)));
                 }
@@ -2700,7 +2763,10 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         subtrie_updates,
                     ) {
                         trace!(target: TRACE_TARGET, proof_key = ?proof.key, proof_parent = ?proof.parent, "Subtrie collapse would need blinded sibling, requesting proof");
-                        proof_required_fn(proof.key, proof.parent);
+                        event_fn(LeafUpdateEvent::ProofRequired {
+                            key: proof.key,
+                            parent: proof.parent,
+                        });
                         newly_blocked.extend(
                             (subtrie_start..update_idx).map(|idx| (idx as u32, proof.blocked_on)),
                         );
@@ -2747,13 +2813,19 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             unreachable!()
                         };
 
-                        subtrie.update_leaves(subtrie_updates);
+                        subtrie.update_leaves(subtrie_updates, report_touched);
 
                         for (target_idx, proof) in subtrie.required_proofs.drain(..) {
-                            proof_required_fn(proof.key, proof.parent);
+                            event_fn(LeafUpdateEvent::ProofRequired {
+                                key: proof.key,
+                                parent: proof.parent,
+                            });
                             newly_blocked
                                 .push(((subtrie_start + target_idx) as u32, proof.blocked_on));
                         }
+                        // Must run before the subtrie can be unwrapped, which would migrate its
+                        // nodes into the upper arena.
+                        subtrie.emit_touched(subtrie_start, &sorted, &mut event_fn);
 
                         // Check if the subtrie's root became empty after updates.
                         self.maybe_unwrap_subtrie(&mut cursor);
@@ -2810,7 +2882,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         );
                         match result {
                             RemoveLeafResult::NeedsProof { proof_key, parent, .. } => {
-                                proof_required_fn(proof_key, parent);
+                                event_fn(LeafUpdateEvent::ProofRequired { key: proof_key, parent });
                                 // The collapse waits for a blinded sibling, which is not on the
                                 // removed leaf's own path.
                                 newly_blocked.push((update_idx as u32, BlockedOn::Retryable));
@@ -2832,7 +2904,19 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             RemoveLeafResult::NotFound => {}
                         }
                     }
-                    LeafUpdate::Touched => {}
+                    LeafUpdate::Touched => {
+                        if report_touched {
+                            let value =
+                                matches!(find_result, SeekResult::RevealedLeaf).then(|| {
+                                    let head = cursor.head().expect("cursor is non-empty").index;
+                                    match &self.upper_arena[head] {
+                                        ArenaSparseNode::Leaf { value, .. } => value.as_slice(),
+                                        node => unreachable!("RevealedLeaf but head is {node:?}"),
+                                    }
+                                });
+                            event_fn(LeafUpdateEvent::Touched { key, value });
+                        }
+                    }
                 },
             }
 
@@ -2855,14 +2939,14 @@ impl SparseTrie for ArenaParallelSparseTrie {
         // Apply updates to taken subtries, in parallel if more than one.
         if taken.len() == 1 {
             let (_, ref mut subtrie, ref range) = taken[0];
-            subtrie.update_leaves(&sorted[range.clone()]);
+            subtrie.update_leaves(&sorted[range.clone()], report_touched);
         } else {
             use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
             let parent_span = tracing::Span::current();
             taken.par_iter_mut().for_each(|(_, subtrie, range)| {
                 let _guard = parent_span.enter();
-                subtrie.update_leaves(&sorted[range.clone()]);
+                subtrie.update_leaves(&sorted[range.clone()], report_touched);
             });
         }
 
@@ -2871,9 +2955,12 @@ impl SparseTrie for ArenaParallelSparseTrie {
         let taken_paths: Vec<Nibbles> = taken.iter().map(|(_, s, _)| s.path).collect();
         for (child_idx, mut subtrie, range) in taken {
             for (target_idx, proof) in subtrie.required_proofs.drain(..) {
-                proof_required_fn(proof.key, proof.parent);
+                event_fn(LeafUpdateEvent::ProofRequired { key: proof.key, parent: proof.parent });
                 newly_blocked.push(((range.start + target_idx) as u32, proof.blocked_on));
             }
+            // Must run before the restored subtrie can be unwrapped below, which would migrate
+            // its nodes into the upper arena.
+            subtrie.emit_touched(range.start, &sorted, &mut event_fn);
 
             // Restore the subtrie into the upper arena.
             self.upper_arena[child_idx] = ArenaSparseNode::Subtrie(subtrie);
@@ -2938,7 +3025,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
 mod tests {
     use super::TRACE_TARGET;
     use crate::{
-        ArenaParallelSparseTrie, ArenaParallelismThresholds, LeafUpdate, SparseTrie, TrieNodeEpoch,
+        ArenaParallelSparseTrie, ArenaParallelismThresholds, LeafUpdate, LeafUpdateEvent,
+        SparseTrie, TrieNodeEpoch,
     };
     use alloy_primitives::{map::B256Map, B256, U256};
     use rand::{seq::SliceRandom, Rng, SeedableRng};
@@ -3010,12 +3098,38 @@ mod tests {
                 })
                 .collect();
 
+            // Touch every key the changeset leaves alone, plus a few keys that do not exist.
+            // The changeset cannot alter their values, so each must be reported exactly once
+            // with the value the base dataset holds for it.
+            let expected_touched: B256Map<Option<Vec<u8>>> = self
+                .storage()
+                .iter()
+                .filter(|(key, _)| !changes.contains_key(*key))
+                .map(|(&key, value)| (key, Some(alloy_rlp::encode_fixed_size(value).to_vec())))
+                .chain(
+                    (0u8..4)
+                        .map(|i| B256::repeat_byte(0xf0 | i))
+                        .filter(|key| {
+                            !self.storage().contains_key(key) && !changes.contains_key(key)
+                        })
+                        .map(|key| (key, None)),
+                )
+                .collect();
+            leaf_updates.extend(expected_touched.keys().map(|&key| (key, LeafUpdate::Touched)));
+
             // Reveal-update loop: call update_leaves, collect required proofs, fetch them,
             // reveal, and repeat until no more proofs are needed.
+            let mut reported_touched = B256Map::<Option<Vec<u8>>>::default();
             loop {
                 let mut targets: Vec<ProofV2Target> = Vec::new();
-                apst.update_leaves(&mut leaf_updates, |key, parent| {
-                    targets.push(ProofV2Target::new(key).with_parent(parent));
+                apst.update_leaves_with_events(&mut leaf_updates, true, |event| match event {
+                    LeafUpdateEvent::ProofRequired { key, parent } => {
+                        targets.push(ProofV2Target::new(key).with_parent(parent));
+                    }
+                    LeafUpdateEvent::Touched { key, value } => {
+                        let previous = reported_touched.insert(key, value.map(<[u8]>::to_vec));
+                        assert!(previous.is_none(), "touched leaf {key:?} reported twice");
+                    }
                 })
                 .expect("update_leaves should succeed");
 
@@ -3026,6 +3140,12 @@ mod tests {
                 let (mut proof_nodes, _) = self.proof_v2(&mut targets);
                 apst.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
             }
+
+            pretty_assertions::assert_eq!(
+                reported_touched,
+                expected_touched,
+                "touched leaf values mismatch"
+            );
 
             // Compute root and take updates from the APST.
             let actual_root = apst.root(epoch(0));

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -1,12 +1,12 @@
 mod branch_child_idx;
 mod cursor;
+mod node_arena;
 mod nodes;
 
 use branch_child_idx::{BranchChildIdx, BranchChildIter};
 use cursor::{ArenaCursor, NextResult, SeekResult};
-use nodes::{
-    ArenaSparseNode, ArenaSparseNodeBranch, ArenaSparseNodeBranchChild, ArenaSparseNodeState,
-};
+use node_arena::{BranchChild, Index, NodeArena};
+use nodes::{ArenaSparseNode, ArenaSparseNodeBranch, ArenaSparseNodeState};
 
 use crate::{
     LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, SparseTrieUpdates, TrieNodeEpoch,
@@ -20,14 +20,8 @@ use reth_trie_common::{
     BranchNodeMasks, BranchNodeRef, ExtensionNodeRef, LeafNodeRef, Nibbles, ProofTrieNodeV2,
     ProofV2TargetParent, RlpNode, TrieNodeV2, EMPTY_ROOT_HASH,
 };
-use slotmap::{DefaultKey, SlotMap};
 use smallvec::SmallVec;
 use tracing::{instrument, trace};
-
-/// Alias for the slotmap key type used as node references throughout the arena trie.
-type Index = DefaultKey;
-/// Alias for the slotmap used as the node arena throughout the arena trie.
-type NodeArena = SlotMap<Index, ArenaSparseNode>;
 
 const TRACE_TARGET: &str = "trie::arena";
 
@@ -35,11 +29,11 @@ const TRACE_TARGET: &str = "trie::arena";
 /// depth or deeper belong to lower subtries.
 const UPPER_TRIE_MAX_DEPTH: usize = 2;
 
-/// Compacts an arena by BFS-copying all reachable nodes into a fresh `SlotMap`, dropping
+/// Compacts an arena by BFS-copying all reachable nodes into a fresh arena, dropping
 /// unreachable (pruned) slots. Parents are stored before children for cache-friendly top-down
 /// traversal.
 fn compact_arena(arena: &mut NodeArena, root: &mut Index) {
-    let mut new_arena = SlotMap::with_capacity(arena.len());
+    let mut new_arena = NodeArena::with_capacity(arena.len());
     let mut queue = VecDeque::new();
 
     let root_node = arena.remove(*root).expect("root exists");
@@ -51,25 +45,23 @@ fn compact_arena(arena: &mut NodeArena, root: &mut Index) {
         // its Branch.children have not been rewritten yet — every Revealed(idx) here is
         // still an old-arena index, and the child is still present in `arena` because
         // only this parent's iteration can remove it (each child has exactly one parent).
-        let old_children: SmallVec<[(usize, Index); 16]> = match &new_arena[new_idx] {
-            ArenaSparseNode::Branch(b) => b
-                .children
-                .iter()
-                .enumerate()
-                .filter_map(|(i, c)| match c {
-                    ArenaSparseNodeBranchChild::Revealed(old_idx) => Some((i, *old_idx)),
-                    _ => None,
-                })
-                .collect(),
+        let old_children: SmallVec<[(usize, BranchChild); 16]> = match &new_arena[new_idx] {
+            ArenaSparseNode::Branch(b) => b.children.iter().copied().enumerate().collect(),
             _ => continue,
         };
 
-        for (child_pos, old_child_idx) in old_children {
-            let child_node = arena.remove(old_child_idx).expect("child exists");
-            let new_child_idx = new_arena.insert(child_node);
+        for (child_pos, old_child) in old_children {
+            let new_child = match old_child.revealed_index() {
+                Some(old_child_idx) => {
+                    let child_node = arena.remove(old_child_idx).expect("child exists");
+                    let new_child_idx = new_arena.insert(child_node);
+                    queue.push_back(new_child_idx);
+                    BranchChild::revealed(new_child_idx)
+                }
+                None => new_arena.insert_blinded(arena.take_blinded(old_child)),
+            };
             let ArenaSparseNode::Branch(b) = &mut new_arena[new_idx] else { unreachable!() };
-            b.children[child_pos] = ArenaSparseNodeBranchChild::Revealed(new_child_idx);
-            queue.push_back(new_child_idx);
+            b.children[child_pos] = new_child;
         }
     }
 
@@ -136,7 +128,7 @@ impl ArenaSparseSubtrie {
     /// [`ArenaSparseNode::EmptyRoot`]. The caller must overwrite `subtrie.arena[subtrie.root]`
     /// before use.
     fn new(record_updates: bool) -> Box<Self> {
-        let mut arena = SlotMap::new();
+        let mut arena = NodeArena::new();
         let root =
             arena.insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed });
         let buffers = ArenaTrieBuffers {
@@ -189,7 +181,7 @@ impl ArenaSparseSubtrie {
 
         let old_count = self.arena.len();
         // Do not reserve the old arena's size: discarded nodes should release their capacity.
-        let mut new_arena = SlotMap::new();
+        let mut new_arena = NodeArena::new();
         let mut new_num_leaves = 0u64;
 
         // The subtrie root is retained by the owning upper trie.
@@ -203,8 +195,7 @@ impl ArenaSparseSubtrie {
         }
 
         while let Some(frame) = stack.last_mut() {
-            let Some((child_pos, nibble, old_child_idx)) = frame.next_revealed_child(&new_arena)
-            else {
+            let Some((child_pos, nibble, child)) = frame.next_child(&new_arena) else {
                 stack.pop();
                 continue;
             };
@@ -212,6 +203,15 @@ impl ArenaSparseSubtrie {
             let parent_new_idx = frame.new_idx;
             let mut child_path = frame.branch_logical_path;
             child_path.push(nibble);
+
+            let Some(old_child_idx) = child.revealed_index() else {
+                let new_child = new_arena.insert_blinded(self.arena.take_blinded(child));
+                let ArenaSparseNode::Branch(b) = &mut new_arena[parent_new_idx] else {
+                    unreachable!()
+                };
+                b.children[child_pos] = new_child;
+                continue;
+            };
 
             let child_epoch = self.arena[old_child_idx]
                 .state_ref()
@@ -232,10 +232,11 @@ impl ArenaSparseSubtrie {
                     cached_rlp_node = ?rlp_node,
                     "pruning node",
                 );
+                let new_child = new_arena.insert_blinded(rlp_node);
                 let ArenaSparseNode::Branch(b) = &mut new_arena[parent_new_idx] else {
                     unreachable!()
                 };
-                b.children[child_pos] = ArenaSparseNodeBranchChild::Blinded(rlp_node);
+                b.children[child_pos] = new_child;
             } else {
                 let child_node = self.arena.remove(old_child_idx).expect("child exists");
                 let new_child_idx = new_arena.insert(child_node);
@@ -250,7 +251,7 @@ impl ArenaSparseSubtrie {
                 let ArenaSparseNode::Branch(b) = &mut new_arena[parent_new_idx] else {
                     unreachable!()
                 };
-                b.children[child_pos] = ArenaSparseNodeBranchChild::Revealed(new_child_idx);
+                b.children[child_pos] = BranchChild::revealed(new_child_idx);
             }
         }
 
@@ -272,19 +273,15 @@ impl ArenaSparseSubtrie {
         }
 
         impl CopyFrame {
-            fn next_revealed_child(&mut self, new_arena: &NodeArena) -> Option<(usize, u8, Index)> {
+            fn next_child(&mut self, new_arena: &NodeArena) -> Option<(usize, u8, BranchChild)> {
                 let ArenaSparseNode::Branch(b) = &new_arena[self.new_idx] else { unreachable!() };
 
-                loop {
-                    let nibble = self.remaining_child_mask.first_set_bit_index()?;
-                    self.remaining_child_mask.unset_bit(nibble);
-                    let child_idx = BranchChildIdx::new(self.state_mask, nibble)
-                        .expect("remaining_child_mask must be a subset of state_mask");
+                let nibble = self.remaining_child_mask.first_set_bit_index()?;
+                self.remaining_child_mask.unset_bit(nibble);
+                let child_idx = BranchChildIdx::new(self.state_mask, nibble)
+                    .expect("remaining_child_mask must be a subset of state_mask");
 
-                    if let ArenaSparseNodeBranchChild::Revealed(old_idx) = b.children[child_idx] {
-                        return Some((child_idx.get(), nibble, old_idx))
-                    }
-                }
+                Some((child_idx.get(), nibble, b.children[child_idx]))
             }
         }
 
@@ -542,7 +539,7 @@ impl Default for ArenaParallelismThresholds {
 ///
 /// ## Structure
 ///
-/// Uses arena allocation ([`slotmap::SlotMap`]) for node storage with direct index-based child
+/// Uses arena allocation ([`NodeArena`]) for node storage with direct index-based child
 /// pointers, avoiding the per-node hashing overhead of a `HashMap`-based trie. The trie is split
 /// into two tiers:
 ///
@@ -561,7 +558,7 @@ impl Default for ArenaParallelismThresholds {
 ///
 /// Nodes are lazily revealed from proof data via [`SparseTrie::reveal_nodes`]. Each node is
 /// placed into the upper arena or delegated to its subtrie based on path depth. Unrevealed
-/// children are stored as `ArenaSparseNodeBranchChild::Blinded` with their RLP encoding.
+/// children are stored as blinded [`BranchChild`]s referencing their RLP encoding.
 /// When multiple subtries have pending reveals, they are processed in parallel using rayon
 /// (controlled by [`ArenaParallelismThresholds::min_revealed_nodes`]).
 ///
@@ -591,7 +588,7 @@ impl Default for ArenaParallelismThresholds {
 /// ## Pruning
 ///
 /// [`SparseTrie::prune`] replaces nodes older than its epoch cutoff with
-/// `ArenaSparseNodeBranchChild::Blinded` entries using their cached RLP, then compacts the
+/// blinded [`BranchChild`] entries using their cached RLP, then compacts the
 /// arenas. Subtries are pruned in parallel when their leaf count exceeds
 /// [`ArenaParallelismThresholds::min_leaves_for_prune`].
 #[derive(Debug, Clone)]
@@ -645,15 +642,8 @@ impl ArenaParallelSparseTrie {
         let mut root_node =
             mem::replace(&mut self.upper_arena[child_idx], ArenaSparseNode::TakenSubtrie);
 
-        // Migrate any revealed children from the upper arena into the subtrie arena.
-        if let ArenaSparseNode::Branch(b) = &mut root_node {
-            for child in &mut b.children {
-                if let ArenaSparseNodeBranchChild::Revealed(idx) = child {
-                    *idx =
-                        Self::migrate_nodes(&mut subtrie.arena, &mut self.upper_arena, *idx, None);
-                }
-            }
-        }
+        // Migrate any children from the upper arena into the subtrie arena.
+        Self::migrate_children(&mut subtrie.arena, &mut self.upper_arena, &mut root_node);
 
         subtrie.arena[subtrie.root] = root_node;
         let (leaves, dirty) = Self::count_leaves_and_dirty(&subtrie.arena, subtrie.root);
@@ -677,10 +667,7 @@ impl ArenaParallelSparseTrie {
         let short_key = b.short_key;
         let children: SmallVec<[_; 4]> = b
             .child_iter()
-            .filter_map(|(nibble, child)| match child {
-                ArenaSparseNodeBranchChild::Revealed(idx) => Some((nibble, *idx)),
-                ArenaSparseNodeBranchChild::Blinded(_) => None,
-            })
+            .filter_map(|(nibble, child)| Some((nibble, child.revealed_index()?)))
             .collect();
 
         for (nibble, child_idx) in children {
@@ -814,11 +801,7 @@ impl ArenaParallelSparseTrie {
             let (remaining_nibble, remaining_child_idx) = {
                 let b = self.upper_arena[branch_idx].branch_ref();
                 let nibble = b.state_mask.iter().next().expect("branch has at least one child");
-                let child_idx = match &b.children[0] {
-                    ArenaSparseNodeBranchChild::Revealed(idx) => Some(*idx),
-                    ArenaSparseNodeBranchChild::Blinded(_) => None,
-                };
-                (nibble, child_idx)
+                (nibble, b.children[0].revealed_index())
             };
 
             let Some(child_idx) = remaining_child_idx else {
@@ -925,15 +908,15 @@ impl ArenaParallelSparseTrie {
         let mut masks = BranchNodeMasks::default();
 
         for (nibble, child) in branch.child_iter() {
-            let (hash_bit, tree_bit) = match child {
-                ArenaSparseNodeBranchChild::Blinded(_) => (
+            let (hash_bit, tree_bit) = match child.revealed_index() {
+                Some(child_idx) => {
+                    let child = &arena[child_idx];
+                    (child.hash_mask_bit(), child.tree_mask_bit())
+                }
+                None => (
                     branch.branch_masks.hash_mask.is_bit_set(nibble),
                     branch.branch_masks.tree_mask.is_bit_set(nibble),
                 ),
-                ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                    let child = &arena[*child_idx];
-                    (child.hash_mask_bit(), child.tree_mask_bit())
-                }
             };
 
             masks.set_child_bits(nibble, hash_bit, tree_bit);
@@ -994,7 +977,7 @@ impl ArenaParallelSparseTrie {
                     return rlp_node;
                 }
             }
-            ArenaSparseNode::Subtrie(_) | ArenaSparseNode::TakenSubtrie => {
+            ArenaSparseNode::Subtrie(_) | ArenaSparseNode::TakenSubtrie | ArenaSparseNode::Free => {
                 unreachable!("Subtrie/TakenSubtrie should not appear inside a subtrie's own arena");
             }
         }
@@ -1038,13 +1021,13 @@ impl ArenaParallelSparseTrie {
             rlp_node_buf.clear();
             let mut node_epoch = TrieNodeEpoch::UNMODIFIED;
             let state_mask = arena[head_idx].branch_ref().state_mask;
-            for (child_idx, _nibble) in BranchChildIter::new(state_mask) {
-                match &arena[head_idx].branch_ref().children[child_idx] {
-                    ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
-                        rlp_node_buf.push(rlp_node.clone());
+            for (dense_idx, _nibble) in BranchChildIter::new(state_mask) {
+                let child = arena[head_idx].branch_ref().children[dense_idx];
+                match child.revealed_index() {
+                    None => {
+                        rlp_node_buf.push(arena.blinded(child).clone());
                     }
-                    ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                        let child_idx = *child_idx;
+                    Some(child_idx) => {
                         match &arena[child_idx] {
                             ArenaSparseNode::Leaf { .. } => {
                                 Self::encode_leaf(
@@ -1079,7 +1062,9 @@ impl ArenaParallelSparseTrie {
                                     _ => panic!("subtrie root must be a cached Branch or Leaf"),
                                 }
                             }
-                            ArenaSparseNode::TakenSubtrie | ArenaSparseNode::EmptyRoot { .. } => {
+                            ArenaSparseNode::TakenSubtrie |
+                            ArenaSparseNode::EmptyRoot { .. } |
+                            ArenaSparseNode::Free => {
                                 unreachable!("Unexpected child {:?}", arena[child_idx]);
                             }
                         }
@@ -1162,7 +1147,9 @@ impl ArenaParallelSparseTrie {
     ) -> Option<&'a Vec<u8>> {
         loop {
             match &arena[current] {
-                ArenaSparseNode::EmptyRoot { .. } | ArenaSparseNode::TakenSubtrie => return None,
+                ArenaSparseNode::EmptyRoot { .. } |
+                ArenaSparseNode::TakenSubtrie |
+                ArenaSparseNode::Free => return None,
                 ArenaSparseNode::Leaf { key, value, .. } => {
                     let remaining = full_path.slice(path_offset..);
                     return (remaining == *key).then_some(value);
@@ -1178,13 +1165,8 @@ impl ArenaParallelSparseTrie {
 
                     let child_nibble = full_path.get_unchecked(logical_end);
                     let child_idx = BranchChildIdx::new(b.state_mask, child_nibble)?;
-                    match &b.children[child_idx] {
-                        ArenaSparseNodeBranchChild::Blinded(_) => return None,
-                        ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                            current = *child_idx;
-                            path_offset = logical_end + 1;
-                        }
-                    }
+                    current = b.children[child_idx].revealed_index()?;
+                    path_offset = logical_end + 1;
                 }
                 ArenaSparseNode::Subtrie(subtrie) => {
                     return Self::get_leaf_value_in_arena(
@@ -1210,7 +1192,9 @@ impl ArenaParallelSparseTrie {
     ) -> Result<LeafLookup, LeafLookupError> {
         loop {
             match &arena[current] {
-                ArenaSparseNode::EmptyRoot { .. } | ArenaSparseNode::TakenSubtrie => {
+                ArenaSparseNode::EmptyRoot { .. } |
+                ArenaSparseNode::TakenSubtrie |
+                ArenaSparseNode::Free => {
                     return Ok(LeafLookup::NonExistent);
                 }
                 ArenaSparseNode::Leaf { key, value, .. } => {
@@ -1246,8 +1230,10 @@ impl ArenaParallelSparseTrie {
                         return Ok(LeafLookup::NonExistent);
                     };
 
-                    match &b.children[child_idx] {
-                        ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
+                    let child = b.children[child_idx];
+                    match child.revealed_index() {
+                        None => {
+                            let rlp_node = arena.blinded(child);
                             let hash = rlp_node
                                 .as_hash()
                                 .unwrap_or_else(|| keccak256(rlp_node.as_slice()));
@@ -1255,8 +1241,8 @@ impl ArenaParallelSparseTrie {
                             blinded_path.push_unchecked(child_nibble);
                             return Err(LeafLookupError::BlindedNode { path: blinded_path, hash });
                         }
-                        ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                            current = *child_idx;
+                        Some(child_idx) => {
+                            current = child_idx;
                             path_offset = logical_end + 1;
                         }
                     }
@@ -1379,9 +1365,9 @@ impl ArenaParallelSparseTrie {
             };
 
         let state_mask = TrieMask::from(1u16 << first_nibble | 1u16 << second_nibble);
-        let mut children = SmallVec::with_capacity(2);
-        children.push(ArenaSparseNodeBranchChild::Revealed(first_child));
-        children.push(ArenaSparseNodeBranchChild::Revealed(second_child));
+        let mut children = SmallVec::new();
+        children.push(BranchChild::revealed(first_child));
+        children.push(BranchChild::revealed(second_child));
 
         let new_branch_idx = arena.insert(ArenaSparseNode::Branch(ArenaSparseNodeBranch {
             state: ArenaSparseNodeState::Dirty,
@@ -1491,7 +1477,7 @@ impl ArenaParallelSparseTrie {
                 });
 
                 let branch = arena[head_idx].branch_mut();
-                branch.set_child(child_nibble, ArenaSparseNodeBranchChild::Revealed(new_leaf));
+                branch.set_child(child_nibble, BranchChild::revealed(new_leaf));
 
                 // Re-seek to position the cursor on the newly inserted leaf.
                 cursor.seek(arena, full_path);
@@ -1764,9 +1750,7 @@ impl ArenaParallelSparseTrie {
         let mut prefix = branch_short_key;
         prefix.push_unchecked(remaining_nibble);
 
-        let ArenaSparseNodeBranchChild::Revealed(child_idx) = branch.children[0] else {
-            unreachable!()
-        };
+        let child_idx = branch.children[0].revealed_index().expect("remaining child is revealed");
 
         // Prepend the prefix to the child's key/short_key and mark dirty.
         // Track whether a leaf was newly dirtied by this collapse.
@@ -1833,8 +1817,8 @@ impl ArenaParallelSparseTrie {
                 let mut leaves = 0u64;
                 let mut dirty = 0u64;
                 for c in &b.children {
-                    if let ArenaSparseNodeBranchChild::Revealed(child_idx) = c {
-                        let (l, d) = Self::count_leaves_and_dirty(arena, *child_idx);
+                    if let Some(child_idx) = c.revealed_index() {
+                        let (l, d) = Self::count_leaves_and_dirty(arena, child_idx);
                         leaves += l;
                         dirty += d;
                     }
@@ -1902,19 +1886,28 @@ impl ArenaParallelSparseTrie {
         let mut node = src.remove(src_idx).expect("node exists in source arena");
 
         // Recursively migrate children first so their new indices are known.
-        if let ArenaSparseNode::Branch(b) = &mut node {
-            for child in &mut b.children {
-                if let ArenaSparseNodeBranchChild::Revealed(child_idx) = child {
-                    *child_idx = Self::migrate_nodes(dst, src, *child_idx, None);
-                }
-            }
-        }
+        Self::migrate_children(dst, src, &mut node);
 
         if let Some(slot) = dst_slot {
             dst[slot] = node;
             slot
         } else {
             dst.insert(node)
+        }
+    }
+
+    /// Moves a branch's children from `src` to `dst`: revealed children are migrated recursively
+    /// with [`Self::migrate_nodes`], blinded children have their RLP moved into `dst`'s side
+    /// table. `node` must already be detached from `src`; non-branch nodes are left untouched.
+    fn migrate_children(dst: &mut NodeArena, src: &mut NodeArena, node: &mut ArenaSparseNode) {
+        let ArenaSparseNode::Branch(b) = node else { return };
+        for child in &mut b.children {
+            *child = match child.revealed_index() {
+                Some(child_idx) => {
+                    BranchChild::revealed(Self::migrate_nodes(dst, src, child_idx, None))
+                }
+                None => dst.insert_blinded(src.take_blinded(*child)),
+            };
         }
     }
 
@@ -1943,10 +1936,11 @@ impl ArenaParallelSparseTrie {
 
         let parent_idx = cursor.parent().expect("pruned child has parent").index;
         let child_nibble = nibble.expect("non-root child");
+        let blinded = arena.insert_blinded(rlp_node);
         let parent_branch = arena[parent_idx].branch_mut();
         let child_idx = BranchChildIdx::new(parent_branch.state_mask, child_nibble)
             .expect("child nibble not found in parent state_mask");
-        parent_branch.children[child_idx] = ArenaSparseNodeBranchChild::Blinded(rlp_node);
+        parent_branch.children[child_idx] = blinded;
 
         node
     }
@@ -1989,10 +1983,11 @@ impl ArenaParallelSparseTrie {
         let dense_child_idx = BranchChildIdx::new(head_branch.state_mask, child_nibble)
             .expect("Blinded result but child nibble not in state_mask");
 
-        let cached_rlp = match &head_branch.children[dense_child_idx] {
-            ArenaSparseNodeBranchChild::Blinded(rlp) => rlp.clone(),
-            ArenaSparseNodeBranchChild::Revealed(_) => return None,
-        };
+        let child = head_branch.children[dense_child_idx];
+        if !child.is_blinded() {
+            return None;
+        }
+        let cached_rlp = arena.take_blinded(child);
 
         trace!(
             target: TRACE_TARGET,
@@ -2002,15 +1997,14 @@ impl ArenaParallelSparseTrie {
         );
 
         let proof_node = mem::replace(node, ProofTrieNodeV2::empty());
-        let mut arena_node = ArenaSparseNode::from_proof_node(proof_node);
+        let mut arena_node = ArenaSparseNode::from_proof_node(arena, proof_node);
 
         let state = arena_node.state_mut();
         *state =
             ArenaSparseNodeState::Cached { rlp_node: cached_rlp, epoch: TrieNodeEpoch::UNMODIFIED };
 
         let child_idx = arena.insert(arena_node);
-        arena[head_idx].branch_mut().children[dense_child_idx] =
-            ArenaSparseNodeBranchChild::Revealed(child_idx);
+        arena[head_idx].branch_mut().children[dense_child_idx] = BranchChild::revealed(child_idx);
 
         Some(child_idx)
     }
@@ -2026,8 +2020,8 @@ impl ArenaParallelSparseTrie {
         }
         if let ArenaSparseNode::Branch(b) = &arena[idx] {
             for child in &b.children {
-                if let ArenaSparseNodeBranchChild::Revealed(child_idx) = child {
-                    Self::collect_reachable_nodes(arena, *child_idx, reachable);
+                if let Some(child_idx) = child.revealed_index() {
+                    Self::collect_reachable_nodes(arena, child_idx, reachable);
                 }
             }
         }
@@ -2053,7 +2047,7 @@ impl Drop for ArenaParallelSparseTrie {
     fn drop(&mut self) {
         Self::assert_no_orphaned_nodes(&self.upper_arena, self.root, "upper arena");
 
-        for (_, node) in &self.upper_arena {
+        for (_, node) in self.upper_arena.iter() {
             if let Some(subtrie) = node.as_subtrie() {
                 Self::assert_no_orphaned_nodes(
                     &subtrie.arena,
@@ -2067,7 +2061,7 @@ impl Drop for ArenaParallelSparseTrie {
 
 impl Default for ArenaParallelSparseTrie {
     fn default() -> Self {
-        let mut upper_arena = SlotMap::new();
+        let mut upper_arena = NodeArena::new();
         let root = upper_arena
             .insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed });
         Self {
@@ -2127,8 +2121,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 trace!(target: TRACE_TARGET, state_mask = ?branch.state_mask, num_children = branch.state_mask.count_bits(), "Setting branch root");
                 let mut children = SmallVec::with_capacity(branch.state_mask.count_bits() as usize);
                 for (stack_ptr, _nibble) in branch.state_mask.iter().enumerate() {
-                    children
-                        .push(ArenaSparseNodeBranchChild::Blinded(branch.stack[stack_ptr].clone()));
+                    let child = self.upper_arena.insert_blinded(branch.stack[stack_ptr].clone());
+                    children.push(child);
                 }
 
                 self.upper_arena[self.root] = ArenaSparseNode::Branch(ArenaSparseNodeBranch {
@@ -2333,7 +2327,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
         // Count total dirty leaves across all subtries to make one global parallelism decision.
         let mut total_dirty_leaves: u64 = 0;
         let mut taken: Vec<(Index, Box<ArenaSparseSubtrie>)> = Vec::new();
-        for (idx, node) in &mut self.upper_arena {
+        for (idx, node) in self.upper_arena.iter_mut() {
             let ArenaSparseNode::Subtrie(s) = node else { continue };
             if s.num_dirty_leaves == 0 {
                 continue;
@@ -2446,7 +2440,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
 
     #[instrument(level = "trace", target = TRACE_TARGET, skip_all)]
     fn clear(&mut self) {
-        self.upper_arena = SlotMap::new();
+        self.upper_arena = NodeArena::new();
         self.root = self
             .upper_arena
             .insert(ArenaSparseNode::EmptyRoot { state: ArenaSparseNodeState::Revealed });

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -411,10 +411,9 @@ impl ArenaSparseSubtrie {
                     self.num_dirty_leaves =
                         (self.num_dirty_leaves as i64 + deltas.num_dirty_leaves_delta) as u64;
 
-                    if let RemoveLeafResult::NeedsProof { key, proof_key, parent } = result {
-                        // The collapse waits for a blinded sibling, which is not on the removed
-                        // leaf's own path, so the update is retried with every batch.
-                        let blocked_on = BlockedOn::Retryable;
+                    if let RemoveLeafResult::NeedsProof { key, proof_key, parent, blocked_on } =
+                        result
+                    {
                         self.required_proofs
                             .push((idx, ArenaRequiredProof { key: proof_key, parent, blocked_on }));
                         self.required_proofs
@@ -569,7 +568,7 @@ enum RemoveLeafResult {
     NotFound,
     /// The branch collapse requires revealing a blinded sibling. The caller must request a
     /// proof for the given key below the revealed logical parent branch.
-    NeedsProof { key: B256, proof_key: B256, parent: ProofV2TargetParent },
+    NeedsProof { key: B256, proof_key: B256, parent: ProofV2TargetParent, blocked_on: BlockedOn },
 }
 
 /// A proof request generated during leaf updates when a blinded node is encountered.
@@ -1638,6 +1637,7 @@ impl ArenaParallelSparseTrie {
                                         .checked_sub(1)
                                         .expect("sibling path has a child nibble"),
                                 ),
+                                blocked_on: BlockedOn::sibling(&sibling_path),
                             },
                             SubtrieCounterDeltas::default(),
                         );
@@ -1762,7 +1762,7 @@ impl ArenaParallelSparseTrie {
             parent: ProofV2TargetParent::new(
                 sibling_path.len().checked_sub(1).expect("sibling path has a child nibble"),
             ),
-            blocked_on: BlockedOn::Retryable,
+            blocked_on: BlockedOn::sibling(&sibling_path),
         })
     }
 
@@ -2869,11 +2869,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             &mut self.buffers.updates,
                         );
                         match result {
-                            RemoveLeafResult::NeedsProof { proof_key, parent, .. } => {
+                            RemoveLeafResult::NeedsProof {
+                                proof_key, parent, blocked_on, ..
+                            } => {
                                 event_fn(LeafUpdateEvent::ProofRequired { key: proof_key, parent });
-                                // The collapse waits for a blinded sibling, which is not on the
-                                // removed leaf's own path.
-                                newly_blocked.push((update_idx as u32, BlockedOn::Retryable));
+                                newly_blocked.push((update_idx as u32, blocked_on));
                             }
                             RemoveLeafResult::Removed => {
                                 // remove_leaf may have called collapse_branch, which

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -669,9 +669,8 @@ impl ArenaParallelSparseTrie {
     /// structural changes like root-level splits or subtrie unwraps that can place
     /// non-subtrie nodes at the boundary depth.
     fn maybe_wrap_branch_children(&mut self, cursor: &ArenaCursor) {
-        let head = cursor.head().expect("cursor is non-empty");
-        let head_idx = head.index;
-        let head_path = head.path;
+        let head_idx = cursor.head().expect("cursor is non-empty").index;
+        let head_path = cursor.head_path();
 
         let ArenaSparseNode::Branch(b) = &self.upper_arena[head_idx] else { return };
         let short_key = b.short_key;
@@ -703,7 +702,7 @@ impl ArenaParallelSparseTrie {
         level = "trace",
         target = TRACE_TARGET,
         skip_all,
-        fields(subtrie_path = ?cursor.head().expect("cursor is non-empty").path),
+        fields(subtrie_path = ?cursor.head_path()),
     )]
     fn maybe_unwrap_subtrie(&mut self, cursor: &mut ArenaCursor) {
         let subtrie_idx = cursor.head().expect("cursor is non-empty").index;
@@ -716,12 +715,8 @@ impl ArenaParallelSparseTrie {
             return;
         }
 
-        let child_nibble = cursor
-            .head()
-            .expect("cursor is non-empty")
-            .path
-            .last()
-            .expect("subtrie path must have at least one nibble");
+        let child_nibble =
+            cursor.head_last_nibble().expect("subtrie path must have at least one nibble");
         let parent_idx = cursor.parent().expect("cursor has parent").index;
 
         // Pop the subtrie entry before mutating, so collapse_branch sees the parent as
@@ -773,9 +768,7 @@ impl ArenaParallelSparseTrie {
     /// - **2+ children**: nothing to do.
     fn maybe_collapse_or_remove_branch(&mut self, cursor: &mut ArenaCursor) {
         loop {
-            let branch_entry = cursor.head().expect("cursor is non-empty");
-            let branch_idx = branch_entry.index;
-            let branch_path = branch_entry.path;
+            let branch_idx = cursor.head().expect("cursor is non-empty").index;
 
             // Read-only phase: extract the count and remaining-child info we need before
             // mutating. All values here are Copy so the borrow is released.
@@ -797,7 +790,7 @@ impl ArenaParallelSparseTrie {
                     return;
                 }
                 // Remove the empty branch from its parent.
-                let branch_nibble = branch_path.last().expect("non-root branch");
+                let branch_nibble = cursor.head_last_nibble().expect("non-root branch");
                 cursor.pop(&mut self.upper_arena);
                 self.upper_arena.remove(branch_idx);
                 let parent_idx = cursor.head().expect("cursor is non-empty").index;
@@ -1020,9 +1013,8 @@ impl ArenaParallelSparseTrie {
                 NextResult::Branch => {}
             };
 
-            let head = cursor.head().expect("cursor is non-empty");
-            let head_idx = head.index;
-            let head_path = head.path;
+            let head_idx = cursor.head().expect("cursor is non-empty").index;
+            let head_path = cursor.head_path();
 
             // The branch at `head_idx` is exhausted. All its dirty child branches
             // have already been encoded and cached. Collect all children's RLP nodes
@@ -1164,14 +1156,15 @@ impl ArenaParallelSparseTrie {
             match &arena[current] {
                 ArenaSparseNode::EmptyRoot { .. } | ArenaSparseNode::TakenSubtrie => return None,
                 ArenaSparseNode::Leaf { key, value, .. } => {
-                    let remaining = full_path.slice(path_offset..);
+                    let remaining = full_path.slice_unchecked(path_offset, full_path.len());
                     return (remaining == *key).then_some(value);
                 }
                 ArenaSparseNode::Branch(b) => {
                     let short_key = &b.short_key;
                     let logical_end = path_offset + short_key.len();
                     if full_path.len() <= logical_end ||
-                        full_path.slice(path_offset..logical_end) != *short_key
+                        (!short_key.is_empty() &&
+                            full_path.slice_unchecked(path_offset, logical_end) != *short_key)
                     {
                         return None;
                     }
@@ -1326,14 +1319,13 @@ impl ArenaParallelSparseTrie {
         new_leaf_path: Nibbles,
         value: &[u8],
     ) -> bool {
-        let old_child_entry = cursor.head().expect("cursor must have head");
-        let old_child_idx = old_child_entry.index;
+        let old_child_idx = cursor.head().expect("cursor must have head").index;
         let old_child_short_key = arena[old_child_idx].short_key().expect("top of stack is a leaf");
         let diverge_len = new_leaf_path.common_prefix_length(old_child_short_key);
 
         trace!(
             target: TRACE_TARGET,
-            path = ?old_child_entry.path,
+            path = ?cursor.head_path(),
             ?new_leaf_path,
             ?old_child_short_key,
             diverge_len,
@@ -1427,10 +1419,9 @@ impl ArenaParallelSparseTrie {
             }
             SeekResult::EmptyRoot => {
                 let head_idx = head.index;
-                let head_path = head.path;
                 arena[head_idx] = ArenaSparseNode::Leaf {
                     state: ArenaSparseNodeState::Dirty,
-                    key: full_path.slice(head_path.len()..),
+                    key: full_path.slice(cursor.head_path_len()..),
                     value: value.to_vec(),
                 };
                 (
@@ -1460,8 +1451,7 @@ impl ArenaParallelSparseTrie {
                 )
             }
             SeekResult::Diverged => {
-                let head_path = head.path;
-                let full_path_from_head = full_path.slice(head_path.len()..);
+                let full_path_from_head = full_path.slice(cursor.head_path_len()..);
 
                 let split_dirtied_existing =
                     Self::split_and_insert_leaf(arena, cursor, root, full_path_from_head, value);
@@ -1482,8 +1472,7 @@ impl ArenaParallelSparseTrie {
             SeekResult::NoChild { child_nibble } => {
                 let head_idx = head.index;
 
-                let head_branch_logical_path = cursor.head_logical_branch_path(arena);
-                let leaf_key = full_path.slice(head_branch_logical_path.len() + 1..);
+                let leaf_key = full_path.slice(cursor.head_logical_branch_path_len(arena) + 1..);
                 let new_leaf = arena.insert(ArenaSparseNode::Leaf {
                     state: ArenaSparseNodeState::Dirty,
                     key: leaf_key,
@@ -1540,9 +1529,8 @@ impl ArenaParallelSparseTrie {
             }
             SeekResult::RevealedLeaf => {
                 // RevealedLeaf guarantees the leaf's full path matches the target exactly.
-                let head = cursor.head().expect("cursor is non-empty");
-                let head_idx = head.index;
-                let head_path = head.path;
+                let head_idx = cursor.head().expect("cursor is non-empty").index;
+                let head_path = cursor.head_path();
 
                 trace!(
                     target: TRACE_TARGET,
@@ -1678,7 +1666,7 @@ impl ArenaParallelSparseTrie {
         }
 
         let child_nibble =
-            subtrie_entry.path.last().expect("subtrie path must have at least one nibble");
+            cursor.head_last_nibble().expect("subtrie path must have at least one nibble");
 
         let parent_entry = cursor.parent()?;
         let parent_branch = arena[parent_entry.index].branch_ref();
@@ -1722,8 +1710,8 @@ impl ArenaParallelSparseTrie {
         root: &mut Index,
         updates: &mut Option<SparseTrieUpdates>,
     ) -> bool {
-        let branch_entry = cursor.head().expect("cursor is non-empty");
-        let branch_idx = branch_entry.index;
+        let branch_idx = cursor.head().expect("cursor is non-empty").index;
+        let branch_path = cursor.head_path();
         let branch = arena[branch_idx].branch_ref();
         let remaining_nibble =
             branch.state_mask.iter().next().expect("branch has at least one child");
@@ -1741,7 +1729,7 @@ impl ArenaParallelSparseTrie {
 
         trace!(
             target: TRACE_TARGET,
-            path = ?branch_entry.path,
+            path = ?branch_path,
             short_key = ?branch_short_key,
             branch_masks = ?branch.branch_masks,
             ?remaining_nibble,
@@ -1787,7 +1775,7 @@ impl ArenaParallelSparseTrie {
                 false
             }
             ArenaSparseNode::Subtrie(subtrie) => {
-                subtrie.path = branch_entry.path;
+                subtrie.path = branch_path;
                 match &mut subtrie.arena[subtrie.root] {
                     ArenaSparseNode::Branch(b) => {
                         let mut new_short_key = prefix;
@@ -1861,9 +1849,8 @@ impl ArenaParallelSparseTrie {
             match result {
                 NextResult::Done => break,
                 NextResult::NonBranch | NextResult::Branch => {
-                    let head = cursor.head().expect("cursor is non-empty");
-                    let path_len = head.path.len();
-                    let node = &self.upper_arena[head.index];
+                    let path_len = cursor.head_path_len();
+                    let node = &self.upper_arena[cursor.head().expect("cursor is non-empty").index];
 
                     if Self::should_be_subtrie(path_len) {
                         debug_assert!(
@@ -1926,7 +1913,7 @@ impl ArenaParallelSparseTrie {
         idx: Index,
         nibble: Option<u8>,
     ) -> ArenaSparseNode {
-        let path = cursor.head().expect("cursor is non-empty").path;
+        let path = cursor.head_path();
         let node = arena.remove(idx).expect("node must exist to be pruned");
         let rlp_node = node
             .state_ref()
@@ -2207,9 +2194,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                     }
                 }
                 SeekResult::RevealedSubtrie => {
-                    let subtrie_entry = cursor.head().expect("cursor is non-empty");
-                    let child_idx = subtrie_entry.index;
-                    let prefix = subtrie_entry.path;
+                    let child_idx = cursor.head().expect("cursor is non-empty").index;
+                    let prefix = cursor.head_path();
 
                     let subtrie_start = node_idx;
                     while node_idx < nodes.len() && nodes[node_idx].path.starts_with(&prefix) {
@@ -2402,7 +2388,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 let (_, subtrie) = taken.pop().expect("taken subtries must not be exhausted");
                 debug_assert_eq!(
                     subtrie.path,
-                    self.buffers.cursor.head().expect("cursor is non-empty").path,
+                    self.buffers.cursor.head_path(),
                     "taken subtrie path mismatch",
                 );
                 self.upper_arena[head_idx] = ArenaSparseNode::Subtrie(subtrie);
@@ -2491,9 +2477,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 break
             }
 
-            let head = cursor.head().expect("cursor is non-empty");
-            let head_idx = head.index;
-            let head_path = head.path;
+            let head_idx = cursor.head().expect("cursor is non-empty").index;
 
             match &self.upper_arena[head_idx] {
                 ArenaSparseNode::Branch(_) | ArenaSparseNode::Leaf { .. } => {
@@ -2514,7 +2498,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         &mut self.upper_arena,
                         &cursor,
                         head_idx,
-                        head_path.last(),
+                        cursor.head_last_nibble(),
                     );
                     pruned += 1;
                 }
@@ -2528,7 +2512,7 @@ impl SparseTrie for ArenaParallelSparseTrie {
                             &mut self.upper_arena,
                             &cursor,
                             head_idx,
-                            head_path.last(),
+                            cursor.head_last_nibble(),
                         );
                         let ArenaSparseNode::Subtrie(s) = &removed else { unreachable!() };
                         pruned += s.arena.len();
@@ -2645,9 +2629,8 @@ impl SparseTrie for ArenaParallelSparseTrie {
                 }
                 // Subtrie — forward all consecutive updates under this subtrie's prefix.
                 SeekResult::RevealedSubtrie => {
-                    let subtrie_entry = cursor.head().expect("cursor is non-empty");
-                    let child_idx = subtrie_entry.index;
-                    let subtrie_root_path = subtrie_entry.path;
+                    let child_idx = cursor.head().expect("cursor is non-empty").index;
+                    let subtrie_root_path = cursor.head_path();
 
                     let subtrie_start = update_idx;
                     while update_idx < sorted.len() &&
@@ -2745,11 +2728,12 @@ impl SparseTrie for ArenaParallelSparseTrie {
                         );
                         match result {
                             UpsertLeafResult::NewChild => {
-                                let head = cursor.head().expect("cursor is non-empty");
-                                if Self::should_be_subtrie(head.path.len()) {
+                                if Self::should_be_subtrie(cursor.head_path_len()) {
                                     // The new child itself sits at the subtrie
                                     // boundary — wrap it directly.
-                                    self.maybe_wrap_in_subtrie(head.index, &head.path);
+                                    let head_idx =
+                                        cursor.head().expect("cursor is non-empty").index;
+                                    self.maybe_wrap_in_subtrie(head_idx, &cursor.head_path());
                                 } else {
                                     // The new child is above the boundary (e.g. a
                                     // split at depth 1 creates children at depth 2).
@@ -2792,9 +2776,11 @@ impl SparseTrie for ArenaParallelSparseTrie {
                                 // 3. A non-Subtrie node at UPPER_TRIE_MAX_DEPTH that needs
                                 //    wrapping.
                                 self.maybe_collapse_or_remove_branch(&mut cursor);
-                                let head =
-                                    cursor.head().expect("cursor always has root after collapse");
-                                self.maybe_wrap_in_subtrie(head.index, &head.path);
+                                let head_idx = cursor
+                                    .head()
+                                    .expect("cursor always has root after collapse")
+                                    .index;
+                                self.maybe_wrap_in_subtrie(head_idx, &cursor.head_path());
                             }
                             RemoveLeafResult::NotFound => {}
                         }

--- a/crates/trie/sparse/src/arena/mod.rs
+++ b/crates/trie/sparse/src/arena/mod.rs
@@ -34,9 +34,10 @@ const UPPER_TRIE_MAX_DEPTH: usize = 2;
 /// traversal.
 fn compact_arena(arena: &mut NodeArena, root: &mut Index) {
     let mut new_arena = NodeArena::with_capacity(arena.len());
+    let mut marks = new_arena.adopt_blinded(arena);
     let mut queue = VecDeque::new();
 
-    let root_node = arena.remove(*root).expect("root exists");
+    let root_node = arena.drain_node(*root);
     let new_root = new_arena.insert(root_node);
     queue.push_back(new_root);
 
@@ -45,32 +46,39 @@ fn compact_arena(arena: &mut NodeArena, root: &mut Index) {
         // its Branch.children have not been rewritten yet — every Revealed(idx) here is
         // still an old-arena index, and the child is still present in `arena` because
         // only this parent's iteration can remove it (each child has exactly one parent).
-        let old_children: SmallVec<[(usize, BranchChild); 16]> = match &new_arena[new_idx] {
-            ArenaSparseNode::Branch(b) => b.children.iter().copied().enumerate().collect(),
+        let old_children: SmallVec<[(usize, Index); 16]> = match &new_arena[new_idx] {
+            ArenaSparseNode::Branch(b) => b
+                .children
+                .iter()
+                .enumerate()
+                .filter_map(|(pos, child)| match child.revealed_index() {
+                    Some(old_child_idx) => Some((pos, old_child_idx)),
+                    // A blinded child needs no rewrite, its slot survived the adoption.
+                    None => {
+                        marks.mark(*child);
+                        None
+                    }
+                })
+                .collect(),
             _ => continue,
         };
 
-        for (child_pos, old_child) in old_children {
-            let new_child = match old_child.revealed_index() {
-                Some(old_child_idx) => {
-                    let child_node = arena.remove(old_child_idx).expect("child exists");
-                    let new_child_idx = new_arena.insert(child_node);
-                    queue.push_back(new_child_idx);
-                    BranchChild::revealed(new_child_idx)
-                }
-                None => new_arena.insert_blinded(arena.take_blinded(old_child)),
-            };
+        for (child_pos, old_child_idx) in old_children {
+            let child_node = arena.drain_node(old_child_idx);
+            let new_child_idx = new_arena.insert(child_node);
+            queue.push_back(new_child_idx);
             let ArenaSparseNode::Branch(b) = &mut new_arena[new_idx] else { unreachable!() };
-            b.children[child_pos] = new_child;
+            b.children[child_pos] = BranchChild::revealed(new_child_idx);
         }
     }
 
     debug_assert!(
-        arena.is_empty(),
+        arena.iter().next().is_none(),
         "compact_arena: {} orphaned nodes remaining after BFS drain",
-        arena.len(),
+        arena.iter().count(),
     );
 
+    new_arena.sweep_blinded(marks);
     *arena = new_arena;
     *root = new_root;
 }
@@ -180,12 +188,14 @@ impl ArenaSparseSubtrie {
         }
 
         let old_count = self.arena.len();
-        // Do not reserve the old arena's size: discarded nodes should release their capacity.
-        let mut new_arena = NodeArena::new();
+        // Reserve an upper bound on the retained nodes and hand the excess back after the copy,
+        // so that copying never reallocates but discarded nodes still release their capacity.
+        let mut new_arena = NodeArena::with_capacity(old_count);
+        let mut marks = new_arena.adopt_blinded(&mut self.arena);
         let mut new_num_leaves = 0u64;
 
         // The subtrie root is retained by the owning upper trie.
-        let root_node = self.arena.remove(self.root).expect("root exists");
+        let root_node = self.arena.drain_node(self.root);
         let new_root = new_arena.insert(root_node);
         let mut stack = Vec::new();
         if let Some(frame) =
@@ -205,11 +215,8 @@ impl ArenaSparseSubtrie {
             child_path.push(nibble);
 
             let Some(old_child_idx) = child.revealed_index() else {
-                let new_child = new_arena.insert_blinded(self.arena.take_blinded(child));
-                let ArenaSparseNode::Branch(b) = &mut new_arena[parent_new_idx] else {
-                    unreachable!()
-                };
-                b.children[child_pos] = new_child;
+                // A blinded child needs no rewrite, its slot survived the adoption.
+                marks.mark(child);
                 continue;
             };
 
@@ -233,12 +240,13 @@ impl ArenaSparseSubtrie {
                     "pruning node",
                 );
                 let new_child = new_arena.insert_blinded(rlp_node);
+                marks.mark(new_child);
                 let ArenaSparseNode::Branch(b) = &mut new_arena[parent_new_idx] else {
                     unreachable!()
                 };
                 b.children[child_pos] = new_child;
             } else {
-                let child_node = self.arena.remove(old_child_idx).expect("child exists");
+                let child_node = self.arena.drain_node(old_child_idx);
                 let new_child_idx = new_arena.insert(child_node);
                 if let Some(frame) = prepare_retained_node(
                     &new_arena,
@@ -255,6 +263,8 @@ impl ArenaSparseSubtrie {
             }
         }
 
+        new_arena.sweep_blinded(marks);
+        new_arena.shrink_nodes_to_fit();
         let pruned = old_count - new_arena.len();
         self.num_leaves = new_num_leaves;
         self.num_dirty_leaves = 0;

--- a/crates/trie/sparse/src/arena/node_arena.rs
+++ b/crates/trie/sparse/src/arena/node_arena.rs
@@ -1,0 +1,257 @@
+use super::ArenaSparseNode;
+use alloc::vec::Vec;
+use core::{
+    fmt,
+    ops::{Index as IndexOps, IndexMut},
+};
+use reth_trie_common::RlpNode;
+
+/// A reference to a node inside a [`NodeArena`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(super) struct Index(u32);
+
+impl Index {
+    /// Returns the index as a `usize`, suitable for indexing into the arena's backing vector.
+    pub(super) const fn get(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Arena of trie nodes addressed by a [`Index`].
+///
+/// Nodes live in a flat vector; [`NodeArena::remove`] leaves an [`ArenaSparseNode::Free`] tombstone
+/// behind and pushes the slot onto a LIFO free list. Unlike a slotmap there are no generation
+/// counters, so an index handed out again refers to the new occupant: an index must not be reused
+/// across a removal unless the caller knows nothing was inserted in between.
+#[derive(Debug, Clone, Default)]
+pub(super) struct NodeArena {
+    nodes: Vec<ArenaSparseNode>,
+    free: Vec<Index>,
+    blinded: Vec<RlpNode>,
+    blinded_free: Vec<u32>,
+}
+
+impl NodeArena {
+    /// Creates an empty arena.
+    pub(super) const fn new() -> Self {
+        Self { nodes: Vec::new(), free: Vec::new(), blinded: Vec::new(), blinded_free: Vec::new() }
+    }
+
+    /// Creates an empty arena with room for `capacity` nodes.
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        Self { nodes: Vec::with_capacity(capacity), ..Self::new() }
+    }
+
+    /// Inserts a node, reusing a free slot when one is available, and returns its index.
+    pub(super) fn insert(&mut self, node: ArenaSparseNode) -> Index {
+        if let Some(idx) = self.free.pop() {
+            self.nodes[idx.get()] = node;
+            return idx;
+        }
+        let idx = Index(self.nodes.len() as u32);
+        self.nodes.push(node);
+        idx
+    }
+
+    /// Removes the node at `idx`, returning it if the slot was occupied.
+    pub(super) fn remove(&mut self, idx: Index) -> Option<ArenaSparseNode> {
+        let slot = self.nodes.get_mut(idx.get())?;
+        if matches!(slot, ArenaSparseNode::Free) {
+            return None;
+        }
+        let node = core::mem::replace(slot, ArenaSparseNode::Free);
+        self.free.push(idx);
+        Some(node)
+    }
+
+    /// Returns the node at `idx`, or `None` if the slot is out of bounds or free.
+    pub(super) fn get(&self, idx: Index) -> Option<&ArenaSparseNode> {
+        match self.nodes.get(idx.get()) {
+            Some(ArenaSparseNode::Free) | None => None,
+            Some(node) => Some(node),
+        }
+    }
+
+    /// Returns `true` if `idx` refers to an occupied slot.
+    pub(super) fn contains_key(&self, idx: Index) -> bool {
+        self.get(idx).is_some()
+    }
+
+    /// Returns the number of occupied slots.
+    pub(super) const fn len(&self) -> usize {
+        self.nodes.len() - self.free.len()
+    }
+
+    /// Returns `true` if the arena holds no occupied slots.
+    pub(super) const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Iterates over the occupied slots.
+    pub(super) fn iter(&self) -> impl Iterator<Item = (Index, &ArenaSparseNode)> + '_ {
+        self.nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| !matches!(node, ArenaSparseNode::Free))
+            .map(|(idx, node)| (Index(idx as u32), node))
+    }
+
+    /// Iterates mutably over the occupied slots.
+    pub(super) fn iter_mut(&mut self) -> impl Iterator<Item = (Index, &mut ArenaSparseNode)> + '_ {
+        self.nodes
+            .iter_mut()
+            .enumerate()
+            .filter(|(_, node)| !matches!(node, ArenaSparseNode::Free))
+            .map(|(idx, node)| (Index(idx as u32), node))
+    }
+
+    /// Stores the RLP of an unrevealed child and returns the child slot referencing it.
+    pub(super) fn insert_blinded(&mut self, rlp: RlpNode) -> BranchChild {
+        let slot = if let Some(slot) = self.blinded_free.pop() {
+            self.blinded[slot as usize] = rlp;
+            slot
+        } else {
+            self.blinded.push(rlp);
+            (self.blinded.len() - 1) as u32
+        };
+        BranchChild::blinded(slot)
+    }
+
+    /// Returns the RLP of a blinded child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `child` is revealed.
+    pub(super) fn blinded(&self, child: BranchChild) -> &RlpNode {
+        &self.blinded[child.blinded_slot().expect("child is revealed") as usize]
+    }
+
+    /// Takes the RLP of a blinded child, releasing its slot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `child` is revealed.
+    pub(super) fn take_blinded(&mut self, child: BranchChild) -> RlpNode {
+        let slot = child.blinded_slot().expect("child is revealed");
+        self.blinded_free.push(slot);
+        core::mem::take(&mut self.blinded[slot as usize])
+    }
+}
+
+impl IndexOps<Index> for NodeArena {
+    type Output = ArenaSparseNode;
+
+    #[inline]
+    fn index(&self, idx: Index) -> &Self::Output {
+        let node = &self.nodes[idx.get()];
+        debug_assert!(!matches!(node, ArenaSparseNode::Free), "indexed a free arena slot");
+        node
+    }
+}
+
+impl IndexMut<Index> for NodeArena {
+    #[inline]
+    fn index_mut(&mut self, idx: Index) -> &mut Self::Output {
+        let node = &mut self.nodes[idx.get()];
+        debug_assert!(!matches!(node, ArenaSparseNode::Free), "indexed a free arena slot");
+        node
+    }
+}
+
+/// A reference from a branch node to one of its children.
+///
+/// Packs the two cases into a single `u32`: a revealed child holds an [`Index`] into the arena's
+/// nodes, a blinded child a slot in the arena's side table of unrevealed RLP. The top bit
+/// discriminates, so both fit in four bytes and a branch's children stay dense and small.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) struct BranchChild(u32);
+
+impl BranchChild {
+    /// Tag bit marking a child as blinded.
+    const BLINDED: u32 = 1 << 31;
+
+    /// Returns a child referencing the revealed node at `idx`.
+    pub(super) const fn revealed(idx: Index) -> Self {
+        debug_assert!(idx.0 & Self::BLINDED == 0, "arena index overflows the blinded tag bit");
+        Self(idx.0)
+    }
+
+    /// Returns a child referencing the blinded RLP at `slot`.
+    const fn blinded(slot: u32) -> Self {
+        debug_assert!(slot & Self::BLINDED == 0, "blinded slot overflows the tag bit");
+        Self(slot | Self::BLINDED)
+    }
+
+    /// Returns `true` if this child reference is blinded (not yet revealed in the arena).
+    pub(super) const fn is_blinded(self) -> bool {
+        self.0 & Self::BLINDED != 0
+    }
+
+    /// Returns the arena index of a revealed child, or `None` if it is blinded.
+    pub(super) const fn revealed_index(self) -> Option<Index> {
+        if self.is_blinded() {
+            None
+        } else {
+            Some(Index(self.0))
+        }
+    }
+
+    /// Returns the side-table slot of a blinded child, or `None` if it is revealed.
+    const fn blinded_slot(self) -> Option<u32> {
+        if self.is_blinded() {
+            Some(self.0 & !Self::BLINDED)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Debug for BranchChild {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.blinded_slot() {
+            Some(slot) => write!(f, "Blinded({slot})"),
+            None => write!(f, "Revealed({})", self.0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    #[test]
+    fn removed_slots_are_recycled() {
+        let mut arena = NodeArena::new();
+        let first = arena.insert(ArenaSparseNode::TakenSubtrie);
+        let second = arena.insert(ArenaSparseNode::TakenSubtrie);
+        assert_eq!(arena.len(), 2);
+
+        assert!(arena.remove(first).is_some());
+        assert!(arena.get(first).is_none());
+        assert!(!arena.contains_key(first));
+        assert!(arena.remove(first).is_none());
+        assert_eq!(arena.len(), 1);
+
+        let third = arena.insert(ArenaSparseNode::TakenSubtrie);
+        assert_eq!(third, first, "the freed slot is handed out again");
+        assert_ne!(third, second);
+        assert_eq!(arena.len(), 2);
+        assert_eq!(arena.iter().count(), 2);
+    }
+
+    #[test]
+    fn blinded_slots_are_recycled() {
+        let mut arena = NodeArena::new();
+        let rlp = RlpNode::word_rlp(&B256::repeat_byte(1));
+        let child = arena.insert_blinded(rlp.clone());
+        assert!(child.is_blinded());
+        assert_eq!(child.revealed_index(), None);
+        assert_eq!(arena.blinded(child), &rlp);
+
+        assert_eq!(arena.take_blinded(child), rlp);
+        let other = RlpNode::word_rlp(&B256::repeat_byte(2));
+        assert_eq!(arena.insert_blinded(other.clone()), child, "the freed slot is reused");
+        assert_eq!(arena.blinded(child), &other);
+    }
+}

--- a/crates/trie/sparse/src/arena/node_arena.rs
+++ b/crates/trie/sparse/src/arena/node_arena.rs
@@ -6,6 +6,9 @@ use core::{
 };
 use reth_trie_common::RlpNode;
 
+/// Bits per word of a [`BlindedMarks`] bitmap.
+const WORD_BITS: usize = u64::BITS as usize;
+
 /// A reference to a node inside a [`NodeArena`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(super) struct Index(u32);
@@ -53,6 +56,17 @@ impl NodeArena {
         idx
     }
 
+    /// Removes the node at `idx` without recycling its slot.
+    ///
+    /// For an arena that is being emptied into a fresh one — pruning and compaction both do that
+    /// and then drop the source — maintaining the free list is wasted work. [`Self::len`] is no
+    /// longer accurate afterwards.
+    pub(super) fn drain_node(&mut self, idx: Index) -> ArenaSparseNode {
+        let node = core::mem::replace(&mut self.nodes[idx.get()], ArenaSparseNode::Free);
+        debug_assert!(!matches!(node, ArenaSparseNode::Free), "drained a free arena slot");
+        node
+    }
+
     /// Removes the node at `idx`, returning it if the slot was occupied.
     pub(super) fn remove(&mut self, idx: Index) -> Option<ArenaSparseNode> {
         let slot = self.nodes.get_mut(idx.get())?;
@@ -80,11 +94,6 @@ impl NodeArena {
     /// Returns the number of occupied slots.
     pub(super) const fn len(&self) -> usize {
         self.nodes.len() - self.free.len()
-    }
-
-    /// Returns `true` if the arena holds no occupied slots.
-    pub(super) const fn is_empty(&self) -> bool {
-        self.len() == 0
     }
 
     /// Iterates over the occupied slots.
@@ -136,6 +145,54 @@ impl NodeArena {
         self.blinded_free.push(slot);
         core::mem::take(&mut self.blinded[slot as usize])
     }
+
+    /// Releases the node vector's unused capacity.
+    pub(super) fn shrink_nodes_to_fit(&mut self) {
+        self.nodes.shrink_to_fit();
+    }
+
+    /// Takes over `src`'s side table of blinded children, so that blinded [`BranchChild`]s copied
+    /// out of `src` stay valid without their RLP being moved one slot at a time.
+    ///
+    /// The copy must record every child it carries over in the returned marks and finish with
+    /// [`Self::sweep_blinded`], which turns the slots left behind into free ones.
+    pub(super) fn adopt_blinded(&mut self, src: &mut Self) -> BlindedMarks {
+        debug_assert!(self.blinded.is_empty(), "adopting into a non-empty side table");
+        self.blinded = core::mem::take(&mut src.blinded);
+        self.blinded_free = core::mem::take(&mut src.blinded_free);
+        BlindedMarks { words: alloc::vec![0; self.blinded.len().div_ceil(WORD_BITS)] }
+    }
+
+    /// Rebuilds the free list of the side table adopted by [`Self::adopt_blinded`] from the slots
+    /// `marks` records as still referenced, and drops its unreferenced tail.
+    pub(super) fn sweep_blinded(&mut self, marks: BlindedMarks) {
+        let words = marks.words;
+        let live = words
+            .iter()
+            .rposition(|word| *word != 0)
+            .map_or(0, |idx| idx * WORD_BITS + WORD_BITS - words[idx].leading_zeros() as usize);
+        debug_assert!(live <= self.blinded.len(), "marked slot outside the side table");
+        self.blinded.truncate(live);
+        self.blinded_free.clear();
+
+        // Push high to low so that `insert_blinded` hands the lowest slot out first and the tail
+        // of the table keeps draining.
+        let word_count = live.div_ceil(WORD_BITS);
+        for (idx, word) in words[..word_count].iter().enumerate().rev() {
+            // The last word covers only the slots below `live`.
+            let covered = if idx + 1 == word_count && live % WORD_BITS != 0 {
+                (1 << (live % WORD_BITS)) - 1
+            } else {
+                u64::MAX
+            };
+            let mut unmarked = !word & covered;
+            while unmarked != 0 {
+                let bit = u64::BITS - 1 - unmarked.leading_zeros();
+                unmarked ^= 1 << bit;
+                self.blinded_free.push(idx as u32 * u64::BITS + bit);
+            }
+        }
+    }
 }
 
 impl IndexOps<Index> for NodeArena {
@@ -155,6 +212,29 @@ impl IndexMut<Index> for NodeArena {
         let node = &mut self.nodes[idx.get()];
         debug_assert!(!matches!(node, ArenaSparseNode::Free), "indexed a free arena slot");
         node
+    }
+}
+
+/// The slots of a side table of blinded children that a copy into a fresh arena carried over.
+///
+/// See [`NodeArena::adopt_blinded`].
+pub(super) struct BlindedMarks {
+    words: Vec<u64>,
+}
+
+impl BlindedMarks {
+    /// Records that `child`'s slot is still referenced.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `child` is revealed.
+    pub(super) fn mark(&mut self, child: BranchChild) {
+        let slot = child.blinded_slot().expect("child is revealed") as usize;
+        let idx = slot / WORD_BITS;
+        if idx >= self.words.len() {
+            self.words.resize(idx + 1, 0);
+        }
+        self.words[idx] |= 1 << (slot % WORD_BITS);
     }
 }
 
@@ -253,5 +333,36 @@ mod tests {
         let other = RlpNode::word_rlp(&B256::repeat_byte(2));
         assert_eq!(arena.insert_blinded(other.clone()), child, "the freed slot is reused");
         assert_eq!(arena.blinded(child), &other);
+    }
+
+    #[test]
+    fn sweeping_an_adopted_table_keeps_marked_slots() {
+        let mut src = NodeArena::new();
+        // More than one word of the mark bitmap.
+        let children: Vec<_> = (0..200u8)
+            .map(|byte| src.insert_blinded(RlpNode::word_rlp(&B256::repeat_byte(byte))))
+            .collect();
+
+        let mut dst = NodeArena::new();
+        let mut marks = dst.adopt_blinded(&mut src);
+        for child in children.iter().step_by(3) {
+            marks.mark(*child);
+        }
+        dst.sweep_blinded(marks);
+
+        let last_marked = (children.len() - 1) / 3 * 3;
+        assert_eq!(dst.blinded.len(), last_marked + 1, "the unmarked tail is dropped");
+
+        // Every unmarked slot below the tail is handed out again, lowest first.
+        let expected: Vec<u32> = (0..=last_marked as u32).filter(|slot| slot % 3 != 0).collect();
+        let handed_out: Vec<u32> = expected
+            .iter()
+            .map(|_| dst.insert_blinded(RlpNode::default()).blinded_slot().unwrap())
+            .collect();
+        assert_eq!(handed_out, expected);
+
+        for (byte, child) in (0..200u8).step_by(3).zip(children.iter().step_by(3)) {
+            assert_eq!(dst.blinded(*child), &RlpNode::word_rlp(&B256::repeat_byte(byte)));
+        }
     }
 }

--- a/crates/trie/sparse/src/arena/nodes.rs
+++ b/crates/trie/sparse/src/arena/nodes.rs
@@ -1,6 +1,6 @@
 use super::{
     branch_child_idx::{BranchChildIdx, BranchChildIter},
-    ArenaSparseSubtrie, Index, NodeArena,
+    ArenaSparseSubtrie, BranchChild, NodeArena,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_primitives::{keccak256, B256};
@@ -50,30 +50,15 @@ impl ArenaSparseNodeState {
     }
 }
 
-/// Represents a reference from a branch node to one of its children.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum ArenaSparseNodeBranchChild {
-    /// The child node has been revealed and is present in the arena.
-    Revealed(Index),
-    /// The child node has not been revealed; only its RLP-encoded node is known.
-    Blinded(RlpNode),
-}
-
-impl ArenaSparseNodeBranchChild {
-    /// Returns `true` if this child reference is blinded (not yet revealed in the arena).
-    pub(super) const fn is_blinded(&self) -> bool {
-        matches!(self, Self::Blinded(_))
-    }
-}
-
 /// The branch-specific data stored in an [`ArenaSparseNode::Branch`].
 #[derive(Debug, Clone)]
 pub(super) struct ArenaSparseNodeBranch {
     /// Cached or dirty state of this node.
     pub(super) state: ArenaSparseNodeState,
     /// Revealed or blinded children, packed densely. The `state_mask` tracks which
-    /// nibble positions have entries in this `SmallVec`.
-    pub(super) children: SmallVec<[ArenaSparseNodeBranchChild; 4]>,
+    /// nibble positions have entries in this `SmallVec`, which is sized to hold the maximum
+    /// of 16 children inline and therefore never spills.
+    pub(super) children: SmallVec<[BranchChild; 16]>,
     /// Bitmask indicating which of the 16 child slots are occupied (have an entry
     /// in `children`).
     pub(super) state_mask: TrieMask,
@@ -92,7 +77,7 @@ impl ArenaSparseNodeBranch {
 
     /// Inserts a child at `nibble`, updating the state mask, children array, and marking the
     /// branch as dirty.
-    pub(super) fn set_child(&mut self, nibble: u8, child: ArenaSparseNodeBranchChild) {
+    pub(super) fn set_child(&mut self, nibble: u8, child: BranchChild) {
         let insert_pos = BranchChildIdx::insertion_point(self.state_mask, nibble);
         self.state_mask.set_bit(nibble);
         self.children.insert(insert_pos.get(), child);
@@ -118,7 +103,7 @@ impl ArenaSparseNodeBranch {
     /// # Panics
     ///
     /// Panics (debug) if the branch does not have exactly 2 children, or if `nibble` is not set.
-    pub(super) fn sibling_child(&self, nibble: u8) -> &ArenaSparseNodeBranchChild {
+    pub(super) fn sibling_child(&self, nibble: u8) -> BranchChild {
         debug_assert_eq!(
             self.state_mask.count_bits(),
             2,
@@ -127,14 +112,12 @@ impl ArenaSparseNodeBranch {
         let child_idx =
             BranchChildIdx::new(self.state_mask, nibble).expect("nibble not found in state_mask");
         // With exactly 2 children the dense array has indices 0 and 1.
-        &self.children[1 - child_idx.get()]
+        self.children[1 - child_idx.get()]
     }
 
-    /// Iterates over `(nibble, &ArenaSparseNodeBranchChild)` pairs in nibble order.
-    pub(super) fn child_iter(
-        &self,
-    ) -> impl Iterator<Item = (u8, &ArenaSparseNodeBranchChild)> + '_ {
-        BranchChildIter::new(self.state_mask).map(|(idx, nibble)| (nibble, &self.children[idx]))
+    /// Iterates over `(nibble, child)` pairs in nibble order.
+    pub(super) fn child_iter(&self) -> impl Iterator<Item = (u8, BranchChild)> + '_ {
+        BranchChildIter::new(self.state_mask).map(|(idx, nibble)| (nibble, self.children[idx]))
     }
 
     /// Returns a [`BranchNodeCompact`] from this branch's masks and children hashes.
@@ -142,13 +125,9 @@ impl ArenaSparseNodeBranch {
         let mut hashes = Vec::with_capacity(self.branch_masks.hash_mask.count_bits() as usize);
         for (nibble, child) in self.child_iter() {
             if self.branch_masks.hash_mask.is_bit_set(nibble) {
-                let hash = match child {
-                    ArenaSparseNodeBranchChild::Blinded(rlp_node) => {
-                        rlp_node.as_hash().expect("blinded child must be a hash")
-                    }
-                    ArenaSparseNodeBranchChild::Revealed(child_idx) => {
-                        arena[*child_idx].cached_hash()
-                    }
+                let hash = match child.revealed_index() {
+                    Some(child_idx) => arena[child_idx].cached_hash(),
+                    None => arena.blinded(child).as_hash().expect("blinded child must be a hash"),
                 };
                 hashes.push(hash);
             }
@@ -186,6 +165,9 @@ pub(super) enum ArenaSparseNode {
     Subtrie(Box<ArenaSparseSubtrie>),
     /// Placeholder for a subtrie that has been temporarily taken for parallel operations.
     TakenSubtrie,
+    /// Tombstone left behind by [`NodeArena::remove`](super::NodeArena::remove); the slot is on
+    /// the arena's free list.
+    Free,
 }
 
 impl ArenaSparseNode {
@@ -306,13 +288,14 @@ impl ArenaSparseNode {
 }
 
 impl ArenaSparseNode {
-    /// Converts a [`ProofTrieNodeV2`] into an [`ArenaSparseNode`].
+    /// Converts a [`ProofTrieNodeV2`] into an [`ArenaSparseNode`], storing the RLP of a branch's
+    /// unrevealed children in `arena`'s blinded side table.
     ///
     /// # Panics
     ///
     /// Panics if the node is an `Extension`, which should have been merged into a branch
     /// by [`TrieNodeV2`].
-    pub(super) fn from_proof_node(proof_node: ProofTrieNodeV2) -> Self {
+    pub(super) fn from_proof_node(arena: &mut NodeArena, proof_node: ProofTrieNodeV2) -> Self {
         let ProofTrieNodeV2 { node, masks, .. } = proof_node;
         match node {
             TrieNodeV2::EmptyRoot => Self::EmptyRoot { state: ArenaSparseNodeState::Revealed },
@@ -324,7 +307,7 @@ impl ArenaSparseNode {
             TrieNodeV2::Branch(branch) => {
                 let children = branch.stack[..branch.state_mask.count_bits() as usize]
                     .iter()
-                    .map(|rlp| ArenaSparseNodeBranchChild::Blinded(rlp.clone()))
+                    .map(|rlp| arena.insert_blinded(rlp.clone()))
                     .collect();
                 Self::Branch(ArenaSparseNodeBranch {
                     state: ArenaSparseNodeState::Revealed,

--- a/crates/trie/sparse/src/blocked.rs
+++ b/crates/trie/sparse/src/blocked.rs
@@ -18,6 +18,9 @@ pub struct BlockedLeafUpdates {
     entries: Vec<BlockedLeafUpdate>,
     /// Buffer reused while rebuilding [`Self::entries`].
     scratch: Vec<BlockedLeafUpdate>,
+    /// Keys of the [`BlockedOn::Sibling`] entries by the path of the node they wait for, sorted
+    /// by that path. Their node is not on their own key path, so they cannot be found by it.
+    siblings: Vec<(Nibbles, B256)>,
     /// Number of entries in [`Self::entries`] that are ready to be applied again.
     num_retryable: usize,
 }
@@ -25,7 +28,7 @@ pub struct BlockedLeafUpdates {
 impl BlockedLeafUpdates {
     /// Creates an empty set of blocked updates.
     pub const fn new() -> Self {
-        Self { entries: Vec::new(), scratch: Vec::new(), num_retryable: 0 }
+        Self { entries: Vec::new(), scratch: Vec::new(), siblings: Vec::new(), num_retryable: 0 }
     }
 
     /// Returns the number of blocked updates.
@@ -57,6 +60,7 @@ impl BlockedLeafUpdates {
     pub fn clear(&mut self) {
         self.entries.clear();
         self.scratch.clear();
+        self.siblings.clear();
         self.num_retryable = 0;
     }
 
@@ -80,6 +84,31 @@ impl BlockedLeafUpdates {
                 self.num_retryable += 1;
             }
         }
+
+        if !self.siblings.is_empty() {
+            self.mark_sibling_revealed(path);
+        }
+    }
+
+    /// Marks the entries whose branch collapse waits for the node at `path` as retryable.
+    fn mark_sibling_revealed(&mut self, path: &Nibbles) {
+        let start = self.siblings.partition_point(|(sibling, _)| sibling < path);
+        let mut end = start;
+        while self.siblings.get(end).is_some_and(|(sibling, _)| sibling == path) {
+            end += 1;
+        }
+
+        for index in start..end {
+            let key = self.siblings[index].1;
+            let Some(pos) = self.position(&key) else { continue };
+            let entry = &mut self.entries[pos];
+            if matches!(entry.blocked_on, BlockedOn::Sibling { .. }) {
+                entry.blocked_on = BlockedOn::Retryable;
+                self.num_retryable += 1;
+            }
+        }
+
+        self.siblings.drain(start..end);
     }
 
     /// Moves `updates` and all retryable entries into `batch`, sorted by key and with their
@@ -117,7 +146,7 @@ impl BlockedLeafUpdates {
                     BlockedOn::Retryable => {
                         batch.push((entry.key, Nibbles::default(), entry.update))
                     }
-                    BlockedOn::Reveal(_) => kept.push(entry),
+                    BlockedOn::Reveal(_) | BlockedOn::Sibling { .. } => kept.push(entry),
                 }
             }
             self.entries = kept;
@@ -154,14 +183,16 @@ impl BlockedLeafUpdates {
         #[expect(clippy::iter_with_drain, reason = "retain the scratch buffer allocation")]
         let mut blocked = entries.drain(..).peekable();
         let mut last_index = None;
+        let num_siblings = self.siblings.len();
         for &(index, blocked_on) in indices.iter() {
             if last_index == Some(index) {
                 continue
             }
             last_index = Some(index);
 
-            let (key, _, update) = &mut batch[index as usize];
+            let (key, path, update) = &mut batch[index as usize];
             let key = *key;
+            let path = *path;
             while blocked.peek().is_some_and(|entry| entry.key < key) {
                 merged.push(blocked.next().expect("peeked"));
             }
@@ -170,8 +201,15 @@ impl BlockedLeafUpdates {
                 "leaf update blocked twice for the same key",
             );
 
-            if blocked_on == BlockedOn::Retryable {
-                self.num_retryable += 1;
+            match blocked_on {
+                BlockedOn::Retryable => self.num_retryable += 1,
+                // The sibling is not on this key's path, so index the entry by it.
+                BlockedOn::Sibling { depth, nibble } => {
+                    let mut sibling = path.slice(..depth as usize - 1);
+                    sibling.push_unchecked(nibble);
+                    self.siblings.push((sibling, key));
+                }
+                BlockedOn::Reveal(_) => {}
             }
             merged.push(BlockedLeafUpdate {
                 key,
@@ -183,6 +221,9 @@ impl BlockedLeafUpdates {
 
         self.entries = merged;
         self.scratch = entries;
+        if self.siblings.len() != num_siblings {
+            self.siblings.sort_unstable();
+        }
     }
 
     /// Returns the position of the given key in [`Self::entries`].
@@ -210,9 +251,21 @@ struct BlockedLeafUpdate {
 pub(crate) enum BlockedOn {
     /// A node covering the first N nibbles of the entry's key must be revealed.
     Reveal(u8),
-    /// The entry waits on something that is not on its own path, e.g. the blinded sibling a
-    /// branch collapse needs, and is applied again with every batch.
+    /// The blinded sibling a branch collapse needs must be revealed. It sits at `depth`, where
+    /// it shares the first `depth - 1` nibbles of the entry's key and continues with `nibble`.
+    Sibling { depth: u8, nibble: u8 },
+    /// The entry can be applied again with the next batch.
     Retryable,
+}
+
+impl BlockedOn {
+    /// Waits for the blinded sibling at the given path.
+    pub(crate) fn sibling(path: &Nibbles) -> Self {
+        Self::Sibling {
+            depth: path.len() as u8,
+            nibble: path.last().expect("sibling path has a child nibble"),
+        }
+    }
 }
 
 /// Returns the lowest and highest key that start with the given path.
@@ -278,6 +331,29 @@ mod tests {
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0].0, key(0x11));
         assert_eq!(blocked.len(), 1);
+    }
+
+    #[test]
+    fn sibling_entries_wait_for_the_node_they_collapse_onto() {
+        let sibling = Nibbles::from_nibbles([0x1, 0x2]);
+        let mut blocked = BlockedLeafUpdates::new();
+        let mut batch =
+            vec![(key(0x11), Nibbles::unpack(key(0x11)), LeafUpdate::Changed(Vec::new()))];
+        blocked.block(&mut batch, &mut [(0, BlockedOn::sibling(&sibling))]);
+        assert!(!blocked.has_retryable());
+
+        // Revealing the entry's own path does not unblock the collapse.
+        blocked.mark_revealed(&Nibbles::from_nibbles([0x1, 0x1]));
+        assert!(!blocked.has_retryable());
+
+        blocked.mark_revealed(&sibling);
+        assert!(blocked.has_retryable());
+
+        let mut updates = B256Map::default();
+        blocked.take_batch(&mut updates, &mut batch);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].0, key(0x11));
+        assert!(blocked.is_empty());
     }
 
     #[test]

--- a/crates/trie/sparse/src/blocked.rs
+++ b/crates/trie/sparse/src/blocked.rs
@@ -1,0 +1,307 @@
+//! Leaf updates that a sparse trie could not apply because they hit a blinded node.
+
+use crate::LeafUpdate;
+use alloc::vec::Vec;
+use alloy_primitives::{map::B256Map, B256};
+use core::mem;
+use reth_trie_common::Nibbles;
+
+/// Leaf updates that hit a blinded node and wait for that node to be revealed.
+///
+/// A trie takes ownership of the updates it could not apply, so that later batches only have to
+/// look at the entries whose blinded node was actually revealed. Entries are kept sorted by key,
+/// which for the full-length hashed keys of the state tries is the same order as their unpacked
+/// nibble paths.
+#[derive(Debug, Clone, Default)]
+pub struct BlockedLeafUpdates {
+    /// Blocked entries, sorted by key.
+    entries: Vec<BlockedLeafUpdate>,
+    /// Buffer reused while rebuilding [`Self::entries`].
+    scratch: Vec<BlockedLeafUpdate>,
+    /// Number of entries in [`Self::entries`] that are ready to be applied again.
+    num_retryable: usize,
+}
+
+impl BlockedLeafUpdates {
+    /// Creates an empty set of blocked updates.
+    pub const fn new() -> Self {
+        Self { entries: Vec::new(), scratch: Vec::new(), num_retryable: 0 }
+    }
+
+    /// Returns the number of blocked updates.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if no update is blocked.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns `true` if at least one blocked update can be applied again.
+    pub fn has_retryable(&self) -> bool {
+        self.num_retryable > 0
+    }
+
+    /// Returns the blocked update for the given key, if there is one.
+    pub fn get(&self, key: &B256) -> Option<&LeafUpdate> {
+        self.position(key).map(|pos| &self.entries[pos].update)
+    }
+
+    /// Returns the keys of all blocked updates.
+    pub fn keys(&self) -> impl Iterator<Item = B256> + '_ {
+        self.entries.iter().map(|entry| entry.key)
+    }
+
+    /// Drops all blocked updates, keeping the allocations.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.scratch.clear();
+        self.num_retryable = 0;
+    }
+
+    /// Marks every entry waiting for a node at `path` as retryable.
+    pub(crate) fn mark_revealed(&mut self, path: &Nibbles) {
+        // No entry can wait on the root, and entries waiting on a deeper node are only reachable
+        // once their own blinded node was revealed.
+        if self.entries.is_empty() || path.is_empty() {
+            return
+        }
+
+        let waiting_on = BlockedOn::Reveal(path.len() as u8);
+        let (lower, upper) = prefix_range(path);
+        let start = self.entries.partition_point(|entry| entry.key < lower);
+        for entry in &mut self.entries[start..] {
+            if entry.key > upper {
+                break
+            }
+            if entry.blocked_on == waiting_on {
+                entry.blocked_on = BlockedOn::Retryable;
+                self.num_retryable += 1;
+            }
+        }
+    }
+
+    /// Moves `updates` and all retryable entries into `batch`, sorted by key and with their
+    /// nibble path unpacked.
+    ///
+    /// An update for a key that is already blocked replaces the blocked update in place instead
+    /// of being applied: the blinded node the entry stopped at does not depend on the update
+    /// value, so the entry keeps waiting for the same node. A [`LeafUpdate::Touched`] never
+    /// replaces a known value.
+    pub(crate) fn take_batch(
+        &mut self,
+        updates: &mut B256Map<LeafUpdate>,
+        batch: &mut Vec<(B256, Nibbles, LeafUpdate)>,
+    ) {
+        batch.clear();
+        batch.reserve(updates.len() + self.num_retryable);
+
+        for (key, update) in updates.drain() {
+            if let Some(pos) = self.position(&key) {
+                if update.is_changed() {
+                    self.entries[pos].update = update;
+                }
+                continue
+            }
+            batch.push((key, Nibbles::default(), update));
+        }
+
+        if self.num_retryable > 0 {
+            let mut entries = mem::take(&mut self.entries);
+            let mut kept = mem::take(&mut self.scratch);
+            kept.clear();
+            for entry in entries.drain(..) {
+                match entry.blocked_on {
+                    BlockedOn::Retryable => {
+                        batch.push((entry.key, Nibbles::default(), entry.update))
+                    }
+                    BlockedOn::Reveal(_) => kept.push(entry),
+                }
+            }
+            self.entries = kept;
+            self.scratch = entries;
+            self.num_retryable = 0;
+        }
+
+        batch.sort_unstable_by(|(left, ..), (right, ..)| left.cmp(right));
+        for (key, path, _) in batch.iter_mut() {
+            *path = Nibbles::unpack(key);
+        }
+    }
+
+    /// Blocks the entries of `batch` at the given indices, taking their update out of the batch.
+    ///
+    /// `indices` does not need to be sorted and may contain the same index twice, because a
+    /// removal can require two proofs.
+    pub(crate) fn block(
+        &mut self,
+        batch: &mut [(B256, Nibbles, LeafUpdate)],
+        indices: &mut Vec<(u32, BlockedOn)>,
+    ) {
+        if indices.is_empty() {
+            return
+        }
+        indices.sort_unstable_by_key(|(index, _)| *index);
+
+        // The batch is sorted by key, so walking it by index merges into the sorted entries.
+        let mut entries = mem::take(&mut self.entries);
+        let mut merged = mem::take(&mut self.scratch);
+        merged.clear();
+        merged.reserve(entries.len() + indices.len());
+
+        let mut blocked = entries.drain(..).peekable();
+        let mut last_index = None;
+        for &(index, blocked_on) in indices.iter() {
+            if last_index == Some(index) {
+                continue
+            }
+            last_index = Some(index);
+
+            let (key, _, update) = &mut batch[index as usize];
+            let key = *key;
+            while blocked.peek().is_some_and(|entry| entry.key < key) {
+                merged.push(blocked.next().expect("peeked"));
+            }
+            debug_assert!(
+                blocked.peek().is_none_or(|entry| entry.key != key),
+                "leaf update blocked twice for the same key",
+            );
+
+            if blocked_on == BlockedOn::Retryable {
+                self.num_retryable += 1;
+            }
+            merged.push(BlockedLeafUpdate {
+                key,
+                update: mem::replace(update, LeafUpdate::Touched),
+                blocked_on,
+            });
+        }
+        merged.extend(blocked);
+
+        self.entries = merged;
+        self.scratch = entries;
+    }
+
+    /// Returns the position of the given key in [`Self::entries`].
+    fn position(&self, key: &B256) -> Option<usize> {
+        if self.entries.is_empty() {
+            return None
+        }
+        self.entries.binary_search_by(|entry| entry.key.cmp(key)).ok()
+    }
+}
+
+/// A leaf update waiting for a blinded node to be revealed.
+#[derive(Debug, Clone)]
+struct BlockedLeafUpdate {
+    /// Full hashed key of the leaf.
+    key: B256,
+    /// The update to apply once the trie is revealed deeply enough.
+    update: LeafUpdate,
+    /// What this entry is waiting for.
+    blocked_on: BlockedOn,
+}
+
+/// Describes when a [`BlockedLeafUpdate`] should be applied again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BlockedOn {
+    /// A node covering the first N nibbles of the entry's key must be revealed.
+    Reveal(u8),
+    /// The entry waits on something that is not on its own path, e.g. the blinded sibling a
+    /// branch collapse needs, and is applied again with every batch.
+    Retryable,
+}
+
+/// Returns the lowest and highest key that start with the given path.
+fn prefix_range(path: &Nibbles) -> (B256, B256) {
+    let mut lower = [0u8; 32];
+    path.pack_to(&mut lower);
+
+    let mut upper = lower;
+    let len = path.len();
+    if len % 2 == 1 {
+        upper[len / 2] |= 0x0f;
+    }
+    for byte in &mut upper[len.div_ceil(2)..] {
+        *byte = 0xff;
+    }
+
+    (lower.into(), upper.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> B256 {
+        B256::repeat_byte(byte)
+    }
+
+    #[test]
+    fn prefix_range_covers_all_keys_with_prefix() {
+        let (lower, upper) = prefix_range(&Nibbles::from_nibbles([0x1, 0x2, 0x3]));
+        assert_eq!(lower, B256::from_slice(&[[0x12, 0x30].as_slice(), &[0u8; 30]].concat()));
+        assert_eq!(upper, B256::from_slice(&[[0x12, 0x3f].as_slice(), &[0xffu8; 30]].concat()));
+    }
+
+    #[test]
+    fn only_entries_waiting_on_the_revealed_path_become_retryable() {
+        let mut blocked = BlockedLeafUpdates::new();
+        let mut batch = vec![
+            (key(0x11), Nibbles::unpack(key(0x11)), LeafUpdate::Touched),
+            (key(0x12), Nibbles::unpack(key(0x12)), LeafUpdate::Changed(vec![1])),
+            (key(0x22), Nibbles::unpack(key(0x22)), LeafUpdate::Touched),
+        ];
+        blocked.block(
+            &mut batch,
+            &mut vec![
+                (0, BlockedOn::Reveal(2)),
+                (1, BlockedOn::Reveal(2)),
+                (2, BlockedOn::Retryable),
+            ],
+        );
+        assert_eq!(blocked.len(), 3);
+        assert!(blocked.has_retryable());
+
+        // The retryable entry is taken even though nothing was revealed for it.
+        let mut updates = B256Map::default();
+        blocked.take_batch(&mut updates, &mut batch);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].0, key(0x22));
+        assert_eq!(blocked.len(), 2);
+
+        // Revealing an unrelated path leaves both entries blocked.
+        blocked.mark_revealed(&Nibbles::from_nibbles([0x2, 0x2]));
+        assert!(!blocked.has_retryable());
+
+        blocked.mark_revealed(&Nibbles::from_nibbles([0x1, 0x1]));
+        blocked.take_batch(&mut updates, &mut batch);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].0, key(0x11));
+        assert_eq!(blocked.len(), 1);
+    }
+
+    #[test]
+    fn newer_changed_update_replaces_the_blocked_one() {
+        let mut blocked = BlockedLeafUpdates::new();
+        let mut batch = vec![(key(0x11), Nibbles::unpack(key(0x11)), LeafUpdate::Changed(vec![1]))];
+        blocked.block(&mut batch, &mut vec![(0, BlockedOn::Reveal(2))]);
+
+        let mut updates = B256Map::from_iter([(key(0x11), LeafUpdate::Touched)]);
+        blocked.take_batch(&mut updates, &mut batch);
+        assert!(batch.is_empty(), "a touch must not be applied ahead of the blocked update");
+        assert_eq!(blocked.get(&key(0x11)), Some(&LeafUpdate::Changed(vec![1])));
+
+        let mut updates = B256Map::from_iter([(key(0x11), LeafUpdate::Changed(vec![2]))]);
+        blocked.take_batch(&mut updates, &mut batch);
+        assert!(batch.is_empty(), "the entry stays blocked on the same node");
+        assert_eq!(blocked.get(&key(0x11)), Some(&LeafUpdate::Changed(vec![2])));
+
+        blocked.mark_revealed(&Nibbles::from_nibbles([0x1, 0x1]));
+        blocked.take_batch(&mut updates, &mut batch);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].2, LeafUpdate::Changed(vec![2]));
+        assert!(blocked.is_empty());
+    }
+}

--- a/crates/trie/sparse/src/blocked.rs
+++ b/crates/trie/sparse/src/blocked.rs
@@ -29,17 +29,17 @@ impl BlockedLeafUpdates {
     }
 
     /// Returns the number of blocked updates.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.entries.len()
     }
 
     /// Returns `true` if no update is blocked.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
     /// Returns `true` if at least one blocked update can be applied again.
-    pub fn has_retryable(&self) -> bool {
+    pub const fn has_retryable(&self) -> bool {
         self.num_retryable > 0
     }
 
@@ -111,6 +111,7 @@ impl BlockedLeafUpdates {
             let mut entries = mem::take(&mut self.entries);
             let mut kept = mem::take(&mut self.scratch);
             kept.clear();
+            #[expect(clippy::iter_with_drain, reason = "retain the scratch buffer allocation")]
             for entry in entries.drain(..) {
                 match entry.blocked_on {
                     BlockedOn::Retryable => {
@@ -124,7 +125,7 @@ impl BlockedLeafUpdates {
             self.num_retryable = 0;
         }
 
-        batch.sort_unstable_by(|(left, ..), (right, ..)| left.cmp(right));
+        batch.sort_unstable_by_key(|&(key, ..)| key);
         for (key, path, _) in batch.iter_mut() {
             *path = Nibbles::unpack(key);
         }
@@ -137,7 +138,7 @@ impl BlockedLeafUpdates {
     pub(crate) fn block(
         &mut self,
         batch: &mut [(B256, Nibbles, LeafUpdate)],
-        indices: &mut Vec<(u32, BlockedOn)>,
+        indices: &mut [(u32, BlockedOn)],
     ) {
         if indices.is_empty() {
             return
@@ -150,6 +151,7 @@ impl BlockedLeafUpdates {
         merged.clear();
         merged.reserve(entries.len() + indices.len());
 
+        #[expect(clippy::iter_with_drain, reason = "retain the scratch buffer allocation")]
         let mut blocked = entries.drain(..).peekable();
         let mut last_index = None;
         for &(index, blocked_on) in indices.iter() {
@@ -255,11 +257,7 @@ mod tests {
         ];
         blocked.block(
             &mut batch,
-            &mut vec![
-                (0, BlockedOn::Reveal(2)),
-                (1, BlockedOn::Reveal(2)),
-                (2, BlockedOn::Retryable),
-            ],
+            &mut [(0, BlockedOn::Reveal(2)), (1, BlockedOn::Reveal(2)), (2, BlockedOn::Retryable)],
         );
         assert_eq!(blocked.len(), 3);
         assert!(blocked.has_retryable());
@@ -286,7 +284,7 @@ mod tests {
     fn newer_changed_update_replaces_the_blocked_one() {
         let mut blocked = BlockedLeafUpdates::new();
         let mut batch = vec![(key(0x11), Nibbles::unpack(key(0x11)), LeafUpdate::Changed(vec![1]))];
-        blocked.block(&mut batch, &mut vec![(0, BlockedOn::Reveal(2))]);
+        blocked.block(&mut batch, &mut [(0, BlockedOn::Reveal(2))]);
 
         let mut updates = B256Map::from_iter([(key(0x11), LeafUpdate::Touched)]);
         blocked.take_batch(&mut updates, &mut batch);

--- a/crates/trie/sparse/src/lib.rs
+++ b/crates/trie/sparse/src/lib.rs
@@ -15,6 +15,9 @@ mod trie;
 #[cfg(feature = "std")]
 pub use trie::*;
 
+mod blocked;
+pub use blocked::*;
+
 mod traits;
 pub use traits::*;
 

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -332,6 +332,60 @@ where
         any_err
     }
 
+    /// Reveals account trie proof nodes on the calling thread.
+    ///
+    /// Unlike [`Self::reveal_decoded_multiproof_v2`] this touches only the account trie, so a
+    /// caller that owns some of the storage tries itself can reveal the two halves separately.
+    pub fn reveal_account_proof_nodes(
+        &mut self,
+        mut nodes: Vec<ProofTrieNodeV2>,
+    ) -> SparseStateTrieResult<()> {
+        if nodes.is_empty() {
+            return Ok(())
+        }
+
+        #[cfg(feature = "metrics")]
+        self.metrics.increment_total_account_nodes(nodes.len() as u64);
+
+        let result = self.state.reveal_v2_proof_nodes(&mut nodes, self.retain_updates);
+        self.deferred_drops.proof_nodes_bufs.push(nodes);
+
+        Ok(result?)
+    }
+
+    /// Reveals storage trie proof nodes for `address` on the calling thread, creating the trie if
+    /// it does not exist yet.
+    pub fn reveal_storage_proof_nodes(
+        &mut self,
+        address: B256,
+        mut nodes: Vec<ProofTrieNodeV2>,
+    ) -> SparseStateTrieResult<()> {
+        if nodes.is_empty() {
+            return Ok(())
+        }
+
+        #[cfg(feature = "metrics")]
+        self.metrics.increment_total_storage_nodes(nodes.len() as u64);
+
+        let retain_updates = self.retain_updates;
+        let result = self
+            .storage
+            .get_or_create_trie_mut(address)
+            .reveal_v2_proof_nodes(&mut nodes, retain_updates);
+        self.deferred_drops.proof_nodes_bufs.push(nodes);
+
+        Ok(result?)
+    }
+
+    /// Records storage trie nodes that were revealed into a trie taken out of this state trie, so
+    /// the reveal metrics stay complete.
+    pub const fn record_revealed_storage_nodes(&mut self, nodes: usize) {
+        #[cfg(feature = "metrics")]
+        self.metrics.increment_total_storage_nodes(nodes as u64);
+        #[cfg(not(feature = "metrics"))]
+        let _ = nodes;
+    }
+
     /// Calculates the hashes of subtries.
     ///
     /// If the trie has not been revealed, this function does nothing.

--- a/crates/trie/sparse/src/state.rs
+++ b/crates/trie/sparse/src/state.rs
@@ -80,6 +80,11 @@ impl<A, S> SparseStateTrie<A, S> {
         self
     }
 
+    /// Returns whether branch node updates and deletions are retained.
+    pub const fn retains_updates(&self) -> bool {
+        self.retain_updates
+    }
+
     /// Set the accounts trie to the given `RevealableSparseTrie`.
     pub fn set_accounts_trie(&mut self, trie: RevealableSparseTrie<A>) {
         self.state = trie;
@@ -110,6 +115,14 @@ impl<A, S> SparseStateTrie<A, S> {
     /// calculating the state root.
     pub fn take_deferred_drops(&mut self) -> DeferredDrops {
         core::mem::take(&mut self.deferred_drops)
+    }
+
+    /// Queues a proof node buffer for deferred dropping.
+    ///
+    /// Callers that reveal proof nodes into a storage trie taken out of this state trie should
+    /// hand the buffer back here so it is dropped with the rest of them.
+    pub fn defer_drop_proof_nodes(&mut self, nodes: Vec<ProofTrieNodeV2>) {
+        self.deferred_drops.proof_nodes_bufs.push(nodes);
     }
 }
 

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -2,6 +2,7 @@
 
 use core::fmt::Debug;
 
+use crate::BlockedLeafUpdates;
 use alloc::{borrow::Cow, vec::Vec};
 use alloy_primitives::{
     map::{B256Map, HashMap, HashSet},
@@ -223,12 +224,13 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
 
     /// Applies leaf updates to the sparse trie.
     ///
-    /// When a [`LeafUpdate::Changed`] is successfully applied, it is removed from the
-    /// given [`B256Map`]. If it could not be applied due to blinded nodes, it remains
-    /// in the map and the callback is invoked with the required proof target.
+    /// The given [`B256Map`] is drained: updates that could not be applied because they hit a
+    /// blinded node are moved into [`SparseTrie::blocked_updates`] and the callback is invoked
+    /// with the required proof target. An update for a key that is already blocked replaces the
+    /// blocked one.
     ///
-    /// Once that proof is calculated and revealed via [`SparseTrie::reveal_nodes`], the same
-    /// `updates` map can be reused to retry the update.
+    /// Once the proof is revealed via [`SparseTrie::reveal_nodes`], the affected blocked updates
+    /// are applied by the next call to this method, even when `updates` is empty.
     ///
     /// The callback receives `(key, parent)` where `key` is the full 32-byte hashed key
     /// (right-padded with zeros from the blinded path) and `parent` identifies the revealed logical
@@ -244,6 +246,9 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
         updates: &mut B256Map<LeafUpdate>,
         proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
     ) -> SparseTrieResult<()>;
+
+    /// Returns the leaf updates that could not be applied yet because they hit a blinded node.
+    fn blocked_updates(&self) -> &BlockedLeafUpdates;
 }
 
 /// Tracks modifications to the sparse trie structure.

--- a/crates/trie/sparse/src/traits.rs
+++ b/crates/trie/sparse/src/traits.rs
@@ -64,6 +64,28 @@ impl LeafUpdate {
     }
 }
 
+/// An event reported by [`SparseTrie::update_leaves_with_events`] while applying a batch of leaf
+/// updates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeafUpdateEvent<'a> {
+    /// The update for `key` hit a blinded node and a proof below `parent` is required before it
+    /// can be applied.
+    ProofRequired {
+        /// The full 32-byte hashed key that requires a proof.
+        key: B256,
+        /// The revealed logical parent branch of the blinded node.
+        parent: ProofV2TargetParent,
+    },
+    /// A [`LeafUpdate::Touched`] entry was applied, reporting the leaf value the trie holds for
+    /// its key.
+    Touched {
+        /// The full 32-byte hashed key of the touched leaf.
+        key: B256,
+        /// The leaf value at `key`, or `None` when the revealed trie has no leaf there.
+        value: Option<&'a [u8]>,
+    },
+}
+
 /// Trait defining common operations for revealed sparse trie implementations.
 ///
 /// This trait provides a unified interface for the core trie operations needed by
@@ -244,7 +266,25 @@ pub trait SparseTrie: Sized + Debug + Send + Sync {
     fn update_leaves(
         &mut self,
         updates: &mut B256Map<LeafUpdate>,
-        proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
+        mut proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
+    ) -> SparseTrieResult<()> {
+        self.update_leaves_with_events(updates, false, |event| {
+            if let LeafUpdateEvent::ProofRequired { key, parent } = event {
+                proof_required_fn(key, parent)
+            }
+        })
+    }
+
+    /// [`SparseTrie::update_leaves`], reporting every applied [`LeafUpdate::Touched`] entry with
+    /// the leaf value found at its key when `report_touched` is set.
+    ///
+    /// Collecting those values costs an extra lookup per touched entry, so callers that only need
+    /// proof targets should use [`SparseTrie::update_leaves`].
+    fn update_leaves_with_events(
+        &mut self,
+        updates: &mut B256Map<LeafUpdate>,
+        report_touched: bool,
+        event_fn: impl FnMut(LeafUpdateEvent<'_>),
     ) -> SparseTrieResult<()>;
 
     /// Returns the leaf updates that could not be applied yet because they hit a blinded node.

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ArenaParallelSparseTrie, LeafUpdate, SparseTrie as SparseTrieTrait, SparseTrieUpdates,
-    TrieNodeEpoch,
+    ArenaParallelSparseTrie, BlockedLeafUpdates, LeafUpdate, SparseTrie as SparseTrieTrait,
+    SparseTrieUpdates, TrieNodeEpoch,
 };
 use alloc::{borrow::Cow, boxed::Box};
 use alloy_primitives::{map::B256Map, B256};
@@ -198,6 +198,14 @@ impl<T: SparseTrieTrait> RevealableSparseTrie<T> {
         Some((revealed.root(new_epoch), revealed.take_updates()))
     }
 
+    /// Returns the leaf updates the trie could not apply yet because they hit a blinded node.
+    ///
+    /// A blind trie never takes ownership of updates, see [`Self::update_leaves`].
+    pub fn blocked_updates(&self) -> &BlockedLeafUpdates {
+        static EMPTY: BlockedLeafUpdates = BlockedLeafUpdates::new();
+        self.as_revealed_ref().map_or(&EMPTY, SparseTrieTrait::blocked_updates)
+    }
+
     /// Clears this trie, setting it to a blind state.
     ///
     /// If this instance was revealed, or was itself a `Blind` with a pre-allocated
@@ -223,7 +231,7 @@ impl<T: SparseTrieTrait + Default> RevealableSparseTrie<T> {
     ///
     /// For revealed tries, delegates to the inner implementation which will:
     /// - Apply updates where possible
-    /// - Keep blocked updates in the map
+    /// - Take ownership of the updates that hit a blinded node
     /// - Emit proof targets for blinded paths
     pub fn update_leaves(
         &mut self,

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ArenaParallelSparseTrie, BlockedLeafUpdates, LeafUpdate, SparseTrie as SparseTrieTrait,
-    SparseTrieUpdates, TrieNodeEpoch,
+    ArenaParallelSparseTrie, BlockedLeafUpdates, LeafUpdate, LeafUpdateEvent,
+    SparseTrie as SparseTrieTrait, SparseTrieUpdates, TrieNodeEpoch,
 };
 use alloc::{borrow::Cow, boxed::Box};
 use alloy_primitives::{map::B256Map, B256};
@@ -238,16 +238,38 @@ impl<T: SparseTrieTrait + Default> RevealableSparseTrie<T> {
         updates: &mut B256Map<LeafUpdate>,
         mut proof_required_fn: impl FnMut(B256, ProofV2TargetParent),
     ) -> SparseTrieResult<()> {
+        self.update_leaves_with_events(updates, false, |event| {
+            if let LeafUpdateEvent::ProofRequired { key, parent } = event {
+                proof_required_fn(key, parent)
+            }
+        })
+    }
+
+    /// [`Self::update_leaves`], reporting every applied [`LeafUpdate::Touched`] entry with the
+    /// leaf value found at its key when `report_touched` is set.
+    ///
+    /// A blind trie reveals nothing, so it never reports a touched value.
+    pub fn update_leaves_with_events(
+        &mut self,
+        updates: &mut B256Map<LeafUpdate>,
+        report_touched: bool,
+        mut event_fn: impl FnMut(LeafUpdateEvent<'_>),
+    ) -> SparseTrieResult<()> {
         match self {
             Self::Blind(_) => {
                 // Nothing is revealed - emit proof targets for all keys without a known parent.
                 for key in updates.keys() {
-                    proof_required_fn(*key, ProofV2TargetParent::NONE);
+                    event_fn(LeafUpdateEvent::ProofRequired {
+                        key: *key,
+                        parent: ProofV2TargetParent::NONE,
+                    });
                 }
                 // All updates remain in the map for retry after proofs are fetched
                 Ok(())
             }
-            Self::Revealed(trie) => trie.update_leaves(updates, proof_required_fn),
+            Self::Revealed(trie) => {
+                trie.update_leaves_with_events(updates, report_touched, event_fn)
+            }
         }
     }
 }

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -624,3 +624,90 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
         "cold path root should match reference (K1 and K5 updated)"
     );
 }
+
+/// A leaf removal whose branch collapse waits for a blinded sibling must ask for that sibling
+/// once, not once per pass.
+///
+/// Mirrors what the engine's storage trie jobs do: proofs arrive in chunks, every arrival runs
+/// another `reveal_nodes` + `update_leaves` pass, and the caller drops an ask for a key it
+/// already requested a proof for. A blocked update that is retried although nothing on the path
+/// it waits for was revealed shows up as such a dropped ask.
+pub(super) fn test_collapse_asks_for_blinded_sibling_once<T: SparseTrie>(new_trie: fn() -> T) {
+    use alloy_primitives::keccak256;
+    use reth_trie_common::ProofV2TargetParent;
+    use std::collections::HashMap;
+
+    const NUM_SLOTS: u64 = 2048;
+    const NUM_UPDATES: u64 = 200;
+    const PROOFS_PER_PASS: usize = 4;
+
+    let base_storage: BTreeMap<B256, U256> =
+        (0..NUM_SLOTS).map(|i| (keccak256(i.to_be_bytes()), U256::from(i + 1))).collect();
+    let harness = SuiteTestHarness::new(base_storage.clone());
+
+    // Only the root is revealed, so every update starts out blinded.
+    let mut trie: T = harness.init_trie_with_targets(&[], true, new_trie);
+
+    let changeset: BTreeMap<B256, U256> = (0..NUM_UPDATES)
+        .map(|i| {
+            let value = if i % 4 == 0 { U256::ZERO } else { U256::from(i + 1000) };
+            (keccak256(i.to_be_bytes()), value)
+        })
+        .collect();
+    let mut leaf_updates = SuiteTestHarness::leaf_updates(&changeset);
+
+    let mut requested: HashMap<B256, ProofV2TargetParent> = HashMap::new();
+    let mut queue: Vec<ProofV2Target> = Vec::new();
+    let mut repeated_asks = 0usize;
+    let mut sibling_asks = 0usize;
+    let mut passes = 0usize;
+
+    loop {
+        passes += 1;
+        assert!(passes < 10_000, "reveal loop did not terminate");
+
+        trie.update_leaves(&mut leaf_updates, |key, parent| {
+            if !changeset.contains_key(&key) {
+                sibling_asks += 1;
+            }
+            match requested.entry(key) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    if parent < *entry.get() {
+                        entry.insert(parent);
+                        queue.push(ProofV2Target::new(key).with_parent(parent));
+                    } else if parent == *entry.get() {
+                        repeated_asks += 1;
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(parent);
+                    queue.push(ProofV2Target::new(key).with_parent(parent));
+                }
+            }
+        })
+        .expect("update_leaves should succeed");
+
+        if queue.is_empty() {
+            break;
+        }
+        let mut chunk: Vec<ProofV2Target> =
+            queue.drain(..PROOFS_PER_PASS.min(queue.len())).collect();
+        let (mut proof_nodes, _) = harness.proof_v2(&mut chunk);
+        trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+    }
+
+    assert!(sibling_asks > 0, "the changeset should collapse a branch onto a blinded sibling");
+    assert_eq!(repeated_asks, 0, "no key should be asked again from the parent it was asked from");
+    assert!(trie.blocked_updates().is_empty(), "every update should have been applied");
+
+    let mut expected_storage = base_storage;
+    for (&key, &value) in &changeset {
+        if value.is_zero() {
+            expected_storage.remove(&key);
+        } else {
+            expected_storage.insert(key, value);
+        }
+    }
+    let expected = SuiteTestHarness::new(expected_storage);
+    assert_eq!(trie.root(epoch(0)), expected.original_root(), "root should match the reference");
+}

--- a/crates/trie/sparse/tests/suite/lifecycle.rs
+++ b/crates/trie/sparse/tests/suite/lifecycle.rs
@@ -150,7 +150,7 @@ pub(super) fn test_incremental_reveal_and_update_with_retry<T: SparseTrie>(new_t
     .expect("update_leaves should succeed");
 
     assert!(!targets.is_empty(), "callback should fire for blinded keys");
-    assert!(!leaf_updates.is_empty(), "blinded keys should remain in updates map");
+    assert_eq!(trie.blocked_updates().len(), 2, "blinded keys should be blocked in the trie");
 
     // Reveal the proof for the requested targets.
     let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
@@ -164,7 +164,7 @@ pub(super) fn test_incremental_reveal_and_update_with_retry<T: SparseTrie>(new_t
     .expect("update_leaves should succeed on retry");
 
     assert!(targets2.is_empty(), "no callback should fire after reveal");
-    assert!(leaf_updates.is_empty(), "all keys should be drained after retry");
+    assert!(trie.blocked_updates().is_empty(), "no key should stay blocked after retry");
 
     // Root should match reference with all 5 updates applied.
     let mut expected_storage = base_storage;
@@ -407,13 +407,13 @@ pub(super) fn test_touched_on_blinded_triggers_proof_then_changed_succeeds<T: Sp
     .expect("update_leaves with Touched should succeed");
 
     assert!(!targets.is_empty(), "callback should fire for Touched on blinded path");
-    assert!(!leaf_updates.is_empty(), "Touched key should remain in map when blinded");
+    assert_eq!(trie.blocked_updates().len(), 1, "Touched key should be blocked when blinded");
 
     // Step 2: Reveal the proof for the requested targets.
     let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
     trie.reveal_nodes(&mut proof_nodes).expect("reveal should succeed");
 
-    // Step 3: Replace Touched with Changed(new_value) in the map.
+    // Step 3: Send Changed(new_value), superseding the blocked Touched.
     let new_value = U256::from(999);
     leaf_updates.insert(target_key, LeafUpdate::Changed(encode_fixed_size(&new_value).to_vec()));
 
@@ -606,10 +606,14 @@ pub(super) fn test_prune_then_reuse_for_next_block<T: SparseTrie>(new_trie: fn()
     let mut changeset_cold: BTreeMap<B256, U256> = BTreeMap::new();
     changeset_cold.insert(keys[4], U256::from(555));
     let mut leaf_updates_cold = SuiteTestHarness::leaf_updates(&changeset_cold);
-    let mut proof_requested = false;
-    trie.update_leaves(&mut leaf_updates_cold, |_, _| proof_requested = true)
-        .expect("update_leaves should succeed");
-    assert!(proof_requested, "leaf older than the cutoff should require a proof");
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates_cold, |key, parent| {
+        targets.push(ProofV2Target::new(key).with_parent(parent));
+    })
+    .expect("update_leaves should succeed");
+    assert!(!targets.is_empty(), "leaf older than the cutoff should require a proof");
+    let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
     harness.reveal_and_update(&mut trie, &mut leaf_updates_cold);
     let root_cold = trie.root(epoch(2));
 

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -242,6 +242,7 @@ sparse_trie_tests! {
     test_remove_nonexistent_leaf_preserves_hashes,
     test_update_leaves_blinded_node_requests_proof,
     test_update_leaves_retry_after_reveal,
+    test_update_leaves_supersede_blocked_update,
     test_remove_leaf_blinded_sibling_requires_reveal,
     test_update_leaves_removal_branch_collapse_blinded_sibling,
     test_update_leaves_subtrie_collapse_requests_proof,

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -22,7 +22,9 @@ use alloy_rlp::{encode_fixed_size, Decodable};
 use alloy_trie::EMPTY_ROOT_HASH;
 use reth_trie::test_utils::TrieTestHarness;
 use reth_trie_common::{Nibbles, ProofV2Target, TrieNodeV2};
-use reth_trie_sparse::{LeafLookup, LeafLookupError, LeafUpdate, SparseTrie, TrieNodeEpoch};
+use reth_trie_sparse::{
+    LeafLookup, LeafLookupError, LeafUpdate, LeafUpdateEvent, SparseTrie, TrieNodeEpoch,
+};
 use std::{collections::BTreeMap, iter::once};
 
 mod find_leaf;
@@ -251,6 +253,7 @@ sparse_trie_tests! {
     test_update_leaves_touched_blinded_requests_proof,
     test_update_leaves_touched_nonexistent_key,
     test_update_leaves_touched_nonexistent_in_populated_trie,
+    test_update_leaves_reports_touched_values,
     test_update_leaves_multiple_mixed_updates,
     test_remove_leaf_marks_ancestors_dirty_unconditionally,
     test_orphaned_value_update_falls_through_to_full_insertion,

--- a/crates/trie/sparse/tests/suite/main.rs
+++ b/crates/trie/sparse/tests/suite/main.rs
@@ -316,4 +316,5 @@ sparse_trie_tests! {
     test_get_leaf_value_for_storage_root_lookup,
     test_find_leaf_before_update_to_check_existence,
     test_prune_then_reuse_for_next_block,
+    test_collapse_asks_for_blinded_sibling_once,
 }

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -588,6 +588,67 @@ pub(super) fn test_update_leaves_retry_after_reveal<T: SparseTrie>(new_trie: fn(
     );
 }
 
+/// A newer update for a key that is already blocked must replace the blocked one, so the stale
+/// value can never be applied on top of it once the proof arrives.
+pub(super) fn test_update_leaves_supersede_blocked_update<T: SparseTrie>(new_trie: fn() -> T) {
+    // Two groups of 16 keys under different first nibbles, so branch children become hash nodes.
+    let mut base_storage = BTreeMap::new();
+
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+    }
+
+    let mut group_b_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        group_b_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage.clone());
+
+    // Reveal only group_a keys, leaving group_b's subtrie blinded.
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false, new_trie);
+
+    let target_key = group_b_keys[0];
+    let stale_value = U256::from(111);
+    let new_value = U256::from(999);
+
+    let mut leaf_updates =
+        SuiteTestHarness::leaf_updates(&BTreeMap::from([(target_key, stale_value)]));
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    trie.update_leaves(&mut leaf_updates, |key, parent| {
+        targets.push(ProofV2Target::new(key).with_parent(parent));
+    })
+    .expect("update_leaves should succeed");
+    assert_eq!(trie.blocked_updates().len(), 1, "the first update should be blocked");
+
+    // The newer value hits the same blinded node, so it takes the blocked entry's place.
+    let mut newer = SuiteTestHarness::leaf_updates(&BTreeMap::from([(target_key, new_value)]));
+    trie.update_leaves(&mut newer, |_, _| {}).expect("update_leaves should succeed");
+    assert!(newer.is_empty(), "the newer update should be taken over by the trie");
+    assert_eq!(trie.blocked_updates().len(), 1, "the key should be blocked exactly once");
+
+    let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+    trie.update_leaves(&mut leaf_updates, |_, _| {}).expect("update_leaves should succeed");
+    assert!(trie.blocked_updates().is_empty(), "the update should be applied after the reveal");
+
+    let mut expected_storage = base_storage;
+    expected_storage.insert(target_key, new_value);
+    let expected_harness = SuiteTestHarness::new(expected_storage);
+    assert_eq!(
+        trie.root(epoch(0)),
+        expected_harness.original_root(),
+        "the newer value must win over the blocked one"
+    );
+}
+
 pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie>(new_trie: fn() -> T) {
     // Build a branch with two children: one revealed leaf at nibble 0x1, and a blinded
     // subtrie at nibble 0x2 (16 keys so it becomes a hash node > 32 bytes).

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -512,10 +512,12 @@ pub(super) fn test_update_leaves_blinded_node_requests_proof<T: SparseTrie>(new_
     // The callback should have been invoked.
     assert!(!targets.is_empty(), "callback should be invoked for a blinded node");
 
-    // The key should remain in the updates map (not drained).
-    assert!(
-        !leaf_updates.is_empty(),
-        "key should remain in updates map when blinded node is encountered"
+    // The trie should have taken ownership of the update (not drained).
+    assert!(leaf_updates.is_empty(), "updates map should be drained");
+    assert_eq!(
+        trie.blocked_updates().len(),
+        1,
+        "key should be blocked in the trie when blinded node is encountered"
     );
 }
 
@@ -558,7 +560,7 @@ pub(super) fn test_update_leaves_retry_after_reveal<T: SparseTrie>(new_trie: fn(
     })
     .expect("update_leaves should succeed");
     assert!(!targets.is_empty(), "callback should fire for blinded node");
-    assert!(!leaf_updates.is_empty(), "key should remain in map after blinded hit");
+    assert_eq!(trie.blocked_updates().len(), 1, "key should be blocked after blinded hit");
 
     // Reveal the proof for the requested targets.
     let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
@@ -621,7 +623,7 @@ pub(super) fn test_remove_leaf_blinded_sibling_requires_reveal<T: SparseTrie>(ne
     })
     .expect("update_leaves should succeed");
     assert!(!targets.is_empty(), "callback should fire for blinded sibling");
-    assert!(!leaf_updates.is_empty(), "key should remain in map after blinded hit");
+    assert_eq!(trie.blocked_updates().len(), 1, "key should be blocked after blinded hit");
 
     // Reveal the blinded sibling subtrie.
     let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
@@ -690,8 +692,8 @@ pub(super) fn test_update_leaves_removal_branch_collapse_blinded_sibling<T: Spar
     // Callback should have fired for the blinded sibling path.
     assert!(!targets.is_empty(), "callback should fire for blinded sibling");
 
-    // Update should remain in the map (not drained).
-    assert!(!leaf_updates.is_empty(), "update should remain in map after blinded hit");
+    // Update should be blocked in the trie (not applied).
+    assert!(!trie.blocked_updates().is_empty(), "update should be blocked after blinded hit");
 
     // Leaf value should be preserved (atomic rollback).
     let value_after = trie.get_leaf_value(&revealed_path);
@@ -760,8 +762,8 @@ pub(super) fn test_update_leaves_subtrie_collapse_requests_proof<T: SparseTrie>(
         !targets.is_empty(),
         "callback should fire for blinded sibling during subtrie collapse"
     );
-    // At least one removal key should remain in the map for retry.
-    assert!(!leaf_updates.is_empty(), "removal keys should remain in map after blinded hit");
+    // At least one removal key should be blocked for retry.
+    assert!(!trie.blocked_updates().is_empty(), "removal keys should be blocked after blinded hit");
 }
 
 /// Multiple keys hitting the same blinded node each trigger a callback.
@@ -811,8 +813,8 @@ pub(super) fn test_update_leaves_multiple_keys_same_blinded_node<T: SparseTrie>(
 
     // Callback should fire for each key (3 invocations).
     assert_eq!(targets.len(), 3, "callback should fire once per key hitting the blinded node");
-    // All updates should remain in the map for retry.
-    assert_eq!(leaf_updates.len(), 3, "all keys should remain in map after blinded hit");
+    // All updates should be blocked for retry.
+    assert_eq!(trie.blocked_updates().len(), 3, "all keys should be blocked after blinded hit");
 }
 
 /// `LeafUpdate::Touched` on a fully revealed path should be a no-op.
@@ -892,8 +894,8 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie>(
 
     // Callback should have been invoked for the blinded node.
     assert!(!targets.is_empty(), "callback should fire for Touched on blinded path");
-    // Key should remain in the updates map.
-    assert!(!leaf_updates.is_empty(), "Touched key should remain in map when blinded");
+    // Key should be blocked in the trie.
+    assert_eq!(trie.blocked_updates().len(), 1, "Touched key should be blocked when blinded");
     // Root should be unchanged (no mutation).
     assert_eq!(
         trie.root(epoch(0)),
@@ -1369,8 +1371,8 @@ pub(super) fn test_branch_collapse_multi_empty_subtries_blinded_remaining<T: Spa
 
     // Callback should fire for the blinded child at 0xd8.
     assert!(!targets.is_empty(), "callback should fire for blinded child during branch collapse");
-    // Removal keys should remain in the map for retry.
-    assert!(!leaf_updates.is_empty(), "removal keys should remain in map after blinded hit");
+    // Removal keys should be blocked for retry.
+    assert!(!trie.blocked_updates().is_empty(), "removal keys should be blocked after blinded hit");
 
     // Reveal the blinded subtrie.
     let (mut proof_nodes, _) = harness.proof_v2(&mut targets);

--- a/crates/trie/sparse/tests/suite/update_leaves.rs
+++ b/crates/trie/sparse/tests/suite/update_leaves.rs
@@ -965,6 +965,78 @@ pub(super) fn test_update_leaves_touched_blinded_requests_proof<T: SparseTrie>(
     );
 }
 
+/// `update_leaves_with_events` reports the leaf value behind every applied `Touched` entry:
+/// the stored value for a revealed leaf, `None` for a revealed key without a leaf, and nothing
+/// at all while the key's path is still blinded.
+pub(super) fn test_update_leaves_reports_touched_values<T: SparseTrie>(new_trie: fn() -> T) {
+    // Two groups of 16 keys under different first nibbles, so revealing only group A leaves
+    // group B behind a blinded node.
+    let mut base_storage = BTreeMap::new();
+    let mut group_a_keys = Vec::new();
+    for i in 0u8..16 {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x10 | i;
+        group_a_keys.push(key);
+        base_storage.insert(key, U256::from(i as u64 + 1));
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20 | i;
+        base_storage.insert(key, U256::from(i as u64 + 100));
+    }
+
+    let harness = SuiteTestHarness::new(base_storage);
+    let mut trie: T = harness.init_trie_with_targets(&group_a_keys, false, new_trie);
+
+    let revealed = group_a_keys[3];
+    let absent = B256::with_last_byte(0x77);
+    let blinded = {
+        let mut key = B256::ZERO;
+        key.0[0] = 0x20;
+        key
+    };
+    let changed = group_a_keys[5];
+
+    let mut leaf_updates: B256Map<LeafUpdate> = [
+        (revealed, LeafUpdate::Touched),
+        (absent, LeafUpdate::Touched),
+        (blinded, LeafUpdate::Touched),
+        (changed, LeafUpdate::Changed(encode_fixed_size(&U256::from(999)).to_vec())),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut targets: Vec<ProofV2Target> = Vec::new();
+    let mut touched: Vec<(B256, Option<Vec<u8>>)> = Vec::new();
+    trie.update_leaves_with_events(&mut leaf_updates, true, |event| match event {
+        LeafUpdateEvent::ProofRequired { key, parent } => {
+            targets.push(ProofV2Target::new(key).with_parent(parent));
+        }
+        LeafUpdateEvent::Touched { key, value } => touched.push((key, value.map(<[u8]>::to_vec))),
+    })
+    .expect("update_leaves should succeed");
+
+    touched.sort_unstable();
+    assert_eq!(
+        touched,
+        vec![(absent, None), (revealed, Some(encode_fixed_size(&U256::from(4)).to_vec()))],
+        "only applied touched entries are reported, the blinded one is not",
+    );
+    assert_eq!(targets.len(), 1, "only the blinded key needs a proof");
+
+    // Revealing the blinded subtrie lets the retry report its value.
+    let (mut proof_nodes, _) = harness.proof_v2(&mut targets);
+    trie.reveal_nodes(&mut proof_nodes).expect("reveal_nodes should succeed");
+
+    touched.clear();
+    trie.update_leaves_with_events(&mut leaf_updates, true, |event| {
+        if let LeafUpdateEvent::Touched { key, value } = event {
+            touched.push((key, value.map(<[u8]>::to_vec)));
+        }
+    })
+    .expect("update_leaves should succeed on retry");
+
+    assert_eq!(touched, vec![(blinded, Some(encode_fixed_size(&U256::from(100)).to_vec()))]);
+}
+
 /// Touched on a nonexistent key in an empty trie is drained silently.
 ///
 /// An empty (default) trie has an Empty root — all paths are accessible (no blinded nodes).

--- a/crates/trie/trie/src/witness.rs
+++ b/crates/trie/trie/src/witness.rs
@@ -182,7 +182,12 @@ where
                 let mut targets = MultiProofTargetsV2::default();
 
                 for (&hashed_address, slot_updates) in storage_updates.iter_mut() {
-                    if slot_updates.is_empty() {
+                    // Updates the trie took ownership of are retried by `update_leaves` itself.
+                    if slot_updates.is_empty() &&
+                        sparse_trie
+                            .storage_trie_ref(&hashed_address)
+                            .is_none_or(|trie| !trie.blocked_updates().has_retryable())
+                    {
                         continue;
                     }
                     let storage_trie = sparse_trie


### PR DESCRIPTION
Branched off #27184 (`mattsse/sparse-proof-rounds`), so the diff against that branch is the last commit only.

The re-ask churn #27184 measured inside the storage jobs (24,000 dropped asks per block from the same parent and 16,000 from a deeper one, over about 3,000 storage proof keys) comes from one state: a leaf removal whose branch collapse needs a blinded sibling was blocked as `Retryable`, which has no gate at all and is drained back into the batch on every pass. For as long as the sibling's proof is in flight, each pass of that address' job re-walks to the leaf, runs `remove_leaf` down to the same `NeedsProof` and emits the sibling ask plus the removal's own ask again, and the job's `fetched` dedup drops both. The cost is one walk and two dropped asks per blocked removal per pass, which is why a whale contract reaches 526,000 of them on block 25,861,997.

The entry now names the node it waits for instead. That node is not on the entry's own key path, so the blocked set keeps a second index from sibling path to entry key and `reveal_nodes` promotes only the entries whose sibling actually arrived; everything on a key's own path keeps the depth gate it already had, and nothing on the producer or dispatch side changes.

Measured with a coordinator-shaped reproduction in the sparse suite (only the root revealed, the same `fetched` dedup rule, proofs delivered in chunks with one reveal and one `update_leaves` pass per chunk): on 65,536 slots with 2,000 updates of which every fourth is a removal, total asks go from 33,864 to 4,636, dropped-same-parent from 14,614 to 0 and dropped-deeper-parent from 17,030 to 2,416; with one proof per pass on 400 updates, from 17,086 / 8,019 / 8,626 to 1,048 / 0 / 607. The re-asks that remain are bounded by the depth of a key's path rather than by the number of passes: the worst key went from 399 to 3. The new suite test fails with 372 repeated asks before the change. `cargo nextest run -p reth-trie-sparse` (191), `-p reth-engine-tree` (201) and `-p reth-trie` (89) pass.

Risk: a collapse now depends on the proof for the sibling key revealing a node at exactly that sibling's path, the same assumption the existing depth gate already makes for a key's own blinded node; if it did not hold the entry would sit until the task's stall detector fires instead of spinning. The second ask the subtrie removal path emits for the removal's own key is still always dropped and is left for a follow-up.

Three pairs of 300M-gas BAL blocks against the counters branch: the churn is gone as designed, storage
re-asks from the same parent go from 28,359 per block (295,158 on the worst block) to zero and from a
deeper parent from 16,824 to 169, and the sparse trie task idles 12.4 -> 19.7 ms more per block. Mean
newPayload latency -1.22% (±3.13%), P50 -2.9%, P99 -2.7%, all within noise at three pairs; a six-pair run
over 60 blocks is queued.


The six-pair run over 60 blocks does not hold up on latency: mean +1.49% (±1.17%), P50 -1.1%, state
root wait 15.63 -> 17.91 ms (+14.6%, ±6.3%), P99 202 -> 300 ms. No block stalled or fell back. The
tail is one block: 25,861,997 goes from 202 to 300 ms in every repeat, the other per-block deltas
scatter ±20-40 ms both ways. That block has many removals whose branch collapse waits on a blinded
sibling; the working hypothesis is that under the old unconditional retry many of those removals
applied as soon as another update in the same pass gave the branch a second child, without the
sibling proof, whereas the gate now always waits for the sibling round trip. A second trigger,
promoting a sibling-blocked removal when an update lands under its branch, is the next step; until
then this is a CPU fix, not a latency one.
