### PR TITLE
fix(rpc): support chain-specific simulate timestamps

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -121,11 +121,22 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
                 // explicit `number` and `time` override and the chain is contiguous (see the
                 // execution-apis spec note: "If the block number is increased more than 1 compared
                 // to the previous block, new empty blocks are generated in between.").
-                let block_state_calls = simulate::sanitize_chain(
+                let block_state_calls = simulate::sanitize_chain_with_timestamp_policy(
                     block_state_calls,
                     &parent,
                     chain_id,
                     max_simulate_blocks,
+                    |parent_number, parent_timestamp, block_number, timestamp_increment| {
+                        this.next_simulate_block_timestamp(
+                            parent_number,
+                            parent_timestamp,
+                            block_number,
+                            timestamp_increment,
+                        )
+                    },
+                    |timestamp, parent_timestamp| {
+                        this.is_simulate_block_timestamp_valid(timestamp, parent_timestamp)
+                    },
                 )?;
 
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
@@ -530,6 +541,22 @@ pub trait Call:
                    + From<ProviderError>,
     > + SpawnBlocking
 {
+    /// Returns the timestamp to use when a simulated block omits a timestamp override.
+    fn next_simulate_block_timestamp(
+        &self,
+        _parent_number: u64,
+        parent_timestamp: u64,
+        _block_number: u64,
+        timestamp_increment: u64,
+    ) -> Option<u64> {
+        parent_timestamp.checked_add(timestamp_increment)
+    }
+
+    /// Returns whether a simulated block timestamp is valid relative to its parent.
+    fn is_simulate_block_timestamp_valid(&self, timestamp: u64, parent_timestamp: u64) -> bool {
+        timestamp > parent_timestamp
+    }
+
     /// Returns default gas limit to use for `eth_call` and tracing RPC methods.
     ///
     /// Data access in default trait method implementations.

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -177,6 +177,28 @@ pub fn sanitize_chain<TxReq, H>(
 where
     H: BlockHeader,
 {
+    sanitize_chain_with_timestamp_policy(
+        blocks,
+        parent,
+        chain_id,
+        max_simulate_blocks,
+        |_, prev_timestamp, _, timestamp_increment| prev_timestamp.checked_add(timestamp_increment),
+        |timestamp, prev_timestamp| timestamp > prev_timestamp,
+    )
+}
+
+/// Sanitizes a chain using chain-specific timestamp generation and validation policies.
+pub fn sanitize_chain_with_timestamp_policy<TxReq, H>(
+    blocks: Vec<SimBlock<TxReq>>,
+    parent: &SealedHeader<H>,
+    chain_id: u64,
+    max_simulate_blocks: u64,
+    mut next_timestamp: impl FnMut(u64, u64, u64, u64) -> Option<u64>,
+    mut timestamp_is_valid: impl FnMut(u64, u64) -> bool,
+) -> Result<Vec<SimBlock<TxReq>>, EthApiError>
+where
+    H: BlockHeader,
+{
     let timestamp_increment = Chain::from(chain_id)
         .average_blocktime_hint()
         .map(|d| d.as_secs().saturating_add(u64::from(d.subsec_nanos() > 0)))
@@ -216,13 +238,18 @@ where
         if gap > 1 {
             for i in 1..gap {
                 let filler_number = prev_number + i;
-                let filler_time =
-                    prev_timestamp.checked_add(timestamp_increment).ok_or_else(|| {
-                        EthApiError::other(EthSimulateError::BlockTimestampInvalid {
-                            got: prev_timestamp,
-                            parent: prev_timestamp,
-                        })
-                    })?;
+                let filler_time = next_timestamp(
+                    prev_number + i - 1,
+                    prev_timestamp,
+                    filler_number,
+                    timestamp_increment,
+                )
+                .ok_or_else(|| {
+                    EthApiError::other(EthSimulateError::BlockTimestampInvalid {
+                        got: prev_timestamp,
+                        parent: prev_timestamp,
+                    })
+                })?;
                 out.push(SimBlock {
                     block_overrides: Some(BlockOverrides {
                         number: Some(U256::from(filler_number)),
@@ -239,7 +266,7 @@ where
         prev_number = target_number;
         // Default timestamp to prev + increment if not specified, otherwise validate ordering.
         let block_time = if let Some(t) = overrides.time {
-            if t <= prev_timestamp {
+            if !timestamp_is_valid(t, prev_timestamp) {
                 return Err(EthApiError::other(EthSimulateError::BlockTimestampInvalid {
                     got: t,
                     parent: prev_timestamp,
@@ -247,7 +274,13 @@ where
             }
             t
         } else {
-            let t = prev_timestamp.checked_add(timestamp_increment).ok_or_else(|| {
+            let t = next_timestamp(
+                prev_number.saturating_sub(1),
+                prev_timestamp,
+                prev_number,
+                timestamp_increment,
+            )
+            .ok_or_else(|| {
                 EthApiError::other(EthSimulateError::BlockTimestampInvalid {
                     got: prev_timestamp,
                     parent: prev_timestamp,
@@ -744,6 +777,27 @@ mod tests {
         let times: Vec<u64> =
             out.iter().map(|b| b.block_overrides.as_ref().unwrap().time.unwrap()).collect();
         assert_eq!(times, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn sanitize_chain_supports_chain_specific_repeated_timestamps() {
+        let parent = parent_at(10, 100);
+        let blocks = vec![SimBlock::<()> {
+            block_overrides: Some(BlockOverrides { time: Some(100), ..Default::default() }),
+            ..Default::default()
+        }];
+
+        let out = super::sanitize_chain_with_timestamp_policy(
+            blocks,
+            &parent,
+            Chain::mainnet().id(),
+            256,
+            |_, parent_timestamp, _, _| Some(parent_timestamp),
+            |timestamp, parent_timestamp| timestamp >= parent_timestamp,
+        )
+        .unwrap();
+
+        assert_eq!(out[0].block_overrides.as_ref().unwrap().time, Some(100));
     }
 
     #[test]


### PR DESCRIPTION
Base is introducing 200ms blocks while retaining second-granular header timestamps, so valid consecutive blocks can share the same timestamp. The current `eth_simulateV1` sanitizer rejects those explicit timestamps and rounds subsecond defaults up to one second.

This adds opt-in timestamp generation and validation hooks to `Call`, while preserving Reth's existing strictly-increasing behavior by default. Base uses the hooks in base/base#5023; the release-branch integration is base/reth#19.