### PR TITLE
feat(txpool): make replacement policy extensible

### DIFF
--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -3,7 +3,7 @@ use crate::{
     pool::{NEW_TX_LISTENER_BUFFER_SIZE, PENDING_TX_LISTENER_BUFFER_SIZE},
     PoolSize, TransactionOrigin,
 };
-use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
+use alloy_consensus::{constants::EIP4844_TX_TYPE_ID, Transaction};
 use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::{map::AddressSet, Address};
 use std::{ops::Mul, time::Duration};
@@ -202,6 +202,44 @@ impl PriceBumpConfig {
         }
         self.default_price_bump
     }
+
+    /// Returns whether `replacement` is underpriced relative to `existing`.
+    pub fn is_replacement_underpriced<T: Transaction + ?Sized>(
+        &self,
+        existing: &T,
+        replacement: &T,
+    ) -> bool {
+        let price_bump = self.price_bump(existing.ty());
+        let required_bumped_fee =
+            |existing_fee: u128| existing_fee.saturating_mul(100 + price_bump).div_ceil(100);
+
+        if replacement.max_fee_per_gas() < required_bumped_fee(existing.max_fee_per_gas()) {
+            return true
+        }
+
+        let existing_max_priority_fee_per_gas =
+            existing.max_priority_fee_per_gas().unwrap_or_default();
+        let replacement_max_priority_fee_per_gas =
+            replacement.max_priority_fee_per_gas().unwrap_or_default();
+        if existing_max_priority_fee_per_gas != 0 &&
+            replacement_max_priority_fee_per_gas != 0 &&
+            replacement_max_priority_fee_per_gas <
+                required_bumped_fee(existing_max_priority_fee_per_gas)
+        {
+            return true
+        }
+
+        if let Some(existing_max_blob_fee_per_gas) = existing.max_fee_per_blob_gas() {
+            let replacement_max_blob_fee_per_gas =
+                replacement.max_fee_per_blob_gas().unwrap_or_default();
+            if replacement_max_blob_fee_per_gas < required_bumped_fee(existing_max_blob_fee_per_gas)
+            {
+                return true
+            }
+        }
+
+        false
+    }
 }
 
 impl Default for PriceBumpConfig {
@@ -278,7 +316,56 @@ impl LocalTransactionConfig {
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::{TxEip1559, TxEip4844};
+
     use super::*;
+
+    #[test]
+    fn replacement_uses_configured_price_bump() {
+        let config = PriceBumpConfig { default_price_bump: 25, ..Default::default() };
+        let existing =
+            TxEip1559 { max_fee_per_gas: 100, max_priority_fee_per_gas: 10, ..Default::default() };
+        let mut replacement = existing.clone();
+        replacement.max_fee_per_gas = 125;
+        replacement.max_priority_fee_per_gas = 12;
+        assert!(config.is_replacement_underpriced(&existing, &replacement));
+
+        replacement.max_priority_fee_per_gas = 13;
+        assert!(!config.is_replacement_underpriced(&existing, &replacement));
+
+        replacement.max_fee_per_gas = 124;
+        assert!(config.is_replacement_underpriced(&existing, &replacement));
+    }
+
+    #[test]
+    fn blob_replacement_requires_all_fee_bumps() {
+        let config = PriceBumpConfig::default();
+        let existing = TxEip4844 {
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+            max_fee_per_blob_gas: 50,
+            ..Default::default()
+        };
+        let replacement = TxEip4844 {
+            max_fee_per_gas: 200,
+            max_priority_fee_per_gas: 20,
+            max_fee_per_blob_gas: 100,
+            ..existing.clone()
+        };
+        assert!(!config.is_replacement_underpriced(&existing, &replacement));
+
+        let mut underpriced = replacement.clone();
+        underpriced.max_fee_per_gas -= 1;
+        assert!(config.is_replacement_underpriced(&existing, &underpriced));
+
+        let mut underpriced = replacement.clone();
+        underpriced.max_priority_fee_per_gas -= 1;
+        assert!(config.is_replacement_underpriced(&existing, &underpriced));
+
+        let mut underpriced = replacement;
+        underpriced.max_fee_per_blob_gas -= 1;
+        assert!(config.is_replacement_underpriced(&existing, &underpriced));
+    }
 
     #[test]
     fn test_pool_size_sanity() {

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -203,24 +203,36 @@ impl PriceBumpConfig {
         self.default_price_bump
     }
 
-    /// Returns whether `replacement` is underpriced relative to `existing`.
+    /// Determines whether a candidate transaction (`maybe_replacement`) is underpriced compared to
+    /// an existing transaction in the pool.
+    ///
+    /// A transaction is considered underpriced if it doesn't meet the required fee bump threshold.
+    /// This applies to both standard gas fees and, for blob-carrying transactions (EIP-4844),
+    /// the blob-specific fees.
+    #[inline]
     pub fn is_replacement_underpriced<T: Transaction + ?Sized>(
         &self,
         existing: &T,
-        replacement: &T,
+        maybe_replacement: &T,
     ) -> bool {
+        // Retrieve the required price bump percentage for this type of transaction.
+        //
+        // The bump is different for EIP-4844 and other transactions. See `PriceBumpConfig`.
         let price_bump = self.price_bump(existing.ty());
         let required_bumped_fee =
             |existing_fee: u128| existing_fee.saturating_mul(100 + price_bump).div_ceil(100);
 
-        if replacement.max_fee_per_gas() < required_bumped_fee(existing.max_fee_per_gas()) {
+        // Check if the max fee per gas is underpriced.
+        if maybe_replacement.max_fee_per_gas() < required_bumped_fee(existing.max_fee_per_gas()) {
             return true
         }
 
         let existing_max_priority_fee_per_gas =
             existing.max_priority_fee_per_gas().unwrap_or_default();
         let replacement_max_priority_fee_per_gas =
-            replacement.max_priority_fee_per_gas().unwrap_or_default();
+            maybe_replacement.max_priority_fee_per_gas().unwrap_or_default();
+
+        // Check max priority fee per gas (relevant for EIP-1559 transactions only)
         if existing_max_priority_fee_per_gas != 0 &&
             replacement_max_priority_fee_per_gas != 0 &&
             replacement_max_priority_fee_per_gas <
@@ -229,9 +241,11 @@ impl PriceBumpConfig {
             return true
         }
 
+        // Check max blob fee per gas
         if let Some(existing_max_blob_fee_per_gas) = existing.max_fee_per_blob_gas() {
+            // This enforces that blob txs can only be replaced by blob txs
             let replacement_max_blob_fee_per_gas =
-                replacement.max_fee_per_blob_gas().unwrap_or_default();
+                maybe_replacement.max_fee_per_blob_gas().unwrap_or_default();
             if replacement_max_blob_fee_per_gas < required_bumped_fee(existing_max_blob_fee_per_gas)
             {
                 return true

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -2116,7 +2116,9 @@ impl<T: PoolTransaction> AllTransactions<T> {
                 let maybe_replacement = transaction.as_ref();
 
                 // Ensure the new transaction is not underpriced
-                if existing_transaction.is_underpriced(maybe_replacement, &self.price_bumps) {
+                if existing_transaction
+                    .is_replacement_underpriced(maybe_replacement, &self.price_bumps)
+                {
                     return Err(InsertErr::Underpriced {
                         transaction: pool_tx.transaction,
                         existing: *entry.get().transaction.hash(),

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -58,7 +58,7 @@ use crate::{
         TransactionListenerKind,
     },
     validate::{TransactionValidationOutcome, TransactionValidator, ValidPoolTransaction},
-    AddedTransactionOutcome, AllTransactionsEvents,
+    AddedTransactionOutcome, AllTransactionsEvents, PriceBumpConfig,
 };
 use alloy_consensus::{error::ValueError, transaction::TxHashRef, BlockHeader, Signed, Typed2718};
 use alloy_eips::{
@@ -1489,6 +1489,17 @@ pub trait PoolTransaction:
         } else {
             Ok(())
         }
+    }
+
+    /// Returns whether `replacement` is underpriced relative to this transaction.
+    ///
+    /// Implementations may override this to define transaction-specific replacement semantics.
+    fn is_replacement_underpriced(
+        &self,
+        replacement: &Self,
+        price_bumps: &PriceBumpConfig,
+    ) -> bool {
+        price_bumps.is_replacement_underpriced(self, replacement)
     }
 
     /// Allows to communicate to the pool that the transaction doesn't require a nonce check.

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1493,6 +1493,8 @@ pub trait PoolTransaction:
 
     /// Returns whether `replacement` is underpriced relative to this transaction.
     ///
+    /// Called on the existing transaction when another transaction would replace it.
+    /// By default, delegates to [`PriceBumpConfig::is_replacement_underpriced`].
     /// Implementations may override this to define transaction-specific replacement semantics.
     fn is_replacement_underpriced(
         &self,

--- a/crates/transaction-pool/src/validate/mod.rs
+++ b/crates/transaction-pool/src/validate/mod.rs
@@ -460,52 +460,14 @@ impl<T: PoolTransaction> ValidPoolTransaction<T> {
         self.transaction.encoded_2718_consensus()
     }
 
-    /// Determines whether a candidate transaction (`maybe_replacement`) is underpriced compared to
-    /// an existing transaction in the pool.
-    ///
-    /// A transaction is considered underpriced if it doesn't meet the required fee bump threshold.
-    /// This applies to both standard gas fees and, for blob-carrying transactions (EIP-4844),
-    /// the blob-specific fees.
+    /// Returns whether `maybe_replacement` is underpriced relative to this transaction.
     #[inline]
-    pub fn is_underpriced(&self, maybe_replacement: &Self, price_bumps: &PriceBumpConfig) -> bool {
-        // Retrieve the required price bump percentage for this type of transaction.
-        //
-        // The bump is different for EIP-4844 and other transactions. See `PriceBumpConfig`.
-        let price_bump = price_bumps.price_bump(self.tx_type());
-        let required_bumped_fee =
-            |existing_fee: u128| existing_fee.saturating_mul(100 + price_bump).div_ceil(100);
-
-        // Check if the max fee per gas is underpriced.
-        if maybe_replacement.max_fee_per_gas() < required_bumped_fee(self.max_fee_per_gas()) {
-            return true
-        }
-
-        let existing_max_priority_fee_per_gas =
-            self.transaction.max_priority_fee_per_gas().unwrap_or_default();
-        let replacement_max_priority_fee_per_gas =
-            maybe_replacement.transaction.max_priority_fee_per_gas().unwrap_or_default();
-
-        // Check max priority fee per gas (relevant for EIP-1559 transactions only)
-        if existing_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas != 0 &&
-            replacement_max_priority_fee_per_gas <
-                required_bumped_fee(existing_max_priority_fee_per_gas)
-        {
-            return true
-        }
-
-        // Check max blob fee per gas
-        if let Some(existing_max_blob_fee_per_gas) = self.transaction.max_fee_per_blob_gas() {
-            // This enforces that blob txs can only be replaced by blob txs
-            let replacement_max_blob_fee_per_gas =
-                maybe_replacement.transaction.max_fee_per_blob_gas().unwrap_or_default();
-            if replacement_max_blob_fee_per_gas < required_bumped_fee(existing_max_blob_fee_per_gas)
-            {
-                return true
-            }
-        }
-
-        false
+    pub fn is_replacement_underpriced(
+        &self,
+        maybe_replacement: &Self,
+        price_bumps: &PriceBumpConfig,
+    ) -> bool {
+        self.transaction.is_replacement_underpriced(&maybe_replacement.transaction, price_bumps)
     }
 }
 


### PR DESCRIPTION
Adds an overridable `PoolTransaction::is_replacement_underpriced` hook so downstream transaction types can customize replacement pricing without changing pool internals. Moves the existing standard/blob fee-bump calculation into `PriceBumpConfig` so overrides can reuse it, and renames the delegating `ValidPoolTransaction` helper from `is_underpriced` to `is_replacement_underpriced`. Default replacement behavior is unchanged; this contains no Base-specific validity policy.

Validated with `cargo test --locked -p reth-transaction-pool` (266 unit tests, 15 integration tests, 3 doctests passed), `cargo +nightly clippy --locked -p reth-transaction-pool --all-targets --all-features -- -D warnings`, and `cargo +nightly fmt --all --check`. Includes regression tests for custom price-bump configuration and all three blob replacement fee thresholds.